### PR TITLE
fix: use enhancedDevnet webhookType for Helius devnet webhooks

### DIFF
--- a/packages/server/src/services/HeliusWebhookManager.ts
+++ b/packages/server/src/services/HeliusWebhookManager.ts
@@ -87,10 +87,8 @@ export class HeliusWebhookManager {
       webhookURL,
       transactionTypes: ["ANY"],
       accountAddresses: config.allProgramIds,
-      webhookType: "enhanced" as const,
+      webhookType: isDevnet ? "enhancedDevnet" : "enhanced",
       authHeader: config.webhookSecret || undefined,
-      // Helius requires network field — defaults to mainnet-beta if omitted
-      ...(isDevnet ? { network: "devnet" } : {}),
     };
   }
 

--- a/packages/server/tests/unit/helius-webhook-manager.test.ts
+++ b/packages/server/tests/unit/helius-webhook-manager.test.ts
@@ -78,7 +78,7 @@ describe("HeliusWebhookManager", () => {
     expect(createCall[1].method).toBe("POST");
     const body = JSON.parse(createCall[1].body);
     expect(body.webhookURL).toBe("https://my-server.com/webhook/trades");
-    expect(body.webhookType).toBe("enhanced");
+    expect(body.webhookType).toBe("enhancedDevnet");
   });
 
   it("updates existing webhook when URL matches", async () => {
@@ -113,7 +113,7 @@ describe("HeliusWebhookManager", () => {
     await mgr.start();
 
     const body = JSON.parse((globalThis.fetch as any).mock.calls[1][1].body);
-    expect(body.network).toBe("devnet");
+    expect(body.webhookType).toBe("enhancedDevnet");
   });
 
   it("does not set network field for mainnet RPC", async () => {
@@ -126,7 +126,7 @@ describe("HeliusWebhookManager", () => {
     await mgr.start();
 
     const body = JSON.parse((globalThis.fetch as any).mock.calls[1][1].body);
-    expect(body.network).toBeUndefined();
+    expect(body.webhookType).toBe("enhanced");
   });
 
   it("handles API errors gracefully (falls back to polling)", async () => {


### PR DESCRIPTION
## Problem
Helius webhook registration was failing on devnet because we were using `webhookType: 'enhanced'` with a separate `network: 'devnet'` field. 

## Root Cause
Helius API requires `webhookType: 'enhancedDevnet'` for devnet — not `'enhanced'` + `network: 'devnet'`. The `network` field is only for the UI, not the API.

**Docs:** https://www.helius.dev/docs/faqs/webhooks

## Fix
- Devnet: `webhookType: 'enhancedDevnet'`
- Mainnet: `webhookType: 'enhanced'` (unchanged)
- Removed the unnecessary `network` field

## Tests
All 7 HeliusWebhookManager tests passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved webhook payload structure to accurately classify webhook types based on network environment (devnet/mainnet), ensuring proper identification of webhook sources across different deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->