### PR TITLE
fix: route devnet-mint RPC through /api/rpc proxy (Helius key exposure)

### DIFF
--- a/app/app/devnet-mint/devnet-mint-content.tsx
+++ b/app/app/devnet-mint/devnet-mint-content.tsx
@@ -30,7 +30,15 @@ import { ShimmerSkeleton } from "@/components/ui/ShimmerSkeleton";
 import { LogoUpload } from "@/components/create/LogoUpload";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
 
-const HELIUS_RPC = `https://devnet.helius-rpc.com/?api-key=${process.env.NEXT_PUBLIC_HELIUS_API_KEY ?? ""}`;
+/**
+ * Use the server-side RPC proxy to avoid exposing HELIUS_API_KEY in the client bundle.
+ * The proxy forwards JSON-RPC requests to Helius keeping the key server-side only.
+ * Falls back to the public devnet RPC if window is not available (SSR edge case).
+ */
+const HELIUS_RPC =
+  typeof window !== "undefined"
+    ? `${window.location.origin}/api/rpc`
+    : "https://api.devnet.solana.com";
 // Public devnet RPC for airdrop (Helius may not forward airdrop requests)
 const PUBLIC_DEVNET_RPC = "https://api.devnet.solana.com";
 


### PR DESCRIPTION
## Problem

Bug `32c66b7a` (HIGH): `NEXT_PUBLIC_HELIUS_API_KEY` was embedded in the client bundle via `devnet-mint-content.tsx`. Anyone viewing the page source could extract the key and use it to make authenticated Helius API calls.

## Fix

Route the RPC connection through the existing `/api/rpc` server-side proxy instead:

```ts
// Before (key in client bundle):
const HELIUS_RPC = `https://devnet.helius-rpc.com/?api-key=${process.env.NEXT_PUBLIC_HELIUS_API_KEY ?? ''}`;

// After (key stays server-side):
const HELIUS_RPC = typeof window !== 'undefined'
  ? `${window.location.origin}/api/rpc`
  : 'https://api.devnet.solana.com';
```

The `/api/rpc` proxy already exists for this exact purpose (see `app/api/rpc/route.ts`). It uses `HELIUS_API_KEY` (non-NEXT_PUBLIC, server-only) and proxies standard JSON-RPC POST requests.

## Impact

- No client-bundle API key exposure
- Devnet-only page; devnet Helius keys have lower value than mainnet, but still good hygiene
- SSR edge case handled with public devnet fallback
- Zero functional change — same JSON-RPC wire protocol, same endpoint behaviour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized devnet RPC request routing through server-side proxy for improved reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->