### PR TITLE
fix: Rate limiting + fallback RPC + resilient health endpoint

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -13,6 +13,8 @@ export const config = {
   supabaseUrl: process.env.SUPABASE_URL ?? "",
   supabaseKey: process.env.SUPABASE_KEY ?? "",
   heliusApiKey: process.env.HELIUS_API_KEY ?? "",
+  fallbackRpcUrl: process.env.FALLBACK_RPC_URL ?? "https://api.devnet.solana.com",
   port: Number(process.env.PORT ?? 3001),
   crankIntervalMs: Number(process.env.CRANK_INTERVAL_MS ?? 10_000),
+  crankInactiveIntervalMs: Number(process.env.CRANK_INACTIVE_INTERVAL_MS ?? 60_000),
 } as const;

--- a/packages/server/src/routes/health.ts
+++ b/packages/server/src/routes/health.ts
@@ -4,29 +4,61 @@ import { getConnection } from "../utils/solana.js";
 const startTime = Date.now();
 
 export function healthRoutes(deps: {
-  crankService: { getStatus: () => Record<string, unknown> };
+  crankService: {
+    getStatus: () => Record<string, unknown>;
+    getLastCycleResult: () => { success: number; failed: number; skipped: number };
+    isRunning: boolean;
+  };
   liquidationService?: { getStatus: () => Record<string, unknown> };
 }): Hono {
   const app = new Hono();
 
   app.get("/health", async (c) => {
     let rpcLatencyMs = -1;
+    let rpcStatus: "ok" | "degraded" | "down" = "down";
+
     try {
       const start = Date.now();
       await getConnection().getSlot();
       rpcLatencyMs = Date.now() - start;
+      rpcStatus = rpcLatencyMs < 5000 ? "ok" : "degraded";
     } catch {
-      rpcLatencyMs = -1;
+      rpcStatus = "down";
     }
 
-    const crankStatus = deps.crankService.getStatus();
+    let crankStatus: Record<string, unknown> = {};
+    let crankCycle = { success: 0, failed: 0, skipped: 0 };
+    let crankRunning = false;
+    try {
+      crankStatus = deps.crankService.getStatus();
+      crankCycle = deps.crankService.getLastCycleResult();
+      crankRunning = deps.crankService.isRunning;
+    } catch {
+      // Service may not be initialized yet
+    }
+
+    let liquidationStatus: Record<string, unknown> | null = null;
+    try {
+      liquidationStatus = deps.liquidationService?.getStatus() ?? null;
+    } catch {
+      // ignore
+    }
+
+    const overallStatus = rpcStatus === "down" ? "degraded" : "ok";
+
     return c.json({
-      status: "ok",
+      status: overallStatus,
       uptimeMs: Date.now() - startTime,
-      rpcLatencyMs,
-      connectedMarkets: Object.keys(crankStatus).length,
+      services: {
+        rpc: { status: rpcStatus, latencyMs: rpcLatencyMs },
+        crank: {
+          status: crankRunning ? "running" : "stopped",
+          markets: Object.keys(crankStatus).length,
+          lastCycle: crankCycle,
+        },
+        liquidation: liquidationStatus,
+      },
       crankStatus,
-      liquidation: deps.liquidationService?.getStatus() ?? null,
     });
   });
 

--- a/packages/server/src/utils/rpc-client.ts
+++ b/packages/server/src/utils/rpc-client.ts
@@ -1,0 +1,107 @@
+import { Connection } from "@solana/web3.js";
+import { config } from "../config.js";
+
+const MAX_TOKENS = 10;
+const REFILL_INTERVAL_MS = 1_000;
+let tokens = MAX_TOKENS;
+let lastRefill = Date.now();
+
+function refillTokens(): void {
+  const now = Date.now();
+  const elapsed = now - lastRefill;
+  if (elapsed >= REFILL_INTERVAL_MS) {
+    const refills = Math.floor(elapsed / REFILL_INTERVAL_MS);
+    tokens = Math.min(MAX_TOKENS, tokens + refills * MAX_TOKENS);
+    lastRefill += refills * REFILL_INTERVAL_MS;
+  }
+}
+
+const waitQueue: Array<() => void> = [];
+
+function drainQueue(): void {
+  refillTokens();
+  while (waitQueue.length > 0 && tokens > 0) {
+    tokens--;
+    const resolve = waitQueue.shift()!;
+    resolve();
+  }
+}
+
+setInterval(drainQueue, 100);
+
+export async function acquireToken(): Promise<void> {
+  refillTokens();
+  if (tokens > 0) { tokens--; return; }
+  return new Promise<void>((resolve) => { waitQueue.push(resolve); });
+}
+
+let _primaryConnection: Connection | null = null;
+let _fallbackConnection: Connection | null = null;
+
+export function getPrimaryConnection(): Connection {
+  if (!_primaryConnection) _primaryConnection = new Connection(config.rpcUrl, "confirmed");
+  return _primaryConnection;
+}
+
+export function getFallbackConnection(): Connection {
+  if (!_fallbackConnection) _fallbackConnection = new Connection(config.fallbackRpcUrl, "confirmed");
+  return _fallbackConnection;
+}
+
+interface CacheEntry { data: unknown; fetchedAt: number; }
+const accountCache = new Map<string, CacheEntry>();
+const CACHE_TTL_MS = 5_000;
+
+export function getCachedAccountInfo(key: string): unknown | undefined {
+  const entry = accountCache.get(key);
+  if (!entry) return undefined;
+  if (Date.now() - entry.fetchedAt > CACHE_TTL_MS) { accountCache.delete(key); return undefined; }
+  return entry.data;
+}
+
+export function setCachedAccountInfo(key: string, data: unknown): void {
+  accountCache.set(key, { data, fetchedAt: Date.now() });
+}
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, entry] of accountCache) {
+    if (now - entry.fetchedAt > CACHE_TTL_MS) accountCache.delete(key);
+  }
+}, 30_000);
+
+export function backoffMs(attempt: number, baseMs = 1000, maxMs = 30_000): number {
+  return Math.min(baseMs * 2 ** attempt + Math.random() * 500, maxMs);
+}
+
+function is429(err: unknown): boolean {
+  if (err instanceof Error) {
+    const msg = err.message.toLowerCase();
+    return msg.includes("429") || msg.includes("too many requests") || msg.includes("rate limit");
+  }
+  return false;
+}
+
+export async function rateLimitedCall<T>(
+  fn: (conn: Connection) => Promise<T>,
+  options?: { readOnly?: boolean; maxRetries?: number },
+): Promise<T> {
+  const maxRetries = options?.maxRetries ?? 3;
+  const readOnly = options?.readOnly ?? false;
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    await acquireToken();
+    try {
+      return await fn(getPrimaryConnection());
+    } catch (err) {
+      if (is429(err) && readOnly) {
+        try { return await fn(getFallbackConnection()); }
+        catch (fe) { console.warn("[RPC] Fallback failed:", fe); }
+      }
+      if (attempt < maxRetries - 1) {
+        const delay = backoffMs(attempt);
+        await new Promise((r) => setTimeout(r, delay));
+      } else { throw err; }
+    }
+  }
+  throw new Error("rateLimitedCall: unreachable");
+}


