### PR TITLE
fix: update Railway API URL to percolator-api1-production (404 fix)

### DIFF
--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://percolator-api-production.up.railway.app";
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://percolator-api1-production.up.railway.app";
 
 const nextConfig: NextConfig = {
   transpilePackages: ["@percolator/core"],


### PR DESCRIPTION
## Bug

Production API URL in `next.config.ts` points to `percolator-api-production.up.railway.app` which returns **404 'Application not found'**.

All data routes (`/api/markets/*`, `/api/funding/*`, `/api/insurance/*`, etc.) that proxy to the backend are failing.

## Fix

Update default `API_URL` to `percolator-api1-production.up.railway.app` which is the current active Railway deployment.

### Verification
```bash
# Old URL (404):
curl https://percolator-api-production.up.railway.app/health
# {"status":"error","code":404,"message":"Application not found"}

# New URL (healthy):
curl https://percolator-api1-production.up.railway.app/health
# {"status":"ok","checks":{"db":true,"rpc":true},"uptime":162746}
```

## Impact

- ✅ All backend proxy routes will resolve correctly
- ✅ Market data, funding rates, insurance, open interest will load
- ✅ Zero functional changes — same backend, correct URL
- 🔒 One-line change, zero risk

## Related

PR #219 also updates this URL as part of a larger security headers PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend API endpoint configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->