### PR TITLE
fix: wrap useSearchParams in Suspense to fix Vercel build

### DIFF
--- a/app/app/create/page.tsx
+++ b/app/app/create/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Suspense } from "react";
 import { useWallet } from "@solana/wallet-adapter-react";
 import { useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
@@ -11,7 +12,8 @@ const WalletMultiButton = dynamic(
   { ssr: false }
 );
 
-export default function CreatePage() {
+/** Inner component that reads search params (needs Suspense boundary) */
+function CreatePageInner() {
   const { connected } = useWallet();
   const searchParams = useSearchParams();
   const initialMint = searchParams.get("mint") ?? undefined;
@@ -69,5 +71,14 @@ export default function CreatePage() {
         </ScrollReveal>
       </div>
     </div>
+  );
+}
+
+/** Page wrapper with Suspense for useSearchParams */
+export default function CreatePage() {
+  return (
+    <Suspense>
+      <CreatePageInner />
+    </Suspense>
   );
 }


### PR DESCRIPTION
The `useSearchParams()` hook added in PR #110 (for `?mint=` prefill) broke Vercel builds — Next.js requires a Suspense boundary for static prerendering when using `useSearchParams()`.

Wraps the inner component in `<Suspense>` to fix the prerender error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved page loading structure for the create section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->