### PR TITLE
fix(ci): downgrade Cargo.lock v4→v3 for solana-verify Docker

### DIFF
--- a/.github/workflows/verified-build.yml
+++ b/.github/workflows/verified-build.yml
@@ -47,6 +47,15 @@ jobs:
       - name: Install solana-verify
         run: cargo install solana-verify
 
+      - name: Downgrade Cargo.lock to v3 for solana-verify Docker compatibility
+        run: |
+          # solana-verify's Docker image ships an older Cargo that can't parse lockfile v4.
+          # v3 format is identical to v4 except for the version header — safe to downgrade.
+          if head -3 program/Cargo.lock | grep -q 'version = 4'; then
+            sed -i 's/^version = 4$/version = 3/' program/Cargo.lock
+            echo "Downgraded program/Cargo.lock from v4 to v3"
+          fi
+
       - name: Verified Build (full variant)
         run: |
           solana-verify build --library-name percolator_prog -- \


### PR DESCRIPTION
## Problem
The `Verified Build (solana-verify)` CI workflow has been failing on every push since the Cargo.lock was upgraded to format v4 (Rust 1.85+). The solana-verify Docker image ships an older Cargo that doesn't understand v4.

**Error:** `lock file version 4 was found, but this version of Cargo does not understand this lock file`

## Fix
Add a pre-build step that sed-replaces `version = 4` → `version = 3` in the lockfile. The formats are identical except for the header — this is a safe, no-op downgrade.

## Notes
- Only affects CI, no changes to the committed Cargo.lock
- The `Build Solana Program` workflow (non-verified) already passes fine
- Once solana-verify updates their Docker image to Rust 1.85+, this step becomes a no-op