### PR TITLE
fix: faucet UX overhaul — airdrop fallback + inline progress

### DIFF
--- a/app/app/create/page.tsx
+++ b/app/app/create/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useWallet } from "@solana/wallet-adapter-react";
+import { useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import { CreateMarketWizard } from "@/components/create/CreateMarketWizard";
 import { ScrollReveal } from "@/components/ui/ScrollReveal";
@@ -12,6 +13,8 @@ const WalletMultiButton = dynamic(
 
 export default function CreatePage() {
   const { connected } = useWallet();
+  const searchParams = useSearchParams();
+  const initialMint = searchParams.get("mint") ?? undefined;
 
   return (
     <div className="min-h-[calc(100vh-48px)] relative">
@@ -61,7 +64,7 @@ export default function CreatePage() {
         {/* Main wizard container */}
         <ScrollReveal delay={0.1}>
           <div className="border border-[var(--border)] bg-[var(--panel-bg)]">
-            <CreateMarketWizard />
+            <CreateMarketWizard initialMint={initialMint} />
           </div>
         </ScrollReveal>
       </div>

--- a/app/app/devnet-mint/devnet-mint-content.tsx
+++ b/app/app/devnet-mint/devnet-mint-content.tsx
@@ -24,12 +24,14 @@ import {
   PROGRAM_ID as TOKEN_METADATA_PROGRAM_ID,
 } from "@metaplex-foundation/mpl-token-metadata";
 import gsap from "gsap";
+import Link from "next/link";
 import { ScrollReveal } from "@/components/ui/ScrollReveal";
 import { ShimmerSkeleton } from "@/components/ui/ShimmerSkeleton";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
 
-const DEVNET_RPC = `https://devnet.helius-rpc.com/?api-key=${process.env.NEXT_PUBLIC_HELIUS_API_KEY ?? ""}`;
-const DEFAULT_RECIPIENT = "";
+const HELIUS_RPC = `https://devnet.helius-rpc.com/?api-key=${process.env.NEXT_PUBLIC_HELIUS_API_KEY ?? ""}`;
+// Public devnet RPC for airdrop (Helius may not forward airdrop requests)
+const PUBLIC_DEVNET_RPC = "https://api.devnet.solana.com";
 
 const DevnetMintContent: FC = () => {
   const { publicKey, signTransaction, connected } = useWallet();
@@ -39,22 +41,32 @@ const DevnetMintContent: FC = () => {
   const [balance, setBalance] = useState<number | null>(null);
   const [decimals, setDecimals] = useState(9);
   const [supply, setSupply] = useState("100000");
-  const [recipient, setRecipient] = useState(DEFAULT_RECIPIENT);
+  const [recipient, setRecipient] = useState("");
   const [mintAddress, setMintAddress] = useState<string | null>(null);
-  const [status, setStatus] = useState("");
   const [loading, setLoading] = useState(false);
   const [airdropping, setAirdropping] = useState(false);
+  const [airdropStatus, setAirdropStatus] = useState<string | null>(null);
+  const [airdropFailed, setAirdropFailed] = useState(false);
+  const [createStatus, setCreateStatus] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [tokenName, setTokenName] = useState("Test Token");
   const [tokenSymbol, setTokenSymbol] = useState("TEST");
   const [mintColor, setMintColor] = useState<string | null>(null);
   const [lastTxSig, setLastTxSig] = useState<string | null>(null);
 
-  const connection = useMemo(() => new Connection(DEVNET_RPC, "confirmed"), []);
+  // Mint More state
+  const [existingMint, setExistingMint] = useState("");
+  const [mintMoreAmount, setMintMoreAmount] = useState("100000");
+  const [mintingMore, setMintingMore] = useState(false);
+  const [mintMoreStatus, setMintMoreStatus] = useState<string | null>(null);
+  const [mintAuthError, setMintAuthError] = useState<string | null>(null);
 
-  // Set recipient to connected wallet if no custom address entered
+  const connection = useMemo(() => new Connection(HELIUS_RPC, "confirmed"), []);
+  const airdropConnection = useMemo(() => new Connection(PUBLIC_DEVNET_RPC, "confirmed"), []);
+
+  // Set recipient to connected wallet
   useEffect(() => {
-    if (publicKey && (!recipient || recipient === DEFAULT_RECIPIENT)) {
+    if (publicKey && !recipient) {
       setRecipient(publicKey.toBase58());
     }
   }, [publicKey]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -78,66 +90,67 @@ const DevnetMintContent: FC = () => {
   useEffect(() => {
     const el = successCardRef.current;
     if (!el || !mintAddress) return;
-
     if (prefersReducedMotion) {
       gsap.set(el, { opacity: 1, scale: 1 });
       return;
     }
-
-    gsap.fromTo(
-      el,
-      { opacity: 0, scale: 0.85 },
-      { opacity: 1, scale: 1, duration: 0.5, ease: "back.out(1.4)" }
-    );
+    gsap.fromTo(el, { opacity: 0, scale: 0.85 }, { opacity: 1, scale: 1, duration: 0.5, ease: "back.out(1.4)" });
   }, [mintAddress, prefersReducedMotion]);
 
-  // Airdrop 2 SOL
+  // Airdrop 2 SOL — uses public devnet RPC (more reliable for airdrops)
   const handleAirdrop = useCallback(async () => {
     if (!publicKey) return;
     setAirdropping(true);
-    setStatus("Requesting 2 SOL airdrop…");
+    setAirdropStatus("Requesting 2 SOL airdrop...");
+    setAirdropFailed(false);
     try {
-      const sig = await connection.requestAirdrop(publicKey, 2 * LAMPORTS_PER_SOL);
-      // Poll for confirmation using getSignatureStatuses (more reliable than confirmTransaction)
+      const sig = await airdropConnection.requestAirdrop(publicKey, 2 * LAMPORTS_PER_SOL);
       const startTime = Date.now();
       const TIMEOUT_MS = 60_000;
       while (Date.now() - startTime < TIMEOUT_MS) {
-        const { value } = await connection.getSignatureStatuses([sig]);
-        const status = value?.[0];
-        if (status?.confirmationStatus === "confirmed" || status?.confirmationStatus === "finalized") {
-          if (status.err) throw new Error(`Transaction failed: ${JSON.stringify(status.err)}`);
+        const { value } = await airdropConnection.getSignatureStatuses([sig]);
+        const s = value?.[0];
+        if (s?.confirmationStatus === "confirmed" || s?.confirmationStatus === "finalized") {
+          if (s.err) throw new Error(`Transaction failed: ${JSON.stringify(s.err)}`);
           break;
         }
         await new Promise(r => setTimeout(r, 2000));
       }
-      setStatus("Airdrop successful!");
+      setAirdropStatus("Airdrop successful!");
+      setAirdropFailed(false);
       await refreshBalance();
     } catch (e: unknown) {
-      setStatus(`Airdrop failed: ${e instanceof Error ? e.message : String(e)}`);
+      const msg = e instanceof Error ? e.message : String(e);
+      setAirdropStatus(`Airdrop failed: ${msg}`);
+      setAirdropFailed(true);
     } finally {
       setAirdropping(false);
     }
-  }, [publicKey, refreshBalance]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [publicKey, airdropConnection, refreshBalance]);
+
+  const webFaucetUrl = publicKey
+    ? `https://faucet.solana.com/?address=${publicKey.toBase58()}&cluster=devnet`
+    : "https://faucet.solana.com/";
 
   // Create mint + mint tokens
   const handleCreateAndMint = useCallback(async () => {
     if (!publicKey || !signTransaction) return;
     setLoading(true);
-    setStatus("Creating mint…");
+    setCreateStatus("Creating mint account...");
     setMintAddress(null);
 
     try {
-      // Check SOL balance before attempting — prevents silent freeze on empty wallets
       const walletBalance = await connection.getBalance(publicKey);
       if (walletBalance < 0.01 * LAMPORTS_PER_SOL) {
-        throw new Error("Not enough SOL. You need at least 0.01 SOL to create a mint. Use the airdrop button above.");
+        throw new Error("Not enough SOL. You need at least 0.01 SOL. Use the airdrop button above.");
       }
 
       const mintKeypair = Keypair.generate();
       const recipientPubkey = new PublicKey(recipient);
       const lamports = await getMinimumBalanceForRentExemptMint(connection);
 
-      // Build transaction: create account + init mint
+      setCreateStatus("Building transaction...");
+
       const tx = new Transaction();
       tx.add(
         SystemProgram.createAccount({
@@ -147,76 +160,59 @@ const DevnetMintContent: FC = () => {
           lamports,
           programId: TOKEN_PROGRAM_ID,
         }),
-        createInitializeMintInstruction(
-          mintKeypair.publicKey,
-          decimals,
-          publicKey,
-          publicKey
-        )
+        createInitializeMintInstruction(mintKeypair.publicKey, decimals, publicKey, publicKey)
       );
 
-      // ATA + mint to
       const ata = await getAssociatedTokenAddress(mintKeypair.publicKey, recipientPubkey);
-      tx.add(
-        createAssociatedTokenAccountInstruction(publicKey, ata, recipientPubkey, mintKeypair.publicKey)
-      );
+      tx.add(createAssociatedTokenAccountInstruction(publicKey, ata, recipientPubkey, mintKeypair.publicKey));
 
       const rawSupply = BigInt(supply) * BigInt(10 ** decimals);
-      tx.add(
-        createMintToInstruction(mintKeypair.publicKey, ata, publicKey, rawSupply)
-      );
+      tx.add(createMintToInstruction(mintKeypair.publicKey, ata, publicKey, rawSupply));
 
-      // Add Metaplex metadata
+      // Metaplex metadata
       const [metadataPDA] = PublicKey.findProgramAddressSync(
         [Buffer.from("metadata"), TOKEN_METADATA_PROGRAM_ID.toBuffer(), mintKeypair.publicKey.toBuffer()],
         TOKEN_METADATA_PROGRAM_ID
       );
-      const metadataIx = createCreateMetadataAccountV3Instruction(
-        { metadata: metadataPDA, mint: mintKeypair.publicKey, mintAuthority: publicKey, payer: publicKey, updateAuthority: publicKey },
-        { createMetadataAccountArgsV3: { data: { name: tokenName, symbol: tokenSymbol, uri: "", sellerFeeBasisPoints: 0, creators: null, collection: null, uses: null }, isMutable: true, collectionDetails: null } }
+      tx.add(
+        createCreateMetadataAccountV3Instruction(
+          { metadata: metadataPDA, mint: mintKeypair.publicKey, mintAuthority: publicKey, payer: publicKey, updateAuthority: publicKey },
+          { createMetadataAccountArgsV3: { data: { name: tokenName, symbol: tokenSymbol, uri: "", sellerFeeBasisPoints: 0, creators: null, collection: null, uses: null }, isMutable: true, collectionDetails: null } }
+        )
       );
-      tx.add(metadataIx);
 
-      // Get fresh blockhash
       const { blockhash } = await connection.getLatestBlockhash("confirmed");
       tx.feePayer = publicKey;
       tx.recentBlockhash = blockhash;
-
-      // Partially sign with mint keypair
       tx.partialSign(mintKeypair);
 
-      // Sign with wallet, then send raw tx directly via our Helius RPC (bypasses Phantom's RPC)
-      if (!signTransaction) throw new Error("Wallet does not support signTransaction");
+      setCreateStatus("Approve in your wallet...");
       const signed = await signTransaction(tx);
-      const sig = await connection.sendRawTransaction(signed.serialize(), {
-        skipPreflight: true,
-      });
-      setStatus(`Tx sent: ${sig.slice(0, 12)}… Confirming…`);
 
-      // Poll for confirmation using getSignatureStatuses (more reliable than confirmTransaction)
+      setCreateStatus("Sending transaction...");
+      const sig = await connection.sendRawTransaction(signed.serialize(), { skipPreflight: true });
+      setLastTxSig(sig);
+      setCreateStatus("Confirming on-chain...");
+
       const startTime = Date.now();
       const TIMEOUT_MS = 60_000;
       while (Date.now() - startTime < TIMEOUT_MS) {
         const { value } = await connection.getSignatureStatuses([sig]);
-        const status = value?.[0];
-        if (status?.confirmationStatus === "confirmed" || status?.confirmationStatus === "finalized") {
-          if (status.err) throw new Error(`Transaction failed: ${JSON.stringify(status.err)}`);
+        const s = value?.[0];
+        if (s?.confirmationStatus === "confirmed" || s?.confirmationStatus === "finalized") {
+          if (s.err) throw new Error(`Transaction failed: ${JSON.stringify(s.err)}`);
           break;
         }
         await new Promise(r => setTimeout(r, 2000));
       }
 
-      // Generate deterministic color from mint address
       const colorHash = mintKeypair.publicKey.toBuffer().slice(0, 3);
-      const color = `#${colorHash[0].toString(16).padStart(2,'0')}${colorHash[1].toString(16).padStart(2,'0')}${colorHash[2].toString(16).padStart(2,'0')}`;
-      setMintColor(color);
-
+      setMintColor(`#${colorHash[0].toString(16).padStart(2, "0")}${colorHash[1].toString(16).padStart(2, "0")}${colorHash[2].toString(16).padStart(2, "0")}`);
       setMintAddress(mintKeypair.publicKey.toBase58());
-      setLastTxSig(sig);
-      setStatus("Done! Token created and minted.");
+      setCreateStatus(null);
       await refreshBalance();
     } catch (e: unknown) {
-      setStatus(`Error: ${e instanceof Error ? e.message : String(e)}`);
+      setCreateStatus(`Error: ${e instanceof Error ? e.message : String(e)}`);
     } finally {
       setLoading(false);
     }
@@ -230,13 +226,7 @@ const DevnetMintContent: FC = () => {
     }
   };
 
-  // Mint more of an existing token
-  const [existingMint, setExistingMint] = useState("");
-  const [mintMoreAmount, setMintMoreAmount] = useState("100000");
-  const [mintingMore, setMintingMore] = useState(false);
-  const [mintAuthError, setMintAuthError] = useState<string | null>(null);
-
-  // Check mint authority when user pastes an address
+  // Check mint authority when user pastes an existing mint
   useEffect(() => {
     setMintAuthError(null);
     if (!existingMint || existingMint.length < 32 || !publicKey) return;
@@ -252,7 +242,7 @@ const DevnetMintContent: FC = () => {
         if (!authority) {
           if (!cancelled) setMintAuthError("This token has no mint authority (supply is fixed)");
         } else if (authority !== publicKey.toBase58()) {
-          if (!cancelled) setMintAuthError(`You're not the mint authority. Only ${authority.slice(0, 8)}... can mint more. Create your own token above instead.`);
+          if (!cancelled) setMintAuthError(`You're not the mint authority. Only ${authority.slice(0, 8)}... can mint more.`);
         }
       } catch {
         if (!cancelled) setMintAuthError("Invalid address");
@@ -261,14 +251,14 @@ const DevnetMintContent: FC = () => {
     return () => { cancelled = true; };
   }, [existingMint, publicKey, connection]);
 
+  // Mint more of existing token
   const handleMintMore = useCallback(async () => {
     if (!publicKey || !signTransaction || !existingMint || mintAuthError) return;
     setMintingMore(true);
-    setStatus("Minting more tokens…");
+    setMintMoreStatus("Minting tokens...");
     try {
       const mintPk = new PublicKey(existingMint);
       const recipientPk = new PublicKey(recipient);
-      // Fetch mint info to get decimals
       const mintInfo = await connection.getParsedAccountInfo(mintPk);
       if (!mintInfo.value) throw new Error("Mint not found");
       const parsedMint = (mintInfo.value.data as any)?.parsed;
@@ -277,8 +267,6 @@ const DevnetMintContent: FC = () => {
 
       const ata = await getAssociatedTokenAddress(mintPk, recipientPk);
       const tx = new Transaction();
-
-      // Create ATA if it doesn't exist
       const ataInfo = await connection.getAccountInfo(ata);
       if (!ataInfo) {
         tx.add(createAssociatedTokenAccountInstruction(publicKey, ata, recipientPk, mintPk));
@@ -290,69 +278,56 @@ const DevnetMintContent: FC = () => {
       const { blockhash } = await connection.getLatestBlockhash("confirmed");
       tx.feePayer = publicKey;
       tx.recentBlockhash = blockhash;
+
+      setMintMoreStatus("Approve in your wallet...");
       const signed = await signTransaction(tx);
-      const sig = await connection.sendRawTransaction(signed.serialize(), {
-        skipPreflight: true,
-      });
-      // Poll for confirmation using getSignatureStatuses (more reliable than confirmTransaction)
-      const startTimeMM = Date.now();
-      const TIMEOUT_MS_MM = 60_000;
-      while (Date.now() - startTimeMM < TIMEOUT_MS_MM) {
+      const sig = await connection.sendRawTransaction(signed.serialize(), { skipPreflight: true });
+      setLastTxSig(sig);
+      setMintMoreStatus("Confirming...");
+
+      const startTime = Date.now();
+      while (Date.now() - startTime < 60_000) {
         const { value } = await connection.getSignatureStatuses([sig]);
-        const status = value?.[0];
-        if (status?.confirmationStatus === "confirmed" || status?.confirmationStatus === "finalized") {
-          if (status.err) throw new Error(`Transaction failed: ${JSON.stringify(status.err)}`);
+        const s = value?.[0];
+        if (s?.confirmationStatus === "confirmed" || s?.confirmationStatus === "finalized") {
+          if (s.err) throw new Error(`Transaction failed: ${JSON.stringify(s.err)}`);
           break;
         }
         await new Promise(r => setTimeout(r, 2000));
       }
-      setLastTxSig(sig);
-      setStatus(`Minted ${Number(mintMoreAmount).toLocaleString()} more tokens!`);
+      setMintMoreStatus(`Minted ${Number(mintMoreAmount).toLocaleString()} tokens!`);
       await refreshBalance();
     } catch (e: unknown) {
-      setStatus(`Error: ${e instanceof Error ? e.message : String(e)}`);
+      setMintMoreStatus(`Error: ${e instanceof Error ? e.message : String(e)}`);
     } finally {
       setMintingMore(false);
     }
   }, [publicKey, signTransaction, existingMint, mintMoreAmount, recipient, refreshBalance]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const cardClass =
-    "bg-[var(--panel-bg)] border border-[var(--border)] p-6";
-  const btnPrimary =
-    "border border-[var(--accent)]/40 text-[var(--accent)] bg-transparent px-5 py-2.5 text-sm font-semibold transition-all duration-200 hover:border-[var(--accent)]/70 hover:bg-[var(--accent)]/[0.08] active:scale-[0.98] disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:scale-100";
-  const inputClass =
-    "w-full bg-[var(--panel-bg)] border border-[var(--border)] px-3 py-2 text-sm text-white placeholder-[var(--text-muted)] focus:border-[var(--accent)]/40 focus:outline-none transition-shadow duration-200";
+  const cardClass = "bg-[var(--panel-bg)] border border-[var(--border)] p-6";
+  const btnPrimary = "border border-[var(--accent)]/40 text-[var(--accent)] bg-transparent px-5 py-2.5 text-sm font-semibold transition-all duration-200 hover:border-[var(--accent)]/70 hover:bg-[var(--accent)]/[0.08] active:scale-[0.98] disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:scale-100";
+  const inputClass = "w-full bg-[var(--panel-bg)] border border-[var(--border)] px-3 py-2 text-sm text-white placeholder-[var(--text-muted)] focus:border-[var(--accent)]/40 focus:outline-none transition-shadow duration-200";
 
-  /* ---- Loading skeleton while wallet connects ---- */
+  const lowSol = balance !== null && balance < 0.01;
+
+  /* ---- Not connected ---- */
   if (!connected) {
     return (
       <div className="min-h-[calc(100vh-48px)] relative">
         <div className="absolute inset-x-0 top-0 h-48 bg-grid pointer-events-none" />
         <div className="relative mx-auto max-w-4xl px-4 py-10">
-          <div className="mb-2 text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--accent)]/60">
-            // faucet
-          </div>
+          <div className="mb-2 text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--accent)]/60">// faucet</div>
           <h1 className="text-xl font-medium tracking-[-0.01em] text-white sm:text-2xl" style={{ fontFamily: "var(--font-heading)" }}>
             <span className="font-normal text-white/50">Devnet </span>Token Factory
           </h1>
-          <p className="mt-2 mb-8 text-[13px] text-[var(--text-secondary)]">
-            Create SPL tokens on devnet for testing with the launch wizard.
-          </p>
-
+          <p className="mt-2 mb-8 text-[13px] text-[var(--text-secondary)]">Create SPL tokens on devnet for testing with the launch wizard.</p>
           <div className="max-w-xl space-y-6">
-            {/* Step 1 - Connect Wallet (always visible) */}
             <ScrollReveal delay={0}>
               <div className={cardClass}>
-                <h2 className="mb-3 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-muted)]">
-                  Step 1 · Connect Wallet
-                </h2>
-                <p className="text-sm text-[var(--warning)]">
-                  Connect your wallet using the button in the header
-                </p>
+                <h2 className="mb-3 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-muted)]">Step 1 · Connect Wallet</h2>
+                <p className="text-sm text-[var(--warning)]">Connect your wallet using the button in the header</p>
               </div>
             </ScrollReveal>
-
-            {/* Shimmer skeleton placeholders for remaining steps */}
             <ShimmerSkeleton className="h-[88px]" />
             <ShimmerSkeleton className="h-[200px]" />
             <ShimmerSkeleton className="h-[100px]" />
@@ -363,237 +338,213 @@ const DevnetMintContent: FC = () => {
     );
   }
 
-  /* ---- Step cards data for staggered ScrollReveal ---- */
-  const stepCards = [
-    // Step 1 - Wallet
-    <div key="step1" className={cardClass}>
-      <h2 className="mb-3 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-muted)]">
-        Step 1 · Connect Wallet
-      </h2>
-      <p className="text-sm text-[var(--accent)]">
-        Connected: <span className="font-mono text-xs">{publicKey?.toBase58()}</span>
-      </p>
-    </div>,
-
-    // Step 2 - Airdrop
-    <div key="step2" className={cardClass}>
-      <h2 className="mb-3 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-muted)]">
-        Step 2 · Devnet SOL
-      </h2>
-      <div className="flex items-center justify-between">
-        <span className="text-sm text-white">
-          Balance:{" "}
-          <span className="font-mono text-[var(--accent)]">
-            {balance !== null ? `${balance.toFixed(4)} SOL` : "…"}
-          </span>
-        </span>
-        <button className={btnPrimary} onClick={handleAirdrop} disabled={airdropping}>
-          {airdropping ? "Airdropping…" : "Airdrop 2 SOL"}
-        </button>
-      </div>
-    </div>,
-
-    // Step 3 - Config
-    <div key="step3" className={cardClass}>
-      <h2 className="mb-4 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-muted)]">
-        Step 3 · Token Config
-      </h2>
-      <div className="space-y-3">
-        <div className="flex gap-3">
-          <div className="flex-1">
-            <label className="mb-1 block text-xs text-[var(--text-secondary)]">Decimals</label>
-            <input
-              type="number"
-              min={0}
-              max={18}
-              value={decimals}
-              onChange={(e) => setDecimals(Number(e.target.value))}
-              className={inputClass}
-            />
-          </div>
-          <div className="flex-[2]">
-            <label className="mb-1 block text-xs text-[var(--text-secondary)]">Supply</label>
-            <input
-              type="text"
-              value={supply}
-              onChange={(e) => setSupply(e.target.value.replace(/[^0-9]/g, ""))}
-              className={inputClass}
-            />
-          </div>
-        </div>
-        <div className="flex gap-3">
-          <div className="flex-1">
-            <label className="mb-1 block text-xs text-[var(--text-secondary)]">Token Name</label>
-            <input
-              type="text"
-              value={tokenName}
-              onChange={(e) => setTokenName(e.target.value)}
-              className={inputClass}
-            />
-          </div>
-          <div className="flex-1">
-            <label className="mb-1 block text-xs text-[var(--text-secondary)]">Symbol</label>
-            <input
-              type="text"
-              value={tokenSymbol}
-              onChange={(e) => setTokenSymbol(e.target.value)}
-              className={inputClass}
-            />
-          </div>
-        </div>
-        <div>
-          <label className="mb-1 block text-xs text-[var(--text-secondary)]">Recipient Address</label>
-          <input
-            type="text"
-            value={recipient}
-            onChange={(e) => setRecipient(e.target.value)}
-            className={inputClass}
-          />
-        </div>
-      </div>
-    </div>,
-
-    // Step 4 - Create
-    <div key="step4" className={cardClass}>
-      <h2 className="mb-3 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-muted)]">
-        Step 4 · Create &amp; Mint
-      </h2>
-      <button
-        className={`${btnPrimary} w-full`}
-        onClick={handleCreateAndMint}
-        disabled={loading || !recipient}
-      >
-        {loading ? "Creating…" : `Create Mint + Mint ${Number(supply).toLocaleString()} Tokens`}
-      </button>
-    </div>,
-
-    // Mint More - existing token
-    <div key="mintmore" className={cardClass}>
-      <h2 className="mb-3 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-muted)]">
-        Mint More (Existing Token)
-      </h2>
-      <p className="mb-3 text-xs text-[var(--text-muted)]">Already deployed a market? Mint more of the same token to your wallet.</p>
-      <div className="space-y-3">
-        <div>
-          <label className="mb-1 block text-xs text-[var(--text-secondary)]">Existing Mint Address</label>
-          <input
-            type="text"
-            value={existingMint}
-            onChange={(e) => setExistingMint(e.target.value)}
-            placeholder="Paste token mint address..."
-            className={inputClass}
-          />
-        </div>
-        <div>
-          <label className="mb-1 block text-xs text-[var(--text-secondary)]">Amount to Mint</label>
-          <input
-            type="text"
-            value={mintMoreAmount}
-            onChange={(e) => setMintMoreAmount(e.target.value.replace(/[^0-9]/g, ""))}
-            className={inputClass}
-          />
-        </div>
-        {mintAuthError && (
-          <p className="text-[11px] text-[var(--short)]">{mintAuthError}</p>
-        )}
-        <button
-          className={`${btnPrimary} w-full`}
-          onClick={handleMintMore}
-          disabled={mintingMore || !existingMint || !mintMoreAmount || !!mintAuthError}
-        >
-          {mintingMore ? "Minting…" : `Mint ${Number(mintMoreAmount).toLocaleString()} More Tokens`}
-        </button>
-      </div>
-    </div>,
-  ];
-
   return (
     <div className="min-h-[calc(100vh-48px)] relative">
       <div className="absolute inset-x-0 top-0 h-48 bg-grid pointer-events-none" />
       <div className="relative mx-auto max-w-4xl px-4 py-10">
         <ScrollReveal>
           <div className="mb-8">
-            <div className="mb-2 text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--accent)]/60">
-              // faucet
-            </div>
+            <div className="mb-2 text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--accent)]/60">// faucet</div>
             <h1 className="text-xl font-medium tracking-[-0.01em] text-white sm:text-2xl" style={{ fontFamily: "var(--font-heading)" }}>
               <span className="font-normal text-white/50">Devnet </span>Token Factory
             </h1>
-            <p className="mt-2 text-[13px] text-[var(--text-secondary)]">
-              Create SPL tokens on devnet for testing with the launch wizard.
-            </p>
+            <p className="mt-2 text-[13px] text-[var(--text-secondary)]">Create SPL tokens on devnet for testing with the launch wizard.</p>
           </div>
         </ScrollReveal>
 
-      <div className="max-w-xl space-y-6">
+        <div className="max-w-xl space-y-6">
 
-        {/* Step cards with staggered scroll reveals */}
-        {stepCards.map((card, i) => (
-          <ScrollReveal key={i} delay={i * 0.1}>
-            {card}
+          {/* Step 1 — Wallet */}
+          <ScrollReveal delay={0}>
+            <div className={cardClass}>
+              <h2 className="mb-3 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-muted)]">Step 1 · Connect Wallet</h2>
+              <p className="text-sm text-[var(--accent)]">
+                Connected: <span className="font-mono text-xs">{publicKey?.toBase58()}</span>
+              </p>
+            </div>
           </ScrollReveal>
-        ))}
 
-        {/* Status */}
-        {status && (
-          <p className="text-center text-sm text-[var(--text-secondary)]">
-            {status}
-            {lastTxSig && !status.startsWith("Error") && (
-              <>
-                {" "}
-                <a
-                  href={`https://explorer.solana.com/tx/${lastTxSig}?cluster=devnet`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-[var(--accent)] hover:underline break-all"
-                >
-                  View tx →
-                </a>
-              </>
-            )}
-          </p>
-        )}
-
-        {/* Result - GSAP scale-in animation */}
-        {mintAddress && (
-          <div
-            ref={successCardRef}
-            className={`${cardClass} border-[var(--accent)]/30`}
-            style={prefersReducedMotion ? undefined : { opacity: 0 }}
-          >
-            <div className="mb-3 flex items-center gap-2">
-              {mintColor && (
-                <span
-                  className="inline-block h-6 w-6 rounded-full border border-[var(--border)]"
-                  style={{ backgroundColor: mintColor }}
-                />
+          {/* Step 2 — Devnet SOL */}
+          <ScrollReveal delay={0.1}>
+            <div className={cardClass}>
+              <h2 className="mb-3 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-muted)]">Step 2 · Devnet SOL</h2>
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-white">
+                  Balance:{" "}
+                  <span className={`font-mono ${lowSol ? "text-[var(--short)]" : "text-[var(--accent)]"}`}>
+                    {balance !== null ? `${balance.toFixed(4)} SOL` : "..."}
+                  </span>
+                </span>
+                <button className={btnPrimary} onClick={handleAirdrop} disabled={airdropping}>
+                  {airdropping ? "Airdropping..." : "Airdrop 2 SOL"}
+                </button>
+              </div>
+              {/* Inline airdrop status */}
+              {airdropStatus && (
+                <p className={`mt-3 text-xs ${airdropStatus.startsWith("Airdrop successful") ? "text-[var(--accent)]" : airdropFailed ? "text-[var(--short)]" : "text-[var(--text-muted)]"}`}>
+                  {airdropStatus}
+                </p>
               )}
-              <h2 className="text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--accent)]">
-                {tokenName} ({tokenSymbol}) Created
-              </h2>
+              {/* Fallback web faucet link */}
+              {airdropFailed && (
+                <div className="mt-2 border border-[var(--warning)]/20 bg-[var(--warning)]/[0.04] p-3">
+                  <p className="text-xs text-[var(--warning)]">
+                    Devnet faucet might be rate-limited.{" "}
+                    <a href={webFaucetUrl} target="_blank" rel="noopener noreferrer" className="underline hover:text-[var(--accent)]">
+                      Try the Solana web faucet →
+                    </a>
+                  </p>
+                </div>
+              )}
+              {lowSol && !airdropping && (
+                <p className="mt-2 text-xs text-[var(--short)]">You need SOL to create tokens. Airdrop some first.</p>
+              )}
             </div>
-            <div className="flex items-center gap-2">
-              <code className="flex-1 overflow-hidden text-ellipsis rounded bg-[var(--panel-bg)] px-3 py-2 text-xs text-white">
-                {mintAddress}
-              </code>
-              <button
-                onClick={copyMint}
-                className="rounded-sm border border-[var(--border)] px-3 py-2 text-xs text-[var(--text-secondary)] transition-all duration-150 hover:bg-[var(--accent)]/[0.06] hover:text-white hover:scale-[1.02] active:scale-[0.98]"
-              >
-                {copied ? "Copied!" : "Copy"}
-              </button>
+          </ScrollReveal>
+
+          {/* Step 3 — Token Config */}
+          <ScrollReveal delay={0.2}>
+            <div className={cardClass}>
+              <h2 className="mb-4 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-muted)]">Step 3 · Token Config</h2>
+              <div className="space-y-3">
+                <div className="flex gap-3">
+                  <div className="flex-1">
+                    <label className="mb-1 block text-xs text-[var(--text-secondary)]">Token Name</label>
+                    <input type="text" value={tokenName} onChange={(e) => setTokenName(e.target.value)} className={inputClass} />
+                  </div>
+                  <div className="flex-1">
+                    <label className="mb-1 block text-xs text-[var(--text-secondary)]">Symbol</label>
+                    <input type="text" value={tokenSymbol} onChange={(e) => setTokenSymbol(e.target.value)} className={inputClass} />
+                  </div>
+                </div>
+                <div className="flex gap-3">
+                  <div className="flex-1">
+                    <label className="mb-1 block text-xs text-[var(--text-secondary)]">Decimals</label>
+                    <input type="number" min={0} max={18} value={decimals} onChange={(e) => setDecimals(Number(e.target.value))} className={inputClass} />
+                  </div>
+                  <div className="flex-[2]">
+                    <label className="mb-1 block text-xs text-[var(--text-secondary)]">Supply</label>
+                    <input type="text" value={supply} onChange={(e) => setSupply(e.target.value.replace(/[^0-9]/g, ""))} className={inputClass} />
+                  </div>
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs text-[var(--text-secondary)]">Recipient Address</label>
+                  <input type="text" value={recipient} onChange={(e) => setRecipient(e.target.value)} className={inputClass} />
+                </div>
+              </div>
             </div>
-            <a
-              href={`https://explorer.solana.com/address/${mintAddress}?cluster=devnet`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mt-3 inline-block text-sm text-[var(--accent)] underline hover:text-[var(--accent)]/80"
-            >
-              View on Solana Explorer
-            </a>
-          </div>
-        )}
-      </div>
+          </ScrollReveal>
+
+          {/* Step 4 — Create & Mint (or show success) */}
+          <ScrollReveal delay={0.3}>
+            {mintAddress ? (
+              /* ── Success card ── */
+              <div ref={successCardRef} className={`${cardClass} border-[var(--accent)]/30`} style={prefersReducedMotion ? undefined : { opacity: 0 }}>
+                <div className="mb-4 flex items-center gap-2">
+                  {mintColor && (
+                    <span className="inline-block h-6 w-6 rounded-full border border-[var(--border)]" style={{ backgroundColor: mintColor }} />
+                  )}
+                  <h2 className="text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--accent)]">
+                    {tokenName} ({tokenSymbol}) Created
+                  </h2>
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <code className="flex-1 overflow-hidden text-ellipsis bg-[var(--bg)] border border-[var(--border)] px-3 py-2 text-xs text-white">{mintAddress}</code>
+                  <button onClick={copyMint} className="border border-[var(--border)] px-3 py-2 text-xs text-[var(--text-secondary)] transition-all hover:bg-[var(--accent)]/[0.06] hover:text-white active:scale-[0.98]">
+                    {copied ? "Copied!" : "Copy"}
+                  </button>
+                </div>
+
+                <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+                  <Link href={`/create?mint=${mintAddress}`} className={`${btnPrimary} text-center`}>
+                    Create Market →
+                  </Link>
+                  <a href={`https://explorer.solana.com/address/${mintAddress}?cluster=devnet`} target="_blank" rel="noopener noreferrer" className="text-xs text-[var(--text-muted)] hover:text-[var(--accent)] underline">
+                    View on Explorer
+                  </a>
+                  {lastTxSig && (
+                    <a href={`https://explorer.solana.com/tx/${lastTxSig}?cluster=devnet`} target="_blank" rel="noopener noreferrer" className="text-xs text-[var(--text-muted)] hover:text-[var(--accent)] underline">
+                      View tx
+                    </a>
+                  )}
+                </div>
+
+                <button onClick={() => { setMintAddress(null); setCreateStatus(null); setLastTxSig(null); }} className="mt-4 text-xs text-[var(--text-dim)] hover:text-[var(--text-muted)] underline">
+                  Create another token
+                </button>
+              </div>
+            ) : (
+              /* ── Create button + progress ── */
+              <div className={cardClass}>
+                <h2 className="mb-3 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-muted)]">Step 4 · Create &amp; Mint</h2>
+
+                {lowSol && (
+                  <p className="mb-3 text-xs text-[var(--short)]">Not enough SOL — you need at least 0.01 SOL. Airdrop some in Step 2.</p>
+                )}
+
+                {/* Inline progress */}
+                {loading && createStatus && (
+                  <div className="mb-3 flex items-center gap-2">
+                    <span className="h-3 w-3 animate-spin border border-[var(--border)] border-t-[var(--accent)]" />
+                    <span className="text-xs text-[var(--text-muted)]">{createStatus}</span>
+                  </div>
+                )}
+
+                {/* Error inline */}
+                {!loading && createStatus?.startsWith("Error") && (
+                  <p className="mb-3 text-xs text-[var(--short)]">{createStatus}</p>
+                )}
+
+                <button className={`${btnPrimary} w-full`} onClick={handleCreateAndMint} disabled={loading || !recipient || lowSol}>
+                  {loading ? "Creating..." : `Create Mint + Mint ${Number(supply).toLocaleString()} Tokens`}
+                </button>
+              </div>
+            )}
+          </ScrollReveal>
+
+          {/* Mint More — existing token */}
+          <ScrollReveal delay={0.4}>
+            <div className={cardClass}>
+              <h2 className="mb-2 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-muted)]">Mint More (Existing Token)</h2>
+              <p className="mb-3 text-xs text-[var(--text-muted)]">Already created a market? Need more tokens for trading or deposits? Mint more of a token you own.</p>
+              <div className="space-y-3">
+                <div>
+                  <label className="mb-1 block text-xs text-[var(--text-secondary)]">Existing Mint Address</label>
+                  <input type="text" value={existingMint} onChange={(e) => setExistingMint(e.target.value.trim())} placeholder="Paste token mint address..." className={inputClass} />
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs text-[var(--text-secondary)]">Amount to Mint</label>
+                  <input type="text" value={mintMoreAmount} onChange={(e) => setMintMoreAmount(e.target.value.replace(/[^0-9]/g, ""))} className={inputClass} />
+                </div>
+                {mintAuthError && <p className="text-[11px] text-[var(--short)]">{mintAuthError}</p>}
+                {mintingMore && mintMoreStatus && (
+                  <div className="flex items-center gap-2">
+                    <span className="h-3 w-3 animate-spin border border-[var(--border)] border-t-[var(--accent)]" />
+                    <span className="text-xs text-[var(--text-muted)]">{mintMoreStatus}</span>
+                  </div>
+                )}
+                {!mintingMore && mintMoreStatus && (
+                  <p className={`text-xs ${mintMoreStatus.startsWith("Error") ? "text-[var(--short)]" : "text-[var(--accent)]"}`}>
+                    {mintMoreStatus}
+                    {lastTxSig && !mintMoreStatus.startsWith("Error") && (
+                      <>
+                        {" "}
+                        <a href={`https://explorer.solana.com/tx/${lastTxSig}?cluster=devnet`} target="_blank" rel="noopener noreferrer" className="underline hover:text-white">
+                          View tx →
+                        </a>
+                      </>
+                    )}
+                  </p>
+                )}
+                <button className={`${btnPrimary} w-full`} onClick={handleMintMore} disabled={mintingMore || !existingMint || !mintMoreAmount || !!mintAuthError}>
+                  {mintingMore ? "Minting..." : `Mint ${Number(mintMoreAmount).toLocaleString()} More Tokens`}
+                </button>
+              </div>
+            </div>
+          </ScrollReveal>
+
+        </div>
       </div>
     </div>
   );

--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -85,11 +85,12 @@ const btnSecondary = "border border-[var(--border)] bg-transparent px-4 py-2 tex
 /** Quick Launch sub-component */
 const QuickLaunchPanel: FC<{
   onFallbackToManual: (mint: string, pool: DexPoolResult | null) => void;
-}> = ({ onFallbackToManual }) => {
+  initialMint?: string;
+}> = ({ onFallbackToManual, initialMint }) => {
   const { publicKey } = useWallet();
   const { connection } = useConnection();
   const { state, create, reset } = useCreateMarket();
-  const [quickMint, setQuickMint] = useState("");
+  const [quickMint, setQuickMint] = useState(initialMint ?? "");
   const [quickSlabTier, setQuickSlabTier] = useState<SlabTierKey>("small");
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [tradingFeeBps, setTradingFeeBps] = useState<number | null>(null);
@@ -486,7 +487,7 @@ const CreationProgress: FC<{
 };
 
 /* ─── Main Wizard ─── */
-export const CreateMarketWizard: FC = () => {
+export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }) => {
   const { publicKey } = useWallet();
   const { connection } = useConnection();
   const { state, create, reset } = useCreateMarket();
@@ -678,7 +679,7 @@ export const CreateMarketWizard: FC = () => {
         ))}
       </div>
 
-      {wizardMode === "quick" && <QuickLaunchPanel onFallbackToManual={handleFallbackToManual} />}
+      {wizardMode === "quick" && <QuickLaunchPanel onFallbackToManual={handleFallbackToManual} initialMint={initialMint} />}
 
       {wizardMode === "manual" && (
         <div className="border border-[var(--border)] divide-y divide-[var(--border)]">


### PR DESCRIPTION
**Issues fixed:**

1. **SOL airdrop not working** — Was using Helius RPC which doesn't forward airdrop requests. Now uses public devnet RPC for airdrops. If devnet faucet is dry/rate-limited, shows a fallback link to faucet.solana.com.

2. **Token creation result buried at bottom** — Success card now replaces the create button inline. User sees it immediately without scrolling.

3. **No clear next step after minting** — Success card now has a 'Create Market →' button that links to `/create?mint=ADDRESS`. Create page accepts the query param and pre-fills Quick Launch.

4. **Status messages shared and easy to miss** — Each section now has its own inline status. Create shows step-by-step progress (Creating mint → Building tx → Approve in wallet → Confirming).

5. **Low SOL not caught before clicking** — Step 4 now shows a warning and disables the button if balance < 0.01 SOL.

**No design changes** — same cards, colors, fonts, layout. Just better flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pre-fill market creation wizard by passing mint address via URL parameter
  * Added "Mint More" functionality to augment token supply on devnet
  * Improved step-by-step status feedback during airdrop and mint creation
  * Integrated direct market creation flow from devnet minting
  * Copy mint address and view transactions in explorer

* **Improvements**
  * Enhanced error recovery with fallback faucet options
  * Better status indicators for each transaction step

<!-- end of auto-generated comment: release notes by coderabbit.ai -->