### PR TITLE
fix: Add refresh function to usePortfolio hook

### DIFF
--- a/app/hooks/usePortfolio.ts
+++ b/app/hooks/usePortfolio.ts
@@ -27,6 +27,7 @@ export interface PortfolioData {
   totalPnl: bigint;
   totalDeposited: bigint;
   loading: boolean;
+  refresh: () => void;
 }
 
 /**
@@ -39,6 +40,7 @@ export function usePortfolio(): PortfolioData {
   const [totalPnl, setTotalPnl] = useState<bigint>(0n);
   const [totalDeposited, setTotalDeposited] = useState<bigint>(0n);
   const [loading, setLoading] = useState(true);
+  const [refreshCounter, setRefreshCounter] = useState(0);
 
   useEffect(() => {
     if (!publicKey) {
@@ -106,7 +108,9 @@ export function usePortfolio(): PortfolioData {
 
     load();
     return () => { cancelled = true; };
-  }, [connection, publicKey]);
+  }, [connection, publicKey, refreshCounter]);
 
-  return { positions, totalPnl, totalDeposited, loading };
+  const refresh = () => setRefreshCounter((c) => c + 1);
+
+  return { positions, totalPnl, totalDeposited, loading, refresh };
 }


### PR DESCRIPTION
Fixes TypeScript error in PR #128.

## Issue
PR #128 added  to the destructured return of  but didn't add it to the  interface or return it from the hook.

## Fix
- Added  to  interface
- Added  state to trigger re-fetches
- Added  to useEffect dependency array
- Return  function that increments counter

## Testing
- ✅ TypeScript compiles without errors
- ✅ Refresh functionality works as intended

Related: #128 (P-HIGH-2 implementation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added manual refresh functionality for portfolio data, allowing users to trigger an update of their portfolio information on demand without reloading the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->