### PR TITLE
fix: security headers, dynamic sys.online, devnet badge visibility, market explorer link

### DIFF
--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -514,7 +514,21 @@ const CreationProgress: FC<{
           <div className="mt-6 border border-[var(--accent)]/20 bg-[var(--accent)]/[0.04] p-6 text-center">
             <h3 className="mb-1 text-[15px] font-bold text-white">Market is Live</h3>
             <p className="mb-1 text-[12px] text-[var(--text-secondary)]">Your perpetual futures market has been deployed.</p>
-            <p className="mb-4 font-mono text-[10px] text-[var(--text-dim)] break-all">{state.slabAddress}</p>
+            <div className="mb-3 flex items-center justify-center gap-2">
+              <code className="font-mono text-[10px] text-[var(--accent)]/80 bg-[var(--bg)] border border-[var(--border)] px-3 py-1.5 rounded-sm break-all">
+                {state.slabAddress}
+              </code>
+            </div>
+            <div className="mb-4 flex items-center justify-center gap-3">
+              <a
+                href={`https://explorer.solana.com/address/${state.slabAddress}?cluster=devnet`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[10px] text-[var(--text-muted)] hover:text-[var(--accent)] underline transition-colors"
+              >
+                View on Explorer →
+              </a>
+            </div>
             <div className="flex flex-col items-center gap-2 sm:flex-row sm:justify-center">
               <Link href={`/trade/${state.slabAddress}`} className="border border-[var(--accent)]/50 bg-[var(--accent)]/[0.08] px-6 py-2.5 text-[12px] font-bold uppercase tracking-[0.1em] text-[var(--accent)] transition-all hud-btn-corners hover:bg-[var(--accent)]/[0.15]">
                 Start Trading →

--- a/app/components/layout/Header.tsx
+++ b/app/components/layout/Header.tsx
@@ -143,11 +143,13 @@ export const Header: FC = () => {
             ref={badgeRef}
             onClick={handleNetworkSwitch}
             disabled
+            title={network === "devnet" ? "Devnet — test environment, no real funds" : "Mainnet"}
+            aria-label={`Network: ${network}`}
             className={[
-              "rounded-sm px-2 py-1 text-[11px] font-semibold uppercase tracking-wider border transition-all duration-200 cursor-not-allowed opacity-60",
+              "rounded-sm px-2.5 py-1 text-[11px] font-bold uppercase tracking-wider border-2 transition-all duration-200 cursor-not-allowed",
               network === "devnet"
-                ? "text-[var(--warning)]/80 border-[var(--warning)]/15 bg-[var(--warning)]/[0.04]"
-                : "text-[var(--accent)]/80 border-[var(--accent)]/15 bg-[var(--accent)]/[0.04]",
+                ? "text-[var(--warning)] border-[var(--warning)]/40 bg-[var(--warning)]/[0.08]"
+                : "text-[var(--accent)] border-[var(--accent)]/30 bg-[var(--accent)]/[0.06]",
             ].join(" ")}
           >
             {network}


### PR DESCRIPTION
Cherry-picked from #219 onto clean main (original had simulator branch as base).

## Changes
- **CSP + security headers** (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy)
- **Dynamic sys.online** — new /api/health endpoint, badge shows real Railway API status
- **Devnet badge visibility** — removed opacity-60, full contrast on mobile
- **Market creation explorer link** — after deploying a market, links to Solana Explorer
- **Rewrites refactored** — uses fallback pattern so local Next.js API routes take priority

Fixes bugs: 331e9377 (CSP), e887afc7 (X-Frame-Options), 62549a6c (sys.online), f3a5bb8a (devnet badge), d8b454c7 (explorer link)