### PR TITLE
Refactor leverage filter to use minimum leverage

### DIFF
--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -172,10 +172,17 @@ function MarketsPageInner() {
       });
     }
     // Leverage filter
-    if (leverageFilter !== "all") {
-      const maxLev = parseInt(leverageFilter);
-      list = list.filter((m) => m.maxLeverage >= maxLev);
-    }
+const minLev =
+  leverageFilter === "all"
+    ? null
+    : (() => {
+        const match = /^(\d+)x$/i.exec(leverageFilter.trim());
+        return match ? Number(match[1]) : null;
+      })();
+
+if (minLev != null) {
+  list = list.filter((m) => Number.isFinite(m.maxLeverage) && m.maxLeverage >= minLev);
+  }
     // Oracle filter
     if (oracleFilter === "admin") {
       list = list.filter((m) => m.isAdminOracle);


### PR DESCRIPTION

The Markets page leverage filter currently assumes it can directly parse filter values like `"5x"`, `"10x"`, `"20x"` using numeric parsing that’s brittle if the format changes. This PR makes leverage filter parsing explicit and safe, and ensures markets with invalid/unknown leverage (e.g., `0` or non-finite) are excluded when a leverage filter is active.

---

Changes
- Add a small helper to parse `LeverageFilter` values:
  - Accepts values matching `^(\d+)x$` (case-insensitive) and returns the numeric minimum leverage.
  - Returns `null` for `"all"` (no filtering) or unexpected values (fails safe).
- Update leverage filtering logic to:
  - Only apply filtering when `minLev != null`
  - Filter using `Number.isFinite(m.maxLeverage) && m.maxLeverage >= minLev`
  - This excludes markets with invalid leverage when a filter is active (common case: `maxLeverage = 0` when unknown)

---

Motivation / Context
- `leverageFilter` values are string tokens (`"5x"`, `"10x"`, `"20x"`) rather than raw numbers.
- `m.maxLeverage` can be `0` when computed from on-chain params where `initialMarginBps <= 0n`, which indicates unknown/invalid leverage.
- When a user selects a leverage filter (e.g., `10x+`), showing unknown leverage markets is misleading; they should be excluded.

---

File(s) Changed
- `app/app/markets/page.tsx`

---

Implementation Notes
- No UI labels or URL param keys are changed.
- Parsing is strict (`/^(\\d+)x$/i`) to avoid accidental acceptance of unexpected formats (e.g., `"10x+"`, `"x10"`, `"10"`).
- Behavior remains unchanged when leverage filter is `"all"`.



Test Plan
Manual verification in the Markets page UI:

1. Baseline
   - Open `/markets`
   - Confirm page loads and markets render.

2. Leverage filter behavior
   - Select `5x+` → only markets with `maxLeverage >= 5` appear; markets with unknown leverage (0 / non-finite) do **not** appear.
   - Select `10x+` → only markets with `maxLeverage >= 10` appear; invalid leverages excluded.
   - Select `20x+` → only markets with `maxLeverage >= 20` appear; invalid leverages excluded.

3. Reset
   - Select `all` → all markets reappear (including those with unknown leverage).

4. **Regression**
   - Search, oracle filter, and sorting still behave as before.
   - No console errors related to leverage parsing.

---

## Acceptance Criteria
- `5x+`, `10x+`, `20x+` filters work correctly with string filter values.
- Markets with invalid/unknown leverage (`maxLeverage` not finite or `0`) are excluded when a leverage filter is active.
- `"all"` continues to show all markets (no leverage filtering).
- No runtime errors and TypeScript remains clean.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved leverage filter reliability by enhancing validation logic to handle various input formats and edge cases more gracefully, reducing potential errors during filtering operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->