### PR TITLE
fix: sequential discovery with rate limit protection

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -17,4 +17,6 @@ export const config = {
   port: Number(process.env.PORT ?? 3001),
   crankIntervalMs: Number(process.env.CRANK_INTERVAL_MS ?? 10_000),
   crankInactiveIntervalMs: Number(process.env.CRANK_INACTIVE_INTERVAL_MS ?? 60_000),
+  /** How often to rediscover markets (default 5min to avoid rate limits) */
+  discoveryIntervalMs: Number(process.env.DISCOVERY_INTERVAL_MS ?? 300_000),
 } as const;


### PR DESCRIPTION
Fixes market discovery returning 0 markets due to RPC 429 rate limiting.

**Changes:**
- Discovery calls are now sequential (not parallel) with 2s delay between programs
- Discovery only runs every 5min instead of every 10s crank cycle
- If 0 markets, retries immediately on next cycle
- Prevents 429 from both Helius and public devnet RPC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Market discovery interval is now configurable (default 5 minutes) via environment variable.

* **Bug Fixes**
  * Discovery process changed from parallel to sequential execution to prevent rate limit errors.
  * Rediscovery now occurs periodically based on configured intervals rather than continuously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->