### PR TITLE
fix: replace mock data fallbacks with on-chain data

### DIFF
--- a/app/components/market/InsuranceDashboard.tsx
+++ b/app/components/market/InsuranceDashboard.tsx
@@ -89,8 +89,21 @@ export const InsuranceDashboard: FC<{ slabAddress: string; simulation?: boolean 
         setError(null);
       } catch (err) {
         setError(err instanceof Error ? err.message : "Unknown error");
-        // Fallback to mock data on error (for demo)
-        setInsuranceData(MOCK_INSURANCE);
+        // Fallback to on-chain data when API unavailable
+        if (engine) {
+          const balance = engine.insuranceFund?.balance ?? 0n;
+          const feeRev = engine.insuranceFund?.feeRevenue ?? 0n;
+          const totalOi = engine.totalOpenInterest ?? 0n;
+          const ratio = totalOi > 0n ? Number(balance * 10000n / totalOi) / 100 : 0;
+          setInsuranceData({
+            balance: balance.toString(),
+            feeRevenue: feeRev.toString(),
+            totalRisk: totalOi.toString(),
+            coverageRatio: ratio,
+            dailyAccumulationRate: 0,
+            historicalBalance: [],
+          });
+        }
       } finally {
         setLoading(false);
       }
@@ -289,7 +302,7 @@ export const InsuranceDashboard: FC<{ slabAddress: string; simulation?: boolean 
 
         {error && !mockMode && (
           <div className="mt-2 text-[9px] text-[var(--warning)]">
-            {error} (using mock data)
+            {error} (using on-chain data)
           </div>
         )}
       </div>

--- a/app/components/trade/FundingRateCard.tsx
+++ b/app/components/trade/FundingRateCard.tsx
@@ -90,8 +90,22 @@ export const FundingRateCard: FC<{ slabAddress: string; simulation?: boolean }> 
         setError(null);
       } catch (err) {
         setError(err instanceof Error ? err.message : "Unknown error");
-        // Fallback to mock data on error (for demo)
-        setFundingData(MOCK_FUNDING);
+        // Fallback to on-chain data when API unavailable
+        if (engine && fundingRate !== null) {
+          const rate = Number(fundingRate);
+          const hourly = (rate * 9000) / 100;
+          const apr = hourly * 24 * 365;
+          const netLp = engine.netLpPos ?? 0n;
+          setFundingData({
+            currentRateBpsPerSlot: rate,
+            hourlyRatePercent: hourly,
+            aprPercent: apr,
+            direction: rate > 0 ? "long_pays_short" : rate < 0 ? "short_pays_long" : "neutral",
+            nextFundingSlot: 0,
+            netLpPosition: netLp,
+            currentSlot: 0,
+          });
+        }
       } finally {
         setLoading(false);
       }
@@ -248,7 +262,7 @@ export const FundingRateCard: FC<{ slabAddress: string; simulation?: boolean }> 
 
         {error && !mockMode && (
           <div className="mt-2 text-[9px] text-[var(--warning)]">
-            {error} (using mock data)
+            {error} (using on-chain data)
           </div>
         )}
       </div>


### PR DESCRIPTION
When API calls fail (market not in Supabase markets table), FundingRateCard, OpenInterestCard, and InsuranceDashboard were falling back to hardcoded mock data — showing fake 36.79% APR, $5.2M OI, etc.

Now they derive real values from on-chain state via useEngineState() when API is unavailable. Also fixes trade page invisible bug (gsap-fade CSS fallback) and SlabProvider silent failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error handling to use real on-chain data instead of mock data as fallback across dashboard components.
  * Updated error messages to transparently indicate when on-chain data is being displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->