### PR TITLE
fix: UI/UX batch - table overflow, truncation, mobile scroll, cost estimates

### DIFF
--- a/app/app/create/page.tsx
+++ b/app/app/create/page.tsx
@@ -57,7 +57,7 @@ function CreatePageInner() {
               className="mt-2 text-[11px] text-[var(--text-dim)]"
               style={{ fontFamily: "var(--font-mono)" }}
             >
-              small: ~0.5 SOL &middot; medium: ~2 SOL &middot; large: ~7 SOL
+              small: ~0.44 SOL &middot; medium: ~1.8 SOL &middot; large: ~7 SOL
             </div>
           </div>
         </ScrollReveal>

--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -402,7 +402,7 @@ function MarketsPageInner() {
             <>
               <div className="relative rounded-sm border border-[var(--border)] hud-corners overflow-x-auto">
                 {/* Header row */}
-                <div className="grid min-w-[640px] grid-cols-[2fr_1fr_1fr_1fr_1fr_0.7fr_0.7fr] gap-3 border-b border-[var(--border)] bg-[var(--bg-surface)] px-4 py-2.5 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">
+                <div className="grid min-w-[700px] grid-cols-[minmax(140px,2fr)_minmax(70px,1fr)_minmax(70px,1fr)_minmax(70px,1fr)_minmax(70px,1fr)_minmax(50px,0.7fr)_minmax(50px,0.7fr)] gap-3 border-b border-[var(--border)] bg-[var(--bg-surface)] px-4 py-2.5 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">
                   <div>token</div>
                   <div className="text-right">price</div>
                   <div className="text-right">OI</div>
@@ -423,7 +423,7 @@ function MarketsPageInner() {
                       key={m.slabAddress}
                       href={`/trade/${m.slabAddress}`}
                       className={[
-                        "grid min-w-[640px] grid-cols-[2fr_1fr_1fr_1fr_1fr_0.7fr_0.7fr] gap-3 items-center px-4 py-3 transition-all duration-200 hover:bg-[var(--accent)]/[0.04] hover:border-l-2 hover:border-l-[var(--accent)]/30",
+                        "grid min-w-[700px] grid-cols-[minmax(140px,2fr)_minmax(70px,1fr)_minmax(70px,1fr)_minmax(70px,1fr)_minmax(70px,1fr)_minmax(50px,0.7fr)_minmax(50px,0.7fr)] gap-3 items-center px-4 py-3 transition-all duration-200 hover:bg-[var(--accent)]/[0.04] hover:border-l-2 hover:border-l-[var(--accent)]/30",
                         i > 0 ? "border-t border-[var(--border)]" : "",
                       ].join(" ")}
                     >
@@ -440,16 +440,16 @@ function MarketsPageInner() {
                           {tokenMetaMap.get(m.mintAddress)?.name ? `${tokenMetaMap.get(m.mintAddress)!.name} · ${shortenAddress(m.mintAddress)}` : shortenAddress(m.mintAddress)}
                         </div>
                       </div>
-                      <div className="text-right">
+                      <div className="text-right truncate">
                         <span className="text-sm text-white" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
                           {lastPrice != null
                             ? `$${lastPrice < 0.01 ? lastPrice.toFixed(6) : lastPrice < 1 ? lastPrice.toFixed(4) : lastPrice.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
                             : "\u2014"}
                         </span>
                       </div>
-                      <div className="text-right text-sm text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>{oiTokens}</div>
-                      <div className="text-right text-sm text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>\u2014</div>
-                      <div className="text-right text-sm text-[var(--text)]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>{insuranceTokens}</div>
+                      <div className="text-right text-sm text-[var(--text-secondary)] truncate" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>{oiTokens}</div>
+                      <div className="text-right text-sm text-[var(--text-secondary)] truncate" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>\u2014</div>
+                      <div className="text-right text-sm text-[var(--text)] truncate" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>{insuranceTokens}</div>
                       <div className="text-right text-sm text-[var(--text-secondary)]">{m.maxLeverage}x</div>
                       <div className="text-right"><HealthBadge level={health.level} /></div>
                     </Link>

--- a/app/app/portfolio/page.tsx
+++ b/app/app/portfolio/page.tsx
@@ -144,9 +144,9 @@ export default function PortfolioPage() {
               </Link>
             </div>
           ) : (
-            <div className="overflow-hidden border border-[var(--border)] hud-corners">
+            <div className="overflow-x-auto border border-[var(--border)] hud-corners">
               {/* Header */}
-              <div className="grid grid-cols-[2fr_0.7fr_1fr_1fr_1fr_1fr] gap-3 border-b border-[var(--border)] bg-[var(--bg-surface)] px-4 py-2.5 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">
+              <div className="grid min-w-[600px] grid-cols-[2fr_0.7fr_1fr_1fr_1fr_1fr] gap-3 border-b border-[var(--border)] bg-[var(--bg-surface)] px-4 py-2.5 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">
                 <div>Market</div>
                 <div className="text-center">Side</div>
                 <div className="text-right">Size</div>
@@ -165,7 +165,7 @@ export default function PortfolioPage() {
                     key={`${pos.slabAddress}-${i}`}
                     href={`/trade/${pos.slabAddress}`}
                     className={[
-                      "grid grid-cols-[2fr_0.7fr_1fr_1fr_1fr_1fr] gap-3 items-center px-4 py-3 transition-all duration-200 hover:bg-[var(--accent)]/[0.04] hover:border-l-2 hover:border-l-[var(--accent)]/30",
+                      "grid min-w-[600px] grid-cols-[2fr_0.7fr_1fr_1fr_1fr_1fr] gap-3 items-center px-4 py-3 transition-all duration-200 hover:bg-[var(--accent)]/[0.04] hover:border-l-2 hover:border-l-[var(--accent)]/30",
                       i > 0 ? "border-t border-[var(--border)]" : "",
                     ].join(" ")}
                   >
@@ -186,10 +186,10 @@ export default function PortfolioPage() {
                         {side.toUpperCase()}
                       </span>
                     </div>
-                    <div className="text-right text-sm text-white" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>{formatTokenAmount(sizeAbs)}</div>
-                    <div className="text-right text-sm text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>{formatPriceE6(pos.account.entryPrice)}</div>
-                    <div className="text-right text-sm text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>{formatTokenAmount(pos.account.capital)}</div>
-                    <div className={`text-right text-sm font-medium ${pnlPositive ? "text-[var(--long)]" : "text-[var(--short)]"}`} style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
+                    <div className="text-right text-sm text-white truncate" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>{formatTokenAmount(sizeAbs)}</div>
+                    <div className="text-right text-sm text-[var(--text-secondary)] truncate" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>{formatPriceE6(pos.account.entryPrice)}</div>
+                    <div className="text-right text-sm text-[var(--text-secondary)] truncate" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>{formatTokenAmount(pos.account.capital)}</div>
+                    <div className={`text-right text-sm font-medium truncate ${pnlPositive ? "text-[var(--long)]" : "text-[var(--short)]"}`} style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
                       {formatPnl(pos.account.pnl)}
                     </div>
                   </Link>


### PR DESCRIPTION
## UI/UX Bug Batch Fixes

### Bug bb2902a4 - Markets column overflow
- Added `minmax()` constraints on grid columns to prevent large values bleeding into adjacent columns
- Added `truncate` class on value cells (price, OI, volume, insurance)
- Increased min-width from 640px to 700px

### Bug 81ec7313 - Markets table not scrollable on mobile
- Already fixed in PR #155 (overflow-x-clip → overflow-x-auto). Verified on main. ✅

### Bug 0ceb260b - Portfolio table overflow/scroll
- Changed `overflow-hidden` → `overflow-x-auto` on positions table container
- Added `min-w-[600px]` to grid rows for consistent layout on mobile
- Added `truncate` on value cells (size, entry, capital, PnL)

### Bug 4d1c861d - SOL cost discrepancy create vs guide
- Harmonized create page estimates to match guide page (~0.5→~0.44 SOL for small, ~2→~1.8 SOL for medium)

### Not fixed in this PR (require backend/investigation):
- **Bug 2e3ec9dc** - Trades showing 'No trade yet': requires trade indexer to populate supabase trades table. UI is correct, backend indexer needs to record trades.
- **Bug 267a67ef** - Long/Short not working on specific CA: market-specific issue requiring on-chain investigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Market deployment cost estimates adjusted for small and medium market tiers.

* **UI Improvements**
  * Markets table now displays volume, insurance, and max leverage columns.
  * Portfolio table now supports horizontal scrolling for improved content visibility.
  * Enhanced text truncation across tables to prevent content overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->