### PR TITLE
fix(trade-history): correct schema mismatch — use 'price' not 'price_e6'

### DIFF
--- a/app/components/trade/TradeHistory.tsx
+++ b/app/components/trade/TradeHistory.tsx
@@ -8,7 +8,7 @@ interface Trade {
   id: string;
   side: "long" | "short";
   size: number | string;
-  price_e6: number | string;
+  price: number | string;  // DB column is `price` (NUMERIC), not `price_e6`
   fee: number;
   trader: string;
   tx_signature: string;
@@ -120,7 +120,7 @@ export const TradeHistory: FC<{ slabAddress: string }> = ({ slabAddress }) => {
                   {trade.size != null ? formatTokenAmount(toBigInt(Math.abs(typeof trade.size === "number" ? trade.size : parseFloat(trade.size)))) : "—"}
                 </div>
                 <div className="text-right text-[var(--text-muted)]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
-                  {trade.price_e6 != null ? formatPriceE6(toBigInt(trade.price_e6)) : "—"}
+                  {trade.price != null ? formatPriceE6(BigInt(Math.round(Number(trade.price) * 1e6))) : "—"}
                 </div>
               </a>
             ))}


### PR DESCRIPTION
## Critical Bug Fix

Fixes the schema mismatch documented in AUDIT-TRADE.md #1 (critical issue).

### Problem
- Frontend  component expected `price_e6` column
- Database schema has `price` (NUMERIC) column
- Result: trades never displayed correctly, always showed "—" for price

### Solution
- Updated `Trade` interface to use `price` instead of `price_e6`
- Convert NUMERIC price to e6 format: `BigInt(Math.round(Number(trade.price) * 1e6))`
- Now compatible with DB schema in `001_initial_schema.sql`

### Testing
- Type check passes (`tsc --noEmit`)
- Build should pass once CI runs

### Related
- Ref: AUDIT-TRADE.md critical issue #1
- Note: Trade history will remain empty until indexer is deployed/running to populate the `trades` table

---
**DO NOT MERGE** without Khubair's review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved clarity of the trade data model by aligning field naming with the underlying database structure, ensuring better consistency between the application layer and database schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->