### PR TITLE
fix: add missing 'export const dynamic' to 6 API routes

### DIFF
--- a/app/app/api/applications/route.ts
+++ b/app/app/api/applications/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServiceClient } from "@/lib/supabase";
 
+export const dynamic = 'force-dynamic';
+
 const rateMap = new Map<string, { count: number; resetAt: number }>();
 
 function isRateLimited(ip: string): boolean {

--- a/app/app/api/bugs/route.ts
+++ b/app/app/api/bugs/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServiceClient } from "@/lib/supabase";
 
+export const dynamic = 'force-dynamic';
+
 const rateMap = new Map<string, { count: number; resetAt: number }>();
 
 function isRateLimited(ip: string): boolean {

--- a/app/app/api/crank/[slab]/route.ts
+++ b/app/app/api/crank/[slab]/route.ts
@@ -9,6 +9,8 @@ import {
   SYSVAR_CLOCK_PUBKEY,
   sendAndConfirmTransaction,
 } from "@solana/web3.js";
+
+export const dynamic = 'force-dynamic';
 import {
   encodeKeeperCrank,
   encodePushOraclePrice,

--- a/app/app/api/crank/route.ts
+++ b/app/app/api/crank/route.ts
@@ -8,6 +8,8 @@ import {
   SYSVAR_CLOCK_PUBKEY,
   sendAndConfirmTransaction,
 } from "@solana/web3.js";
+
+export const dynamic = 'force-dynamic';
 import {
   encodeKeeperCrank,
   encodePushOraclePrice,

--- a/app/app/api/ideas/route.ts
+++ b/app/app/api/ideas/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServiceClient } from "@/lib/supabase";
 
+export const dynamic = 'force-dynamic';
+
 // Simple in-memory rate limiter (resets on cold start — fine for serverless)
 const rateMap = new Map<string, { count: number; resetAt: number }>();
 

--- a/app/app/api/launch/route.ts
+++ b/app/app/api/launch/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { PublicKey } from "@solana/web3.js";
 import { SLAB_TIERS, type SlabTierKey } from "@percolator/core";
 
+export const dynamic = 'force-dynamic';
+
 const SUPPORTED_DEX_IDS = new Set(["pumpswap", "raydium", "meteora"]);
 
 interface DexPoolDetection {


### PR DESCRIPTION
All Next.js API routes that fetch external data or query databases should have `export const dynamic = 'force-dynamic'` to prevent unwanted caching.

## Routes Fixed
- `/api/launch` — external API calls + RPC queries
- `/api/bugs` — Supabase DB queries
- `/api/ideas` — Supabase DB queries
- `/api/applications` — Supabase DB queries
- `/api/crank` — RPC + Supabase
- `/api/crank/[slab]` — RPC + Supabase

## Why
Without this declaration, Next.js may cache the responses in production, leading to stale data for users. This is especially critical for real-time data like crank status and bug reports.

## Verification
All routes now follow the same pattern as existing routes like `/api/funding/[slab]/route.ts` and `/api/oi/[slab]/route.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API route configuration to enforce dynamic rendering across multiple endpoints (applications, bugs, crank, ideas, and launch), preventing static caching. This ensures real-time data freshness and maintains consistency across all API endpoints. The change improves data reliability and user experience by guaranteeing that users always receive the most current information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->