### PR TITLE
fix: Enable horizontal scroll on markets table (mobile)

### DIFF
--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -400,7 +400,7 @@ function MarketsPageInner() {
             </div>
           ) : (
             <>
-              <div className="relative rounded-sm border border-[var(--border)] hud-corners overflow-x-clip">
+              <div className="relative rounded-sm border border-[var(--border)] hud-corners overflow-x-auto">
                 {/* Header row */}
                 <div className="grid min-w-[640px] grid-cols-[2fr_1fr_1fr_1fr_1fr_0.7fr_0.7fr] gap-3 border-b border-[var(--border)] bg-[var(--bg-surface)] px-4 py-2.5 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">
                   <div>token</div>


### PR DESCRIPTION
One-line fix: `overflow-x-clip` → `overflow-x-auto` on markets table wrapper. Credit to @itsdaboy for identifying this in PR #147.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Markets table now supports horizontal scrolling, improving content visibility on smaller screens and devices with limited viewport width.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->