### PR TITLE
fix: Align root @solana/spl-token version with app package (0.4.14)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "tsx": "^4.21.0"
   },
   "dependencies": {
-    "@solana/spl-token": "^0.3.11",
+    "@solana/spl-token": "^0.4.14",
     "@solana/web3.js": "^1.98.4"
   }
 }


### PR DESCRIPTION
## Summary
Root `package.json` was still on `@solana/spl-token: ^0.3.11` while the app package upgraded to `0.4.14` in PR #130.

## Changes
- Updated root package.json dependency from `^0.3.11` → `^0.4.14`
- Aligns with app/package.json version

## Why
Prevents potential dependency conflicts in the pnpm monorepo workspace.

## Testing
- [x] TypeScript compilation passes
- [x] No breaking changes (app already using 0.4.14)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Solana SPL Token dependency to the latest version for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->