### PR TITLE
fix: Create missing api-auth module (fixes runtime 500s)

### DIFF
--- a/app/app/api/crank/[slab]/route.ts
+++ b/app/app/api/crank/[slab]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireAuth, UNAUTHORIZED } from "@/lib/api-auth";
 import {
   Connection,
   Keypair,

--- a/app/lib/api-auth.ts
+++ b/app/lib/api-auth.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Simple API key auth for internal/indexer routes.
+ * Checks `x-api-key` header against INDEXER_API_KEY env var.
+ * If INDEXER_API_KEY is not set, all requests are allowed (dev mode).
+ */
+export function requireAuth(req: NextRequest): boolean {
+  const expectedKey = process.env.INDEXER_API_KEY;
+  if (!expectedKey) return true; // No key configured = open (dev mode)
+  const providedKey = req.headers.get("x-api-key");
+  return providedKey === expectedKey;
+}
+
+export const UNAUTHORIZED = NextResponse.json(
+  { error: "Unauthorized — missing or invalid x-api-key header" },
+  { status: 401 }
+);


### PR DESCRIPTION
## Problem
4 API routes import `@/lib/api-auth` but the module didn't exist. Routes were 500ing at runtime when called by the backend/indexer.

## Changes
- Created `app/lib/api-auth.ts` — exports `requireAuth(req)` and `UNAUTHORIZED` response
- Auth checks `x-api-key` header against `INDEXER_API_KEY` env var
- Dev mode: if no key configured, all requests allowed
- Added missing import to `app/app/api/crank/[slab]/route.ts`

## Files
- `app/lib/api-auth.ts` (new)
- `app/app/api/crank/[slab]/route.ts` (import fix)