### PR TITLE
fix: show ∞ for unliquidatable short positions in liq price columns

### DIFF
--- a/app/components/trade/PositionPanel.tsx
+++ b/app/components/trade/PositionPanel.tsx
@@ -10,7 +10,7 @@ import { useTrade } from "@/hooks/useTrade";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { useTokenMeta } from "@/hooks/useTokenMeta";
 import { AccountKind } from "@percolator/core";
-import { formatTokenAmount, formatUsd } from "@/lib/format";
+import { formatTokenAmount, formatUsd, formatLiqPrice } from "@/lib/format";
 import { useLivePrice } from "@/hooks/useLivePrice";
 import {
   computeMarkPnl,
@@ -244,7 +244,7 @@ export const PositionPanel: FC<{ slabAddress: string }> = ({ slabAddress }) => {
             <div className="flex items-center justify-between py-1.5">
               <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Liq. Price</span>
               <span className="text-[11px] text-[var(--warning)]" style={{ fontFamily: "var(--font-mono)" }}>
-                {liqPriceE6 > 0n ? formatUsd(liqPriceE6) : "-"}
+                {formatLiqPrice(liqPriceE6)}
               </span>
             </div>
             <div className="flex items-center justify-between py-1.5">

--- a/app/lib/format.ts
+++ b/app/lib/format.ts
@@ -19,10 +19,28 @@ export function formatBps(bps: bigint | number): string {
   return `${(n / 100).toFixed(2)}%`;
 }
 
+/**
+ * Sentinel returned by computeLiqPrice when a short position is over-collateralised
+ * (maintenanceMarginBps >= 100%). Signals "this position cannot be liquidated."
+ * Using max u64 as the sentinel matches the on-chain convention.
+ */
+export const LIQ_PRICE_UNLIQUIDATABLE = 18446744073709551615n; // max u64
+
 export function formatUsd(priceE6: bigint | null | undefined): string {
   if (priceE6 == null) return "$0.00";
   const val = Number(priceE6) / 1_000_000;
   return `$${val.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 6 })}`;
+}
+
+/**
+ * Format a liquidation price in e6 format.
+ * Returns "∞" when the position is unliquidatable (liqPrice === max u64),
+ * "-" when zero/null, otherwise delegates to formatUsd.
+ */
+export function formatLiqPrice(liqPriceE6: bigint | null | undefined): string {
+  if (liqPriceE6 == null || liqPriceE6 === 0n) return "-";
+  if (liqPriceE6 >= LIQ_PRICE_UNLIQUIDATABLE) return "∞";
+  return formatUsd(liqPriceE6);
 }
 
 export function shortenAddress(address: string, chars: number = 4): string {


### PR DESCRIPTION
## Summary

Companion fix to PR #215 (the `computeLiqPrice` short-position sentinel change).

**Problem:** After #215 merges, `computeLiqPrice` returns `18446744073709551615n` (max u64) for short positions with ≥100% maintenance margin. Both `AccountsCard` and `PositionPanel` currently pass that value straight into `formatUsd()`:

```typescript
// AccountsCard line ~178
<span>{formatUsd(row.liqPrice)}</span>  // → "$18,446,744,073,709.55" 😱

// PositionPanel line ~247
{liqPriceE6 > 0n ? formatUsd(liqPriceE6) : "-"}  // same problem
```

This would show a ~$18T liquidation price in the UI, which looks like a serious bug even though the math is correct.

Additionally, the `liqHealthPct` calculation in `AccountsCard` uses `Number(liqPrice - ...))` on max u64 values, which silently loses precision due to IEEE 754 truncation (max u64 > `Number.MAX_SAFE_INTEGER`). The result is approximately correct but imprecise.

## Changes

### `app/lib/format.ts`
- Export `LIQ_PRICE_UNLIQUIDATABLE` constant (max u64) as the shared sentinel
- Add `formatLiqPrice()` helper: returns `"∞"` for the sentinel, `"-"` for zero/null, `formatUsd()` otherwise

### `app/components/trade/AccountsCard.tsx`
- Use `formatLiqPrice()` in the Liq Price column
- Short-circuit `liqHealthPct = 100` when `liqPrice >= LIQ_PRICE_UNLIQUIDATABLE` (avoids precision loss entirely)

### `app/components/trade/PositionPanel.tsx`
- Use `formatLiqPrice()` for the liq price row (replaces manual `> 0n` guard)

## Merge order

Merge after #215. Can be merged before #215 without breaking anything — on current main `computeLiqPrice` never returns max u64, so `formatLiqPrice` just falls through to `formatUsd` normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed liquidation price display and health percentage calculation for unliquidatable positions.

* **Improvements**
  * Liquidation price now displays "∞" for unliquidatable positions and properly shows 100% health for such positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->