### PR TITLE
feat(ui): original DeFi terminal redesign

### DIFF
--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -19,7 +19,7 @@ function formatNum(n: number | null | undefined): string {
 }
 
 function shortenAddress(addr: string, chars = 4): string {
-  return `${addr.slice(0, chars)}...${addr.slice(-chars)}`;
+  return `${addr.slice(0, chars)}…${addr.slice(-chars)}`;
 }
 
 type SortKey = "volume" | "oi" | "recent" | "health";
@@ -50,209 +50,180 @@ export default function MarketsPage() {
 
   const merged = useMemo<MergedMarket[]>(() => {
     const sbMap = new Map<string, MarketWithStats>();
-    for (const m of supabaseMarkets) {
-      sbMap.set(m.slab_address, m);
-    }
+    for (const m of supabaseMarkets) sbMap.set(m.slab_address, m);
     return discovered.map((d) => {
       const addr = d.slabAddress.toBase58();
       const sb = sbMap.get(addr) ?? null;
-      return {
-        slabAddress: addr,
-        symbol: sb?.symbol ?? null,
-        name: sb?.name ?? null,
-        onChain: d,
-        supabase: sb,
-      };
+      return { slabAddress: addr, symbol: sb?.symbol ?? null, name: sb?.name ?? null, onChain: d, supabase: sb };
     });
   }, [discovered, supabaseMarkets]);
 
   const filtered = useMemo(() => {
     let list = merged;
-
-    // Search filter
     if (search.trim()) {
       const q = search.toLowerCase();
-      list = list.filter(
-        (m) =>
-          (m.symbol?.toLowerCase().includes(q)) ||
-          (m.name?.toLowerCase().includes(q)) ||
-          m.slabAddress.toLowerCase().includes(q)
+      list = list.filter((m) =>
+        m.symbol?.toLowerCase().includes(q) || m.name?.toLowerCase().includes(q) || m.slabAddress.toLowerCase().includes(q)
       );
     }
-
-    // Sort
     list = [...list].sort((a, b) => {
       switch (sortBy) {
-        case "volume":
-          return (b.supabase?.volume_total ?? 0) - (a.supabase?.volume_total ?? 0);
-        case "oi":
-          return Number(b.onChain.engine.totalOpenInterest - a.onChain.engine.totalOpenInterest);
+        case "volume": return (b.supabase?.volume_total ?? 0) - (a.supabase?.volume_total ?? 0);
+        case "oi": return Number(b.onChain.engine.totalOpenInterest - a.onChain.engine.totalOpenInterest);
         case "health": {
           const ha = computeMarketHealth(a.onChain.engine);
           const hb = computeMarketHealth(b.onChain.engine);
           const order: Record<string, number> = { healthy: 0, caution: 1, warning: 2, empty: 3 };
           return (order[ha.level] ?? 5) - (order[hb.level] ?? 5);
         }
-        case "recent":
-        default:
-          return 0; // keep discovery order (most recent first usually)
+        default: return 0;
       }
     });
-
     return list;
   }, [merged, search, sortBy]);
 
   const loading = discoveryLoading && supabaseLoading;
 
   return (
-    <div className="mx-auto max-w-7xl px-4 py-12">
-      <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h1 className="text-3xl font-bold text-white">Markets</h1>
-          <p className="mt-1 text-slate-400">Perpetual futures for any Solana token</p>
+    <div className="terminal-grid min-h-[calc(100vh-48px)]">
+      <div className="mx-auto max-w-[1800px] px-3 py-6 lg:px-4">
+        {/* Header */}
+        <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-white">Markets</h1>
+            <p className="mt-0.5 text-sm text-[#4a5068]">Perpetual futures for any Solana token</p>
+          </div>
+          <Link
+            href="/launch"
+            className="rounded-lg bg-[#00d4aa] px-5 py-2 text-center text-sm font-bold text-[#080a0f] transition-all hover:bg-[#00e8bb] hover:shadow-[0_0_20px_rgba(0,212,170,0.15)]"
+          >
+            + Launch Market
+          </Link>
         </div>
-        <Link
-          href="/launch"
-          className="rounded-xl bg-emerald-500 px-6 py-2.5 text-center font-semibold text-white transition-all duration-150 hover:bg-emerald-400 hover:shadow-lg hover:shadow-emerald-500/20 focus-visible:ring-2 focus-visible:ring-emerald-500"
-        >
-          + Launch Market
-        </Link>
-      </div>
 
-      {/* Search & Sort */}
-      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center">
-        <div className="relative flex-1">
-          <svg className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#52525b]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-          </svg>
-          <input
-            type="text"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search by token name or address..."
-            className="w-full rounded-lg border border-[#1e2433] bg-[#111318] py-2.5 pl-10 pr-4 text-sm text-[#e4e4e7] placeholder-[#52525b] transition-colors focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/30"
-          />
-        </div>
-        <div className="flex gap-1.5">
-          {(
-            [
+        {/* Search & Sort */}
+        <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center">
+          <div className="relative flex-1">
+            <svg className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[#2a2f40]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search token or address…"
+              className="w-full rounded-lg border border-[#1a1d2a] bg-[#0c0e14] py-2 pl-9 pr-4 text-sm text-[#e8eaf0] placeholder-[#2a2f40] focus:border-[#00d4aa]/40 focus:outline-none focus:ring-1 focus:ring-[#00d4aa]/20"
+            />
+          </div>
+          <div className="flex gap-1 rounded-lg bg-[#0c0e14] p-0.5 ring-1 ring-[#1a1d2a]">
+            {([
               { key: "volume" as SortKey, label: "Volume" },
               { key: "oi" as SortKey, label: "OI" },
               { key: "health" as SortKey, label: "Health" },
               { key: "recent" as SortKey, label: "Recent" },
-            ] as const
-          ).map((opt) => (
-            <button
-              key={opt.key}
-              onClick={() => setSortBy(opt.key)}
-              className={`rounded-lg px-3 py-2 text-xs font-medium transition-all duration-150 ${
-                sortBy === opt.key
-                  ? "bg-blue-600 text-white shadow-sm shadow-blue-600/20"
-                  : "bg-[#111318] text-[#71717a] hover:bg-[#1a1d24] hover:text-[#a1a1aa]"
-              }`}
-            >
-              {opt.label}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      {loading ? (
-        <div className="space-y-3">
-          {[1, 2, 3, 4, 5].map((i) => (
-            <div key={i} className="h-[72px] animate-pulse rounded-xl border border-[#1e2433] bg-[#111318]" />
-          ))}
-        </div>
-      ) : filtered.length === 0 ? (
-        <div className="rounded-2xl border border-[#1e2433] bg-[#111318] p-16 text-center">
-          {search ? (
-            <>
-              <div className="mb-4 text-5xl">🔍</div>
-              <h3 className="mb-2 text-xl font-semibold text-white">No markets found</h3>
-              <p className="text-slate-400">Try a different search term.</p>
-            </>
-          ) : (
-            <>
-              <div className="mb-4 text-5xl">🚀</div>
-              <h3 className="mb-2 text-xl font-semibold text-white">No markets yet</h3>
-              <p className="mb-6 text-slate-400">Be the first to launch a perpetual futures market.</p>
-              <Link
-                href="/launch"
-                className="inline-block rounded-xl bg-emerald-500 px-8 py-3 font-semibold text-white hover:bg-emerald-400"
+            ]).map((opt) => (
+              <button
+                key={opt.key}
+                onClick={() => setSortBy(opt.key)}
+                className={`rounded-md px-3 py-1.5 text-[11px] font-medium transition-all ${
+                  sortBy === opt.key
+                    ? "bg-[#1a1d2a] text-white"
+                    : "text-[#4a5068] hover:text-[#7a8194]"
+                }`}
               >
-                Launch First Market
-              </Link>
-            </>
-          )}
-        </div>
-      ) : (
-        <div className="overflow-hidden rounded-xl border border-[#1e2433]">
-          {/* Header */}
-          <div className="grid grid-cols-8 gap-4 border-b border-[#1e2433] bg-[#0a0b0f] px-6 py-3 text-xs font-medium uppercase tracking-wider text-slate-500">
-            <div className="col-span-2">Market</div>
-            <div className="text-right">Price</div>
-            <div className="text-right">Open Interest</div>
-            <div className="text-right">Capital</div>
-            <div className="text-right">Insurance</div>
-            <div className="text-right">Leverage</div>
-            <div className="text-right">Health</div>
+                {opt.label}
+              </button>
+            ))}
           </div>
-
-          {/* Rows */}
-          {filtered.map((m) => {
-            const health = computeMarketHealth(m.onChain.engine);
-            const maxLev = m.onChain.params.initialMarginBps > 0n
-              ? Math.floor(10000 / Number(m.onChain.params.initialMarginBps))
-              : 0;
-            const oiTokens = formatTokenAmount(m.onChain.engine.totalOpenInterest);
-            const capitalTokens = formatTokenAmount(m.onChain.engine.cTot);
-            const insuranceTokens = formatTokenAmount(m.onChain.engine.insuranceFund.balance);
-            const lastPrice = m.supabase?.last_price;
-
-            return (
-              <Link
-                key={m.slabAddress}
-                href={`/trade/${m.slabAddress}`}
-                className="grid grid-cols-8 gap-4 border-b border-[#1e2433] bg-[#111318] px-6 py-4 transition-all duration-150 hover:bg-[#1a1d24] hover:shadow-sm"
-              >
-                <div className="col-span-2">
-                  <div className="font-semibold text-white">
-                    {m.symbol ? `${m.symbol}/USD` : shortenAddress(m.slabAddress)}
-                  </div>
-                  <div className="text-xs text-slate-500">
-                    {m.name ?? shortenAddress(m.onChain.config.collateralMint.toBase58())}
-                  </div>
-                </div>
-                <div className="text-right">
-                  <div className="font-mono text-white">
-                    {lastPrice != null ? `$${lastPrice < 0.01 ? lastPrice.toFixed(6) : lastPrice < 1 ? lastPrice.toFixed(4) : lastPrice.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}` : "—"}
-                  </div>
-                </div>
-                <div className="text-right">
-                  <div className="font-mono text-slate-300">{oiTokens}</div>
-                </div>
-                <div className="text-right">
-                  <div className="font-mono text-slate-300">{capitalTokens}</div>
-                </div>
-                <div className="text-right">
-                  <div className="font-mono text-emerald-400">{insuranceTokens}</div>
-                </div>
-                <div className="text-right">
-                  <div className="text-slate-300">{maxLev}x</div>
-                </div>
-                <div className="text-right">
-                  <HealthBadge level={health.level} />
-                </div>
-              </Link>
-            );
-          })}
         </div>
-      )}
 
-      {/* Recent Activity */}
-      <div className="mt-12">
-        <h2 className="mb-4 text-xl font-bold text-white">Recent Activity</h2>
-        <ActivityFeed />
+        {/* Table */}
+        {loading ? (
+          <div className="space-y-1">
+            {[1, 2, 3, 4, 5].map((i) => (
+              <div key={i} className="h-[56px] animate-pulse rounded-lg bg-[#0c0e14] ring-1 ring-[#1a1d2a]" />
+            ))}
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="rounded-xl bg-[#0c0e14] p-16 text-center ring-1 ring-[#1a1d2a]">
+            {search ? (
+              <>
+                <div className="mb-3 text-3xl text-[#1a1d2a]">🔍</div>
+                <h3 className="mb-1 text-lg font-semibold text-white">No markets found</h3>
+                <p className="text-sm text-[#4a5068]">Try a different search.</p>
+              </>
+            ) : (
+              <>
+                <div className="mb-3 text-3xl text-[#1a1d2a]">🚀</div>
+                <h3 className="mb-1 text-lg font-semibold text-white">No markets yet</h3>
+                <p className="mb-4 text-sm text-[#4a5068]">Be the first.</p>
+                <Link href="/launch" className="inline-block rounded-lg bg-[#00d4aa] px-6 py-2.5 text-sm font-bold text-[#080a0f]">
+                  Launch First Market
+                </Link>
+              </>
+            )}
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-lg ring-1 ring-[#1a1d2a]">
+            {/* Header row */}
+            <div className="grid grid-cols-8 gap-4 bg-[#080a0f] px-4 py-2.5 text-[9px] font-medium uppercase tracking-wider text-[#2a2f40]">
+              <div className="col-span-2">Market</div>
+              <div className="text-right">Price</div>
+              <div className="text-right">Open Interest</div>
+              <div className="text-right">Capital</div>
+              <div className="text-right">Insurance</div>
+              <div className="text-right">Max Lev</div>
+              <div className="text-right">Health</div>
+            </div>
+
+            {filtered.map((m, i) => {
+              const health = computeMarketHealth(m.onChain.engine);
+              const maxLev = m.onChain.params.initialMarginBps > 0n
+                ? Math.floor(10000 / Number(m.onChain.params.initialMarginBps)) : 0;
+              const oiTokens = formatTokenAmount(m.onChain.engine.totalOpenInterest);
+              const capitalTokens = formatTokenAmount(m.onChain.engine.cTot);
+              const insuranceTokens = formatTokenAmount(m.onChain.engine.insuranceFund.balance);
+              const lastPrice = m.supabase?.last_price;
+
+              return (
+                <Link
+                  key={m.slabAddress}
+                  href={`/trade/${m.slabAddress}`}
+                  className={`grid grid-cols-8 gap-4 px-4 py-3 transition-all hover:bg-[#131620] ${
+                    i > 0 ? "border-t border-[#1a1d2a]/50" : ""
+                  } bg-[#0c0e14]`}
+                >
+                  <div className="col-span-2">
+                    <div className="font-semibold text-white">
+                      {m.symbol ? `${m.symbol}/USD` : shortenAddress(m.slabAddress)}
+                    </div>
+                    <div className="text-[11px] text-[#2a2f40]">
+                      {m.name ?? shortenAddress(m.onChain.config.collateralMint.toBase58())}
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <span className="data-cell text-sm text-white">
+                      {lastPrice != null
+                        ? `$${lastPrice < 0.01 ? lastPrice.toFixed(6) : lastPrice < 1 ? lastPrice.toFixed(4) : lastPrice.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+                        : "—"}
+                    </span>
+                  </div>
+                  <div className="data-cell text-right text-sm text-[#7a8194]">{oiTokens}</div>
+                  <div className="data-cell text-right text-sm text-[#7a8194]">{capitalTokens}</div>
+                  <div className="data-cell text-right text-sm text-[#00d4aa]">{insuranceTokens}</div>
+                  <div className="text-right text-sm text-[#7a8194]">{maxLev}×</div>
+                  <div className="text-right"><HealthBadge level={health.level} /></div>
+                </Link>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Activity */}
+        <div className="mt-8">
+          <h2 className="mb-4 text-lg font-bold text-white">Recent Activity</h2>
+          <ActivityFeed />
+        </div>
       </div>
     </div>
   );

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -26,8 +26,7 @@ export default function Home() {
           volume: data.reduce((s, m) => s + (m.volume_total || 0), 0),
           insurance: data.reduce((s, m) => s + (m.insurance_fund || 0), 0),
         });
-        // Top 3 by volume
-        const sorted = [...data].sort((a, b) => (b.volume_total || 0) - (a.volume_total || 0)).slice(0, 3);
+        const sorted = [...data].sort((a, b) => (b.volume_total || 0) - (a.volume_total || 0)).slice(0, 4);
         setFeatured(sorted.map((m) => ({ slab_address: m.slab_address, symbol: m.symbol, volume_total: m.volume_total || 0 })));
       }
     }
@@ -35,48 +34,50 @@ export default function Home() {
   }, []);
 
   return (
-    <div className="relative overflow-hidden">
-      {/* Background glow effects */}
+    <div className="relative overflow-hidden terminal-grid">
+      {/* Background effects */}
       <div className="pointer-events-none absolute inset-0">
-        <div className="absolute left-1/2 top-0 -translate-x-1/2 h-[600px] w-[800px] rounded-full bg-emerald-500/5 blur-[120px]" />
-        <div className="absolute right-0 top-1/3 h-[400px] w-[400px] rounded-full bg-emerald-500/3 blur-[100px]" />
+        <div className="absolute left-1/2 top-0 -translate-x-1/2 h-[800px] w-[1000px] rounded-full bg-[#00d4aa]/3 blur-[200px]" />
+        <div className="absolute left-0 top-1/4 h-[400px] w-[400px] rounded-full bg-[#00d4aa]/2 blur-[150px]" />
       </div>
 
       {/* Hero */}
-      <div className="relative mx-auto max-w-6xl px-4 pb-20 pt-20 md:pt-32">
+      <div className="relative mx-auto max-w-5xl px-4 pb-16 pt-20 md:pt-28">
         <div className="text-center">
-          {/* Badge */}
-          <div className="mb-8 inline-flex items-center gap-2 rounded-full border border-emerald-500/20 bg-emerald-500/5 px-5 py-2 text-sm text-emerald-400 backdrop-blur-sm">
-            <span className="relative flex h-2 w-2">
-              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
-              <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-400" />
+          {/* Live badge */}
+          <div className="mb-6 inline-flex items-center gap-2 rounded-full bg-[#00d4aa]/5 px-4 py-1.5 text-[12px] font-medium text-[#00d4aa] ring-1 ring-[#00d4aa]/15">
+            <span className="relative flex h-1.5 w-1.5">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[#00d4aa] opacity-75" />
+              <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-[#00d4aa]" />
             </span>
-            Live on Solana Mainnet
+            Live on Solana
           </div>
 
           {/* Title */}
-          <h1 className="mb-6 text-6xl font-extrabold tracking-tight text-white md:text-8xl">
-            Percolator
+          <h1 className="mb-4 text-5xl font-extrabold tracking-tight text-white md:text-7xl lg:text-8xl">
+            <span className="bg-gradient-to-r from-white via-white to-[#00d4aa]/80 bg-clip-text text-transparent">
+              Percolator
+            </span>
           </h1>
-          <p className="mx-auto mb-4 max-w-xl text-xl font-medium text-slate-300 md:text-2xl">
-            Trade any token with leverage. No permission needed.
+          <p className="mx-auto mb-3 max-w-lg text-lg font-medium text-[#b0b7c8] md:text-xl">
+            Permissionless perpetual futures on Solana
           </p>
-          <p className="mx-auto mb-10 max-w-2xl text-base text-slate-500">
-            Deploy a leveraged perpetual futures market on Solana in one click.
-            No smart contract. No governance. Just paste a token mint and go.
+          <p className="mx-auto mb-8 max-w-xl text-sm text-[#4a5068]">
+            Deploy a leveraged perp market for any SPL token in one click.
+            Up to 20× leverage. No governance. No permission.
           </p>
 
-          {/* CTA */}
-          <div className="mb-12 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          {/* CTAs */}
+          <div className="mb-10 flex flex-col items-center justify-center gap-3 sm:flex-row">
             <Link
               href="/launch"
-              className="group relative overflow-hidden rounded-2xl bg-emerald-500 px-10 py-4 text-base font-bold text-white transition-all hover:bg-emerald-400 hover:shadow-2xl hover:shadow-emerald-500/20"
+              className="group rounded-xl bg-[#00d4aa] px-8 py-3.5 text-sm font-bold text-[#080a0f] transition-all hover:bg-[#00e8bb] hover:shadow-[0_0_30px_rgba(0,212,170,0.2)]"
             >
-              <span className="relative z-10">Launch a Market →</span>
+              Launch a Market →
             </Link>
             <Link
               href="/markets"
-              className="rounded-2xl border border-[#1e2433] bg-[#111318]/80 px-10 py-4 text-base font-semibold text-slate-300 backdrop-blur-sm transition-all hover:border-slate-600 hover:bg-[#1a1d24]"
+              className="rounded-xl bg-[#0f1118] px-8 py-3.5 text-sm font-semibold text-[#b0b7c8] ring-1 ring-[#1a1d2a] transition-all hover:bg-[#131620] hover:ring-[#252a3a]"
             >
               Browse Markets
             </Link>
@@ -85,100 +86,74 @@ export default function Home() {
           {/* CA */}
           <button
             onClick={copyCA}
-            className="group mx-auto flex items-center gap-3 rounded-2xl border border-[#1e2433] bg-[#111318]/60 px-6 py-3 backdrop-blur-sm transition-all hover:border-emerald-500/30 hover:bg-[#111318]"
+            className="group mx-auto flex items-center gap-2.5 rounded-lg bg-[#0f1118] px-4 py-2 ring-1 ring-[#1a1d2a] transition-all hover:ring-[#00d4aa]/20"
           >
-            <span className="text-[10px] font-bold uppercase tracking-widest text-emerald-400">CA</span>
-            <code className="font-mono text-xs text-slate-400 transition-colors group-hover:text-slate-200 sm:text-sm">
+            <span className="text-[10px] font-bold tracking-widest text-[#00d4aa]">CA</span>
+            <code className="data-cell text-[11px] text-[#4a5068] transition-colors group-hover:text-[#7a8194]">
               {CA}
             </code>
-            <span className="rounded-lg bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-400 transition-colors group-hover:bg-emerald-500/20">
+            <span className="rounded bg-[#00d4aa]/10 px-1.5 py-0.5 text-[10px] font-semibold text-[#00d4aa]">
               {copied ? "✓" : "Copy"}
             </span>
           </button>
         </div>
       </div>
 
-      {/* How it works */}
-      <div className="relative mx-auto max-w-6xl px-4 pb-20">
-        <h2 className="mb-4 text-center text-sm font-bold uppercase tracking-widest text-emerald-400">
-          How it works
-        </h2>
-        <p className="mb-12 text-center text-3xl font-bold text-white">
-          Three steps. One click.
-        </p>
-
-        <div className="grid gap-px overflow-hidden rounded-3xl border border-[#1e2433] bg-[#1e2433] md:grid-cols-3">
+      {/* Stats bar */}
+      <div className="relative mx-auto max-w-5xl px-4 pb-16">
+        <div className="grid grid-cols-3 gap-px overflow-hidden rounded-xl bg-[#1a1d2a] ring-1 ring-[#1a1d2a]">
           {[
-            {
-              num: "01",
-              icon: "🪙",
-              title: "Pick a Token",
-              desc: "Paste any Solana token mint. We auto-fetch metadata and pull the live price from Jupiter.",
-            },
-            {
-              num: "02",
-              icon: "⚙️",
-              title: "Set Parameters",
-              desc: "Choose max leverage (2-20x), trading fees, and seed your initial liquidity pool.",
-            },
-            {
-              num: "03",
-              icon: "⚡",
-              title: "Deploy & Trade",
-              desc: "Market goes live on-chain instantly. Share the link. Anyone can trade it.",
-            },
-          ].map((item) => (
-            <div key={item.num} className="group bg-[#0a0b0f] p-10 transition-colors hover:bg-[#0d0e13]">
-              <div className="mb-6 flex items-center gap-3">
-                <span className="text-2xl">{item.icon}</span>
-                <span className="font-mono text-xs text-slate-600">{item.num}</span>
-              </div>
-              <h3 className="mb-3 text-xl font-bold text-white">{item.title}</h3>
-              <p className="text-sm leading-relaxed text-slate-400">{item.desc}</p>
-            </div>
-          ))}
-        </div>
-      </div>
-
-      {/* Stats */}
-      <div className="relative mx-auto max-w-6xl px-4 pb-20">
-        <div className="grid gap-px overflow-hidden rounded-3xl border border-[#1e2433] bg-[#1e2433] md:grid-cols-3">
-          {[
-            { label: "Markets Deployed", value: stats.markets || "—" },
-            { label: "Total Volume", value: stats.volume ? `$${(stats.volume / 1000).toFixed(0)}K` : "—" },
-            { label: "Insurance Locked", value: stats.insurance ? `$${(stats.insurance / 1000).toFixed(0)}K` : "—" },
+            { label: "Markets", value: stats.markets || "—" },
+            { label: "Volume", value: stats.volume ? `$${(stats.volume / 1000).toFixed(0)}K` : "—" },
+            { label: "Insurance", value: stats.insurance ? `$${(stats.insurance / 1000).toFixed(0)}K` : "—" },
           ].map((s) => (
-            <div key={s.label} className="bg-[#0a0b0f] p-10 text-center">
-              <p className="text-4xl font-extrabold text-white">{s.value}</p>
-              <p className="mt-2 text-sm font-medium text-slate-500">{s.label}</p>
+            <div key={s.label} className="bg-[#0c0e14] p-6 text-center">
+              <p className="data-cell text-2xl font-bold text-white md:text-3xl">{s.value}</p>
+              <p className="mt-1 text-[11px] font-medium uppercase tracking-widest text-[#4a5068]">{s.label}</p>
             </div>
           ))}
         </div>
       </div>
 
-      {/* Featured Markets */}
+      {/* How it works */}
+      <div className="relative mx-auto max-w-5xl px-4 pb-16">
+        <div className="mb-2 text-[11px] font-bold uppercase tracking-[0.2em] text-[#00d4aa]/60">Protocol</div>
+        <h2 className="mb-8 text-2xl font-bold text-white">Three steps. One click.</h2>
+
+        <div className="grid gap-px overflow-hidden rounded-xl bg-[#1a1d2a] md:grid-cols-3">
+          {[
+            { num: "01", title: "Pick Token", desc: "Paste any Solana token mint. Metadata and live price auto-fetched from Jupiter." },
+            { num: "02", title: "Set Params", desc: "Max leverage (2-20×), trading fees, initial liquidity. Full control." },
+            { num: "03", title: "Deploy", desc: "Market goes live on-chain instantly. Share the link. Anyone can trade." },
+          ].map((item) => (
+            <div key={item.num} className="group bg-[#0c0e14] p-8 transition-colors hover:bg-[#0f1118]">
+              <div className="mb-4 data-cell text-xs text-[#00d4aa]/40">{item.num}</div>
+              <h3 className="mb-2 text-base font-bold text-white">{item.title}</h3>
+              <p className="text-[13px] leading-relaxed text-[#4a5068]">{item.desc}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Featured markets */}
       {featured.length > 0 && (
-        <div className="relative mx-auto max-w-6xl px-4 pb-20">
-          <h2 className="mb-4 text-center text-sm font-bold uppercase tracking-widest text-emerald-400">
-            Featured Markets
-          </h2>
-          <p className="mb-8 text-center text-2xl font-bold text-white">
-            Top markets by volume
-          </p>
-          <div className="grid gap-4 md:grid-cols-3">
+        <div className="relative mx-auto max-w-5xl px-4 pb-16">
+          <div className="mb-2 text-[11px] font-bold uppercase tracking-[0.2em] text-[#00d4aa]/60">Active</div>
+          <h2 className="mb-6 text-2xl font-bold text-white">Top Markets</h2>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
             {featured.map((m) => (
               <Link
                 key={m.slab_address}
                 href={`/trade/${m.slab_address}`}
-                className="group rounded-2xl border border-[#1e2433] bg-[#111318] p-6 transition-all duration-200 hover:border-emerald-500/30 hover:bg-[#1a1d24] hover:shadow-lg hover:shadow-emerald-500/5"
+                className="group rounded-xl bg-[#0c0e14] p-5 ring-1 ring-[#1a1d2a] transition-all hover:ring-[#00d4aa]/20 hover:bg-[#0f1118]"
               >
-                <div className="mb-2 text-lg font-bold text-white group-hover:text-emerald-300">
-                  {m.symbol ? `${m.symbol}/USD` : `${m.slab_address.slice(0, 6)}...`}
+                <div className="mb-1.5 text-sm font-bold text-white group-hover:text-[#00d4aa]">
+                  {m.symbol ? `${m.symbol}/USD` : `${m.slab_address.slice(0, 6)}…`}
                 </div>
-                <div className="text-sm text-slate-400">
-                  Volume: <span className="font-mono text-slate-200">{m.volume_total >= 1000 ? `$${(m.volume_total / 1000).toFixed(1)}K` : `$${m.volume_total.toLocaleString()}`}</span>
+                <div className="data-cell text-xs text-[#4a5068]">
+                  Vol: <span className="text-[#7a8194]">{m.volume_total >= 1000 ? `$${(m.volume_total / 1000).toFixed(1)}K` : `$${m.volume_total.toLocaleString()}`}</span>
                 </div>
-                <div className="mt-3 text-xs font-medium text-emerald-400 opacity-0 transition-opacity group-hover:opacity-100">
+                <div className="mt-2 text-[11px] font-medium text-[#00d4aa] opacity-0 transition-opacity group-hover:opacity-100">
                   Trade →
                 </div>
               </Link>
@@ -187,97 +162,58 @@ export default function Home() {
         </div>
       )}
 
-      {/* Features */}
-      <div className="relative mx-auto max-w-6xl px-4 pb-20">
-        <div className="grid gap-6 md:grid-cols-2">
-          <div className="rounded-3xl border border-[#1e2433] bg-[#111318] p-10">
-            <div className="mb-4 text-3xl">🔒</div>
-            <h3 className="mb-3 text-xl font-bold text-white">Permissionless</h3>
-            <p className="text-sm leading-relaxed text-slate-400">
-              No whitelisting. No governance votes. No approvals. Anyone can deploy a market for any SPL token.
-              The protocol is immutable — deployed on toly&apos;s Percolator program.
-            </p>
-          </div>
-          <div className="rounded-3xl border border-[#1e2433] bg-[#111318] p-10">
-            <div className="mb-4 text-3xl">🔥</div>
-            <h3 className="mb-3 text-xl font-bold text-white">Deflationary by Design</h3>
-            <p className="text-sm leading-relaxed text-slate-400">
-              Every trade pays fees into the insurance fund. Admin keys can be burned —
-              making fees permanently locked. More trading = more tokens removed from circulation.
-            </p>
-          </div>
-          <div className="rounded-3xl border border-[#1e2433] bg-[#111318] p-10">
-            <div className="mb-4 text-3xl">📊</div>
-            <h3 className="mb-3 text-xl font-bold text-white">Real Leverage</h3>
-            <p className="text-sm leading-relaxed text-slate-400">
-              Up to 20x leverage on any token. Long or short with real on-chain settlement.
-              No synthetic assets — pure perpetual futures backed by collateral.
-            </p>
-          </div>
-          <div className="rounded-3xl border border-[#1e2433] bg-[#111318] p-10">
-            <div className="mb-4 text-3xl">⚡</div>
-            <h3 className="mb-3 text-xl font-bold text-white">Solana Speed</h3>
-            <p className="text-sm leading-relaxed text-slate-400">
-              Sub-second trade execution. Negligible gas fees. Automated keeper bots crank funding rates.
-              Oracle prices pushed from Jupiter/DexScreener in real-time.
-            </p>
-          </div>
+      {/* Features grid */}
+      <div className="relative mx-auto max-w-5xl px-4 pb-16">
+        <div className="grid gap-3 md:grid-cols-2">
+          {[
+            { icon: "🔓", title: "Permissionless", desc: "No whitelisting. No governance. Anyone can deploy a market for any SPL token. Protocol is immutable." },
+            { icon: "🔥", title: "Deflationary", desc: "Every trade pays fees into the insurance fund. Admin keys can be burned — fees permanently locked." },
+            { icon: "📊", title: "Real Leverage", desc: "Up to 20× on any token. Long or short with real on-chain settlement. Pure perpetual futures." },
+            { icon: "⚡", title: "Solana Speed", desc: "Sub-second execution. Negligible gas. Automated keepers. Oracle prices from Jupiter/DexScreener." },
+          ].map((f) => (
+            <div key={f.title} className="rounded-xl bg-[#0c0e14] p-6 ring-1 ring-[#1a1d2a] transition-colors hover:bg-[#0f1118]">
+              <div className="mb-3 text-xl">{f.icon}</div>
+              <h3 className="mb-2 text-sm font-bold text-white">{f.title}</h3>
+              <p className="text-[13px] leading-relaxed text-[#4a5068]">{f.desc}</p>
+            </div>
+          ))}
         </div>
       </div>
 
       {/* Bottom CTA */}
-      <div className="relative mx-auto max-w-6xl px-4 pb-24">
-        <div className="rounded-3xl border border-emerald-500/20 bg-gradient-to-b from-emerald-500/5 to-transparent p-16 text-center">
-          <h2 className="mb-4 text-4xl font-extrabold text-white">
-            Ready to launch?
-          </h2>
-          <p className="mb-8 text-slate-400">
-            Deploy your own perpetual futures market in under 60 seconds.
-          </p>
+      <div className="relative mx-auto max-w-5xl px-4 pb-20">
+        <div className="rounded-xl bg-gradient-to-b from-[#00d4aa]/5 to-transparent p-12 text-center ring-1 ring-[#00d4aa]/10">
+          <h2 className="mb-3 text-3xl font-extrabold text-white">Ready to launch?</h2>
+          <p className="mb-6 text-sm text-[#4a5068]">Deploy your own perpetual futures market in under 60 seconds.</p>
           <Link
             href="/launch"
-            className="inline-block rounded-2xl bg-emerald-500 px-12 py-4 text-base font-bold text-white transition-all hover:bg-emerald-400 hover:shadow-2xl hover:shadow-emerald-500/20"
+            className="inline-block rounded-xl bg-[#00d4aa] px-10 py-3.5 text-sm font-bold text-[#080a0f] transition-all hover:bg-[#00e8bb] hover:shadow-[0_0_30px_rgba(0,212,170,0.2)]"
           >
             Launch a Market →
           </Link>
         </div>
       </div>
 
-      {/* On-chain footer info */}
-      <div className="relative mx-auto max-w-6xl px-4 pb-12">
-        <div className="flex flex-wrap items-center justify-center gap-6 text-xs text-slate-600">
+      {/* On-chain info */}
+      <div className="relative mx-auto max-w-5xl px-4 pb-8">
+        <div className="flex flex-wrap items-center justify-center gap-4 text-[11px] text-[#2a2f40]">
           <span>
             Program:{" "}
-            <a
-              href="https://solscan.io/account/GM8zjJ8LTBMv9xEsverh6H6wLyevgMHEJXcEzyY3rY24"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-mono text-slate-500 hover:text-emerald-400"
-            >
-              GM8zjJ...Y3rY24
+            <a href="https://solscan.io/account/GM8zjJ8LTBMv9xEsverh6H6wLyevgMHEJXcEzyY3rY24" target="_blank" rel="noopener noreferrer" className="data-cell text-[#4a5068] hover:text-[#00d4aa]">
+              GM8zjJ…Y3rY24
             </a>
           </span>
-          <span className="text-slate-700">|</span>
+          <span className="text-[#1a1d2a]">|</span>
           <span>
             Token:{" "}
-            <a
-              href={`https://solscan.io/token/${CA}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-mono text-slate-500 hover:text-emerald-400"
-            >
-              {CA.slice(0, 6)}...{CA.slice(-4)}
+            <a href={`https://solscan.io/token/${CA}`} target="_blank" rel="noopener noreferrer" className="data-cell text-[#4a5068] hover:text-[#00d4aa]">
+              {CA.slice(0, 6)}…{CA.slice(-4)}
             </a>
           </span>
-          <span className="text-slate-700">|</span>
+          <span className="text-[#1a1d2a]">|</span>
           <span>
             Built on{" "}
-            <a
-              href="https://x.com/aaboroday"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-slate-500 hover:text-emerald-400"
-            >
+            <a href="https://x.com/aaboroday" target="_blank" rel="noopener noreferrer" className="text-[#4a5068] hover:text-[#00d4aa]">
               toly&apos;s Percolator
             </a>
           </span>

--- a/app/app/portfolio/page.tsx
+++ b/app/app/portfolio/page.tsx
@@ -23,120 +23,116 @@ export default function PortfolioPage() {
 
   if (!connected) {
     return (
-      <div className="mx-auto max-w-7xl px-4 py-12">
-        <h1 className="mb-2 text-3xl font-bold text-white">Portfolio</h1>
-        <p className="mb-8 text-slate-400">View all your positions across markets.</p>
-        <div className="rounded-2xl border border-[#1e2433] bg-[#111318] p-16 text-center">
-          <p className="mb-4 text-slate-400">Connect your wallet to view positions</p>
-          <WalletMultiButton />
+      <div className="terminal-grid min-h-[calc(100vh-48px)]">
+        <div className="mx-auto max-w-[1800px] px-3 py-6 lg:px-4">
+          <h1 className="mb-1 text-2xl font-bold text-white">Portfolio</h1>
+          <p className="mb-6 text-sm text-[#4a5068]">View all your positions across markets</p>
+          <div className="rounded-xl bg-[#0c0e14] p-16 text-center ring-1 ring-[#1a1d2a]">
+            <p className="mb-4 text-sm text-[#4a5068]">Connect your wallet to view positions</p>
+            <WalletMultiButton />
+          </div>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="mx-auto max-w-7xl px-4 py-12">
-      <h1 className="mb-2 text-3xl font-bold text-white">Portfolio</h1>
-      <p className="mb-8 text-slate-400">All your positions across Percolator markets.</p>
+    <div className="terminal-grid min-h-[calc(100vh-48px)]">
+      <div className="mx-auto max-w-[1800px] px-3 py-6 lg:px-4">
+        <h1 className="mb-1 text-2xl font-bold text-white">Portfolio</h1>
+        <p className="mb-6 text-sm text-[#4a5068]">All positions across Percolator markets</p>
 
-      {/* Aggregate Stats */}
-      <div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
-        <div className="rounded-xl border border-[#1e2433] bg-[#111318] p-5">
-          <p className="text-xs text-slate-500">Total Deposited</p>
-          <p className="mt-1 text-xl font-bold text-white">
-            {loading ? "..." : formatTokenAmount(totalDeposited)}
-          </p>
+        {/* Summary cards */}
+        <div className="mb-6 grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <div className="rounded-lg bg-[#0c0e14] p-4 ring-1 ring-[#1a1d2a]">
+            <p className="text-[10px] font-medium uppercase tracking-wider text-[#2a2f40]">Total Deposited</p>
+            <p className="mt-1 data-cell text-xl font-bold text-white">
+              {loading ? "…" : formatTokenAmount(totalDeposited)}
+            </p>
+          </div>
+          <div className="rounded-lg bg-[#0c0e14] p-4 ring-1 ring-[#1a1d2a]">
+            <p className="text-[10px] font-medium uppercase tracking-wider text-[#2a2f40]">Total PnL</p>
+            <p className={`mt-1 data-cell text-xl font-bold ${totalPnl >= 0n ? "text-[#00e68a]" : "text-[#ff4d6a]"}`}>
+              {loading ? "…" : formatPnl(totalPnl)}
+            </p>
+          </div>
+          <div className="rounded-lg bg-[#0c0e14] p-4 ring-1 ring-[#1a1d2a]">
+            <p className="text-[10px] font-medium uppercase tracking-wider text-[#2a2f40]">Active Positions</p>
+            <p className="mt-1 data-cell text-xl font-bold text-white">
+              {loading ? "…" : positions.length}
+            </p>
+          </div>
         </div>
-        <div className="rounded-xl border border-[#1e2433] bg-[#111318] p-5">
-          <p className="text-xs text-slate-500">Total PnL</p>
-          <p className={`mt-1 text-xl font-bold ${totalPnl >= 0n ? "text-emerald-400" : "text-red-400"}`}>
-            {loading ? "..." : formatPnl(totalPnl)}
-          </p>
-        </div>
-        <div className="rounded-xl border border-[#1e2433] bg-[#111318] p-5">
-          <p className="text-xs text-slate-500">Active Positions</p>
-          <p className="mt-1 text-xl font-bold text-white">
-            {loading ? "..." : positions.length}
-          </p>
-        </div>
+
+        {/* Positions */}
+        {loading ? (
+          <div className="space-y-2">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="h-16 animate-pulse rounded-lg bg-[#0c0e14] ring-1 ring-[#1a1d2a]" />
+            ))}
+          </div>
+        ) : positions.length === 0 ? (
+          <div className="rounded-xl bg-[#0c0e14] p-16 text-center ring-1 ring-[#1a1d2a]">
+            <div className="mb-3 text-3xl text-[#1a1d2a]">📊</div>
+            <h3 className="mb-1 text-lg font-semibold text-white">No positions yet</h3>
+            <p className="mb-4 text-sm text-[#4a5068]">Browse markets to start trading.</p>
+            <Link href="/markets" className="inline-block rounded-lg bg-[#00d4aa] px-6 py-2.5 text-sm font-bold text-[#080a0f]">
+              Browse Markets
+            </Link>
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-lg ring-1 ring-[#1a1d2a]">
+            {/* Header */}
+            <div className="grid grid-cols-6 gap-4 bg-[#080a0f] px-4 py-2.5 text-[9px] font-medium uppercase tracking-wider text-[#2a2f40]">
+              <div>Market</div>
+              <div className="text-center">Side</div>
+              <div className="text-right">Size</div>
+              <div className="text-right">Entry</div>
+              <div className="text-right">Capital</div>
+              <div className="text-right">PnL</div>
+            </div>
+
+            {positions.map((pos, i) => {
+              const side = pos.account.positionSize > 0n ? "Long" : pos.account.positionSize < 0n ? "Short" : "Flat";
+              const sizeAbs = pos.account.positionSize < 0n ? -pos.account.positionSize : pos.account.positionSize;
+              const pnlPositive = pos.account.pnl >= 0n;
+
+              return (
+                <Link
+                  key={`${pos.slabAddress}-${i}`}
+                  href={`/trade/${pos.slabAddress}`}
+                  className={`grid grid-cols-6 gap-4 px-4 py-3 transition-all hover:bg-[#131620] ${
+                    i > 0 ? "border-t border-[#1a1d2a]/50" : ""
+                  } bg-[#0c0e14]`}
+                >
+                  <div>
+                    <span className="data-cell text-sm font-semibold text-white">
+                      {pos.slabAddress.slice(0, 8)}…
+                    </span>
+                  </div>
+                  <div className="text-center">
+                    <span className={`rounded px-2 py-0.5 text-[10px] font-bold ${
+                      side === "Long"
+                        ? "bg-[#00e68a]/10 text-[#00e68a]"
+                        : side === "Short"
+                        ? "bg-[#ff4d6a]/10 text-[#ff4d6a]"
+                        : "bg-[#1a1d2a] text-[#4a5068]"
+                    }`}>
+                      {side.toUpperCase()}
+                    </span>
+                  </div>
+                  <div className="data-cell text-right text-sm text-white">{formatTokenAmount(sizeAbs)}</div>
+                  <div className="data-cell text-right text-sm text-[#7a8194]">{formatPriceE6(pos.account.entryPrice)}</div>
+                  <div className="data-cell text-right text-sm text-[#7a8194]">{formatTokenAmount(pos.account.capital)}</div>
+                  <div className={`data-cell text-right text-sm font-medium ${pnlPositive ? "text-[#00e68a]" : "text-[#ff4d6a]"}`}>
+                    {formatPnl(pos.account.pnl)}
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        )}
       </div>
-
-      {/* Positions */}
-      {loading ? (
-        <div className="space-y-4">
-          {[1, 2, 3].map((i) => (
-            <div key={i} className="h-20 animate-pulse rounded-xl border border-[#1e2433] bg-[#111318]" />
-          ))}
-        </div>
-      ) : positions.length === 0 ? (
-        <div className="rounded-2xl border border-[#1e2433] bg-[#111318] p-16 text-center">
-          <div className="mb-4 text-5xl">📊</div>
-          <h3 className="mb-2 text-xl font-semibold text-white">No positions yet</h3>
-          <p className="mb-6 text-slate-400">Browse markets to start trading.</p>
-          <Link
-            href="/markets"
-            className="inline-block rounded-xl bg-emerald-500 px-8 py-3 font-semibold text-white hover:bg-emerald-400"
-          >
-            Browse Markets
-          </Link>
-        </div>
-      ) : (
-        <div className="space-y-3">
-          {positions.map((pos, i) => {
-            const side = pos.account.positionSize > 0n ? "Long" : pos.account.positionSize < 0n ? "Short" : "Flat";
-            const sizeAbs = pos.account.positionSize < 0n ? -pos.account.positionSize : pos.account.positionSize;
-            const pnlPositive = pos.account.pnl >= 0n;
-
-            return (
-              <Link
-                key={`${pos.slabAddress}-${i}`}
-                href={`/trade/${pos.slabAddress}`}
-                className="block rounded-xl border border-[#1e2433] bg-[#111318] p-5 transition-colors hover:bg-[#1a1d24]"
-              >
-                <div className="flex flex-wrap items-center justify-between gap-4">
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-2">
-                      <span className="font-semibold text-white">
-                        {pos.slabAddress.slice(0, 8)}...
-                      </span>
-                      <span className={`rounded px-2 py-0.5 text-xs font-bold ${
-                        side === "Long"
-                          ? "bg-emerald-500/10 text-emerald-400"
-                          : side === "Short"
-                          ? "bg-red-500/10 text-red-400"
-                          : "bg-slate-500/10 text-slate-400"
-                      }`}>
-                        {side}
-                      </span>
-                    </div>
-                  </div>
-
-                  <div className="flex items-center gap-6 text-sm">
-                    <div>
-                      <p className="text-xs text-slate-500">Size</p>
-                      <p className="font-mono text-white">{formatTokenAmount(sizeAbs)}</p>
-                    </div>
-                    <div>
-                      <p className="text-xs text-slate-500">Entry</p>
-                      <p className="font-mono text-white">{formatPriceE6(pos.account.entryPrice)}</p>
-                    </div>
-                    <div>
-                      <p className="text-xs text-slate-500">Capital</p>
-                      <p className="font-mono text-white">{formatTokenAmount(pos.account.capital)}</p>
-                    </div>
-                    <div>
-                      <p className="text-xs text-slate-500">PnL</p>
-                      <p className={`font-mono ${pnlPositive ? "text-emerald-400" : "text-red-400"}`}>
-                        {formatPnl(pos.account.pnl)}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </Link>
-            );
-          })}
-        </div>
-      )}
     </div>
   );
 }

--- a/app/components/layout/Footer.tsx
+++ b/app/components/layout/Footer.tsx
@@ -7,106 +7,32 @@ const CA = "8PzFWyLpCVEmbZmVJcaRTU5r69XKJx1rd7YGpWvnpump";
 
 export const Footer: FC = () => {
   return (
-    <footer className="border-t border-[#1e2433]/50 bg-[#0a0b0f]">
-      <div className="mx-auto max-w-7xl px-4 py-12">
-        <div className="grid gap-10 md:grid-cols-4">
-          {/* Brand */}
-          <div className="md:col-span-2">
-            <div className="mb-3 flex items-center gap-2.5 text-lg font-extrabold text-white">
-              <span className="flex h-7 w-7 items-center justify-center rounded-md bg-emerald-500 text-xs font-black text-white">
-                P
-              </span>
+    <footer className="border-t border-[#1a1d2a] bg-[#080a0f]">
+      <div className="mx-auto max-w-[1800px] px-4 py-8">
+        <div className="flex flex-col items-center justify-between gap-6 sm:flex-row">
+          {/* Left */}
+          <div className="flex items-center gap-4">
+            <Link href="/" className="flex items-center gap-2 text-sm font-bold text-white">
+              <div className="relative flex h-5 w-5 items-center justify-center">
+                <div className="absolute inset-0 rounded bg-[#00d4aa] opacity-20 blur-sm" />
+                <span className="relative text-[10px] font-black text-[#00d4aa]">⬡</span>
+              </div>
               Percolator
-            </div>
-            <p className="mb-4 max-w-sm text-sm leading-relaxed text-slate-500">
-              Permissionless perpetual futures for any Solana token.
-              Deploy a market in one click. Trade with up to 20x leverage.
-            </p>
-            <div className="flex items-center gap-3">
-              <a
-                href="https://x.com/i/communities/1980346190404415886"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex h-8 w-8 items-center justify-center rounded-lg border border-[#1e2433] text-slate-500 transition-colors hover:border-slate-600 hover:text-white"
-              >
-                <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="currentColor">
-                  <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-                </svg>
-              </a>
-              <a
-                href="https://github.com/dcccrypto/percolator-launch"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex h-8 w-8 items-center justify-center rounded-lg border border-[#1e2433] text-slate-500 transition-colors hover:border-slate-600 hover:text-white"
-              >
-                <svg className="h-3.5 w-3.5" viewBox="0 0 16 16" fill="currentColor">
-                  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-                </svg>
-              </a>
-              <a
-                href={`https://solscan.io/token/${CA}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex h-8 items-center justify-center rounded-lg border border-[#1e2433] px-2.5 text-xs font-medium text-slate-500 transition-colors hover:border-slate-600 hover:text-white"
-              >
-                Solscan
-              </a>
-            </div>
+            </Link>
+            <span className="text-[11px] text-[#2a2f40]">Permissionless perps on Solana</span>
           </div>
 
-          {/* Product */}
-          <div>
-            <h4 className="mb-4 text-xs font-bold uppercase tracking-widest text-slate-500">Product</h4>
-            <div className="flex flex-col gap-2.5">
-              <Link href="/launch" className="text-sm text-slate-400 transition-colors hover:text-white">
-                Launch Market
-              </Link>
-              <Link href="/markets" className="text-sm text-slate-400 transition-colors hover:text-white">
-                Browse Markets
-              </Link>
-              <a
-                href="https://solscan.io/account/GM8zjJ8LTBMv9xEsverh6H6wLyevgMHEJXcEzyY3rY24"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-sm text-slate-400 transition-colors hover:text-white"
-              >
-                Program ↗
-              </a>
-            </div>
+          {/* Center links */}
+          <div className="flex items-center gap-4 text-[11px]">
+            <Link href="/launch" className="text-[#4a5068] transition-colors hover:text-white">Launch</Link>
+            <Link href="/markets" className="text-[#4a5068] transition-colors hover:text-white">Markets</Link>
+            <a href="https://x.com/i/communities/1980346190404415886" target="_blank" rel="noopener noreferrer" className="text-[#4a5068] transition-colors hover:text-white">X Community</a>
+            <a href="https://github.com/dcccrypto/percolator-launch" target="_blank" rel="noopener noreferrer" className="text-[#4a5068] transition-colors hover:text-white">GitHub</a>
+            <a href={`https://solscan.io/token/${CA}`} target="_blank" rel="noopener noreferrer" className="text-[#4a5068] transition-colors hover:text-white">Solscan</a>
           </div>
 
-          {/* Community */}
-          <div>
-            <h4 className="mb-4 text-xs font-bold uppercase tracking-widest text-slate-500">Community</h4>
-            <div className="flex flex-col gap-2.5">
-              <a
-                href="https://x.com/i/communities/1980346190404415886"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-sm text-slate-400 transition-colors hover:text-white"
-              >
-                X Community ↗
-              </a>
-              <a
-                href="https://github.com/dcccrypto/percolator-launch"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-sm text-slate-400 transition-colors hover:text-white"
-              >
-                GitHub ↗
-              </a>
-            </div>
-          </div>
-        </div>
-
-        {/* Bottom */}
-        <div className="mt-10 flex flex-col items-center justify-between gap-4 border-t border-[#1e2433]/50 pt-6 sm:flex-row">
-          <p className="text-xs text-slate-600">
-            Built on toly&apos;s Percolator protocol. Fully on-chain. Permissionless.
-          </p>
-          <p className="font-mono text-[10px] text-slate-700">
-            {CA}
-          </p>
+          {/* Right: CA */}
+          <div className="data-cell text-[10px] text-[#1a1d2a]">{CA}</div>
         </div>
       </div>
     </footer>

--- a/app/components/market/HealthBadge.tsx
+++ b/app/components/market/HealthBadge.tsx
@@ -2,23 +2,21 @@ import { FC } from "react";
 import type { HealthLevel } from "@/lib/health";
 
 const STYLES: Record<HealthLevel, string> = {
-  healthy: "bg-green-900/40 text-green-400",
-  caution: "bg-yellow-900/40 text-yellow-400",
-  warning: "bg-red-900/40 text-red-400",
-  empty: "bg-[#1a1a2e] text-[#71717a]",
+  healthy: "bg-[#00e68a]/10 text-[#00e68a] ring-1 ring-[#00e68a]/20",
+  caution: "bg-[#ffaa00]/10 text-[#ffaa00] ring-1 ring-[#ffaa00]/20",
+  warning: "bg-[#ff4d6a]/10 text-[#ff4d6a] ring-1 ring-[#ff4d6a]/20",
+  empty: "bg-[#1a1d2a] text-[#4a5068]",
 };
 
 const LABELS: Record<HealthLevel, string> = {
   healthy: "Healthy",
   caution: "Caution",
-  warning: "Low Liquidity",
+  warning: "Low Liq",
   empty: "Empty",
 };
 
 export const HealthBadge: FC<{ level: HealthLevel }> = ({ level }) => (
-  <span
-    className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${STYLES[level]}`}
-  >
+  <span className={`inline-block rounded-md px-1.5 py-0.5 text-[10px] font-bold ${STYLES[level]}`}>
     {LABELS[level]}
   </span>
 );

--- a/app/components/trade/AccountsCard.tsx
+++ b/app/components/trade/AccountsCard.tsx
@@ -10,7 +10,7 @@ import { AccountKind } from "@percolator/core";
 
 type SortKey = "idx" | "owner" | "direction" | "position" | "entry" | "liqPrice" | "cost" | "pnl" | "capital" | "margin";
 type SortDir = "asc" | "desc";
-type Tab = "open" | "idle" | "leaderboard" | "alltime";
+type Tab = "open" | "idle" | "leaderboard";
 
 interface AccountRow {
   idx: number;
@@ -20,44 +20,28 @@ interface AccountRow {
   positionSize: bigint;
   entryPrice: bigint;
   liqPrice: bigint;
-  liqHealthPct: number; // 0..100 how far from liq (100 = safe)
+  liqHealthPct: number;
   cost: bigint;
   pnl: bigint;
   capital: bigint;
   marginPct: number;
 }
 
-function computeLiqPrice(
-  entryPrice: bigint,
-  capital: bigint,
-  positionSize: bigint,
-  maintenanceMarginBps: bigint,
-): bigint {
+function computeLiqPrice(entryPrice: bigint, capital: bigint, positionSize: bigint, maintenanceMarginBps: bigint): bigint {
   if (positionSize === 0n || entryPrice === 0n) return 0n;
   const absPos = positionSize < 0n ? -positionSize : positionSize;
-  // maintMargin = absPos * price * maintenanceMarginBps / 10000 / 1e6
-  // For longs: liqPrice = entryPrice - (capital * 1e6 / absPos) * (10000 / (10000 + maintBps))
-  // For shorts: liqPrice = entryPrice + (capital * 1e6 / absPos) * (10000 / (10000 + maintBps))
-  // Simplified: liqPrice = entryPrice -/+ (capital * 10000 * 1e6) / (absPos * (10000 + maintBps))
   const maintBps = Number(maintenanceMarginBps);
   const capitalPerUnit = Number(capital) * 1e6 / Number(absPos);
   const adjusted = capitalPerUnit * 10000 / (10000 + maintBps);
-
   if (positionSize > 0n) {
-    // Long: liquidated when price drops
     const liq = Number(entryPrice) - adjusted;
     return liq > 0 ? BigInt(Math.round(liq)) : 0n;
   } else {
-    // Short: liquidated when price rises
     return BigInt(Math.round(Number(entryPrice) + adjusted));
   }
 }
 
-function computeMarginPct(
-  capital: bigint,
-  positionSize: bigint,
-  priceE6: bigint,
-): number {
+function computeMarginPct(capital: bigint, positionSize: bigint, priceE6: bigint): number {
   if (positionSize === 0n || priceE6 === 0n) return 100;
   const absPos = positionSize < 0n ? -positionSize : positionSize;
   const notional = Number(absPos) * Number(priceE6) / 1e6;
@@ -79,77 +63,37 @@ export const AccountsCard: FC = () => {
 
   const rows: AccountRow[] = useMemo(() => {
     return accounts.map(({ idx, account }) => {
-      const direction: "LONG" | "SHORT" | "IDLE" =
-        account.positionSize > 0n ? "LONG" : account.positionSize < 0n ? "SHORT" : "IDLE";
+      const direction: "LONG" | "SHORT" | "IDLE" = account.positionSize > 0n ? "LONG" : account.positionSize < 0n ? "SHORT" : "IDLE";
       const liqPrice = computeLiqPrice(account.entryPrice, account.capital, account.positionSize, maintBps);
-      // Health: how far current price is from liq as % of entry-to-liq range
       let liqHealthPct = 100;
       if (account.positionSize !== 0n && liqPrice > 0n && oraclePrice > 0n) {
         if (account.positionSize > 0n) {
-          // Long: healthy if price >> liqPrice
           const range = Number(account.entryPrice - liqPrice);
           const dist = Number(oraclePrice - liqPrice);
           liqHealthPct = range > 0 ? Math.max(0, Math.min(100, (dist / range) * 100)) : 0;
         } else {
-          // Short: healthy if price << liqPrice
           const range = Number(liqPrice - account.entryPrice);
           const dist = Number(liqPrice - oraclePrice);
           liqHealthPct = range > 0 ? Math.max(0, Math.min(100, (dist / range) * 100)) : 0;
         }
       }
-      // cost = |positionSize| * entryPrice / 1e6
       const absPos = account.positionSize < 0n ? -account.positionSize : account.positionSize;
       const cost = absPos * account.entryPrice / 1_000_000n;
       const marginPct = computeMarginPct(account.capital, account.positionSize, oraclePrice);
-      return {
-        idx,
-        kind: account.kind,
-        owner: account.owner.toBase58(),
-        direction,
-        positionSize: account.positionSize,
-        entryPrice: account.entryPrice,
-        liqPrice,
-        liqHealthPct,
-        cost,
-        pnl: account.pnl,
-        capital: account.capital,
-        marginPct,
-      };
+      return { idx, kind: account.kind, owner: account.owner.toBase58(), direction, positionSize: account.positionSize, entryPrice: account.entryPrice, liqPrice, liqHealthPct, cost, pnl: account.pnl, capital: account.capital, marginPct };
     });
   }, [accounts, maintBps, oraclePrice]);
 
   const openPositions = useMemo(() => rows.filter((r) => r.direction !== "IDLE"), [rows]);
   const idleAccounts = useMemo(() => rows.filter((r) => r.direction === "IDLE"), [rows]);
-
-  // Leaderboard: sorted by PnL desc
-  const leaderboard = useMemo(
-    () => [...openPositions].sort((a, b) => (Number(b.pnl) - Number(a.pnl))),
-    [openPositions],
-  );
-
-  // All-time: all accounts sorted by capital desc
-  const allTime = useMemo(
-    () => [...rows].sort((a, b) => (Number(b.capital) - Number(a.capital))),
-    [rows],
-  );
+  const leaderboard = useMemo(() => [...openPositions].sort((a, b) => Number(b.pnl) - Number(a.pnl)), [openPositions]);
 
   const toggleSort = useCallback((key: SortKey) => {
-    setSortKey((prev) => {
-      if (prev === key) {
-        setSortDir((d) => (d === "asc" ? "desc" : "asc"));
-        return key;
-      }
-      setSortDir("desc");
-      return key;
-    });
+    setSortKey((prev) => { if (prev === key) { setSortDir((d) => d === "asc" ? "desc" : "asc"); return key; } setSortDir("desc"); return key; });
   }, []);
 
   const sortedRows = useMemo(() => {
-    const base = tab === "open" ? openPositions
-      : tab === "idle" ? idleAccounts
-      : tab === "leaderboard" ? leaderboard
-      : allTime;
-
+    const base = tab === "open" ? openPositions : tab === "idle" ? idleAccounts : leaderboard;
     const sorted = [...base];
     const dir = sortDir === "asc" ? 1 : -1;
     sorted.sort((a, b) => {
@@ -168,157 +112,107 @@ export const AccountsCard: FC = () => {
       }
     });
     return sorted;
-  }, [tab, openPositions, idleAccounts, leaderboard, allTime, sortKey, sortDir]);
+  }, [tab, openPositions, idleAccounts, leaderboard, sortKey, sortDir]);
 
-  if (loading) {
-    return (
-      <div className="rounded-xl border border-[#1e1e2e] bg-[#12121a] p-5">
-        <p className="text-sm text-[#71717a]">Loading accounts...</p>
-      </div>
-    );
-  }
+  if (loading) return <div className="p-4"><p className="text-sm text-[#4a5068]">Loading…</p></div>;
 
   const tabs: { key: Tab; label: string; count: number }[] = [
-    { key: "open", label: "Open Positions", count: openPositions.length },
-    { key: "idle", label: "Idle Accounts", count: idleAccounts.length },
+    { key: "open", label: "Open", count: openPositions.length },
+    { key: "idle", label: "Idle", count: idleAccounts.length },
     { key: "leaderboard", label: "Leaderboard", count: openPositions.length },
-    { key: "alltime", label: "All-Time", count: rows.length },
   ];
 
-  const isOpenLike = tab === "open" || tab === "leaderboard" || tab === "alltime";
+  const isOpenLike = tab === "open" || tab === "leaderboard";
 
   const SortHeader: FC<{ label: string; sKey: SortKey; align?: "left" | "right" }> = ({ label, sKey, align = "right" }) => (
-    <th
-      onClick={() => toggleSort(sKey)}
-      className={`cursor-pointer select-none pb-2 font-medium ${align === "left" ? "text-left" : "text-right"} hover:text-[#71717a]`}
-    >
+    <th onClick={() => toggleSort(sKey)} className={`cursor-pointer select-none pb-2 font-medium ${align === "left" ? "text-left" : "text-right"} hover:text-[#4a5068]`}>
       {label}
-      {sortKey === sKey ? (
-        <span className="ml-0.5 text-blue-400">{sortDir === "asc" ? "↑" : "↓"}</span>
-      ) : (
-        <span className="ml-0.5 text-[#3f3f46]">↕</span>
-      )}
+      {sortKey === sKey ? <span className="ml-0.5 text-[#00d4aa]">{sortDir === "asc" ? "↑" : "↓"}</span> : <span className="ml-0.5 text-[#1a1d2a]">↕</span>}
     </th>
   );
 
   function liqBarColor(pct: number): string {
-    if (pct >= 70) return "bg-emerald-500";
-    if (pct >= 40) return "bg-yellow-500";
-    if (pct >= 20) return "bg-orange-500";
-    return "bg-red-500";
+    if (pct >= 70) return "bg-[#00e68a]";
+    if (pct >= 40) return "bg-[#ffaa00]";
+    if (pct >= 20) return "bg-[#ff8800]";
+    return "bg-[#ff4d6a]";
   }
 
   return (
-    <div className="rounded-xl border border-[#1e1e2e] bg-[#12121a] p-5">
-      <div className="mb-4 flex items-center justify-between">
-        <div className="flex gap-2">
-          {tabs.map((t) => (
-            <button
-              key={t.key}
-              onClick={() => setTab(t.key)}
-              className={`rounded-lg px-3 py-1 text-xs font-medium ${
-                tab === t.key ? "bg-blue-600 text-white" : "bg-[#1a1a2e] text-[#71717a] hover:bg-[#1e1e2e]"
-              }`}
-            >
-              {t.label} ({t.count})
-            </button>
-          ))}
-        </div>
-        <span className="rounded-full bg-[#1a1a2e] px-2 py-0.5 text-xs text-[#52525b]">
-          {accounts.length} total
-        </span>
+    <div className="p-4">
+      <div className="mb-3 flex items-center gap-2">
+        {tabs.map((t) => (
+          <button key={t.key} onClick={() => setTab(t.key)}
+            className={`rounded-md px-2.5 py-1 text-[11px] font-medium transition-all ${
+              tab === t.key ? "bg-[#1a1d2a] text-white" : "text-[#4a5068] hover:text-[#7a8194]"
+            }`}>
+            {t.label} <span className="text-[#2a2f40]">({t.count})</span>
+          </button>
+        ))}
+        <span className="ml-auto data-cell text-[10px] text-[#2a2f40]">{accounts.length} total</span>
       </div>
 
       {sortedRows.length === 0 ? (
-        <p className="text-sm text-[#52525b]">
-          {tab === "open" ? "No open positions" : tab === "idle" ? "No idle accounts" : "No accounts"}
+        <p className="py-4 text-center text-sm text-[#4a5068]">
+          {tab === "open" ? "No open positions" : tab === "idle" ? "No idle accounts" : "No data"}
         </p>
       ) : (
         <div className="overflow-x-auto">
-          <table className="w-full text-xs">
+          <table className="w-full text-[11px]">
             <thead>
-              <tr className="text-[10px] uppercase text-[#52525b]">
+              <tr className="text-[9px] uppercase tracking-wider text-[#2a2f40]">
                 <SortHeader label="#" sKey="idx" align="left" />
                 <SortHeader label="Owner" sKey="owner" align="left" />
-                {isOpenLike && <SortHeader label="Direction" sKey="direction" align="left" />}
+                {isOpenLike && <SortHeader label="Side" sKey="direction" align="left" />}
                 {isOpenLike && <SortHeader label="Position" sKey="position" />}
                 {isOpenLike && <SortHeader label="Entry" sKey="entry" />}
-                {isOpenLike && <SortHeader label="Liq Price" sKey="liqPrice" />}
-                {isOpenLike && <SortHeader label="Cost" sKey="cost" />}
+                {isOpenLike && <SortHeader label="Liq" sKey="liqPrice" />}
                 <SortHeader label="PnL" sKey="pnl" />
                 <SortHeader label="Capital" sKey="capital" />
                 {isOpenLike && <SortHeader label="Margin" sKey="margin" />}
               </tr>
             </thead>
-            <tbody className="divide-y divide-[#1e1e2e]/50">
+            <tbody className="divide-y divide-[#1a1d2a]/30">
               {sortedRows.map((row, i) => {
                 const absPos = row.positionSize < 0n ? -row.positionSize : row.positionSize;
                 return (
-                  <tr key={row.idx} className="hover:bg-[#1a1a2e]/50">
-                    <td className="py-1.5 text-[#52525b]">{i + 1}</td>
-                    <td className="py-1.5 font-mono text-[#71717a]">{shortenAddress(row.owner)}</td>
+                  <tr key={row.idx} className="hover:bg-[#0f1118]">
+                    <td className="py-1.5 text-[#2a2f40]">{i + 1}</td>
+                    <td className="data-cell py-1.5 text-[#4a5068]">{shortenAddress(row.owner)}</td>
                     {isOpenLike && (
                       <td className="py-1.5">
-                        {row.direction === "IDLE" ? (
-                          <span className="text-[#52525b]">-</span>
-                        ) : (
-                          <span className={`rounded px-1.5 py-0.5 text-[10px] font-bold ${
-                            row.direction === "LONG"
-                              ? "bg-emerald-900/40 text-emerald-400"
-                              : "bg-red-900/40 text-red-400"
-                          }`}>
-                            {row.direction}
-                          </span>
+                        {row.direction === "IDLE" ? <span className="text-[#2a2f40]">—</span> : (
+                          <span className={`rounded px-1.5 py-0.5 text-[9px] font-bold ${
+                            row.direction === "LONG" ? "bg-[#00e68a]/10 text-[#00e68a]" : "bg-[#ff4d6a]/10 text-[#ff4d6a]"
+                          }`}>{row.direction}</span>
                         )}
                       </td>
                     )}
                     {isOpenLike && (
-                      <td className={`py-1.5 text-right font-mono ${
-                        row.positionSize > 0n ? "text-emerald-400" : row.positionSize < 0n ? "text-red-400" : "text-[#52525b]"
-                      }`}>
-                        {row.positionSize !== 0n ? formatTokenAmount(absPos) : "-"}
+                      <td className={`data-cell py-1.5 text-right ${row.positionSize > 0n ? "text-[#00e68a]" : row.positionSize < 0n ? "text-[#ff4d6a]" : "text-[#2a2f40]"}`}>
+                        {row.positionSize !== 0n ? formatTokenAmount(absPos) : "—"}
                       </td>
                     )}
-                    {isOpenLike && (
-                      <td className="py-1.5 text-right font-mono text-[#e4e4e7]">
-                        {row.entryPrice > 0n ? formatUsd(row.entryPrice) : "-"}
-                      </td>
-                    )}
+                    {isOpenLike && <td className="data-cell py-1.5 text-right text-[#e8eaf0]">{row.entryPrice > 0n ? formatUsd(row.entryPrice) : "—"}</td>}
                     {isOpenLike && (
                       <td className="py-1.5 text-right">
                         {row.positionSize !== 0n ? (
-                          <div className="flex items-center justify-end gap-1.5">
-                            <span className="font-mono text-[#e4e4e7]">{formatUsd(row.liqPrice)}</span>
-                            <div className="h-1.5 w-10 rounded-full bg-[#1a1a2e]">
-                              <div
-                                className={`h-1.5 rounded-full ${liqBarColor(row.liqHealthPct)}`}
-                                style={{ width: `${Math.max(4, row.liqHealthPct)}%` }}
-                              />
+                          <div className="flex items-center justify-end gap-1">
+                            <span className="data-cell text-[#e8eaf0]">{formatUsd(row.liqPrice)}</span>
+                            <div className="h-1 w-8 rounded-full bg-[#1a1d2a]">
+                              <div className={`h-1 rounded-full ${liqBarColor(row.liqHealthPct)}`} style={{ width: `${Math.max(4, row.liqHealthPct)}%` }} />
                             </div>
                           </div>
-                        ) : "-"}
+                        ) : "—"}
                       </td>
                     )}
-                    {isOpenLike && (
-                      <td className="py-1.5 text-right font-mono text-[#a1a1aa]">
-                        {row.cost > 0n ? formatTokenAmount(row.cost) : "-"}
-                      </td>
-                    )}
-                    <td className={`py-1.5 text-right font-mono ${
-                      row.pnl > 0n ? "text-emerald-400" : row.pnl < 0n ? "text-red-400" : "text-[#52525b]"
-                    }`}>
+                    <td className={`data-cell py-1.5 text-right ${row.pnl > 0n ? "text-[#00e68a]" : row.pnl < 0n ? "text-[#ff4d6a]" : "text-[#2a2f40]"}`}>
                       {formatPnl(row.pnl)}
                     </td>
-                    <td className="py-1.5 text-right font-mono text-[#e4e4e7]">
-                      {formatTokenAmount(row.capital)}
-                    </td>
+                    <td className="data-cell py-1.5 text-right text-[#e8eaf0]">{formatTokenAmount(row.capital)}</td>
                     {isOpenLike && (
-                      <td className={`py-1.5 text-right font-mono ${
-                        row.marginPct > 50 ? "text-emerald-400"
-                          : row.marginPct > 20 ? "text-yellow-400"
-                          : "text-red-400"
-                      }`}>
-                        {row.positionSize !== 0n ? `${row.marginPct.toFixed(1)}%` : "-"}
+                      <td className={`data-cell py-1.5 text-right ${row.marginPct > 50 ? "text-[#00e68a]" : row.marginPct > 20 ? "text-[#ffaa00]" : "text-[#ff4d6a]"}`}>
+                        {row.positionSize !== 0n ? `${row.marginPct.toFixed(1)}%` : "—"}
                       </td>
                     )}
                   </tr>

--- a/app/components/trade/MarketBookCard.tsx
+++ b/app/components/trade/MarketBookCard.tsx
@@ -24,8 +24,8 @@ export const MarketBookCard: FC = () => {
 
   if (loading || !engine || !config || !params) {
     return (
-      <div className="rounded-xl border border-[#1e1e2e] bg-[#12121a] p-5">
-        <p className="text-sm text-[#71717a]">{loading ? "Loading..." : "Market not loaded"}</p>
+      <div className="p-4">
+        <p className="text-sm text-[#4a5068]">{loading ? "Loading…" : "—"}</p>
       </div>
     );
   }
@@ -34,81 +34,63 @@ export const MarketBookCard: FC = () => {
   const feeBps = Number(params.tradingFeeBps);
   const bestBid = oraclePrice > 0n ? Number(oraclePrice) * (1 - feeBps / 10000) : 0;
   const bestAsk = oraclePrice > 0n ? Number(oraclePrice) * (1 + feeBps / 10000) : 0;
-
-  // LP depth = sum of LP capital
   const lpTotalCapital = lps.reduce((sum, { account }) => sum + account.capital, 0n);
-
-  // Max depth for bar scaling
   const maxLpCapital = lps.length > 0
-    ? lps.reduce((max, { account }) => account.capital > max ? account.capital : max, 0n)
-    : 1n;
+    ? lps.reduce((max, { account }) => account.capital > max ? account.capital : max, 0n) : 1n;
 
   return (
-    <div className="rounded-xl border border-[#1e1e2e] bg-[#12121a] p-5">
-      <div className="mb-4 flex items-center justify-between">
-        <h3 className="text-xs font-medium uppercase tracking-wider text-[#71717a]">Market Book</h3>
-        <span className="rounded-full bg-[#1a1a2e] px-2 py-0.5 text-xs text-[#71717a]">
-          {lps.length} LP{lps.length !== 1 ? "s" : ""} quoting
-        </span>
-      </div>
-
+    <div className="p-4">
       {/* Price ladder */}
-      <div className="mb-4 flex items-center justify-between rounded-lg bg-[#1a1a28] px-3 py-2.5">
-        <div className="text-center">
-          <p className="text-[10px] uppercase text-[#52525b]">Best Bid</p>
-          <p className="font-mono text-sm font-medium text-emerald-400">
-            ${(bestBid / 1_000_000).toFixed(6)}
-          </p>
+      <div className="mb-4 grid grid-cols-3 gap-px overflow-hidden rounded-lg bg-[#1a1d2a]">
+        <div className="bg-[#080a0f] p-3 text-center">
+          <p className="text-[9px] uppercase tracking-wider text-[#4a5068]">Bid</p>
+          <p className="data-cell text-sm font-medium text-[#00e68a]">${(bestBid / 1_000_000).toFixed(6)}</p>
         </div>
-        <div className="text-center">
-          <p className="text-[10px] uppercase text-[#52525b]">Oracle</p>
-          <p className="font-mono text-sm font-medium text-[#e4e4e7]">
-            {formatUsd(oraclePrice)}
-          </p>
+        <div className="bg-[#080a0f] p-3 text-center">
+          <p className="text-[9px] uppercase tracking-wider text-[#4a5068]">Oracle</p>
+          <p className="data-cell text-sm font-medium text-[#e8eaf0]">{formatUsd(oraclePrice)}</p>
         </div>
-        <div className="text-center">
-          <p className="text-[10px] uppercase text-[#52525b]">Best Ask</p>
-          <p className="font-mono text-sm font-medium text-red-400">
-            ${(bestAsk / 1_000_000).toFixed(6)}
-          </p>
+        <div className="bg-[#080a0f] p-3 text-center">
+          <p className="text-[9px] uppercase tracking-wider text-[#4a5068]">Ask</p>
+          <p className="data-cell text-sm font-medium text-[#ff4d6a]">${(bestAsk / 1_000_000).toFixed(6)}</p>
         </div>
       </div>
 
-      {/* Depth summary */}
-      <div className="mb-4 flex gap-2">
-        <div className="flex-1 rounded-lg bg-emerald-900/20 p-2 text-center">
-          <p className="text-[10px] uppercase text-emerald-400/70">Bid Depth</p>
-          <p className="text-sm font-medium text-emerald-400">{formatTokenAmount(lpTotalCapital)}</p>
+      {/* Depth bars */}
+      <div className="mb-4 grid grid-cols-2 gap-2">
+        <div className="rounded-md bg-[#00e68a]/5 p-2.5 text-center ring-1 ring-[#00e68a]/10">
+          <p className="text-[9px] uppercase tracking-wider text-[#00e68a]/60">Bid Depth</p>
+          <p className="data-cell text-sm font-semibold text-[#00e68a]">{formatTokenAmount(lpTotalCapital)}</p>
         </div>
-        <div className="flex-1 rounded-lg bg-red-900/20 p-2 text-center">
-          <p className="text-[10px] uppercase text-red-400/70">Ask Depth</p>
-          <p className="text-sm font-medium text-red-400">{formatTokenAmount(lpTotalCapital)}</p>
+        <div className="rounded-md bg-[#ff4d6a]/5 p-2.5 text-center ring-1 ring-[#ff4d6a]/10">
+          <p className="text-[9px] uppercase tracking-wider text-[#ff4d6a]/60">Ask Depth</p>
+          <p className="data-cell text-sm font-semibold text-[#ff4d6a]">{formatTokenAmount(lpTotalCapital)}</p>
         </div>
       </div>
 
       {/* LP table */}
       {lps.length > 0 && (
         <div>
-          <div className="mb-1 flex text-[10px] uppercase text-[#52525b]">
+          <div className="mb-1 flex text-[9px] uppercase tracking-wider text-[#2a2f40]">
             <span className="w-6">#</span>
             <span className="flex-1">LP</span>
             <span className="w-24 text-right">Capital</span>
             <span className="w-24 text-right">Net Pos</span>
-            <span className="w-16" />
+            <span className="w-20" />
           </div>
           {lps.map(({ idx, account }, i) => {
             const pct = maxLpCapital > 0n ? Number(account.capital * 100n / maxLpCapital) : 0;
             return (
-              <div key={idx} className="flex items-center py-1 text-xs">
-                <span className="w-6 text-[#52525b]">{i + 1}</span>
-                <span className="flex-1 font-mono text-[#71717a]">{shortenAddress(account.owner.toBase58())}</span>
-                <span className="w-24 text-right text-[#e4e4e7]">{formatTokenAmount(account.capital)}</span>
-                <span className={`w-24 text-right ${account.positionSize >= 0n ? "text-emerald-400" : "text-red-400"}`}>
+              <div key={idx} className="flex items-center border-t border-[#1a1d2a]/30 py-1.5 text-[11px]">
+                <span className="w-6 text-[#2a2f40]">{i + 1}</span>
+                <span className="data-cell flex-1 text-[#4a5068]">{shortenAddress(account.owner.toBase58())}</span>
+                <span className="data-cell w-24 text-right text-[#e8eaf0]">{formatTokenAmount(account.capital)}</span>
+                <span className={`data-cell w-24 text-right ${account.positionSize >= 0n ? "text-[#00e68a]" : "text-[#ff4d6a]"}`}>
                   {formatTokenAmount(account.positionSize < 0n ? -account.positionSize : account.positionSize)}
                 </span>
-                <span className="w-16 pl-2">
-                  <div className="h-1.5 rounded-full bg-[#1a1a2e]">
-                    <div className="h-1.5 rounded-full bg-blue-500/60" style={{ width: `${pct}%` }} />
+                <span className="w-20 pl-3">
+                  <div className="h-1 rounded-full bg-[#1a1d2a]">
+                    <div className="h-1 rounded-full bg-[#00d4aa]/50" style={{ width: `${pct}%` }} />
                   </div>
                 </span>
               </div>


### PR DESCRIPTION
## What
Complete UI overhaul — dark DeFi trading terminal aesthetic (Drift/Jupiter Perps style). NOT a copy of MidTermDev.

## Changes
- Redesigned home page with terminal aesthetic
- Markets page with health badges, OI stats, LP depth
- Portfolio page with position management
- Simplified Footer, AccountsCard, MarketBookCard
- 444 additions, 741 deletions across 7 components

## Screenshots
Deploy preview needed — Supabase env var missing in build (pre-existing issue, not from these changes). TypeScript compiles clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Featured markets expanded from top 3 to top 4 by volume
  * Enhanced portfolio positions table with Market, Side, Size, Entry, Capital, and PnL columns

* **UI/UX Improvements**
  * Redesigned Markets and Portfolio pages with terminal-grid layout and updated typography
  * Home page styling overhaul with new teal/green color scheme and refreshed sections
  * Simplified footer with reorganized navigation and streamlined layout
  * Improved health badges with new visual styling
  * Enhanced market book card with updated price ladder and depth visualization
  * Removed all-time leaderboard tab for cleaner interface

* **Chores**
  * Updated build workflow with targeted dependency version management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->