### PR TITLE
fix: Job applications failing - remove ip field

### DIFF
--- a/app/app/api/applications/route.ts
+++ b/app/app/api/applications/route.ts
@@ -115,7 +115,6 @@ export async function POST(req: NextRequest) {
       availability,
       solana_wallet,
       status: "new",
-      ip,
     });
 
     if (error) throw error;


### PR DESCRIPTION
## Bug Fix

**Problem:** Job application form submissions were failing

**Root Cause:**
- Code tried to insert `ip` field into `job_applications` table
- Table schema doesn't have `ip` column
- Database rejected the insert

**Fix:**
Removed `ip` from the insert statement

**Note:**
- Rate limiting still uses IP (stored in-memory)
- Just not persisted to database anymore

**Impact:**
✅ Job applications can now submit successfully

---
**Files changed:** 1 file, -1 line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary field from application submission data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->