### PR TITLE
fix: TypeScript errors in simulation service

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -111,7 +111,7 @@ app.get("/api/simulation/history", (c) => {
 
 app.get("/api/simulation/bots", (c) => {
   const state = simulationService.getState();
-  return c.json(state.bots ?? []);
+  return c.json(state?.bots ?? []);
 });
 
 // Root

--- a/packages/server/src/services/SimulationService.ts
+++ b/packages/server/src/services/SimulationService.ts
@@ -71,6 +71,18 @@ interface BotStats {
   warmupStartSlot: string;
 }
 
+interface SimulationStateSnapshot {
+  running: boolean;
+  slabAddress: string;
+  scenario: Scenario;
+  currentPrice: number;
+  currentPriceE6: string;
+  livePriceE6: string | null;
+  uptime: number;
+  stats: object;
+  bots: BotStats[];
+}
+
 interface SimStats {
   tradesCount: number;
   liquidationsCount: number;
@@ -439,7 +451,7 @@ export class SimulationService {
     return { ok: true, stats };
   }
 
-  getState(): object | null {
+  getState(): SimulationStateSnapshot | null {
     if (!this.state) return null;
 
     // Enrich bot stats with on-chain data


### PR DESCRIPTION
## Problem
CI failing on main branch with TypeScript errors:
- `'state' is possibly 'null'` in `packages/server/src/index.ts:114`
- `Property 'bots' does not exist on type 'object'` in same line

## Root Cause
The `SimulationService.getState()` method was returning `object | null` instead of a properly typed interface, causing:
1. No null-safety when accessing the returned state
2. No type information about the `bots` property

## Solution
- Created `SimulationStateSnapshot` interface to properly type the return value of `getState()`
- Updated `getState()` return type from `object | null` to `SimulationStateSnapshot | null`
- Fixed `index.ts` to use optional chaining: `state?.bots ?? []`

## Testing
- ✅ `npx tsc --noEmit` passes in packages/server
- CI should now pass type-check job

## Related
Fixes the type-check failures blocking CI on main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential null reference error when bots are undefined in the simulation API endpoint

* **Improvements**
  * Enhanced simulation state reporting with a more comprehensive snapshot structure including price data, uptime metrics, and bot statistics for better simulation monitoring

<!-- end of auto-generated comment: release notes by coderabbit.ai -->