### PR TITLE
Auto-register missing markets in StatsCollector

### DIFF
--- a/packages/server/src/db/queries.ts
+++ b/packages/server/src/db/queries.ts
@@ -12,6 +12,8 @@ export interface MarketRow {
   initial_price_e6: number | null;
   max_leverage: number;
   trading_fee_bps: number;
+  lp_collateral: string | null;
+  matcher_context: string | null;
   status: string;
   created_at: string;
   updated_at: string;
@@ -85,6 +87,14 @@ export async function getMarketBySlabAddress(slabAddress: string): Promise<Marke
     .single();
   if (error && error.code !== "PGRST116") throw error;
   return (data as MarketRow) ?? null;
+}
+
+export async function insertMarket(market: Omit<MarketRow, "id" | "created_at" | "updated_at">): Promise<void> {
+  const { error } = await getSupabase().from("markets").insert(market);
+  // Ignore unique constraint violations (market already exists)
+  if (error && error.code !== "23505") {
+    throw error;
+  }
 }
 
 export async function upsertMarketStats(stats: Partial<MarketStatsRow> & { slab_address: string }): Promise<void> {


### PR DESCRIPTION
## Problem
When new markets are created on-chain, StatsCollector skips them because they're not in the Supabase `markets` table (FK constraint). 27 markets were missing from the database.

## Solution
Added auto-registration of missing markets at the start of each StatsCollector collection cycle:

1. **Compare on-chain vs DB:** Compare markets from CrankService against Supabase `markets` table
2. **Auto-insert missing markets:** For any markets found on-chain but not in DB, auto-insert them
3. **Derive metadata from on-chain state:**
   - `symbol`: First 8 chars of mint address
   - `name`: "Market " + first 8 chars of slab address
   - `max_leverage`: floor(10000 / initialMarginBps)
   - `trading_fee_bps`: 10
   - `decimals`: 9
   - `status`: "active"
   - Extract: slab_address, mint (collateralMint), admin (deployer), oracleAuthority, initial_price_e6 from on-chain state

## Changes
- **StatsCollector.ts:** Added `syncMarkets()` method, called at start of each collection cycle
- **queries.ts:** Added `insertMarket()` function with duplicate protection (ignores 23505 unique constraint violations)
- **queries.ts:** Updated `MarketRow` interface to include `lp_collateral` and `matcher_context` fields (as per DB schema)

## Testing
- ✅ Compilation test passed: `cd packages/server && npx tsc --noEmit`
- No modifications to SimulationService or simulation page

## Impact
- Prevents FK constraint violations in `market_stats` table
- Ensures all on-chain markets are tracked in the database
- Markets are auto-registered within 30 seconds of appearing on-chain (next collection cycle)