### PR TITLE
fix: remove broken Vercel webhook, use bot poller for Discord

### DIFF
--- a/app/app/api/bugs/route.ts
+++ b/app/app/api/bugs/route.ts
@@ -113,43 +113,7 @@ export async function POST(req: NextRequest) {
 
     if (error) throw error;
 
-    // Post to Discord #bug-reports channel
-    const discordWebhook = process.env.DISCORD_BUG_WEBHOOK_URL;
-    if (discordWebhook) {
-      const severityColors: Record<string, number> = {
-        critical: 0xFF4466,
-        high: 0xFF6B35,
-        medium: 0xFFB800,
-        low: 0x71717A,
-      };
-      const fields = [
-        { name: "Severity", value: severity.toUpperCase(), inline: true },
-        ...(page ? [{ name: "Page", value: page, inline: true }] : []),
-        ...(page_url ? [{ name: "URL", value: page_url, inline: false }] : []),
-        { name: "Description", value: description.slice(0, 1024), inline: false },
-        ...(steps_to_reproduce ? [{ name: "Steps to Reproduce", value: steps_to_reproduce.slice(0, 1024), inline: false }] : []),
-        ...(transaction_wallet ? [{ name: "Transaction Wallet", value: `\`${transaction_wallet}\``, inline: false }] : []),
-      ];
-
-      try {
-        await fetch(discordWebhook, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            embeds: [{
-              title: `🐛 ${title}`,
-              color: severityColors[severity] ?? 0xFFB800,
-              fields,
-              footer: { text: `Reported by @${twitter_handle}${browser ? ` · ${browser}` : ""}` },
-              timestamp: new Date().toISOString(),
-            }],
-          }),
-        });
-      } catch (e) {
-        console.error("Discord webhook error:", e);
-      }
-    }
-
+    // Discord notification handled by bot poller (polls /api/bugs every 30s)
     return NextResponse.json({ ok: true }, { status: 201 });
   } catch (err) {
     console.error("POST /api/bugs error:", err);


### PR DESCRIPTION
Vercel serverless fetch was sending empty bodies to Discord. Bug report Discord notifications now handled by the bot polling /api/bugs every 30s instead.