### PR TITLE
fix: React #418 hydration mismatch

### DIFF
--- a/app/components/market/InsuranceDashboard.tsx
+++ b/app/components/market/InsuranceDashboard.tsx
@@ -17,7 +17,8 @@ interface InsuranceData {
   totalRisk: string; // Total open interest
 }
 
-// Mock data for development
+// Mock data for development — use fixed timestamps to avoid SSR/client hydration mismatch
+const MOCK_BASE_TS = 1739600000000; // fixed reference point
 const MOCK_INSURANCE: InsuranceData = {
   balance: "125432000000", // $125,432
   feeRevenue: "12543000000", // $12,543
@@ -25,14 +26,14 @@ const MOCK_INSURANCE: InsuranceData = {
   coverageRatio: 8.5, // 8.5x coverage
   totalRisk: "14750000000", // $14,750 total risk
   historicalBalance: [
-    { timestamp: Date.now() - 7 * 24 * 60 * 60 * 1000, balance: 120000 },
-    { timestamp: Date.now() - 6 * 24 * 60 * 60 * 1000, balance: 121200 },
-    { timestamp: Date.now() - 5 * 24 * 60 * 60 * 1000, balance: 122100 },
-    { timestamp: Date.now() - 4 * 24 * 60 * 60 * 1000, balance: 123000 },
-    { timestamp: Date.now() - 3 * 24 * 60 * 60 * 1000, balance: 123800 },
-    { timestamp: Date.now() - 2 * 24 * 60 * 60 * 1000, balance: 124500 },
-    { timestamp: Date.now() - 1 * 24 * 60 * 60 * 1000, balance: 125000 },
-    { timestamp: Date.now(), balance: 125432 },
+    { timestamp: MOCK_BASE_TS - 7 * 24 * 60 * 60 * 1000, balance: 120000 },
+    { timestamp: MOCK_BASE_TS - 6 * 24 * 60 * 60 * 1000, balance: 121200 },
+    { timestamp: MOCK_BASE_TS - 5 * 24 * 60 * 60 * 1000, balance: 122100 },
+    { timestamp: MOCK_BASE_TS - 4 * 24 * 60 * 60 * 1000, balance: 123000 },
+    { timestamp: MOCK_BASE_TS - 3 * 24 * 60 * 60 * 1000, balance: 123800 },
+    { timestamp: MOCK_BASE_TS - 2 * 24 * 60 * 60 * 1000, balance: 124500 },
+    { timestamp: MOCK_BASE_TS - 1 * 24 * 60 * 60 * 1000, balance: 125000 },
+    { timestamp: MOCK_BASE_TS, balance: 125432 },
   ],
 };
 

--- a/app/components/market/OpenInterestCard.tsx
+++ b/app/components/market/OpenInterestCard.tsx
@@ -14,20 +14,21 @@ interface OpenInterestData {
   historicalOi: Array<{ timestamp: number; totalOi: number; longOi: number; shortOi: number }>;
 }
 
-// Mock data for development
+// Mock data for development — use fixed timestamps to avoid SSR/client hydration mismatch
+const MOCK_BASE_TS = 1739600000000; // fixed reference point
 const MOCK_OI: OpenInterestData = {
   totalOi: "5234123000000", // $5,234,123
   longOi: "2850000000000", // $2,850,000 (54.5%)
   shortOi: "2384123000000", // $2,384,123 (45.5%)
   netLpPosition: "465877000000", // +$465,877 (long)
   historicalOi: [
-    { timestamp: Date.now() - 24 * 60 * 60 * 1000, totalOi: 4800000, longOi: 2500000, shortOi: 2300000 },
-    { timestamp: Date.now() - 20 * 60 * 60 * 1000, totalOi: 4950000, longOi: 2600000, shortOi: 2350000 },
-    { timestamp: Date.now() - 16 * 60 * 60 * 1000, totalOi: 5100000, longOi: 2750000, shortOi: 2350000 },
-    { timestamp: Date.now() - 12 * 60 * 60 * 1000, totalOi: 5200000, longOi: 2800000, shortOi: 2400000 },
-    { timestamp: Date.now() - 8 * 60 * 60 * 1000, totalOi: 5150000, longOi: 2820000, shortOi: 2330000 },
-    { timestamp: Date.now() - 4 * 60 * 60 * 1000, totalOi: 5220000, longOi: 2840000, shortOi: 2380000 },
-    { timestamp: Date.now(), totalOi: 5234123, longOi: 2850000, shortOi: 2384123 },
+    { timestamp: MOCK_BASE_TS - 24 * 60 * 60 * 1000, totalOi: 4800000, longOi: 2500000, shortOi: 2300000 },
+    { timestamp: MOCK_BASE_TS - 20 * 60 * 60 * 1000, totalOi: 4950000, longOi: 2600000, shortOi: 2350000 },
+    { timestamp: MOCK_BASE_TS - 16 * 60 * 60 * 1000, totalOi: 5100000, longOi: 2750000, shortOi: 2380000 },
+    { timestamp: MOCK_BASE_TS - 12 * 60 * 60 * 1000, totalOi: 5200000, longOi: 2800000, shortOi: 2400000 },
+    { timestamp: MOCK_BASE_TS - 8 * 60 * 60 * 1000, totalOi: 5150000, longOi: 2820000, shortOi: 2330000 },
+    { timestamp: MOCK_BASE_TS - 4 * 60 * 60 * 1000, totalOi: 5220000, longOi: 2840000, shortOi: 2380000 },
+    { timestamp: MOCK_BASE_TS, totalOi: 5234123, longOi: 2850000, shortOi: 2384123 },
   ],
 };
 


### PR DESCRIPTION
## Root Cause

`InsuranceDashboard` and `OpenInterestCard` used `Date.now()` in **module-level** mock constants (`MOCK_INSURANCE`, `MOCK_OI`). These evaluate at different times on server (SSR) vs client (hydration), producing different timestamp values → React error #418 (text content mismatch).

## Fix

Replace `Date.now()` with a fixed reference timestamp (`MOCK_BASE_TS = 1739600000000`). Mock data timestamps are relative offsets from this fixed point — deterministic across server and client.

## The other errors in the console

- `evmAsk.js` — EVM wallet browser extension (MetaMask etc) injecting into `window.ethereum`. Not our code.
- `percolator-api-production.up.railway.app/prices/...` 404 — transient; Railway is healthy and responding to price requests normally.
- `A listener indicated an asynchronous response...` — browser extension message channel issue, not ours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mock data timestamp consistency in Insurance Dashboard and Open Interest Card components for more reliable rendering performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->