### PR TITLE
chore: remove vercel links from repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Built on [Percolator](https://github.com/aeyakovenko/percolator) by Anatoly Yakovenko. Permissionless, coin-margined, fully on-chain.
 
-[![Live on Devnet](https://img.shields.io/badge/Devnet-Live-14F195?style=flat&logo=solana)](https://percolator-launch.vercel.app)
+[![Live on Devnet](https://img.shields.io/badge/Devnet-Live-14F195?style=flat&logo=solana)](https://percolator.app)
 [![57 PRs Merged](https://img.shields.io/badge/PRs-57%20merged-blue?style=flat)]()
 [![TypeScript](https://img.shields.io/badge/TypeScript-Strict-3178C6?style=flat&logo=typescript)](/)
 [![Tests](https://img.shields.io/badge/Tests-32%2F32%20passing-14F195?style=flat)]()
@@ -316,7 +316,7 @@ We welcome contributions from humans and AI agents.
 4. CI runs TypeScript + ESLint checks automatically
 
 ### For AI Agents
-See [CONTRIBUTING-AGENTS.md](./CONTRIBUTING-AGENTS.md) and the [Agent Guide](https://percolator-launch.vercel.app/agents) for architecture context, prompts, and PR guidelines.
+See [CONTRIBUTING-AGENTS.md](./CONTRIBUTING-AGENTS.md) and the [Agent Guide](https://percolator.app/agents) for architecture context, prompts, and PR guidelines.
 
 ### Branch Protection
 - Direct pushes to `main` are blocked

--- a/app/components/market/ShareCard.tsx
+++ b/app/components/market/ShareCard.tsx
@@ -17,7 +17,7 @@ export const ShareCard: FC<ShareCardProps> = ({ slabAddress, marketName, price, 
   const priceNum = Number(price) / 1e6;
   const fmtPrice = priceNum < 0.01 ? priceNum.toFixed(6) : priceNum < 1 ? priceNum.toFixed(4) : priceNum.toFixed(2);
   const changeStr = change24h != null ? `${change24h >= 0 ? "+" : ""}${change24h.toFixed(2)}%` : "";
-  const tradeUrl = `https://percolator-launch.vercel.app/trade/${slabAddress}`;
+  const tradeUrl = `https://percolator.app/trade/${slabAddress}`;
 
   const copyLink = async () => {
     await navigator.clipboard.writeText(tradeUrl);

--- a/app/scripts/deploy-all-tiers.ts
+++ b/app/scripts/deploy-all-tiers.ts
@@ -320,7 +320,7 @@ async function deployMarket(tier: typeof TIERS[0], mintPk: PublicKey, payerAta: 
     vault: vaultAta.toBase58(),
     matcherCtx: matcherCtxKp.publicKey.toBase58(),
     lpPda: lpPda.toBase58(),
-    url: `https://percolator-launch.vercel.app/trade/${slabKp.publicKey.toBase58()}`,
+    url: `https://percolator.app/trade/${slabKp.publicKey.toBase58()}`,
   };
 }
 

--- a/app/scripts/e2e-devnet-test.ts
+++ b/app/scripts/e2e-devnet-test.ts
@@ -332,7 +332,7 @@ async function main() {
   console.log(`   Vault: ${vaultAta.toBase58()}`);
   console.log(`   Matcher ctx: ${matcherCtxKp.publicKey.toBase58()}`);
   console.log(`   LP PDA: ${lpPda.toBase58()}`);
-  console.log(`\n   Trade URL: https://percolator-launch.vercel.app/trade/${slabKp.publicKey.toBase58()}`);
+  console.log(`\n   Trade URL: https://percolator.app/trade/${slabKp.publicKey.toBase58()}`);
 }
 
 main().catch((e) => {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -29,7 +29,7 @@ const tradeIndexer = new TradeIndexer();
 // Hono app
 const app = new Hono();
 // C1: CORS lockdown — only allow configured origins
-const allowedOrigins = (process.env.ALLOWED_ORIGINS ?? "https://percolator-launch.vercel.app,http://localhost:3000").split(",").map(s => s.trim()).filter(Boolean);
+const allowedOrigins = (process.env.ALLOWED_ORIGINS ?? "https://percolator.app,http://localhost:3000").split(",").map(s => s.trim()).filter(Boolean);
 app.use("*", cors({
   origin: allowedOrigins,
   allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],

--- a/scripts/e2e-devnet-test.ts
+++ b/scripts/e2e-devnet-test.ts
@@ -322,7 +322,7 @@ async function main() {
   console.log(`   Vault: ${vaultAta.toBase58()}`);
   console.log(`   Matcher ctx: ${matcherCtxKp.publicKey.toBase58()}`);
   console.log(`   LP PDA: ${lpPda.toBase58()}`);
-  console.log(`\n   Trade URL: https://percolator-launch.vercel.app/trade/${slabKp.publicKey.toBase58()}`);
+  console.log(`\n   Trade URL: https://percolator.app/trade/${slabKp.publicKey.toBase58()}`);
 }
 
 main().catch((e) => {

--- a/target
+++ b/target
@@ -1,1 +1,0 @@
-program/target

--- a/tests/devnet-e2e.ts
+++ b/tests/devnet-e2e.ts
@@ -249,7 +249,7 @@ async function main() {
 
   console.log("\n=== ALL TESTS PASSED ===");
   console.log(`Market: ${slabKeypair.publicKey.toBase58()}`);
-  console.log(`Trade page: https://percolator-launch.vercel.app/trade/${slabKeypair.publicKey.toBase58()}`);
+  console.log(`Trade page: https://percolator.app/trade/${slabKeypair.publicKey.toBase58()}`);
 }
 
 main().catch(err => {


### PR DESCRIPTION
Replaces all percolator-launch.vercel.app references with percolator.app across README, ShareCard, test/deploy scripts, and CORS config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated domain from percolator-launch.vercel.app to percolator.app across application URLs and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->