### PR TITLE
fix: align DB interfaces with actual Supabase schema

### DIFF
--- a/packages/server/src/db/queries.ts
+++ b/packages/server/src/db/queries.ts
@@ -3,20 +3,33 @@ import { getSupabase } from "./client.js";
 export interface MarketRow {
   id: string;
   slab_address: string;
-  mint: string;
-  admin: string;
-  oracle_type: string;
+  mint_address: string;
+  symbol: string;
+  name: string;
+  decimals: number;
+  deployer: string;
+  oracle_authority: string | null;
+  initial_price_e6: number | null;
+  max_leverage: number;
+  trading_fee_bps: number;
   status: string;
   created_at: string;
-  metadata: Record<string, unknown> | null;
+  updated_at: string;
 }
 
 export interface MarketStatsRow {
   slab_address: string;
-  last_crank_at: string;
-  crank_success_count: number;
-  crank_failure_count: number;
-  last_price_e6: string;
+  last_price: number | null;
+  mark_price: number | null;
+  index_price: number | null;
+  volume_24h: number | null;
+  volume_total: number | null;
+  open_interest_long: number | null;
+  open_interest_short: number | null;
+  insurance_fund: number | null;
+  total_accounts: number | null;
+  funding_rate: number | null;
+  updated_at: string | null;
 }
 
 export interface TradeRow {


### PR DESCRIPTION
## Problem
MarketRow interface had columns (mint, admin, oracle_type, metadata) that don't exist in the real Supabase table. The actual columns are (mint_address, deployer, oracle_authority, etc).

This caused `getMarkets()` to silently return results with wrong field names, meaning the polling trade indexer never found any markets to index — **zero trades were ever captured**.

MarketStatsRow also had stale columns (last_crank_at, crank_success_count) vs real schema (last_price, volume_24h, open_interest).

## Fix
- Updated MarketRow to match real table: mint_address, symbol, name, decimals, deployer, oracle_authority, etc
- Updated MarketStatsRow to match real table: last_price, mark_price, volume_24h, open_interest, etc
- TypeScript compiles clean

## Also Done (manual)
- Backfilled 51 markets into Supabase markets table from live API data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Market information now includes symbol, name, trading fees, leverage limits, and deployer details.
  * Market statistics now track volume metrics, open interest positions, and funding rates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->