### PR TITLE
fix: await Discord webhook in bug report API

### DIFF
--- a/app/app/api/bugs/route.ts
+++ b/app/app/api/bugs/route.ts
@@ -131,19 +131,23 @@ export async function POST(req: NextRequest) {
         ...(transaction_wallet ? [{ name: "Transaction Wallet", value: `\`${transaction_wallet}\``, inline: false }] : []),
       ];
 
-      fetch(discordWebhook, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          embeds: [{
-            title: `🐛 ${title}`,
-            color: severityColors[severity] ?? 0xFFB800,
-            fields,
-            footer: { text: `Reported by @${twitter_handle}${browser ? ` · ${browser}` : ""}` },
-            timestamp: new Date().toISOString(),
-          }],
-        }),
-      }).catch((e) => console.error("Discord webhook error:", e));
+      try {
+        await fetch(discordWebhook, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            embeds: [{
+              title: `🐛 ${title}`,
+              color: severityColors[severity] ?? 0xFFB800,
+              fields,
+              footer: { text: `Reported by @${twitter_handle}${browser ? ` · ${browser}` : ""}` },
+              timestamp: new Date().toISOString(),
+            }],
+          }),
+        });
+      } catch (e) {
+        console.error("Discord webhook error:", e);
+      }
     }
 
     return NextResponse.json({ ok: true }, { status: 201 });


### PR DESCRIPTION
Vercel serverless was terminating before the fetch body was fully sent, causing empty embeds in Discord. Now awaits the webhook call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal error handling for bug reporting functionality. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->