### PR TITLE
fix: trim env var to prevent _bn crash on all browsers

### DIFF
--- a/app/hooks/useMarketDiscovery.ts
+++ b/app/hooks/useMarketDiscovery.ts
@@ -9,12 +9,13 @@ import { getConfig } from "@/lib/config";
 /** Get all unique program IDs to scan (default + all slab tier programs) */
 function getAllProgramIds(): PublicKey[] {
   const cfg = getConfig();
-  const ids = new Set<string>([cfg.programId]);
+  const ids = new Set<string>();
+  if (cfg.programId) ids.add(cfg.programId);
   const byTier = (cfg as any).programsBySlabTier as Record<string, string> | undefined;
   if (byTier) {
-    Object.values(byTier).forEach((id) => ids.add(id));
+    Object.values(byTier).forEach((id) => { if (id) ids.add(id); });
   }
-  return [...ids].map((id) => new PublicKey(id));
+  return [...ids].filter(Boolean).map((id) => new PublicKey(id));
 }
 
 /**

--- a/app/hooks/usePortfolio.ts
+++ b/app/hooks/usePortfolio.ts
@@ -51,9 +51,10 @@ export function usePortfolio(): PortfolioData {
 
     let cancelled = false;
     const cfg = getConfig();
-    const programIds = new Set<string>([cfg.programId]);
+    const programIds = new Set<string>();
+    if (cfg.programId) programIds.add(cfg.programId);
     const byTier = (cfg as any).programsBySlabTier as Record<string, string> | undefined;
-    if (byTier) Object.values(byTier).forEach((id) => programIds.add(id));
+    if (byTier) Object.values(byTier).forEach((id) => { if (id) programIds.add(id); });
     const pkStr = publicKey.toBase58();
 
     async function load() {

--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -11,7 +11,10 @@ function getNetwork(): Network {
     const override = localStorage.getItem("percolator-network") as Network | null;
     if (override === "mainnet" || override === "devnet") return override;
   }
-  return (process.env.NEXT_PUBLIC_DEFAULT_NETWORK as Network) ?? "devnet";
+  // Trim env var to handle trailing whitespace/newlines (Vercel env var copy-paste issue)
+  const envNet = process.env.NEXT_PUBLIC_DEFAULT_NETWORK?.trim();
+  if (envNet === "mainnet" || envNet === "devnet") return envNet;
+  return "devnet";
 }
 
 const CONFIGS = {


### PR DESCRIPTION
## Root Cause

The `NEXT_PUBLIC_DEFAULT_NETWORK` env var on Vercel has a trailing newline character (likely from copy-paste). Turbopack inlines this at build time, producing:

```js
return"devnet\n"  // instead of return"devnet"
```

This means `CONFIGS["devnet\n"]` → `undefined`, so the config object has no `programId`, and `new PublicKey(undefined)` crashes with:

> TypeError: Cannot read properties of undefined (reading '_bn')

Verified by downloading the deployed JS bundle and inspecting raw bytes:
```
0x5c 0x6e  →  \n inside the string literal
```

## Fix

1. **`getNetwork()`** — `.trim()` the env var and validate against known values before using
2. **`getAllProgramIds()`** — filter out falsy values as second line of defense
3. **`usePortfolio`** — same defensive guard

## Also Recommended
Remove or re-set `NEXT_PUBLIC_DEFAULT_NETWORK` on Vercel dashboard (trim the trailing newline). But the code fix makes it resilient regardless.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation and filtering of program identifiers across discovery and portfolio systems to prevent errors from missing or undefined values.
  * Improved network configuration handling with explicit validation, whitespace trimming, and robust fallback behavior for environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->