### PR TITLE
fix: crash-proof trade page, portfolio, and slab provider (4 critical bugs)

### DIFF
--- a/app/app/portfolio/page.tsx
+++ b/app/app/portfolio/page.tsx
@@ -35,9 +35,9 @@ export default function PortfolioPage() {
 
   // In mock mode, use synthetic positions
   const mockPositions = mockMode && !walletConnected ? getMockPortfolioPositions() : null;
-  const positions = mockPositions ?? portfolio.positions;
-  const totalPnl = mockPositions ? mockPositions.reduce((s, p) => s + p.account.pnl, 0n) : portfolio.totalPnl;
-  const totalDeposited = mockPositions ? mockPositions.reduce((s, p) => s + p.account.capital, 0n) : portfolio.totalDeposited;
+  const positions = mockPositions ?? portfolio.positions ?? [];
+  const totalPnl = mockPositions ? mockPositions.reduce((s, p) => s + (p.account.pnl ?? 0n), 0n) : (portfolio.totalPnl ?? 0n);
+  const totalDeposited = mockPositions ? mockPositions.reduce((s, p) => s + (p.account.capital ?? 0n), 0n) : (portfolio.totalDeposited ?? 0n);
   const loading = mockPositions ? false : portfolio.loading;
   const refresh = portfolio.refresh;
 
@@ -157,9 +157,13 @@ export default function PortfolioPage() {
               </div>
 
               {positions.map((pos, i) => {
-                const side = pos.account.positionSize > 0n ? "Long" : pos.account.positionSize < 0n ? "Short" : "Flat";
-                const sizeAbs = pos.account.positionSize < 0n ? -pos.account.positionSize : pos.account.positionSize;
-                const pnlPositive = pos.account.pnl >= 0n;
+                const posSize = pos.account?.positionSize ?? 0n;
+                const posPnl = pos.account?.pnl ?? 0n;
+                const posCapital = pos.account?.capital ?? 0n;
+                const posEntry = pos.account?.entryPrice ?? 0n;
+                const side = posSize > 0n ? "Long" : posSize < 0n ? "Short" : "Flat";
+                const sizeAbs = posSize < 0n ? -posSize : posSize;
+                const pnlPositive = posPnl >= 0n;
 
                 return (
                   <Link
@@ -188,10 +192,10 @@ export default function PortfolioPage() {
                       </span>
                     </div>
                     <div className="text-right text-sm text-white truncate" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>{formatTokenAmount(sizeAbs)}</div>
-                    <div className="text-right text-sm text-[var(--text-secondary)] truncate" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>{formatPriceE6(pos.account.entryPrice)}</div>
-                    <div className="text-right text-sm text-[var(--text-secondary)] truncate" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>{formatTokenAmount(pos.account.capital)}</div>
+                    <div className="text-right text-sm text-[var(--text-secondary)] truncate" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>{formatPriceE6(posEntry)}</div>
+                    <div className="text-right text-sm text-[var(--text-secondary)] truncate" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>{formatTokenAmount(posCapital)}</div>
                     <div className={`text-right text-sm font-medium truncate ${pnlPositive ? "text-[var(--long)]" : "text-[var(--short)]"}`} style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
-                      {formatPnl(pos.account.pnl)}
+                      {formatPnl(posPnl)}
                     </div>
                   </Link>
                 );

--- a/app/app/trade/[slab]/page.tsx
+++ b/app/app/trade/[slab]/page.tsx
@@ -2,6 +2,7 @@
 
 import { use, useState, useRef, useEffect } from "react";
 import gsap from "gsap";
+import { PublicKey } from "@solana/web3.js";
 import { SlabProvider, useSlabState } from "@/components/providers/SlabProvider";
 import { UsdToggleProvider, useUsdToggle } from "@/components/providers/UsdToggleProvider";
 import { TradeForm } from "@/components/trade/TradeForm";
@@ -417,8 +418,41 @@ function TradePageInner({ slab }: { slab: string }) {
   );
 }
 
+function isValidPublicKey(address: string): boolean {
+  try {
+    new PublicKey(address);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function InvalidAddressPage({ address }: { address: string }) {
+  return (
+    <div className="min-h-[calc(100vh-48px)] flex flex-col items-center justify-center gap-3">
+      <div className="border border-[var(--short)]/30 bg-[var(--short)]/5 p-6 text-center max-w-md">
+        <p className="text-sm font-medium text-[var(--short)]">Invalid market address</p>
+        <p className="mt-2 text-[11px] text-[var(--text-secondary)]">
+          The address in the URL is not a valid Solana public key.
+        </p>
+        <p className="mt-2 text-[10px] text-[var(--text-dim)] break-all" style={{ fontFamily: "var(--font-mono)" }}>{address}</p>
+        <a
+          href="/markets"
+          className="mt-4 inline-block border border-[var(--border)] px-4 py-1.5 text-[11px] text-[var(--text-secondary)] hover:border-[var(--accent)]/40 hover:text-[var(--text)] transition-colors"
+        >
+          Browse Markets
+        </a>
+      </div>
+    </div>
+  );
+}
+
 export default function TradePage({ params }: { params: Promise<{ slab: string }> }) {
   const { slab } = use(params);
+
+  if (!isValidPublicKey(slab)) {
+    return <InvalidAddressPage address={slab} />;
+  }
 
   return (
     <SlabProvider slabAddress={slab}>

--- a/app/components/providers/SlabProvider.tsx
+++ b/app/components/providers/SlabProvider.tsx
@@ -92,7 +92,13 @@ export const SlabProvider: FC<{ children: ReactNode; slabAddress: string }> = ({
       return;
     }
 
-    const slabPk = new PublicKey(slabAddress);
+    let slabPk: PublicKey;
+    try {
+      slabPk = new PublicKey(slabAddress);
+    } catch {
+      setState((s) => ({ ...s, slabAddress, loading: false, error: "Invalid market address. Check the URL and try again." }));
+      return;
+    }
     let cancelled = false;
 
     function parseSlab(data: Uint8Array, owner?: PublicKey) {


### PR DESCRIPTION
## Summary

Fixes 4 critical bugs reported in the bug tracker:

### Bug #07f654 — Invalid market pubkey crash
**Root cause:** `SlabProvider` calls `new PublicKey(slabAddress)` without try-catch. Invalid/malformed URLs crash the entire page.

**Fix:** 
- Added try-catch in `SlabProvider` — sets error state instead of crashing
- Added early validation in trade page — shows friendly error with link to markets
- `/trade/notavalidpubkey` now shows 'Invalid market address' instead of white screen

### Bug #10438a — Wallet disconnect crash on Portfolio
**Root cause:** Race condition where account properties could be accessed during disconnect transition.

**Fix:** Added null-coalescing (`?? 0n`) on all BigInt account fields (`positionSize`, `pnl`, `capital`, `entryPrice`)

### Bug #865857 — BigInt/BN crash on Portfolio
**Root cause:** Raw BigInt values from on-chain data leaking into JSX if formatting functions receive unexpected input.

**Fix:** Defensive null guards ensure all BigInt values pass through formatting functions safely

### Bug #c2986a — Admin actions no error handling (VERIFIED)
`useAdminActions` already wraps all actions in try/finally, and `my-markets` page wraps all calls in `handleAction` with try/catch + toast. This bug appears to be a false positive or from an older version.

## Changes
- `SlabProvider.tsx`: try-catch around `new PublicKey()` 
- `trade/[slab]/page.tsx`: pubkey validation + friendly error page
- `portfolio/page.tsx`: defensive BigInt null-coalescing on all account fields

## Testing
- `tsc --noEmit` — zero errors
- Manual: `/trade/invalid` → friendly error, `/portfolio` without wallet → connect prompt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced null safety handling for portfolio data to prevent runtime errors
  * Added address validation for market access with user-friendly error messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->