### PR TITLE
fix: read simUSDC mint from config instead of stale env var

### DIFF
--- a/app/app/simulate/components/SimOnboarding.tsx
+++ b/app/app/simulate/components/SimOnboarding.tsx
@@ -11,10 +11,10 @@ import { getAssociatedTokenAddress } from "@solana/spl-token";
 
 const DISMISS_KEY = "percolator_sim_onboarding_dismissed";
 
-// Read simUSDC mint from env or fall back to empty
-// In production this comes from the config. We guard against empty safely.
+// Read simUSDC mint from config (single source of truth)
+import simMarkets from "@/config/sim-markets.json";
 function getSimMint(): string {
-  return process.env.NEXT_PUBLIC_SIM_USDC_MINT ?? "";
+  return simMarkets.simUSDC?.mint ?? process.env.NEXT_PUBLIC_SIM_USDC_MINT ?? "";
 }
 
 /* ── Checkmark animation ─────────────────────────────────── */


### PR DESCRIPTION
SimOnboarding was reading NEXT_PUBLIC_SIM_USDC_MINT env var which had the old mint address. Now reads from sim-markets.json (single source of truth).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved configuration sourcing to prioritize centralized settings over environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->