### PR TITLE
fix: Align oracle_prices schema with actual DB

### DIFF
--- a/packages/server/src/routes/trades.ts
+++ b/packages/server/src/routes/trades.ts
@@ -48,16 +48,15 @@ export function tradeRoutes(): Hono {
 
     // Default to 24h of price history
     const hoursBack = Math.min(Math.max(Number(c.req.query("hours") ?? 24), 1), 720); // max 30 days
-    const since = new Date(Date.now() - hoursBack * 60 * 60 * 1000).toISOString();
+    const sinceEpoch = Math.floor((Date.now() - hoursBack * 60 * 60 * 1000) / 1000);
 
     try {
-      const prices = await getPriceHistory(slab, since);
+      const prices = await getPriceHistory(slab, sinceEpoch);
       return c.json({
         slab_address: slab,
         prices: prices.map((p) => ({
           price: Number(p.price_e6) / 1_000_000,
           price_e6: p.price_e6,
-          source: p.source,
           timestamp: p.timestamp,
         })),
       });

--- a/packages/server/src/services/StatsCollector.ts
+++ b/packages/server/src/services/StatsCollector.ts
@@ -155,8 +155,7 @@ export class StatsCollector {
                   await insertOraclePrice({
                     slab_address: slabAddress,
                     price_e6: priceE6.toString(),
-                    source: priceEntry?.source ?? "on-chain",
-                    timestamp: new Date().toISOString(),
+                    timestamp: Math.floor(Date.now() / 1000),
                   });
                   this.lastOracleLogTime.set(slabAddress, Date.now());
                 } catch (oracleErr) {


### PR DESCRIPTION
Oracle price logging was failing with PGRST204 because the code assumed columns (source, ISO timestamp) that don't exist in production DB.

**Actual DB schema:** id, slab_address, price_e6, timestamp (BIGINT epoch), tx_signature, created_at

**Fixed:** OraclePriceRow interface, insert function, price history queries, StatsCollector, API route.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified timestamp format in price history data from ISO strings to Unix epoch seconds
  * Removed source field from oracle price data in API responses
  * Updated price history query handling to use epoch-based timestamps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->