### PR TITLE
fix: Price chart API endpoint and response field mapping

### DIFF
--- a/app/components/trade/PriceChart.tsx
+++ b/app/components/trade/PriceChart.tsx
@@ -76,11 +76,11 @@ export const PriceChart: FC<{ slabAddress: string }> = ({ slabAddress }) => {
       return;
     }
 
-    fetch(`/api/prices/${slabAddress}/history`)
+    fetch(`/api/markets/${slabAddress}/prices`)
       .then((r) => r.json())
       .then((d) => {
-        const apiPrices = (d.prices ?? []).map((p: { priceE6: string; timestamp: number }) => ({
-          price_e6: parseInt(p.priceE6),
+        const apiPrices = (d.prices ?? []).map((p: { price_e6: string; timestamp: number }) => ({
+          price_e6: parseInt(p.price_e6),
           timestamp: p.timestamp,
         }));
         if (apiPrices.length > 0) {

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -78,12 +78,12 @@ export const TradingChart: FC<{ slabAddress: string }> = ({ slabAddress }) => {
 
   // Fetch price history
   useEffect(() => {
-    fetch(`/api/prices/${slabAddress}/history`)
+    fetch(`/api/markets/${slabAddress}/prices`)
       .then((r) => r.json())
       .then((d) => {
-        const apiPrices = (d.prices ?? []).map((p: { priceE6: string; timestamp: number }) => ({
+        const apiPrices = (d.prices ?? []).map((p: { price_e6: string; timestamp: number }) => ({
           timestamp: p.timestamp,
-          price: parseInt(p.priceE6) / 1e6,
+          price: parseInt(p.price_e6) / 1e6,
         }));
         setPrices(apiPrices);
       })


### PR DESCRIPTION
## Bug Fix

**Problem:**
Both  and  components were broken due to incorrect API endpoint path and response field mapping.

**Issues Fixed:**
1. ❌ Fetching from `/api/prices/{slab}/history` (doesn't exist)
   ✅ Now fetching from `/api/markets/{slab}/prices` (correct endpoint)

2. ❌ Mapping from `priceE6` (camelCase)
   ✅ Now mapping from `price_e6` (snake_case from DB)

**Impact:**
- Charts were silently failing to load historical price data
- Only live price updates were showing (from SlabProvider)
- Users couldn't see price history or trends

**Testing:**
- Verified API route exists at `app/api/markets/[slab]/prices/route.ts`
- Confirmed DB returns `price_e6` field (snake_case)
- Charts will now load historical data correctly

**Files Changed:**
- `app/components/trade/TradingChart.tsx`
- `app/components/trade/PriceChart.tsx`

cc @dcccrypto for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal data retrieval and processing mechanisms for price information to improve system consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->