### PR TITLE
fix(ci): pnpm 9 + run tsc from app/ dir

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
 
       - uses: actions/setup-node@v4
         with:
@@ -30,7 +30,7 @@ jobs:
         run: cd app && pnpm install --frozen-lockfile
 
       - name: TypeScript check
-        run: npx tsc --noEmit -p app/tsconfig.json
+        run: cd app && npx tsc --noEmit
 
   lint:
     name: ESLint
@@ -40,7 +40,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Problem
All 3 open PRs (#68, #69, #70) have failing CI due to two issues:

1. **pnpm version mismatch** — lockfile is v9.0 but CI used pnpm 8
2. **Wrong tsc package** — `npx tsc` from root dir installs `tsc@2.0.4` (a shell utility), not TypeScript compiler. TypeScript is installed in `app/node_modules`, so must run from `app/` dir.

## Fix
- Bump pnpm to 9 in both jobs
- Change `npx tsc --noEmit -p app/tsconfig.json` → `cd app && npx tsc --noEmit`

## Impact
Unblocks CI for all pending PRs.