### PR TITLE
fix: unify page headers + fix mobile trade layout

### DIFF
--- a/app/app/agents/page.tsx
+++ b/app/app/agents/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { ScrollReveal } from "@/components/ui/ScrollReveal";
 
 const codeBlock = "rounded-sm bg-[#0D0D14] border border-[var(--border)] p-4 text-[12px] font-mono text-[var(--text-secondary)] overflow-x-auto whitespace-pre";
 const card = "rounded-sm bg-[var(--panel-bg)] border border-[var(--border)] p-6";
@@ -11,35 +12,43 @@ const badge = "inline-block rounded-sm px-2 py-0.5 text-[10px] font-semibold upp
 
 export default function AgentsPage() {
   return (
-    <div className="min-h-screen bg-[var(--bg)] px-4 py-12">
-      <div className="mx-auto max-w-3xl space-y-8">
+    <div className="min-h-[calc(100vh-48px)] relative">
+      <div className="absolute inset-x-0 top-0 h-48 bg-grid pointer-events-none" />
+      <div className="relative mx-auto max-w-4xl px-4 py-10 space-y-8">
         {/* Header */}
-        <div className="text-center">
-          <h1 className="text-3xl font-extrabold text-white">
-            Agent Contribution Guide
-          </h1>
-          <p className="mt-3 text-sm text-[var(--text-secondary)]">
-            Use your AI agent to improve Percolator Launch. Fork, build, submit PRs.
-          </p>
-          <div className="mt-4 flex items-center justify-center gap-3">
-            <a
-              href="https://github.com/dcccrypto/percolator-launch"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="rounded-sm border border-[var(--border)] px-4 py-2 text-xs font-medium text-white transition-colors hover:bg-[var(--accent)]/10"
-            >
-              View on GitHub
-            </a>
-            <a
-              href="https://github.com/dcccrypto/percolator-launch/blob/main/CONTRIBUTING-AGENTS.md"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="rounded-sm bg-[var(--accent)] px-4 py-2 text-xs font-semibold text-white transition-opacity hover:opacity-90"
-            >
-              Full Contributing Guide
-            </a>
+        <ScrollReveal>
+          <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <div className="mb-2 text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--accent)]/60">
+                // contribute
+              </div>
+              <h1 className="text-xl font-medium tracking-[-0.01em] text-white sm:text-2xl" style={{ fontFamily: "var(--font-heading)" }}>
+                <span className="font-normal text-white/50">Agent </span>Contribution Guide
+              </h1>
+              <p className="mt-2 text-[13px] text-[var(--text-secondary)]">
+                Use your AI agent to improve Percolator Launch. Fork, build, submit PRs.
+              </p>
+            </div>
+            <div className="flex items-center gap-3">
+              <a
+                href="https://github.com/dcccrypto/percolator-launch"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="border border-[var(--border)] px-4 py-2 text-xs font-medium text-white transition-colors hover:bg-[var(--accent)]/10"
+              >
+                View on GitHub
+              </a>
+              <a
+                href="https://github.com/dcccrypto/percolator-launch/blob/main/CONTRIBUTING-AGENTS.md"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="bg-[var(--accent)] px-4 py-2 text-xs font-semibold text-white transition-opacity hover:opacity-90"
+              >
+                Full Contributing Guide
+              </a>
+            </div>
           </div>
-        </div>
+        </ScrollReveal>
 
         {/* How it works */}
         <div className={card}>

--- a/app/app/devnet-mint/devnet-mint-content.tsx
+++ b/app/app/devnet-mint/devnet-mint-content.tsx
@@ -282,43 +282,47 @@ const DevnetMintContent: FC = () => {
   }, [publicKey, signTransaction, existingMint, mintMoreAmount, recipient, refreshBalance]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const cardClass =
-    "rounded-sm bg-[var(--panel-bg)] border border-[var(--border)] p-6";
+    "bg-[var(--panel-bg)] border border-[var(--border)] p-6";
   const btnPrimary =
-    "rounded-sm bg-[var(--long)] px-5 py-2.5 text-sm font-semibold text-white transition-all duration-150 hover:bg-[var(--long)]/80 hover:scale-[1.02] active:scale-[0.98] disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:scale-100 disabled:hover:shadow-none";
+    "border border-[var(--accent)]/40 text-[var(--accent)] bg-transparent px-5 py-2.5 text-sm font-semibold transition-all duration-200 hover:border-[var(--accent)]/70 hover:bg-[var(--accent)]/[0.08] active:scale-[0.98] disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:scale-100";
   const inputClass =
-    "w-full rounded-sm bg-[var(--panel-bg)] border border-[var(--border)] px-3 py-2 text-sm text-white placeholder-[var(--text-muted)] focus:border-[var(--accent)]/40 focus:outline-none transition-shadow duration-200";
+    "w-full bg-[var(--panel-bg)] border border-[var(--border)] px-3 py-2 text-sm text-white placeholder-[var(--text-muted)] focus:border-[var(--accent)]/40 focus:outline-none transition-shadow duration-200";
 
   /* ---- Loading skeleton while wallet connects ---- */
   if (!connected) {
     return (
-      <div className="min-h-screen bg-[var(--panel-bg)] px-4 py-12">
-        <div className="mx-auto max-w-xl space-y-6">
-          <div className="text-center">
-            <h1 className="text-3xl font-extrabold text-white">
-              Devnet Token Factory
-            </h1>
-            <p className="mt-2 text-sm text-[var(--text-secondary)]">
-              Create SPL tokens on devnet for testing with the launch wizard
-            </p>
+      <div className="min-h-[calc(100vh-48px)] relative">
+        <div className="absolute inset-x-0 top-0 h-48 bg-grid pointer-events-none" />
+        <div className="relative mx-auto max-w-4xl px-4 py-10">
+          <div className="mb-2 text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--accent)]/60">
+            // faucet
           </div>
+          <h1 className="text-xl font-medium tracking-[-0.01em] text-white sm:text-2xl" style={{ fontFamily: "var(--font-heading)" }}>
+            <span className="font-normal text-white/50">Devnet </span>Token Factory
+          </h1>
+          <p className="mt-2 mb-8 text-[13px] text-[var(--text-secondary)]">
+            Create SPL tokens on devnet for testing with the launch wizard.
+          </p>
 
-          {/* Step 1 - Connect Wallet (always visible) */}
-          <ScrollReveal delay={0}>
-            <div className={cardClass}>
-              <h2 className="mb-3 text-sm font-bold uppercase tracking-wider text-[var(--text-secondary)]">
-                Step 1 · Connect Wallet
-              </h2>
-              <p className="text-sm text-[var(--warning)]">
-                Connect your wallet using the button in the header
-              </p>
-            </div>
-          </ScrollReveal>
+          <div className="max-w-xl space-y-6">
+            {/* Step 1 - Connect Wallet (always visible) */}
+            <ScrollReveal delay={0}>
+              <div className={cardClass}>
+                <h2 className="mb-3 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-muted)]">
+                  Step 1 · Connect Wallet
+                </h2>
+                <p className="text-sm text-[var(--warning)]">
+                  Connect your wallet using the button in the header
+                </p>
+              </div>
+            </ScrollReveal>
 
-          {/* Shimmer skeleton placeholders for remaining steps */}
-          <ShimmerSkeleton className="h-[88px]" />
-          <ShimmerSkeleton className="h-[200px]" />
-          <ShimmerSkeleton className="h-[100px]" />
-          <ShimmerSkeleton className="h-[220px]" />
+            {/* Shimmer skeleton placeholders for remaining steps */}
+            <ShimmerSkeleton className="h-[88px]" />
+            <ShimmerSkeleton className="h-[200px]" />
+            <ShimmerSkeleton className="h-[100px]" />
+            <ShimmerSkeleton className="h-[220px]" />
+          </div>
         </div>
       </div>
     );
@@ -328,23 +332,23 @@ const DevnetMintContent: FC = () => {
   const stepCards = [
     // Step 1 - Wallet
     <div key="step1" className={cardClass}>
-      <h2 className="mb-3 text-sm font-bold uppercase tracking-wider text-[var(--text-secondary)]">
+      <h2 className="mb-3 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-muted)]">
         Step 1 · Connect Wallet
       </h2>
-      <p className="text-sm text-[var(--long)]">
+      <p className="text-sm text-[var(--accent)]">
         Connected: <span className="font-mono text-xs">{publicKey?.toBase58()}</span>
       </p>
     </div>,
 
     // Step 2 - Airdrop
     <div key="step2" className={cardClass}>
-      <h2 className="mb-3 text-sm font-bold uppercase tracking-wider text-[var(--text-secondary)]">
+      <h2 className="mb-3 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-muted)]">
         Step 2 · Devnet SOL
       </h2>
       <div className="flex items-center justify-between">
         <span className="text-sm text-white">
           Balance:{" "}
-          <span className="font-mono text-[var(--long)]">
+          <span className="font-mono text-[var(--accent)]">
             {balance !== null ? `${balance.toFixed(4)} SOL` : "…"}
           </span>
         </span>
@@ -356,7 +360,7 @@ const DevnetMintContent: FC = () => {
 
     // Step 3 - Config
     <div key="step3" className={cardClass}>
-      <h2 className="mb-4 text-sm font-bold uppercase tracking-wider text-[var(--text-secondary)]">
+      <h2 className="mb-4 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-muted)]">
         Step 3 · Token Config
       </h2>
       <div className="space-y-3">
@@ -416,7 +420,7 @@ const DevnetMintContent: FC = () => {
 
     // Step 4 - Create
     <div key="step4" className={cardClass}>
-      <h2 className="mb-3 text-sm font-bold uppercase tracking-wider text-[var(--text-secondary)]">
+      <h2 className="mb-3 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-muted)]">
         Step 4 · Create &amp; Mint
       </h2>
       <button
@@ -430,7 +434,7 @@ const DevnetMintContent: FC = () => {
 
     // Mint More - existing token
     <div key="mintmore" className={cardClass}>
-      <h2 className="mb-3 text-sm font-bold uppercase tracking-wider text-[var(--text-secondary)]">
+      <h2 className="mb-3 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-muted)]">
         Mint More (Existing Token)
       </h2>
       <p className="mb-3 text-xs text-[var(--text-muted)]">Already deployed a market? Mint more of the same token to your wallet.</p>
@@ -466,16 +470,24 @@ const DevnetMintContent: FC = () => {
   ];
 
   return (
-    <div className="min-h-screen bg-[var(--panel-bg)] px-4 py-12">
-      <div className="mx-auto max-w-xl space-y-6">
-        <div className="text-center">
-          <h1 className="text-3xl font-extrabold text-white">
-            Devnet Token Factory
-          </h1>
-          <p className="mt-2 text-sm text-[var(--text-secondary)]">
-            Create SPL tokens on devnet for testing with the launch wizard
-          </p>
-        </div>
+    <div className="min-h-[calc(100vh-48px)] relative">
+      <div className="absolute inset-x-0 top-0 h-48 bg-grid pointer-events-none" />
+      <div className="relative mx-auto max-w-4xl px-4 py-10">
+        <ScrollReveal>
+          <div className="mb-8">
+            <div className="mb-2 text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--accent)]/60">
+              // faucet
+            </div>
+            <h1 className="text-xl font-medium tracking-[-0.01em] text-white sm:text-2xl" style={{ fontFamily: "var(--font-heading)" }}>
+              <span className="font-normal text-white/50">Devnet </span>Token Factory
+            </h1>
+            <p className="mt-2 text-[13px] text-[var(--text-secondary)]">
+              Create SPL tokens on devnet for testing with the launch wizard.
+            </p>
+          </div>
+        </ScrollReveal>
+
+      <div className="max-w-xl space-y-6">
 
         {/* Step cards with staggered scroll reveals */}
         {stepCards.map((card, i) => (
@@ -493,7 +505,7 @@ const DevnetMintContent: FC = () => {
         {mintAddress && (
           <div
             ref={successCardRef}
-            className={`${cardClass} border-[var(--long)]/30`}
+            className={`${cardClass} border-[var(--accent)]/30`}
             style={prefersReducedMotion ? undefined : { opacity: 0 }}
           >
             <div className="mb-3 flex items-center gap-2">
@@ -503,7 +515,7 @@ const DevnetMintContent: FC = () => {
                   style={{ backgroundColor: mintColor }}
                 />
               )}
-              <h2 className="text-sm font-bold uppercase tracking-wider text-[var(--long)]">
+              <h2 className="text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--accent)]">
                 {tokenName} ({tokenSymbol}) Created
               </h2>
             </div>
@@ -522,12 +534,13 @@ const DevnetMintContent: FC = () => {
               href={`https://explorer.solana.com/address/${mintAddress}?cluster=devnet`}
               target="_blank"
               rel="noopener noreferrer"
-              className="mt-3 inline-block text-sm text-[var(--long)] underline hover:text-[var(--long)]/80"
+              className="mt-3 inline-block text-sm text-[var(--accent)] underline hover:text-[var(--accent)]/80"
             >
               View on Solana Explorer
             </a>
           </div>
         )}
+      </div>
       </div>
     </div>
   );

--- a/app/app/guide/page.tsx
+++ b/app/app/guide/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { ScrollReveal } from "@/components/ui/ScrollReveal";
 
 const sectionHeader = "mb-2 text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--accent)]/60";
 const sectionTitle = "text-lg font-semibold tracking-[-0.01em] text-white sm:text-xl";
@@ -22,22 +23,26 @@ function Section({ tag, title, children }: { tag: string; title: string; childre
 
 export default function GuidePage() {
   return (
-    <main className="mx-auto max-w-[900px] px-6 py-12 space-y-16">
-      {/* Hero */}
-      <div className="text-center space-y-3">
-        <div className="text-[10px] font-medium uppercase tracking-[0.3em] text-[var(--accent)]/50">
-          // documentation
+    <div className="min-h-[calc(100vh-48px)] relative">
+      <div className="absolute inset-x-0 top-0 h-48 bg-grid pointer-events-none" />
+    <main className="relative mx-auto max-w-4xl px-4 py-10 space-y-16">
+      {/* Header */}
+      <ScrollReveal>
+        <div className="mb-8">
+          <div className="mb-2 text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--accent)]/60">
+            // documentation
+          </div>
+          <h1
+            className="text-xl font-medium tracking-[-0.01em] text-white sm:text-2xl"
+            style={{ fontFamily: "var(--font-heading)" }}
+          >
+            <span className="font-normal text-white/50">Percolator </span>Guide
+          </h1>
+          <p className="mt-2 text-[13px] text-[var(--text-secondary)]">
+            Everything you need to know about launching and trading perpetual futures markets on Solana.
+          </p>
         </div>
-        <h1
-          className="text-2xl font-bold tracking-[-0.02em] text-white sm:text-3xl"
-          style={{ fontFamily: "var(--font-heading)" }}
-        >
-          Percolator Guide
-        </h1>
-        <p className="mx-auto max-w-lg text-[13px] leading-relaxed text-[var(--text-secondary)]">
-          Everything you need to know about launching and trading perpetual futures markets on Solana.
-        </p>
-      </div>
+      </ScrollReveal>
 
       {/* What is Percolator */}
       <Section tag="overview" title="What is Percolator?">
@@ -276,5 +281,6 @@ export default function GuidePage() {
         </div>
       </div>
     </main>
+    </div>
   );
 }

--- a/app/app/my-markets/page.tsx
+++ b/app/app/my-markets/page.tsx
@@ -11,6 +11,7 @@ import { useToast } from "@/hooks/useToast";
 import { GlassCard } from "@/components/ui/GlassCard";
 import { GlowButton } from "@/components/ui/GlowButton";
 import { ShimmerSkeleton } from "@/components/ui/ShimmerSkeleton";
+import { ScrollReveal } from "@/components/ui/ScrollReveal";
 import { getConfig, explorerAccountUrl } from "@/lib/config";
 import { deriveInsuranceLpMint } from "@percolator/core";
 
@@ -327,13 +328,18 @@ const MarketCard: FC<{
 
 /* loading skeleton */
 const LoadingSkeleton: FC = () => (
-  <main className="mx-auto max-w-5xl px-4 py-12">
-    <ShimmerSkeleton className="mb-8 h-9 w-48" />
-    <div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
-      {[1, 2, 3].map((i) => <ShimmerSkeleton key={i} className="h-20" />)}
-    </div>
-    {[1, 2].map((i) => <ShimmerSkeleton key={i} className="mb-4 h-64" />)}
-  </main>
+  <div className="min-h-[calc(100vh-48px)] relative">
+    <div className="absolute inset-x-0 top-0 h-48 bg-grid pointer-events-none" />
+    <main className="relative mx-auto max-w-4xl px-4 py-10">
+      <ShimmerSkeleton className="mb-2 h-3 w-16" />
+      <ShimmerSkeleton className="mb-2 h-7 w-48" />
+      <ShimmerSkeleton className="mb-8 h-4 w-64" />
+      <div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {[1, 2, 3].map((i) => <ShimmerSkeleton key={i} className="h-20" />)}
+      </div>
+      {[1, 2].map((i) => <ShimmerSkeleton key={i} className="mb-4 h-64" />)}
+    </main>
+  </div>
 );
 
 /* main page */
@@ -374,12 +380,21 @@ const MyMarketsPage: FC = () => {
 
   if (!connected) {
     return (
-      <main className="mx-auto max-w-5xl px-4 py-24 text-center">
-        <div className="mx-auto max-w-md rounded-[4px] border border-[#1a1a1f] bg-[#111113] p-8">
-          <h1 className="text-xl font-bold text-white">your markets</h1>
-          <p className="mt-2 text-sm text-[#71717a]">connect your wallet to see what you&apos;ve built.</p>
-        </div>
-      </main>
+      <div className="min-h-[calc(100vh-48px)] relative">
+        <div className="absolute inset-x-0 top-0 h-48 bg-grid pointer-events-none" />
+        <main className="relative mx-auto max-w-4xl px-4 py-10">
+          <div className="mb-2 text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--accent)]/60">
+            // admin
+          </div>
+          <h1 className="text-xl font-medium tracking-[-0.01em] text-white sm:text-2xl" style={{ fontFamily: "var(--font-heading)" }}>
+            <span className="font-normal text-white/50">Your </span>Markets
+          </h1>
+          <p className="mt-2 mb-8 text-[13px] text-[var(--text-secondary)]">manage what you&apos;ve built.</p>
+          <div className="border border-[var(--border)] bg-[var(--panel-bg)] p-10 text-center">
+            <p className="text-[13px] text-[var(--text-secondary)]">connect your wallet to see your markets</p>
+          </div>
+        </main>
+      </div>
     );
   }
 
@@ -387,35 +402,53 @@ const MyMarketsPage: FC = () => {
 
   if (error) {
     return (
-      <main className="mx-auto max-w-5xl px-4 py-24 text-center">
-        <div className="mx-auto max-w-md rounded-[4px] border border-[#1a1a1f] bg-[#111113] p-8">
-          <h1 className="text-xl font-bold text-white">something broke.</h1>
-          <p className="mt-2 text-sm text-[#FF4466]">{error}</p>
-        </div>
-      </main>
+      <div className="min-h-[calc(100vh-48px)] relative">
+        <div className="absolute inset-x-0 top-0 h-48 bg-grid pointer-events-none" />
+        <main className="relative mx-auto max-w-4xl px-4 py-10">
+          <div className="mb-2 text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--accent)]/60">
+            // admin
+          </div>
+          <h1 className="text-xl font-medium tracking-[-0.01em] text-white sm:text-2xl" style={{ fontFamily: "var(--font-heading)" }}>
+            <span className="font-normal text-white/50">Your </span>Markets
+          </h1>
+          <p className="mt-2 mb-8 text-[13px] text-[var(--text-secondary)]">manage what you&apos;ve built.</p>
+          <div className="border border-[var(--border)] bg-[var(--panel-bg)] p-10 text-center">
+            <p className="text-[13px] text-[var(--short)]">{error}</p>
+          </div>
+        </main>
+      </div>
     );
   }
 
   if (myMarkets.length === 0) {
     return (
-      <main className="mx-auto max-w-5xl px-4 py-24 text-center">
-        <div className="mx-auto max-w-md rounded-[4px] border border-[#1a1a1f] bg-[#111113] p-8">
-          <h1 className="text-xl font-bold text-white">nothing here yet.</h1>
-          <p className="mt-2 mb-6 text-sm text-[#71717a]">
-            no markets created or traded on with this wallet.
-            <br />
-            create a market or open a position to see it here.
-          </p>
-          <div className="flex justify-center gap-3">
-            <Link href="/create">
-              <GlowButton>launch a market</GlowButton>
-            </Link>
-            <Link href="/markets">
-              <GlowButton variant="ghost">browse markets</GlowButton>
-            </Link>
+      <div className="min-h-[calc(100vh-48px)] relative">
+        <div className="absolute inset-x-0 top-0 h-48 bg-grid pointer-events-none" />
+        <main className="relative mx-auto max-w-4xl px-4 py-10">
+          <div className="mb-2 text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--accent)]/60">
+            // admin
           </div>
-        </div>
-      </main>
+          <h1 className="text-xl font-medium tracking-[-0.01em] text-white sm:text-2xl" style={{ fontFamily: "var(--font-heading)" }}>
+            <span className="font-normal text-white/50">Your </span>Markets
+          </h1>
+          <p className="mt-2 mb-8 text-[13px] text-[var(--text-secondary)]">manage what you&apos;ve built.</p>
+          <div className="border border-[var(--border)] bg-[var(--panel-bg)] p-10 text-center">
+            <p className="mb-4 text-[13px] text-[var(--text-secondary)]">
+              no markets created or traded on with this wallet.
+              <br />
+              create a market or open a position to see it here.
+            </p>
+            <div className="flex justify-center gap-3">
+              <Link href="/create">
+                <GlowButton>launch a market</GlowButton>
+              </Link>
+              <Link href="/markets">
+                <GlowButton variant="ghost">browse markets</GlowButton>
+              </Link>
+            </div>
+          </div>
+        </main>
+      </div>
     );
   }
 
@@ -424,16 +457,25 @@ const MyMarketsPage: FC = () => {
   const totalInsurance = myMarkets.reduce((acc, m) => acc + m.engine.insuranceFund.balance, 0n);
 
   return (
-    <main ref={pageRef} className="mx-auto max-w-5xl px-4 py-10 gsap-fade">
-      <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <h1 className="text-3xl font-bold text-white" style={{ fontFamily: "var(--font-space-grotesk)" }}>your markets</h1>
-          <p className="mt-1 text-sm text-[#71717a]">manage what you&apos;ve built.</p>
+    <div className="min-h-[calc(100vh-48px)] relative">
+      <div className="absolute inset-x-0 top-0 h-48 bg-grid pointer-events-none" />
+    <main ref={pageRef} className="relative mx-auto max-w-4xl px-4 py-10 gsap-fade">
+      <ScrollReveal>
+        <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <div className="mb-2 text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--accent)]/60">
+              // admin
+            </div>
+            <h1 className="text-xl font-medium tracking-[-0.01em] text-white sm:text-2xl" style={{ fontFamily: "var(--font-heading)" }}>
+              <span className="font-normal text-white/50">Your </span>Markets
+            </h1>
+            <p className="mt-2 text-[13px] text-[var(--text-secondary)]">manage what you&apos;ve built.</p>
+          </div>
+          <Link href="/create">
+            <GlowButton size="sm">+ new market</GlowButton>
+          </Link>
         </div>
-        <Link href="/create">
-          <GlowButton size="sm">+ new market</GlowButton>
-        </Link>
-      </div>
+      </ScrollReveal>
 
       <div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
         {[
@@ -458,6 +500,7 @@ const MyMarketsPage: FC = () => {
         ))}
       </div>
     </main>
+    </div>
   );
 };
 

--- a/app/app/trade/[slab]/page.tsx
+++ b/app/app/trade/[slab]/page.tsx
@@ -60,25 +60,27 @@ function TradePageInner({ slab }: { slab: string }) {
   return (
     <div ref={pageRef} className="mx-auto max-w-7xl px-4 py-6 gsap-fade">
       {/* Header */}
-      <div className="mb-6 flex flex-wrap items-center gap-3">
-        <div className="min-w-0">
-          <h1 className="text-xl font-bold text-white" style={{ fontFamily: "var(--font-space-grotesk)" }}>trade</h1>
-          <p className="truncate text-[11px] text-[#3f3f46]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>{slab}</p>
+      <div className="mb-6 space-y-3">
+        <div className="flex items-end justify-between gap-3">
+          <div className="min-w-0">
+            <h1 className="text-xl font-bold text-white" style={{ fontFamily: "var(--font-space-grotesk)" }}>trade</h1>
+            <p className="truncate text-[11px] text-[#3f3f46] max-w-[180px] sm:max-w-none" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>{slab}</p>
+          </div>
+          {priceUsd != null && (
+            <div className="shrink-0 text-right">
+              <div className="text-2xl font-bold text-white sm:text-3xl" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
+                ${priceUsd < 0.01 ? priceUsd.toFixed(6) : priceUsd < 1 ? priceUsd.toFixed(4) : priceUsd.toFixed(2)}
+              </div>
+            </div>
+          )}
         </div>
-        <div className="ml-auto flex items-center gap-4">
+        <div className="flex items-center gap-3">
           {health && <HealthBadge level={health.level} />}
           <ShareButton
             slabAddress={slab}
             marketName={tokenMeta?.symbol ?? (config?.collateralMint ? `${config.collateralMint.toBase58().slice(0, 4)}…${config.collateralMint.toBase58().slice(-4)}` : "TOKEN")}
             price={BigInt(Math.round((priceUsd ?? 0) * 1e6))}
           />
-          {priceUsd != null && (
-            <div className="text-right">
-              <div className="text-3xl font-bold text-white" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
-                ${priceUsd < 0.01 ? priceUsd.toFixed(6) : priceUsd < 1 ? priceUsd.toFixed(4) : priceUsd.toFixed(2)}
-              </div>
-            </div>
-          )}
         </div>
       </div>
 
@@ -90,13 +92,13 @@ function TradePageInner({ slab }: { slab: string }) {
       )}
 
       {/* Quick start guide */}
-      <div className="mb-4 rounded-[4px] border border-[#1a1a1f] bg-[#111113] px-4 py-2.5 flex items-center gap-6 text-xs text-[#71717a]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
+      <div className="mb-4 rounded-[4px] border border-[#1a1a1f] bg-[#111113] px-4 py-2.5 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-[#71717a]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
         <span className="text-[#3f3f46]">quick start:</span>
-        <span><span className="text-[#00FFB2]">1</span> connect wallet</span>
-        <span className="text-[#1a1a1f]">→</span>
-        <span><span className="text-[#00FFB2]">2</span> deposit collateral</span>
-        <span className="text-[#1a1a1f]">→</span>
-        <span><span className="text-[#00FFB2]">3</span> trade</span>
+        <span className="whitespace-nowrap"><span className="text-[#00FFB2]">1</span> connect wallet</span>
+        <span className="hidden sm:inline text-[#1a1a1f]">&rarr;</span>
+        <span className="whitespace-nowrap"><span className="text-[#00FFB2]">2</span> deposit collateral</span>
+        <span className="hidden sm:inline text-[#1a1a1f]">&rarr;</span>
+        <span className="whitespace-nowrap"><span className="text-[#00FFB2]">3</span> trade</span>
       </div>
 
       {/* Main grid */}


### PR DESCRIPTION
## Summary
- **Guide, Agents, My-Markets, Devnet-Mint pages**: Standardized headers to match the design system used by Markets, Create, and Portfolio — grid background, `ScrollReveal`, `// breadcrumb` tag, split `h1` (dimmed prefix + bold keyword), `13px` description
- **Devnet-Mint (faucet)**: Buttons switched from green (`--long`) to accent purple (`--accent`) to match `GlowButton` styling; step headings restyled to use muted label pattern
- **Trade page (mobile)**: Fixed header overlap — split into two rows (title+price / badges), truncated slab address on small screens, scaled price text, made quick-start bar wrap with hidden arrows on mobile

## Files changed
- `app/app/agents/page.tsx`
- `app/app/devnet-mint/devnet-mint-content.tsx`
- `app/app/guide/page.tsx`
- `app/app/my-markets/page.tsx`
- `app/app/trade/[slab]/page.tsx`

## Test plan
- [ ] Visit `/guide`, `/agents`, `/my-markets`, `/devnet-mint` — verify consistent header pattern (breadcrumb, split title, description, grid bg)
- [ ] Visit `/devnet-mint` — verify buttons are accent purple, not green
- [ ] Visit `/trade/[any-slab]` on mobile viewport — verify no text overlap, price and badges on separate rows, quick-start wraps cleanly
- [ ] Visit `/my-markets` without wallet connected — verify styled empty state
- [ ] Check all pages compile with no errors (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced page layouts with scroll reveal animations on key sections for improved visual presentation.
  * Improved responsive design across multiple pages with better mobile rendering and layout adjustments.
  * Updated typography, spacing, and visual hierarchy for clearer content presentation.
  * Added decorative design elements to refine the overall user interface aesthetic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->