### PR TITLE
fix: tokenMetaMap dep in markets useMemo + short liq price for over-collateralised positions

### DIFF
--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -207,7 +207,7 @@ function MarketsPageInner() {
       }
     });
     return list;
-  }, [effectiveMarkets, debouncedSearch, sortBy, leverageFilter, oracleFilter]);
+  }, [effectiveMarkets, debouncedSearch, sortBy, leverageFilter, oracleFilter, tokenMetaMap]);
 
   // P-MED-3: Infinite scroll observer
   useEffect(() => {

--- a/packages/core/src/math/trading.ts
+++ b/packages/core/src/math/trading.ts
@@ -46,8 +46,10 @@ export function computeLiqPrice(
     const liq = entryPrice - adjusted;
     return liq > 0n ? liq : 0n;
   } else {
-    // Guard: if maintenanceMarginBps >= 10000 (100%), position is effectively unliquidatable
-    if (maintenanceMarginBps >= 10000n) return entryPrice;
+    // Guard: short positions liquidate when price rises above liq price.
+    // With >= 100% maintenance margin the denominator (10000 - maint) would be <= 0,
+    // meaning the position can never be liquidated. Return max u64 to signal this.
+    if (maintenanceMarginBps >= 10000n) return 18446744073709551615n; // max u64 — unliquidatable
     const adjusted = (capitalPerUnitE6 * 10000n) / (10000n - maintenanceMarginBps);
     return entryPrice + adjusted;
   }


### PR DESCRIPTION
## Summary

Two confirmed bugs found on `main` during routine health check.

---

### Bug 1 — Stale markets filter (missing `tokenMetaMap` dep)
**File:** `app/app/markets/page.tsx` line 210

`tokenMetaMap` is read inside the `filtered` useMemo (text-search path queries it for symbol/name) but was not in the dependency array. When token metadata loads asynchronously after the initial render, the memo doesn't recompute — so search results are stale/empty until another dep triggers a re-render.

**Fix:** Add `tokenMetaMap` to the dep array.

> Note: PR #211 (patch-1) and PR #210 (fix-market-page-filter-logic) both address this same bug. This PR supersedes them on this point; #210 also adds an invalid-leverage filter which is independent.

---

### Bug 2 — Wrong liquidation price for over-collateralised short positions
**File:** `packages/core/src/math/trading.ts` — `computeLiqPrice`

For short positions, `liquidationPrice = entryPrice + capitalPerUnit × (10000 / (10000 - maintBps))`. When `maintBps ≥ 10000` (≥100% maintenance margin) the denominator goes to ≤0. The existing guard returned `entryPrice` as a fallback, but this is semantically wrong — it tells the UI that the position liquidates at entry, showing **0% liquidation health** for a position that is actually **unliquidatable**.

**Fix:** Return `18446744073709551615n` (max u64) to signal an effectively infinite liquidation price.

Impact:
- AccountsCard: liquidation health correctly shows ~100% instead of 0%
- PositionPanel: liq price shows as astronomically high rather than entry price
- No on-chain program changes — display/calculation only
- Long positions and shorts with <100% margin are unaffected

> Same fix as PR #207 (fix/liquidation-price-short-positions), which has merge conflicts. This PR has a clean base on latest main.

---

## Changes
| File | Change |
|------|--------|
| `app/app/markets/page.tsx` | Add `tokenMetaMap` to `useMemo` dep array |
| `packages/core/src/math/trading.ts` | Return max u64 for unliquidatable short guard |

## Testing
- [ ] Markets text search stays accurate after token metadata loads
- [ ] Short positions with ≥100% maintenance margin show healthy liq status, not 0%
- [ ] Long positions and normal shorts unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed market list calculation to properly refresh when underlying token data changes
  * Improved liquidation price calculation for short positions to correctly identify unliquidatable positions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->