### PR TITLE
feat: Trade history indexer — fix 'No trades yet' bug

### DIFF
--- a/packages/server/src/db/queries.ts
+++ b/packages/server/src/db/queries.ts
@@ -39,7 +39,7 @@ export interface OraclePriceRow {
 }
 
 export async function getMarkets(): Promise<MarketRow[]> {
-  const { data, error } = await getSupabase().from("markets").select("*").eq("status", "active");
+  const { data, error } = await getSupabase().from("markets").select("*");
   if (error) throw error;
   return (data ?? []) as MarketRow[];
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -96,8 +96,12 @@ if (config.crankKeypair) {
   }).catch((err) => {
     console.error("Failed to start crank service:", err);
   });
+  // Trade indexer also started inside crank block (reactive mode)
 } else {
   console.warn("⚠️  CRANK_KEYPAIR not set — crank service disabled");
+  // Still start trade indexer in polling-only mode (no crank events, but polls markets)
+  tradeIndexer.start();
+  console.log("📊 Trade indexer started (polling-only mode, no crank keypair)");
 }
 
 // Graceful shutdown


### PR DESCRIPTION
## Bug Fix: 2e3ec9dc

**Problem:** The Trades section on each market displays "No trades yet" because the TradeIndexer was purely reactive — it only indexed trades when `crank.success` events fired. If no cranks were running or the server restarted, the trades table stayed empty.

Additionally, `getMarkets()` in queries.ts filtered by a non-existent `status` column, so it always returned an empty array.

**Changes:**

### TradeIndexer enhancements
- **Proactive polling**: Polls all markets every 30s for new trades, regardless of crank events
- **Startup backfill**: On boot, fetches last 100 transactions per market to populate historical trades
- **No crank dependency**: TradeIndexer now starts even without `CRANK_KEYPAIR` (polling-only mode)
- **Better logging**: Reports count of indexed trades per cycle

### Query fix
- Removed invalid `.eq('status', 'active')` filter from `getMarkets()` — the markets table has no status column

### What was already working
- Supabase `trades` table + schema ✅
- Next.js API route `/api/markets/[slab]/trades` ✅  
- Frontend `TradeHistory.tsx` component ✅
- `insertTrade` / `tradeExistsBySignature` DB helpers ✅

The entire pipeline was built but the indexer never actually ran proactively. This PR fixes the activation gap.

**TypeScript:** Both `packages/server` and `app` compile clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server now supports polling-based trade indexing for improved data coverage
  * Automatic backfill of trades on startup ensures comprehensive historical data
  * Increased signature batch sizes for more efficient data processing

* **Improvements**
  * Trade indexing now operates effectively without requiring crank keypair configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->