### PR TITLE
fix: Add explicit type annotations to mock-trade-data.ts

### DIFF
--- a/app/lib/mock-trade-data.ts
+++ b/app/lib/mock-trade-data.ts
@@ -289,12 +289,12 @@ export function getMockPortfolioPositions() {
   for (const [slabAddr, m] of withPositions) {
     const priceE6 = BigInt(Math.round(m.priceUsd * 1_000_000));
     const isLong: boolean = positions.length % 2 === 0;
-    const entryOffset = isLong ? 0.97 : 1.03;
-    const entryE6 = BigInt(Math.round(m.priceUsd * entryOffset * 1_000_000));
-    const posSize = BigInt(Math.round((1000 + positions.length * 500) * 1_000_000)) * (isLong ? 1n : -1n);
-    const priceDiff = priceE6 - entryE6;
-    const pnl = isLong ? (posSize * priceDiff / 1_000_000n) : (-posSize * priceDiff / 1_000_000n);
-    const capital = BigInt(Math.round((500 + positions.length * 200) * 1_000_000));
+    const entryOffset: number = isLong ? 0.97 : 1.03;
+    const entryE6: bigint = BigInt(Math.round(m.priceUsd * entryOffset * 1_000_000));
+    const posSize: bigint = BigInt(Math.round((1000 + positions.length * 500) * 1_000_000)) * (isLong ? 1n : -1n);
+    const priceDiff: bigint = priceE6 - entryE6;
+    const pnl: bigint = isLong ? (posSize * priceDiff / 1_000_000n) : (-posSize * priceDiff / 1_000_000n);
+    const capital: bigint = BigInt(Math.round((500 + positions.length * 200) * 1_000_000));
     const mintPk = (() => { try { return new PublicKey(m.mint); } catch { return PublicKey.default; } })();
 
     positions.push({


### PR DESCRIPTION
## Fixes TypeScript Errors in PR #133

**Problem:**
PR #133 failing CI with TypeScript strict mode errors in `app/lib/mock-trade-data.ts`:
- TS7022: Variables implicitly have type 'any' (entryOffset, entryE6, posSize, priceDiff, pnl, capital)

**Solution:**
Added explicit type annotations to all variables:
- `entryOffset: number`
- `entryE6: bigint`
- `posSize: bigint`
- `priceDiff: bigint`
- `pnl: bigint`
- `capital: bigint`

**Changes:**
- 1 file changed: `app/lib/mock-trade-data.ts`
- 6 lines modified (added type annotations)
- No logic changes

**Resolves:**
- TypeScript Check failures in PR #133
- Type Check failures in PR #133
- Unblocks PR #133 merge

**Testing:**
CI will run TypeScript strict mode checks automatically.