### PR TITLE
fix: Oracle API URL configuration - add .env.example and sensible default (Bug #56c0c103)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# API Backend URL (Railway)
+NEXT_PUBLIC_API_URL=https://percolator-api-production.up.railway.app
+
+# Supabase (if needed for bug reporting)
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=

--- a/app/hooks/usePriceRouter.ts
+++ b/app/hooks/usePriceRouter.ts
@@ -21,7 +21,7 @@ export interface PriceRouterState {
   error: string | null;
 }
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || "";
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || "https://percolator-api-production.up.railway.app";
 
 /**
  * Auto-discover the best oracle source for a given token mint.
@@ -49,9 +49,6 @@ export function usePriceRouter(mintAddress: string | null): PriceRouterState {
 
     (async () => {
       try {
-        if (!API_BASE) {
-          throw new Error("NEXT_PUBLIC_API_URL not configured");
-        }
         const resp = await fetch(`${API_BASE}/oracle/resolve/${mintAddress}`, {
           signal: controller.signal,
         });


### PR DESCRIPTION
Fixes critical oracle integration failure reported by @Iseoluwa_miles.

**Root cause:** NEXT_PUBLIC_API_URL was not configured, causing auto price discovery to fail and forcing admin oracle mode.

**Solution:**
- Add .env.example with NEXT_PUBLIC_API_URL documented
- Set Railway API URL as default fallback in usePriceRouter
- Remove unnecessary API_BASE check (already has default)

**Testing:**
- Verified Railway API health: https://percolator-api-production.up.railway.app/health
- Default fallback now prevents the error message
- Oracle resolution works without explicit .env config

Bug ID: 56c0c103-4db3-4790-a20f-65f6c8650e74
Reporter: @Iseoluwa_miles
Severity: critical

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added environment variable documentation with API and third-party service configuration examples

* **Refactor**
  * Simplified API initialization with production URL as default

<!-- end of auto-generated comment: release notes by coderabbit.ai -->