### PR TITLE
fix: Block market creation when trading fee >= initial margin (Bug #29a57ec7)

### DIFF
--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -143,6 +143,8 @@ const QuickLaunchPanel: FC<{
 
   const handleQuickCreate = () => {
     if (!quickLaunch.config || !publicKey) return;
+    // Guard: trading fee must be less than initial margin
+    if (effectiveTradingFee >= effectiveMargin) return;
     const c = quickLaunch.config;
     const pool = quickLaunch.poolInfo;
     const tier = SLAB_TIERS[quickSlabTier];
@@ -553,7 +555,8 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
 
   const maintenanceMarginBps = Math.floor(initialMarginBps / 2);
   const maxLeverage = Math.floor(10000 / initialMarginBps);
-  const step2Valid = tradingFeeBps >= 1 && tradingFeeBps <= 100 && initialMarginBps >= 100 && initialMarginBps <= 5000;
+  const feeExceedsMargin = tradingFeeBps >= initialMarginBps;
+  const step2Valid = tradingFeeBps >= 1 && tradingFeeBps <= 100 && initialMarginBps >= 100 && initialMarginBps <= 5000 && !feeExceedsMargin;
 
   const lpValid = lpCollateral !== "" && !isNaN(Number(lpCollateral)) && Number(lpCollateral) > 0;
   const insValid = insuranceAmount !== "" && !isNaN(Number(insuranceAmount)) && Number(insuranceAmount) > 0;
@@ -873,6 +876,12 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
                 <FieldHint>{initialMarginBps} bps = {maxLeverage}x max leverage.</FieldHint>
                 <input type="range" min={100} max={5000} step={100} value={initialMarginBps} onChange={(e) => setInitialMarginBps(Number(e.target.value))} className="mt-2 w-full" />
               </div>
+              {feeExceedsMargin && (
+                <div className="border border-[var(--short)]/30 bg-[var(--short)]/5 p-3">
+                  <p className="text-[11px] text-[var(--short)] font-medium">⚠ Trading fee ({tradingFeeBps} bps) must be less than initial margin ({initialMarginBps} bps)</p>
+                  <p className="text-[10px] text-[var(--text-muted)] mt-1">When the fee exceeds the margin, a single trade would consume the entire margin. Lower the trading fee or increase the initial margin.</p>
+                </div>
+              )}
               <div className="grid grid-cols-2 gap-px overflow-hidden border border-[var(--border)] bg-[var(--border)]">
                 <div className="bg-[var(--panel-bg)] p-3">
                   <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">Maintenance Margin</p>


### PR DESCRIPTION
## Bug Report
**ID:** 29a57ec7-7b12-4188-84ee-12f694b76814
**Reporter:** @vip_ultr
**Severity:** HIGH
**Bounty Wallet:** Af5bTkfT7wW8UTEcaJHWB9vmkBmpPB8P9UGzwifBci7H

## Root Cause
The on-chain Solana program rejects LP initialization when `tradingFeeBps >= initialMarginBps`. This makes sense — if the trading fee is equal to or greater than the margin, a single trade would consume the entire margin, making the market non-functional.

The error `invalid account data for instruction` is the program's way of rejecting this invalid parameter combination, but the UI showed no explanation of why it failed.

## Fix
1. **Manual mode:** Added `feeExceedsMargin` validation to `step2Valid` — blocks the Create button
2. **Manual mode:** Added clear warning banner explaining the issue and how to fix it
3. **Quick launch:** Added guard to prevent creation with fee >= margin

## Testing
- TypeScript compiles clean
- When trading fee slider >= initial margin, warning appears and Create button is disabled
- Quick launch silently prevents invalid combinations