### PR TITLE
fix: install libudev-dev for solana-verify CI

### DIFF
--- a/.github/workflows/verified-build.yml
+++ b/.github/workflows/verified-build.yml
@@ -41,6 +41,9 @@ jobs:
           sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.13/install)"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
 
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev pkg-config
+
       - name: Install solana-verify
         run: cargo install solana-verify
 


### PR DESCRIPTION
The Verified Build (solana-verify) workflow has been failing since PR #56 merged — `cargo install solana-verify` needs `libudev-dev` and `pkg-config` system packages.

**Fix:** Added `apt-get install libudev-dev pkg-config` step before the cargo install.

**CI run that failed:** https://github.com/dcccrypto/percolator-launch/actions/runs/21850673886

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI build process to ensure system dependencies are properly configured during the build step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->