### PR TITLE
fix: Centralize PROGRAM_ID configuration (Bug #11 - HIGH)

### DIFF
--- a/packages/core/src/config/program-ids.ts
+++ b/packages/core/src/config/program-ids.ts
@@ -1,0 +1,74 @@
+import { PublicKey } from "@solana/web3.js";
+
+/**
+ * Centralized PROGRAM_ID configuration
+ * 
+ * Default to environment variable, then fall back to network-specific defaults.
+ * This prevents hard-coded program IDs scattered across the codebase.
+ */
+
+export const PROGRAM_IDS = {
+  devnet: {
+    percolator: "FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD",
+    matcher: "4HcGCsyjAqnFua5ccuXyt8KRRQzKFbGTJkVChpS7Yfzy",
+  },
+  mainnet: {
+    percolator: "GM8zjJ8LTBMv9xEsverh6H6wLyevgMHEJXcEzyY3rY24",
+    matcher: "", // TODO: Deploy matcher to mainnet
+  },
+} as const;
+
+export type Network = "devnet" | "mainnet";
+
+/**
+ * Get the Percolator program ID for the current network
+ * 
+ * Priority:
+ * 1. PROGRAM_ID env var (explicit override)
+ * 2. Network-specific default (NETWORK env var)
+ * 3. Devnet default (safest fallback)
+ */
+export function getProgramId(network?: Network): PublicKey {
+  // Explicit override takes precedence
+  if (process.env.PROGRAM_ID) {
+    return new PublicKey(process.env.PROGRAM_ID);
+  }
+
+  // Use provided network or detect from env
+  const targetNetwork = network ?? (process.env.NETWORK as Network) ?? "devnet";
+  const programId = PROGRAM_IDS[targetNetwork].percolator;
+
+  return new PublicKey(programId);
+}
+
+/**
+ * Get the Matcher program ID for the current network
+ */
+export function getMatcherProgramId(network?: Network): PublicKey {
+  // Explicit override takes precedence
+  if (process.env.MATCHER_PROGRAM_ID) {
+    return new PublicKey(process.env.MATCHER_PROGRAM_ID);
+  }
+
+  // Use provided network or detect from env
+  const targetNetwork = network ?? (process.env.NETWORK as Network) ?? "devnet";
+  const programId = PROGRAM_IDS[targetNetwork].matcher;
+
+  if (!programId) {
+    throw new Error(`Matcher program not deployed on ${targetNetwork}`);
+  }
+
+  return new PublicKey(programId);
+}
+
+/**
+ * Get the current network from environment
+ * Defaults to devnet for safety
+ */
+export function getCurrentNetwork(): Network {
+  const network = process.env.NETWORK?.toLowerCase();
+  if (network === "mainnet" || network === "mainnet-beta") {
+    return "mainnet";
+  }
+  return "devnet";
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,3 +4,4 @@ export * from "./runtime/index.js";
 export * from "./math/index.js";
 export * from "./validation.js";
 export * from "./oracle/price-router.js";
+export * from "./config/program-ids.js";

--- a/services/keeper/src/index.ts
+++ b/services/keeper/src/index.ts
@@ -11,12 +11,13 @@ import {
   ACCOUNTS_KEEPER_CRANK,
   buildAccountMetas,
   buildIx,
+  getProgramId,
 } from "@percolator/core";
 import * as dotenv from "dotenv";
 
 dotenv.config();
 
-const PROGRAM_ID = new PublicKey("GM8zjJ8LTBMv9xEsverh6H6wLyevgMHEJXcEzyY3rY24");
+const PROGRAM_ID = getProgramId();
 const CRANK_INTERVAL_MS = 5_000;
 
 async function main() {

--- a/services/oracle/src/index.ts
+++ b/services/oracle/src/index.ts
@@ -11,12 +11,13 @@ import {
   ACCOUNTS_PUSH_ORACLE_PRICE,
   buildAccountMetas,
   buildIx,
+  getProgramId,
 } from "@percolator/core";
 import * as dotenv from "dotenv";
 
 dotenv.config();
 
-const PROGRAM_ID = new PublicKey("GM8zjJ8LTBMv9xEsverh6H6wLyevgMHEJXcEzyY3rY24");
+const PROGRAM_ID = getProgramId();
 const PUSH_INTERVAL_MS = 10_000;
 
 interface MarketEntry {

--- a/tests/devnet-e2e.ts
+++ b/tests/devnet-e2e.ts
@@ -37,7 +37,9 @@ import * as fs from "fs";
 
 // Config
 const RPC_URL = `https://devnet.helius-rpc.com/?api-key=${process.env.HELIUS_API_KEY ?? ""}`;
-const PROGRAM_ID = new PublicKey("FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD"); // small
+// Use centralized config instead of hard-coded ID
+import { getProgramId } from "../packages/core/src/config/program-ids.js";
+const PROGRAM_ID = getProgramId("devnet");
 const MATCHER_ID = new PublicKey("4HcGCsyjAqnFua5ccuXyt8KRRQzKFbGTJkVChpS7Yfzy");
 const CRANK_WALLET = new PublicKey("2JaSzRYrf44fPpQBtRJfnCEgThwCmvpFd3FCXi45VXxm");
 const MINT = new PublicKey("DvH13uxzTzo1xVFwkbJ6YASkZWs6bm3vFDH4xu7kUYTs");


### PR DESCRIPTION
## Bug #11 Fix - Hard-coded PROGRAM_ID

**Reporter:** @sharpmetaa  
**Severity:** HIGH  
**Bounty Wallet:** 3S1Q4FeAHabTgPqfYyVhQ85FPicGUizJhJEwFZEMZaTs

### Problem
8+ files had hard-coded program IDs:
- Risk of wrong network interactions
- Hard to update for new deployments
- No single source of truth

### Solution
Created `packages/core/src/config/program-ids.ts`:
- Centralized PROGRAM_IDS constant
- `getProgramId()` with safe fallbacks
- Env var override support

### Updated Files
1. services/oracle - now uses `getProgramId()`
2. services/keeper - now uses `getProgramId()`
3. tests/devnet-e2e - now uses `getProgramId("devnet")`

### Impact
✅ Single source of truth
✅ Safe defaults (devnet)
✅ Easy env override
✅ Prevents accidents

---
Part of 3-bug backend fix series (#11-13)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced centralized network configuration system supporting devnet and mainnet environments with environment variable overrides for flexible deployment settings.

* **Refactor**
  * Consolidated program configuration across the application to improve consistency and reduce configuration drift.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->