### PR TITLE
Fix: toLocaleString round-trip bug + cached oracle price validation

### DIFF
--- a/app/lib/parseAmount.ts
+++ b/app/lib/parseAmount.ts
@@ -31,12 +31,12 @@ export function formatHumanAmount(raw: bigint, decimals: number): string {
   const remainder = abs % divisor;
 
   if (remainder === 0n) {
-    const w = whole.toLocaleString();
+    const w = whole.toString();
     return negative ? `-${w}` : w;
   }
 
   // Pad fraction to `decimals` digits, then strip trailing zeros
   const fracStr = remainder.toString().padStart(decimals, "0").replace(/0+$/, "");
-  const w = whole.toLocaleString();
+  const w = whole.toString();
   return `${negative ? "-" : ""}${w}.${fracStr}`;
 }

--- a/packages/server/src/services/oracle.ts
+++ b/packages/server/src/services/oracle.ts
@@ -43,7 +43,9 @@ export class OracleService {
       if (cached && Date.now() - cached.fetchedAt < DEX_SCREENER_CACHE_TTL_MS) {
         const pair = cached.data.pairs?.[0];
         if (!pair?.priceUsd) return null;
-        return BigInt(Math.round(parseFloat(pair.priceUsd) * 1_000_000));
+        const p = parseFloat(pair.priceUsd);
+        if (!isFinite(p) || p <= 0) return null;
+        return BigInt(Math.round(p * 1_000_000));
       }
 
       const res = await fetch(`https://api.dexscreener.com/latest/dex/tokens/${mint}`);


### PR DESCRIPTION
## CodeRabbit Follow-up Fixes

Two bugs caught by CodeRabbit on PR #69 that exist on main:

### 1. `formatHumanAmount` round-trip parsing bug (parseAmount.ts)
`whole.toLocaleString()` on BigInt inserts locale-dependent separators (e.g. `"1,000"`). If this output is fed back into `parseHumanAmount` or `BigInt()`, it throws. Changed to `toString()`.

### 2. Cached DexScreener price bypasses validation (oracle.ts)
The fresh-fetch path validates prices with `isFinite(p) && p > 0`, but the cached path didn't — a cached response with `"NaN"`, `"-1"`, or `"Infinity"` would propagate a bad price. Now validates cached prices too.

Both are low-risk, surgical fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized amount formatting by removing locale-specific thousands separators for consistent display across the application.
  * Strengthened price data validation to ensure cached prices are valid and positive, preventing computational errors from invalid data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->