### PR TITLE
fix: revoke blob URL in LogoUpload to prevent memory leak

### DIFF
--- a/app/components/create/LogoUpload.tsx
+++ b/app/components/create/LogoUpload.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FC, useCallback, useRef, useState } from "react";
+import { FC, useCallback, useEffect, useRef, useState } from "react";
 import { MarketLogo } from "@/components/market/MarketLogo";
 
 interface LogoUploadProps {
@@ -65,6 +65,15 @@ export const LogoUpload: FC<LogoUploadProps> = ({ slabAddress, mintAddress, symb
     },
     [endpoint]
   );
+
+  // Cleanup preview URL to prevent memory leaks
+  useEffect(() => {
+    return () => {
+      if (preview) {
+        URL.revokeObjectURL(preview);
+      }
+    };
+  }, [preview]);
 
   if (!endpoint) return null;
 


### PR DESCRIPTION
Fixes memory leak in LogoUpload component where preview blob URLs created by `URL.createObjectURL()` were never revoked.

**Issue:**
- Every time a user uploads a logo, a blob URL is created for the preview
- These URLs stay in memory even after the preview is cleared
- Over time, this leaks memory if users upload multiple logos

**Fix:**
- Added `useEffect` cleanup that revokes the blob URL when the preview changes or component unmounts
- Standard React cleanup pattern for blob URLs

**Testing:**
- Manual testing with multiple uploads
- No functional changes, just cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced logo upload stability and performance through improved resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->