### PR TITLE
Fix @solana/spl-token version mismatch + document bigint-buffer vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@solana/spl-token": "^0.3.11",
+        "@solana/spl-token": "^0.4.14",
         "@solana/web3.js": "^1.98.4"
       },
       "devDependencies": {
@@ -627,21 +627,37 @@
       }
     },
     "node_modules/@solana/spl-token": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.11.tgz",
-      "integrity": "sha512-bvohO3rIMSVL24Pb+I4EYTJ6cL82eFpInEXD/I8K8upOGjpqHsKUoAempR/RnUlI1qSFNyFlWJfu6MNUgfbCQQ==",
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.4.14.tgz",
+      "integrity": "sha512-u09zr96UBpX4U685MnvQsNzlvw9TiY005hk1vJmJr7gMJldoPG1eYU5/wNEyOA5lkMLiR/gOi9SFD4MefOYEsA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
-        "@solana/spl-token-metadata": "^0.1.2",
+        "@solana/spl-token-group": "^0.0.7",
+        "@solana/spl-token-metadata": "^0.1.6",
         "buffer": "^6.0.3"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "@solana/web3.js": "^1.88.0"
+        "@solana/web3.js": "^1.95.5"
+      }
+    },
+    "node_modules/@solana/spl-token-group": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-group/-/spl-token-group-0.0.7.tgz",
+      "integrity": "sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/codecs": "2.0.0-rc.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.3"
       }
     },
     "node_modules/@solana/spl-token-metadata": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "tsx": "^4.21.0"
   },
   "dependencies": {
-    "@solana/spl-token": "^0.3.11",
+    "@solana/spl-token": "^0.4.14",
     "@solana/web3.js": "^1.98.4"
   }
 }


### PR DESCRIPTION
## Summary
Fixes version mismatch between package.json (^0.3.11) and installed version (0.4.14).

## Changes
- Updated package.json to specify @solana/spl-token@^0.4.14 (matches installed version)
- Updated package-lock.json

## Known Issue
3 high severity vulnerabilities remain in bigint-buffer transitive dependency (GHSA-3gc7-fjrx-p6mg). This is a known issue in the Solana ecosystem affecting the entire @solana/spl-token dependency chain.

The suggested fix (downgrade to @solana/spl-token@0.1.8) would be a breaking change. Monitoring for updates from @solana team.

## Testing
- ✅ No TypeScript errors
- ✅ npm install completes successfully
- ✅ Version mismatch resolved

Review needed before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated @solana/spl-token dependency to a newer version for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->