### PR TITLE
fix: Reduce public health endpoint information disclosure (Bug #b3808bb6)

### DIFF
--- a/packages/server/src/routes/health.ts
+++ b/packages/server/src/routes/health.ts
@@ -13,7 +13,42 @@ export function healthRoutes(deps: {
 }): Hono {
   const app = new Hono();
 
+  // Public health check — minimal info only (status + uptime + RPC ok/down)
   app.get("/health", async (c) => {
+    let rpcStatus: "ok" | "degraded" | "down" = "down";
+
+    try {
+      const start = Date.now();
+      await getConnection().getSlot();
+      const latency = Date.now() - start;
+      rpcStatus = latency < 5000 ? "ok" : "degraded";
+    } catch {
+      rpcStatus = "down";
+    }
+
+    const crankRunning = deps.crankService?.isRunning ?? false;
+    const overallStatus = rpcStatus === "down" ? "degraded" : "ok";
+
+    return c.json({
+      status: overallStatus,
+      uptimeMs: Date.now() - startTime,
+      services: {
+        rpc: rpcStatus,
+        crank: crankRunning ? "running" : "stopped",
+        liquidation: deps.liquidationService ? "running" : "stopped",
+      },
+    });
+  });
+
+  // Admin health check — full details (protected by ADMIN_API_KEY)
+  app.get("/health/admin", async (c) => {
+    const authHeader = c.req.header("x-admin-key") ?? c.req.header("authorization")?.replace("Bearer ", "");
+    const adminKey = process.env.ADMIN_API_KEY;
+
+    if (!adminKey || authHeader !== adminKey) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
     let rpcLatencyMs = -1;
     let rpcStatus: "ok" | "degraded" | "down" = "down";
 


### PR DESCRIPTION
## Bug Report
**ID:** b3808bb6-b6cb-41ff-968d-f72911efb2e9
**Reporter:** @matchamaxxer
**Severity:** MEDIUM (security)
**Bounty Wallet:** 5mWPpC4xbT91F7P6yyHTMsq7WiqzCHVbdLUFW7SEovcC

## Root Cause
`/health` endpoint publicly exposed detailed internal operational data:
- RPC latency (ms)
- Crank status per market (market addresses, success/fail counts)
- Liquidation counts and scan numbers
- Internal timestamps and identifiers

This enables reconnaissance of system internals.

## Fix
- **`/health`** — now returns minimal public info only: overall status, uptime, and service running/stopped
- **`/health/admin`** — full details behind `ADMIN_API_KEY` auth (via `x-admin-key` header or `Authorization: Bearer`)

## Migration
Set `ADMIN_API_KEY` env var on Railway. Update monitoring tools to use `/health/admin` with the key.

## Before/After

**Before (/health):** status, uptimeMs, rpc latency, crank market count + cycle stats, liquidation details, full crankStatus with all market addresses

**After (/health):** `{ status, uptimeMs, services: { rpc, crank, liquidation } }` — three string values only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public health check endpoint that reports overall system status, uptime, and per-service health for RPC, crank, and liquidation services
  * Added admin health check endpoint secured with API key authentication, providing detailed diagnostics including RPC latency, service status, and cycle results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->