### PR TITLE
fix(ci): build @percolator/core before typecheck

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install app deps
         run: cd app && pnpm install --frozen-lockfile
 
+      - name: Build core package
+        run: cd packages/core && pnpm run build
+
       - name: TypeScript check
         run: cd app && npx tsc --noEmit
 


### PR DESCRIPTION
## Problem
Every PR CI fails on TypeScript check because `@percolator/core` module can't be resolved. The `tsc --noEmit` step runs in `app/` but the core package's `dist/` directory (where types are exported from) doesn't exist in CI — it's only present locally after a build.

## Fix
Added a `Build core package` step (`cd packages/core && pnpm run build`) before the TypeScript check. This ensures `dist/index.d.ts` exists when `tsc` resolves `@percolator/core`.

## Impact
- Unblocks PR #69 (Deep Audit) and all future PRs
- No runtime changes — CI-only fix
- ESLint job unaffected (already passes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration by adding a core package build verification step to the PR validation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->