### PR TITLE
fix: simulation blockhash expiry, combine txs, fix token preview

### DIFF
--- a/app/app/api/simulation/random-token/route.ts
+++ b/app/app/api/simulation/random-token/route.ts
@@ -1,7 +1,7 @@
-import { NextResponse } from "next/server";
-import { getRandomToken } from "@/lib/simulation/tokens";
+export const dynamic = 'force-dynamic';
 
-export const dynamic = "force-dynamic";
+import { NextResponse } from 'next/server';
+import { getRandomToken } from '@/lib/simulation/tokens';
 
 export async function GET() {
   const token = getRandomToken();


### PR DESCRIPTION
## Fixes

1. **Blockhash not found** — Refactored create-market and fund endpoints to return instruction bundles instead of pre-signed serialized txs. Client builds fresh Transaction with fresh blockhash before each send.

2. **Reduced wallet popups** — Combined oracle setup + LP init. 5 signatures total (down from 6).

3. **Token preview** — Created missing /api/simulation/random-token endpoint.

4. **Cost display** — Shows ~0.5 SOL (reclaimable) with correct tx count.

Zero TS errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized transaction processing for improved efficiency with fresh blockhash handling on the client side.

* **Style**
  * Updated transaction signing flow UI to clarify expected signing count (~5 transactions).
  * Added "(reclaimable)" label to estimated cost display for better cost transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->