### PR TITLE
feat: Webhook diagnostics — /webhook/status + /webhook/re-register

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -61,6 +61,17 @@ app.route("/", oracleRouterRoutes());
 app.route("/", webhookRoutes());
 app.route("/", tradeRoutes());
 
+// Webhook diagnostics
+app.get("/webhook/status", async (c) => {
+  const status = webhookManager.getStatus();
+  const webhooks = await webhookManager.listWebhooks();
+  return c.json({ ...status, registeredWebhooks: webhooks?.length ?? "unknown" });
+});
+app.post("/webhook/re-register", async (c) => {
+  const result = await webhookManager.reRegister();
+  return c.json(result);
+});
+
 // Root
 app.get("/", (c) => c.json({ name: "@percolator/server", version: "0.1.0" }));
 


### PR DESCRIPTION
Debug endpoints for Helius webhook registration:
- `GET /webhook/status` — current status (idle/active/failed), webhook ID, error, registered webhook count
- `POST /webhook/re-register` — force re-registration attempt
- HeliusWebhookManager now tracks status + error for runtime diagnostics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added webhook diagnostics endpoints for improved monitoring and management
  * GET /webhook/status displays webhook manager status and list of registered webhooks
  * POST /webhook/re-register enables webhook re-registration attempts
  * Enhanced webhook status tracking with idle, active, and failed states
  * Improved error tracking and diagnostics for registration failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->