### PR DESCRIPTION
## Problem
Backend on Railway getting 429 rate limited by Helius, causing crank failures, oracle push failures, and 502 health endpoint.

## Changes
- **Rate limiter**: Token-bucket (10 req/s) in new `utils/rpc-client.ts` — all RPC calls go through `acquireToken()`
- **Fallback RPC**: On Helius 429, read-only calls fall back to `https://api.devnet.solana.com`
- **Exponential backoff + jitter**: On 429 errors in `sendWithRetry` and `rateLimitedCall`
- **Account cache**: 5s TTL cache for `getAccountInfo` to reduce redundant reads
- **Staggered cranks**: Markets processed in batches of 3 with 2s gaps between batches
- **Inactive market detection**: Markets with 5+ consecutive failures crank every 60s instead of 10s
- **Resilient health endpoint**: Always responds with service health breakdown (rpc/crank/liquidation status)

## Config
New env vars (all optional with sensible defaults):
- `FALLBACK_RPC_URL` — fallback RPC (default: devnet public)
- `CRANK_INACTIVE_INTERVAL_MS` — interval for inactive markets (default: 60000)

## Still needed
- Set `HELIUS_API_KEY=ecfc91c7-b704-4c37-b10e-a277392830aa` on Railway
- Redeploy after merge