### PR TITLE
fix: Price chart loading + USD toggle for PreTradeSummary

### DIFF
--- a/app/components/trade/PriceChart.tsx
+++ b/app/components/trade/PriceChart.tsx
@@ -75,12 +75,11 @@ export const PriceChart: FC<{ slabAddress: string }> = ({ slabAddress }) => {
       return;
     }
 
-    const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-    fetch(`/api/markets/${slabAddress}/prices?since=${since}&limit=500`)
+    fetch(`/api/prices/${slabAddress}/history`)
       .then((r) => r.json())
       .then((d) => {
-        const apiPrices = (d.prices ?? []).reverse().map((p: { price_e6: number; timestamp: number }) => ({
-          price_e6: p.price_e6,
+        const apiPrices = (d.prices ?? []).map((p: { priceE6: string; timestamp: number }) => ({
+          price_e6: parseInt(p.priceE6),
           timestamp: p.timestamp,
         }));
         if (apiPrices.length > 0) {

--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -15,6 +15,10 @@ const nextConfig: NextConfig = {
         source: "/api/markets/:path*",
         destination: `${API_URL}/markets/:path*`,
       },
+      {
+        source: "/api/prices/:path*",
+        destination: `${API_URL}/prices/:path*`,
+      },
     ];
   },
   webpack: (config, { isServer }) => {


### PR DESCRIPTION
## Fixes

**Issue #1: Price charts not loading**
- Root cause: PriceChart calling `/api/markets/:slab/prices` (doesn't exist)
- Actual endpoint: `/prices/:slab/history`
- Fix: 
  - Added rewrite: `/api/prices/*` → `/prices/*`
  - Updated PriceChart to call `/api/prices/:slab/history`
  - Fixed response parsing (`priceE6` string vs `price_e6` number)

**Issue #2: PreTradeSummary values not affected by USD toggle**
- Notional Value, Trading Fee, Margin Required were always showing in tokens
- Fix: Added USD conversion when toggle enabled
- Formula: `(tokenAmount / 10^decimals) * priceUsd`

## Testing

- [x] Price charts load for markets with oracle_prices data
- [x] PreTradeSummary converts to USD when toggle enabled
- [x] Graceful fallback to tokens when price unavailable

## Backend Route Structure

```
/prices/:slab/history → { prices: [{ priceE6: string, timestamp: number }] }
```

## Components Updated

1. **next.config.ts** - Added prices API rewrite
2. **PriceChart.tsx** - Fixed endpoint + response parsing
3. **PreTradeSummary.tsx** - Added USD toggle support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added USD display toggle for trade summaries, allowing users to view notional values, trading fees, and margins in USD.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->