### PR TITLE
feat: WebSocket real-time price engine (Helius Geyser)

### DIFF
--- a/app/hooks/useLivePrice.ts
+++ b/app/hooks/useLivePrice.ts
@@ -1,48 +1,174 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { useSlabState } from "@/components/providers/SlabProvider";
+import { useMarketAddress } from "@/hooks/useMarketAddress";
 
-const POLL_MS = 10_000;
+const WS_URL = process.env.NEXT_PUBLIC_WS_URL ?? "ws://localhost:3001";
+const RECONNECT_BASE_MS = 1000;
+const RECONNECT_MAX_MS = 30_000;
+const POLL_FALLBACK_MS = 10_000;
+
+interface PriceState {
+  price: number | null;
+  priceE6: bigint | null;
+  change24h: number | null;
+  high24h: number | null;
+  low24h: number | null;
+  loading: boolean;
+}
 
 /**
- * Fetches the live token/USD price from Jupiter API every 10 seconds.
+ * Real-time price hook — connects to the Percolator WebSocket price engine.
+ * Falls back to Jupiter polling if WebSocket is unavailable.
  */
-export function useLivePrice() {
-  const [priceUsd, setPriceUsd] = useState<number | null>(null);
-  const [priceE6, setPriceE6] = useState<bigint | null>(null);
-  const timerRef = useRef<ReturnType<typeof setInterval>>(undefined);
-  const { config: mktConfig } = useSlabState();
+export function useLivePrice(): PriceState {
+  const [state, setState] = useState<PriceState>({
+    price: null,
+    priceE6: null,
+    change24h: null,
+    high24h: null,
+    low24h: null,
+    loading: true,
+  });
 
+  const { config: mktConfig } = useSlabState();
+  const slabAddr = useMarketAddress() || null;
   const mint = mktConfig?.collateralMint?.toBase58() ?? null;
 
-  useEffect(() => {
-    setPriceUsd(null);
-    setPriceE6(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectDelay = useRef(RECONNECT_BASE_MS);
+  const reconnectTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const mountedRef = useRef(true);
+  const pollTimer = useRef<ReturnType<typeof setInterval>>(undefined);
+  const wsConnected = useRef(false);
 
-    if (!mint) return;
-
-    async function fetchPrice() {
-      try {
-        const url = `https://api.jup.ag/price/v2?ids=${mint}`;
-        const resp = await fetch(url, { signal: AbortSignal.timeout(5000) });
-        const json = await resp.json() as Record<string, unknown>;
-        const data = json.data as Record<string, { price?: string }> | undefined;
-        if (!data || !data[mint!]) return;
-        const p = parseFloat(data[mint!].price ?? "0");
-        if (p > 0) {
-          setPriceUsd(p);
-          setPriceE6(BigInt(Math.round(p * 1_000_000)));
-        }
-      } catch {
-        // keep last known price
+  // Jupiter polling fallback
+  const pollJupiter = useCallback(async () => {
+    if (!mint || wsConnected.current) return;
+    try {
+      const url = `https://api.jup.ag/price/v2?ids=${mint}`;
+      const resp = await fetch(url, { signal: AbortSignal.timeout(5000) });
+      const json = (await resp.json()) as Record<string, unknown>;
+      const data = json.data as Record<string, { price?: string }> | undefined;
+      if (!data || !data[mint]) return;
+      const p = parseFloat(data[mint].price ?? "0");
+      if (p > 0 && mountedRef.current) {
+        setState((prev) => ({
+          ...prev,
+          price: p,
+          priceE6: BigInt(Math.round(p * 1_000_000)),
+          loading: false,
+        }));
       }
+    } catch {
+      // keep last known
     }
-
-    fetchPrice();
-    timerRef.current = setInterval(fetchPrice, POLL_MS);
-    return () => clearInterval(timerRef.current);
   }, [mint]);
 
-  return { priceUsd, priceE6 };
+  useEffect(() => {
+    mountedRef.current = true;
+    setState((prev) => ({ ...prev, loading: true }));
+
+    if (!slabAddr) return;
+
+    let ws: WebSocket;
+
+    function connect() {
+      if (!mountedRef.current) return;
+      try {
+        ws = new WebSocket(WS_URL);
+        wsRef.current = ws;
+      } catch {
+        scheduleReconnect();
+        return;
+      }
+
+      ws.onopen = () => {
+        wsConnected.current = true;
+        reconnectDelay.current = RECONNECT_BASE_MS;
+        // Subscribe to this market
+        ws.send(JSON.stringify({ type: "subscribe", slabAddress: slabAddr }));
+      };
+
+      ws.onmessage = (event) => {
+        try {
+          const msg = JSON.parse(event.data as string) as {
+            type: string;
+            slabAddress?: string;
+            data?: { priceE6?: string; source?: string };
+            timestamp?: number;
+          };
+
+          if (msg.type === "price.updated" && msg.slabAddress === slabAddr && msg.data?.priceE6) {
+            const e6 = BigInt(msg.data.priceE6);
+            const usd = Number(e6) / 1_000_000;
+            if (mountedRef.current) {
+              setState((prev) => ({
+                price: usd,
+                priceE6: e6,
+                change24h: prev.change24h,
+                high24h: prev.high24h !== null ? Math.max(prev.high24h, usd) : usd,
+                low24h: prev.low24h !== null ? Math.min(prev.low24h, usd) : usd,
+                loading: false,
+              }));
+            }
+          }
+        } catch {
+          // ignore
+        }
+      };
+
+      ws.onclose = () => {
+        wsConnected.current = false;
+        if (mountedRef.current) scheduleReconnect();
+      };
+
+      ws.onerror = () => {
+        // onclose will fire after
+      };
+    }
+
+    function scheduleReconnect() {
+      if (!mountedRef.current) return;
+      reconnectTimer.current = setTimeout(() => {
+        reconnectDelay.current = Math.min(reconnectDelay.current * 2, RECONNECT_MAX_MS);
+        connect();
+      }, reconnectDelay.current);
+    }
+
+    connect();
+
+    // Also fetch 24h stats via REST
+    fetch(`${WS_URL.replace("ws://", "http://").replace("wss://", "https://")}/prices/${slabAddr}`)
+      .then((r) => r.json())
+      .then((json: { stats?: { change24h?: number; high24h?: string; low24h?: string } }) => {
+        if (json.stats && mountedRef.current) {
+          setState((prev) => ({
+            ...prev,
+            change24h: json.stats?.change24h ?? null,
+            high24h: json.stats?.high24h ? Number(json.stats.high24h) / 1_000_000 : null,
+            low24h: json.stats?.low24h ? Number(json.stats.low24h) / 1_000_000 : null,
+          }));
+        }
+      })
+      .catch(() => {});
+
+    // Jupiter polling fallback
+    pollJupiter();
+    pollTimer.current = setInterval(pollJupiter, POLL_FALLBACK_MS);
+
+    return () => {
+      mountedRef.current = false;
+      wsConnected.current = false;
+      if (reconnectTimer.current) clearTimeout(reconnectTimer.current);
+      if (pollTimer.current) clearInterval(pollTimer.current);
+      if (wsRef.current) {
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+    };
+  }, [slabAddr, pollJupiter]);
+
+  return state;
 }

--- a/packages/server/src/routes/prices.ts
+++ b/packages/server/src/routes/prices.ts
@@ -1,28 +1,56 @@
 import { Hono } from "hono";
 import type { OracleService } from "../services/oracle.js";
+import type { PriceEngine } from "../services/PriceEngine.js";
 
-export function priceRoutes(deps: { oracleService: OracleService }): Hono {
+export function priceRoutes(deps: {
+  oracleService: OracleService;
+  priceEngine: PriceEngine;
+}): Hono {
   const app = new Hono();
 
-  // GET /prices/:slab — current price
+  // GET /prices/:slab — current price + 24h stats
   app.get("/prices/:slab", (c) => {
     const slab = c.req.param("slab");
-    const price = deps.oracleService.getCurrentPrice(slab);
+
+    // Try PriceEngine first (real-time), fallback to OracleService
+    const enginePrice = deps.priceEngine.getLatestPrice(slab);
+    const oraclePrice = deps.oracleService.getCurrentPrice(slab);
+    const price = enginePrice ?? oraclePrice;
+
     if (!price) {
       return c.json({ error: "No price available" }, 404);
     }
+
+    const stats = deps.priceEngine.get24hStats(slab);
+
     return c.json({
       slabAddress: slab,
       priceE6: price.priceE6.toString(),
       source: price.source,
       timestamp: price.timestamp,
+      stats: stats
+        ? {
+            high24h: stats.high24h.toString(),
+            low24h: stats.low24h.toString(),
+            open24h: stats.open24h.toString(),
+            change24h:
+              stats.open24h > 0n
+                ? Number(((stats.current - stats.open24h) * 10000n) / stats.open24h) / 100
+                : 0,
+          }
+        : null,
     });
   });
 
   // GET /prices/:slab/history — price history (in-memory)
   app.get("/prices/:slab/history", (c) => {
     const slab = c.req.param("slab");
-    const history = deps.oracleService.getPriceHistory(slab);
+
+    // Merge: prefer PriceEngine history, fallback to OracleService
+    const engineHistory = deps.priceEngine.getHistory(slab);
+    const oracleHistory = deps.oracleService.getPriceHistory(slab);
+    const history = engineHistory.length > 0 ? engineHistory : oracleHistory;
+
     return c.json({
       slabAddress: slab,
       prices: history.map((p) => ({

--- a/packages/server/src/services/PriceEngine.ts
+++ b/packages/server/src/services/PriceEngine.ts
@@ -1,0 +1,285 @@
+import WebSocket from "ws";
+import { parseConfig, type MarketConfig } from "@percolator/core";
+import { config } from "../config.js";
+import { eventBus } from "./events.js";
+
+interface PriceTick {
+  priceE6: bigint;
+  source: string;
+  timestamp: number;
+}
+
+interface MarketStats {
+  high24h: bigint;
+  low24h: bigint;
+  open24h: bigint;
+  current: bigint;
+}
+
+/**
+ * Real-time price engine using Helius Enhanced WebSocket.
+ * Subscribes to slab account changes and parses oracle prices from on-chain data.
+ */
+export class PriceEngine {
+  private ws: WebSocket | null = null;
+  private subscriptionIds = new Map<number, string>(); // subId -> slabAddress
+  private slabToSubId = new Map<string, number>();
+  private priceHistory = new Map<string, PriceTick[]>();
+  private readonly maxHistory = 100;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectDelay = 1000;
+  private readonly maxReconnectDelay = 30_000;
+  private rpcMsgId = 1;
+  private started = false;
+  private pendingSubscriptions: string[] = [];
+
+  private get wsUrl(): string {
+    return config.rpcUrl.replace("https://", "wss://");
+  }
+
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+    this.connect();
+  }
+
+  stop(): void {
+    this.started = false;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+  }
+
+  /**
+   * Subscribe to a slab account for real-time price updates.
+   */
+  subscribeToSlab(slabAddress: string): void {
+    if (this.slabToSubId.has(slabAddress)) return;
+
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      this.pendingSubscriptions.push(slabAddress);
+      return;
+    }
+
+    this.sendSubscribe(slabAddress);
+  }
+
+  /**
+   * Unsubscribe from a slab account.
+   */
+  unsubscribeFromSlab(slabAddress: string): void {
+    const subId = this.slabToSubId.get(slabAddress);
+    if (subId === undefined || !this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+
+    const msgId = this.rpcMsgId++;
+    this.ws.send(JSON.stringify({
+      jsonrpc: "2.0",
+      id: msgId,
+      method: "accountUnsubscribe",
+      params: [subId],
+    }));
+
+    this.subscriptionIds.delete(subId);
+    this.slabToSubId.delete(slabAddress);
+  }
+
+  /**
+   * Get latest price for a slab.
+   */
+  getLatestPrice(slabAddress: string): PriceTick | null {
+    const history = this.priceHistory.get(slabAddress);
+    if (!history || history.length === 0) return null;
+    return history[history.length - 1];
+  }
+
+  /**
+   * Get price history (last N ticks) for a slab.
+   */
+  getHistory(slabAddress: string): PriceTick[] {
+    return this.priceHistory.get(slabAddress) ?? [];
+  }
+
+  /**
+   * Get 24h stats for a slab.
+   */
+  get24hStats(slabAddress: string): MarketStats | null {
+    const history = this.priceHistory.get(slabAddress);
+    if (!history || history.length === 0) return null;
+
+    const now = Date.now();
+    const cutoff = now - 24 * 60 * 60 * 1000;
+    const recent = history.filter((t) => t.timestamp >= cutoff);
+
+    if (recent.length === 0) {
+      // Use all available history
+      const current = history[history.length - 1].priceE6;
+      let high = current;
+      let low = current;
+      for (const tick of history) {
+        if (tick.priceE6 > high) high = tick.priceE6;
+        if (tick.priceE6 < low) low = tick.priceE6;
+      }
+      return { high24h: high, low24h: low, open24h: history[0].priceE6, current };
+    }
+
+    const current = recent[recent.length - 1].priceE6;
+    let high = current;
+    let low = current;
+    for (const tick of recent) {
+      if (tick.priceE6 > high) high = tick.priceE6;
+      if (tick.priceE6 < low) low = tick.priceE6;
+    }
+    return { high24h: high, low24h: low, open24h: recent[0].priceE6, current };
+  }
+
+  // ─── Private ───
+
+  private connect(): void {
+    if (!this.started) return;
+
+    try {
+      this.ws = new WebSocket(this.wsUrl);
+    } catch (err) {
+      console.error("[PriceEngine] Failed to create WebSocket:", err);
+      this.scheduleReconnect();
+      return;
+    }
+
+    this.ws.on("open", () => {
+      console.log("[PriceEngine] Connected to Helius WebSocket");
+      this.reconnectDelay = 1000;
+
+      // Re-subscribe existing slabs
+      for (const slabAddress of this.slabToSubId.keys()) {
+        this.sendSubscribe(slabAddress);
+      }
+
+      // Subscribe pending
+      while (this.pendingSubscriptions.length > 0) {
+        const slab = this.pendingSubscriptions.pop()!;
+        if (!this.slabToSubId.has(slab)) {
+          this.sendSubscribe(slab);
+        }
+      }
+    });
+
+    this.ws.on("message", (raw) => {
+      try {
+        const msg = JSON.parse(raw.toString());
+        this.handleMessage(msg);
+      } catch {
+        // Ignore malformed messages
+      }
+    });
+
+    this.ws.on("close", () => {
+      console.warn("[PriceEngine] WebSocket closed");
+      this.scheduleReconnect();
+    });
+
+    this.ws.on("error", (err) => {
+      console.error("[PriceEngine] WebSocket error:", err.message);
+    });
+  }
+
+  private scheduleReconnect(): void {
+    if (!this.started || this.reconnectTimer) return;
+    console.log(`[PriceEngine] Reconnecting in ${this.reconnectDelay}ms...`);
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, this.reconnectDelay);
+    this.reconnectDelay = Math.min(this.reconnectDelay * 2, this.maxReconnectDelay);
+  }
+
+  private sendSubscribe(slabAddress: string): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+
+    const msgId = this.rpcMsgId++;
+    // Store pending mapping: msgId -> slabAddress (resolved in handleMessage)
+    this._pendingSubResponses.set(msgId, slabAddress);
+
+    this.ws.send(JSON.stringify({
+      jsonrpc: "2.0",
+      id: msgId,
+      method: "accountSubscribe",
+      params: [
+        slabAddress,
+        { encoding: "base64", commitment: "confirmed" },
+      ],
+    }));
+  }
+
+  private _pendingSubResponses = new Map<number, string>();
+
+  private handleMessage(msg: Record<string, unknown>): void {
+    // Subscription response: { id, result: subscriptionId }
+    if (msg.id !== undefined && msg.result !== undefined) {
+      const msgId = msg.id as number;
+      const subId = msg.result as number;
+      const slabAddress = this._pendingSubResponses.get(msgId);
+      if (slabAddress) {
+        this._pendingSubResponses.delete(msgId);
+        this.subscriptionIds.set(subId, slabAddress);
+        this.slabToSubId.set(slabAddress, subId);
+        console.log(`[PriceEngine] Subscribed to ${slabAddress} (sub=${subId})`);
+      }
+      return;
+    }
+
+    // Account notification: { method: "accountNotification", params: { subscription, result } }
+    if (msg.method === "accountNotification") {
+      const params = msg.params as { subscription: number; result: { value: { data: [string, string] } } };
+      const subId = params.subscription;
+      const slabAddress = this.subscriptionIds.get(subId);
+      if (!slabAddress) return;
+
+      try {
+        const dataArr = params.result?.value?.data;
+        if (!Array.isArray(dataArr) || dataArr[1] !== "base64") return;
+
+        const buf = Buffer.from(dataArr[0], "base64");
+        const data = new Uint8Array(buf);
+
+        // Parse MarketConfig to get authorityPriceE6
+        const mktConfig = parseConfig(data);
+        const priceE6 = mktConfig.authorityPriceE6;
+
+        if (priceE6 === 0n) return; // No price set yet
+
+        const tick: PriceTick = {
+          priceE6,
+          source: "helius-ws",
+          timestamp: Date.now(),
+        };
+
+        this.recordTick(slabAddress, tick);
+
+        // Broadcast via event bus
+        eventBus.publish("price.updated", slabAddress, {
+          priceE6: priceE6.toString(),
+          source: "helius-ws",
+        });
+      } catch (err) {
+        console.error(`[PriceEngine] Failed to parse account data for ${slabAddress}:`, err);
+      }
+    }
+  }
+
+  private recordTick(slabAddress: string, tick: PriceTick): void {
+    let history = this.priceHistory.get(slabAddress);
+    if (!history) {
+      history = [];
+      this.priceHistory.set(slabAddress, history);
+    }
+    history.push(tick);
+    if (history.length > this.maxHistory) {
+      history.splice(0, history.length - this.maxHistory);
+    }
+  }
+}


### PR DESCRIPTION
## Phase 3: Real-time Price Streaming

### What's new

**PriceEngine service** (`packages/server/src/services/PriceEngine.ts`)
- Connects to Helius Enhanced WebSocket for account change notifications
- Subscribes to slab accounts on-demand when frontend clients subscribe
- Parses `authorityPriceE6` from on-chain slab data on each update
- Tracks price history (last 100 ticks per market) in memory
- Auto-reconnect with exponential backoff (1s → 30s max)

**Enhanced REST API**
- `GET /prices/:slab` now returns 24h stats: high, low, open, change%
- Price data merges PriceEngine (real-time) with OracleService (polling) fallback

**WebSocket improvements** (`/ws/prices`)
- Client subscribe messages now auto-register the slab with PriceEngine for Helius streaming
- Broadcasts real-time price updates from both Helius WS and oracle push events

**Frontend hook** (`app/hooks/useLivePrice.ts`)
- WebSocket-first: connects to server WS endpoint, subscribes to current market
- Falls back to Jupiter polling (10s) when WS is unavailable
- Returns `{ price, priceE6, change24h, high24h, low24h, loading }`
- Auto-reconnect with exponential backoff
- Fetches 24h stats via REST on mount

### Zero new TypeScript errors
Only pre-existing errors in `lifecycle.ts` and `CreateMarketWizard.tsx` remain.