### PR TITLE
style: Restyle remaining components to Neon Obsidian design

### DIFF
--- a/app/app/devnet-mint/devnet-mint-content.tsx
+++ b/app/app/devnet-mint/devnet-mint-content.tsx
@@ -234,7 +234,7 @@ const DevnetMintContent: FC = () => {
               ✓ Connected: <span className="font-mono text-xs">{publicKey?.toBase58()}</span>
             </p>
           ) : (
-            <p className="text-sm text-yellow-400">
+            <p className="text-sm text-[#FFB800]">
               Connect your wallet using the button in the header
             </p>
           )}

--- a/app/app/my-markets/page.tsx
+++ b/app/app/my-markets/page.tsx
@@ -61,7 +61,7 @@ const ConfirmDialog: FC<{
             variant={danger ? "secondary" : "primary"}
             size="sm"
             onClick={onConfirm}
-            className={danger ? "!border-red-500/30 !text-red-400 hover:!bg-red-500/10" : ""}
+            className={danger ? "!border-[#FF4466]/30 !text-[#FF4466] hover:!bg-[#FF4466]/10" : ""}
           >
             {confirmLabel}
           </GlowButton>
@@ -161,7 +161,7 @@ const MarketCard: FC<{
               {shortAddr(slab)} &rarr;
             </a>
           </div>
-          <span className={`text-xs font-bold ${healthy ? "text-[#00FFB2]" : "text-red-400"}`}>
+          <span className={`text-xs font-bold ${healthy ? "text-[#00FFB2]" : "text-[#FF4466]"}`}>
             {healthy ? "healthy" : "stale"}
           </span>
         </div>
@@ -208,7 +208,7 @@ const MarketCard: FC<{
           <button
             onClick={() => setShowBurnConfirm(true)}
             disabled={actions.loading === "renounceAdmin"}
-            className="text-xs text-red-400/70 hover:text-red-400 transition-colors disabled:opacity-40"
+            className="text-xs text-[#FF4466]/70 hover:text-[#FF4466] transition-colors disabled:opacity-40"
           >
             burn admin key
           </button>
@@ -321,7 +321,7 @@ const MyMarketsPage: FC = () => {
       <main className="mx-auto max-w-5xl px-4 py-24 text-center">
         <div className="mx-auto max-w-md rounded-[4px] border border-[#1a1a1f] bg-[#111113] p-8">
           <h1 className="text-xl font-bold text-white">something broke.</h1>
-          <p className="mt-2 text-sm text-red-400">{error}</p>
+          <p className="mt-2 text-sm text-[#FF4466]">{error}</p>
         </div>
       </main>
     );

--- a/app/components/market/ActivityFeed.tsx
+++ b/app/components/market/ActivityFeed.tsx
@@ -22,10 +22,10 @@ function eventIcon(type: ActivityItem["eventType"]): string {
 
 function eventColor(type: ActivityItem["eventType"]): string {
   switch (type) {
-    case "new_market": return "text-emerald-400";
-    case "trade": return "text-blue-400";
-    case "large_trade": return "text-yellow-400";
-    case "liquidation": return "text-red-400";
+    case "new_market": return "text-[#00FFB2]";
+    case "trade": return "text-[#00FFB2]";
+    case "large_trade": return "text-[#FFB800]";
+    case "liquidation": return "text-[#FF4466]";
   }
 }
 

--- a/app/components/market/FundingRate.tsx
+++ b/app/components/market/FundingRate.tsx
@@ -17,7 +17,7 @@ export const FundingRate: FC = () => {
   const bpsPerSlot = Number(fundingRate ?? 0n);
   const hourlyRate = bpsPerSlot * 2.5 * 3600;
   const annualizedRate = bpsPerSlot * 2.5 * 3600 * 24 * 365;
-  const rateColor = bpsPerSlot === 0 ? "text-[#3D4563]" : bpsPerSlot > 0 ? "text-emerald-400" : "text-red-400";
+  const rateColor = bpsPerSlot === 0 ? "text-[#3D4563]" : bpsPerSlot > 0 ? "text-[#00FFB2]" : "text-[#FF4466]";
 
   return (
     <div className="rounded-2xl border border-white/[0.06] bg-white/[0.05] p-6">

--- a/app/components/market/MarketBrowser.tsx
+++ b/app/components/market/MarketBrowser.tsx
@@ -40,7 +40,7 @@ export const MarketBrowser: FC = () => {
       : error;
     return (
       <div className="rounded-xl border border-[#1e1e2e] bg-[#12121a] p-8 text-center shadow-sm">
-        <p className="text-red-400">Error: {helpMsg}</p>
+        <p className="text-[#FF4466]">Error: {helpMsg}</p>
       </div>
     );
   }
@@ -92,7 +92,7 @@ export const MarketBrowser: FC = () => {
                       href={`https://solscan.io/token/${mintBase58}`}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-sm font-medium text-blue-400 hover:underline"
+                      className="text-sm font-medium text-[#00FFB2] hover:underline"
                     >
                       {symbol}
                     </a>
@@ -102,7 +102,7 @@ export const MarketBrowser: FC = () => {
                       className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${
                         isAdminOracle(m)
                           ? "bg-amber-900/40 text-amber-400"
-                          : "bg-blue-900/40 text-blue-400"
+                          : "bg-[#00FFB2]/[0.08] text-[#00FFB2]"
                       }`}
                     >
                       {isAdminOracle(m) ? "Admin" : "Pyth"}
@@ -123,7 +123,7 @@ export const MarketBrowser: FC = () => {
                   <td className="px-4 py-3 text-right">
                     <Link
                       href={`/trade?market=${slab}`}
-                      className="rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-blue-700"
+                      className="rounded-lg bg-[#00FFB2] px-3 py-1.5 text-xs font-medium text-[#06080d] transition-colors hover:bg-[#00FFB2]/80"
                     >
                       Trade
                     </Link>

--- a/app/components/market/ShareCard.tsx
+++ b/app/components/market/ShareCard.tsx
@@ -37,7 +37,7 @@ export const ShareCard: FC<ShareCardProps> = ({ slabAddress, marketName, price, 
       <div className="mb-3 flex items-baseline gap-3">
         <span className="font-mono text-xl text-white">${fmtPrice}</span>
         {change24h != null && (
-          <span className={`text-sm font-medium ${change24h >= 0 ? "text-emerald-400" : "text-red-400"}`}>
+          <span className={`text-sm font-medium ${change24h >= 0 ? "text-[#00FFB2]" : "text-[#FF4466]"}`}>
             {changeStr}
           </span>
         )}

--- a/app/components/trade/DepositWithdrawCard.tsx
+++ b/app/components/trade/DepositWithdrawCard.tsx
@@ -43,11 +43,11 @@ export const DepositWithdrawCard: FC<{ slabAddress: string }> = ({ slabAddress }
         <button
           onClick={async () => { try { const sig = await initUser(); setLastSig(sig ?? null); } catch {} }}
           disabled={initLoading}
-          className="w-full rounded-lg bg-blue-600 py-2.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          className="w-full rounded-lg bg-[#00FFB2] py-2.5 text-sm font-medium text-[#06080d] hover:bg-[#00FFB2]/80 disabled:opacity-50"
         >
           {initLoading ? "Creating..." : "Create Account"}
         </button>
-        {initError && <p className="mt-2 text-xs text-red-400">{initError}</p>}
+        {initError && <p className="mt-2 text-xs text-[#FF4466]">{initError}</p>}
         {lastSig && <p className="mt-2 text-xs text-[#52525b]">Tx: {lastSig.slice(0, 12)}...</p>}
       </div>
     );
@@ -90,20 +90,20 @@ export const DepositWithdrawCard: FC<{ slabAddress: string }> = ({ slabAddress }
           value={amount}
           onChange={(e) => setAmount(e.target.value.replace(/[^0-9.]/g, ""))}
           placeholder={`Amount (${symbol})`}
-          className="w-full rounded-lg border border-[#1e1e2e] bg-[#1a1a28] px-3 py-2 text-sm text-[#e4e4e7] placeholder-[#52525b] focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          className="w-full rounded-lg border border-white/[0.06] bg-white/[0.05] px-3 py-2 text-sm text-[#e4e4e7] placeholder-[#52525b] focus:border-[#00FFB2]/40 focus:outline-none focus:ring-1 focus:ring-[#00FFB2]/20"
         />
       </div>
 
       <button
         onClick={handleSubmit}
         disabled={loading || !amount}
-        className="w-full rounded-lg bg-blue-600 py-2.5 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+        className="w-full rounded-lg bg-[#00FFB2] py-2.5 text-sm font-medium text-[#06080d] hover:bg-[#00FFB2]/80 disabled:cursor-not-allowed disabled:opacity-50"
       >
         {loading ? "Sending..." : mode === "deposit" ? "Deposit" : "Withdraw"}
       </button>
 
-      {error && <p className="mt-2 text-xs text-red-400">{error}</p>}
-      {lastSig && <p className="mt-2 text-xs text-[#52525b]">Tx: <a href={`${explorerTxUrl(lastSig)}`} target="_blank" rel="noopener noreferrer" className="text-blue-400 hover:underline">{lastSig.slice(0, 12)}...</a></p>}
+      {error && <p className="mt-2 text-xs text-[#FF4466]">{error}</p>}
+      {lastSig && <p className="mt-2 text-xs text-[#52525b]">Tx: <a href={`${explorerTxUrl(lastSig)}`} target="_blank" rel="noopener noreferrer" className="text-[#00FFB2] hover:underline">{lastSig.slice(0, 12)}...</a></p>}
     </div>
   );
 };

--- a/app/components/trade/EngineHealthCard.tsx
+++ b/app/components/trade/EngineHealthCard.tsx
@@ -7,9 +7,9 @@ import { computeMarketHealth } from "@/lib/health";
 import { formatTokenAmount, formatSlotAge } from "@/lib/format";
 
 const HEALTH_COLORS: Record<string, string> = {
-  healthy: "bg-green-900/40 text-green-400",
-  caution: "bg-yellow-900/40 text-yellow-400",
-  warning: "bg-red-900/40 text-red-400",
+  healthy: "bg-[#00FFB2]/[0.1] text-[#00FFB2]",
+  caution: "bg-[#FFB800]/[0.1] text-[#FFB800]",
+  warning: "bg-[#FF4466]/[0.1] text-[#FF4466]",
   empty: "bg-[#1a1a2e] text-[#71717a]",
 };
 

--- a/app/components/trade/InsuranceLPPanel.tsx
+++ b/app/components/trade/InsuranceLPPanel.tsx
@@ -91,7 +91,7 @@ export function InsuranceLPPanel() {
         <span className="text-lg">🛡️</span>
         <h3 className="text-sm font-semibold text-[#F0F4FF]">Insurance Pool</h3>
         {state.mintExists && (
-          <span className="ml-auto text-[10px] px-1.5 py-0.5 bg-emerald-500/10 text-emerald-400 rounded border border-emerald-500/20">
+          <span className="ml-auto text-[10px] px-1.5 py-0.5 bg-[#00FFB2]/10 text-[#00FFB2] rounded border border-[#00FFB2]/20">
             LIVE
           </span>
         )}
@@ -129,7 +129,7 @@ export function InsuranceLPPanel() {
             </div>
             <div className="text-right">
               <p className="text-[10px] text-[#5a6382] uppercase">Redeemable</p>
-              <p className="text-sm font-mono text-emerald-400">{formatSol(state.userRedeemableValue)} SOL</p>
+              <p className="text-sm font-mono text-[#00FFB2]">{formatSol(state.userRedeemableValue)} SOL</p>
             </div>
           </div>
         </div>
@@ -140,7 +140,7 @@ export function InsuranceLPPanel() {
         <button
           onClick={handleCreateMint}
           disabled={loading}
-          className="w-full py-2 px-4 bg-indigo-600 hover:bg-indigo-500 disabled:bg-white/[0.05] disabled:text-[#5a6382] text-white text-sm font-medium rounded transition-colors mb-3"
+          className="w-full py-2 px-4 bg-[#00FFB2] hover:bg-[#00FFB2]/80 disabled:bg-white/[0.05] disabled:text-[#5a6382] text-[#06080d] text-sm font-medium rounded transition-colors mb-3"
         >
           {loading ? 'Creating...' : 'Create Insurance LP Mint'}
         </button>
@@ -162,7 +162,7 @@ export function InsuranceLPPanel() {
               onClick={() => { setMode('deposit'); setAmount(''); }}
               className={`flex-1 py-1.5 text-xs font-medium rounded transition-colors ${
                 mode === 'deposit'
-                  ? 'bg-emerald-600 text-white'
+                  ? 'bg-[#00FFB2] text-[#06080d]'
                   : 'text-[#8B95B0] hover:text-[#F0F4FF]'
               }`}
             >
@@ -172,7 +172,7 @@ export function InsuranceLPPanel() {
               onClick={() => { setMode('withdraw'); setAmount(''); }}
               className={`flex-1 py-1.5 text-xs font-medium rounded transition-colors ${
                 mode === 'withdraw'
-                  ? 'bg-red-600 text-white'
+                  ? 'bg-[#FF4466] text-white'
                   : 'text-[#8B95B0] hover:text-[#F0F4FF]'
               }`}
             >
@@ -194,7 +194,7 @@ export function InsuranceLPPanel() {
             {mode === 'withdraw' && state.userLpBalance > 0n && (
               <button
                 onClick={() => setAmount((Number(state.userLpBalance) / 1e9).toString())}
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-[10px] text-indigo-400 hover:text-indigo-300"
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-[10px] text-[#00FFB2] hover:text-[#00FFB2]/80"
               >
                 MAX
               </button>
@@ -219,8 +219,8 @@ export function InsuranceLPPanel() {
             disabled={loading || !amount || parseFloat(amount) <= 0}
             className={`w-full py-2 px-4 text-white text-sm font-medium rounded transition-colors disabled:bg-white/[0.05] disabled:text-[#5a6382] ${
               mode === 'deposit'
-                ? 'bg-emerald-600 hover:bg-emerald-500'
-                : 'bg-red-600 hover:bg-red-500'
+                ? 'bg-[#00FFB2] hover:bg-[#00FFB2]/80 text-[#06080d]'
+                : 'bg-[#FF4466] hover:bg-[#FF4466]/80'
             }`}
           >
             {loading
@@ -236,7 +236,7 @@ export function InsuranceLPPanel() {
       {/* Status */}
       {(txStatus || error) && (
         <p className={`text-xs mt-2 ${
-          (txStatus || error || '').includes('Error') ? 'text-red-400' : 'text-emerald-400'
+          (txStatus || error || '').includes('Error') ? 'text-[#FF4466]' : 'text-[#00FFB2]'
         }`}>
           {txStatus || error}
         </p>

--- a/app/components/trade/OrderConfirm.tsx
+++ b/app/components/trade/OrderConfirm.tsx
@@ -32,7 +32,7 @@ export const OrderConfirm: FC<OrderConfirmProps> = ({
             Direction:{" "}
             <span
               className={
-                direction === "long" ? "text-emerald-400" : "text-red-400"
+                direction === "long" ? "text-[#00FFB2]" : "text-[#FF4466]"
               }
             >
               {direction.toUpperCase()}
@@ -53,7 +53,7 @@ export const OrderConfirm: FC<OrderConfirmProps> = ({
           <button
             onClick={onConfirm}
             disabled={loading}
-            className="flex-1 rounded-lg bg-blue-600 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+            className="flex-1 rounded-lg bg-[#00FFB2] py-2 text-sm font-medium text-[#06080d] transition-colors hover:bg-[#00FFB2]/80 disabled:opacity-50"
           >
             {loading ? "Sending..." : "Confirm"}
           </button>

--- a/app/components/ui/CopyableAddress.tsx
+++ b/app/components/ui/CopyableAddress.tsx
@@ -20,7 +20,7 @@ export const CopyableAddress: FC<{ address: string; chars?: number; className?: 
   return (
     <button
       onClick={handleCopy}
-      className={`inline-flex items-center gap-1 font-mono transition-colors hover:text-blue-400 ${className}`}
+      className={`inline-flex items-center gap-1 font-mono transition-colors hover:text-[#00FFB2] ${className}`}
       title="Click to copy"
     >
       <span>{address.slice(0, chars)}...{address.slice(-chars)}</span>

--- a/app/components/ui/Toast.tsx
+++ b/app/components/ui/Toast.tsx
@@ -5,16 +5,16 @@ import { useToastContext, type ToastItem } from "@/hooks/useToast";
 
 const COLORS: Record<ToastItem["type"], { bg: string; border: string; icon: string }> = {
   success: { bg: "bg-emerald-500/10", border: "border-emerald-500/30", icon: "✓" },
-  error: { bg: "bg-red-500/10", border: "border-red-500/30", icon: "✕" },
-  info: { bg: "bg-blue-500/10", border: "border-blue-500/30", icon: "ℹ" },
-  warning: { bg: "bg-yellow-500/10", border: "border-yellow-500/30", icon: "⚠" },
+  error: { bg: "bg-[#FF4466]/10", border: "border-[#FF4466]/30", icon: "✕" },
+  info: { bg: "bg-[#00FFB2]/10", border: "border-[#00FFB2]/30", icon: "ℹ" },
+  warning: { bg: "bg-[#FFB800]/10", border: "border-[#FFB800]/30", icon: "⚠" },
 };
 
 const TEXT_COLORS: Record<ToastItem["type"], string> = {
   success: "text-emerald-400",
-  error: "text-red-400",
-  info: "text-blue-400",
-  warning: "text-yellow-400",
+  error: "text-[#FF4466]",
+  info: "text-[#00FFB2]",
+  warning: "text-[#FFB800]",
 };
 
 const SingleToast: FC<{ item: ToastItem; onDismiss: (id: string) => void }> = ({


### PR DESCRIPTION
Restyles all remaining components with old Tailwind color classes to the Neon Obsidian design system.

**Files changed (12):**
- MarketBrowser, DepositWithdrawCard, EngineHealthCard, InsuranceLPPanel, OrderConfirm, ActivityFeed, FundingRate, ShareCard, Toast, CopyableAddress, devnet-mint-content, my-markets/page

**Color mappings:**
- `blue-*` / `emerald-*` → `#00FFB2` (primary accent)
- `red-*` → `#FF4466` (error/short)
- `yellow-*` → `#FFB800` (warning)
- `indigo-*` → `#00FFB2` (was secondary, now primary)
- Input borders → `border-white/[0.06] bg-white/[0.05]`
- Focus rings → `focus:border-[#00FFB2]/40 focus:ring-[#00FFB2]/20`

No logic changes. Styling only. CreateMarketWizard untouched.