### PR TITLE
fix: clean up simulation table remnants, update supabase schema docs

### DIFF
--- a/supabase/migrations/023_drop_simulation_tables.sql
+++ b/supabase/migrations/023_drop_simulation_tables.sql
@@ -1,0 +1,14 @@
+-- Migration 023: Drop simulation tables
+-- The simulator feature was removed in PRs #225-#227 (2026-02-19).
+-- Migrations 011-013 created these tables but the migration files were
+-- deleted. This migration ensures the tables are cleaned up in any
+-- environment where they still exist.
+
+DROP TABLE IF EXISTS simulation_price_history CASCADE;
+DROP TABLE IF EXISTS simulation_sessions CASCADE;
+
+-- Drop related indexes (CASCADE above handles most, but be explicit)
+DROP INDEX IF EXISTS idx_simulation_sessions_slab;
+DROP INDEX IF EXISTS idx_simulation_sessions_status;
+DROP INDEX IF EXISTS idx_sim_price_history_session;
+DROP INDEX IF EXISTS idx_sim_price_history_slab;

--- a/supabase/migrations/README.md
+++ b/supabase/migrations/README.md
@@ -43,6 +43,9 @@ Migrations are automatically applied when pushed to the linked Supabase project 
 | 018 | `performance_indexes.sql` | Performance indexes for common query patterns (funding, trades, oracle prices, etc.) |
 | 019 | `ideas_table.sql` | User-submitted feature ideas and feedback table |
 | 020 | `job_applications_table.sql` | Beta tester and team member applications with CV uploads |
+| 021 | `fix_rls_policies.sql` | Fix write policies to require service_role (was open to anon) |
+| 022 | `insurance_tables.sql` | Insurance snapshots and LP events tables |
+| 023 | `drop_simulation_tables.sql` | Drop simulation tables (feature removed in PRs #225-#227) |
 
 ## Database Schema Overview
 
@@ -94,19 +97,6 @@ Time-series tracking of open interest and LP aggregate metrics
 - **FK:** `market_slab` → market_stats
 - **Unique:** (market_slab, slot)
 - **Key fields:** total_oi, net_lp_pos, lp_sum_abs, lp_max_abs, slot, timestamp
-
-### Simulation Tables
-
-#### `simulation_sessions`
-Simulation test sessions with different price models and scenarios
-- **PK:** `id` (BIGSERIAL)
-- **Key fields:** slab_address, scenario, model, start_price_e6, current_price_e6, status, updates_count, config (JSONB)
-
-#### `simulation_price_history`
-Records all price updates during simulation sessions
-- **PK:** `id` (BIGSERIAL)
-- **FK:** `session_id` → simulation_sessions
-- **Key fields:** slab_address, price_e6, model, timestamp
 
 ### User-Generated Content Tables
 
@@ -173,12 +163,6 @@ idx_insurance_history_slab_slot ON insurance_history(market_slab, slot DESC)
 idx_oi_history_slab_time ON oi_history(market_slab, timestamp DESC)
 idx_oi_history_slab_slot ON oi_history(market_slab, slot DESC)
 
--- Simulation
-idx_simulation_sessions_slab ON simulation_sessions(slab_address, started_at DESC)
-idx_simulation_sessions_status ON simulation_sessions(status, started_at DESC)
-idx_sim_price_history_session ON simulation_price_history(session_id, timestamp DESC)
-idx_sim_price_history_slab ON simulation_price_history(slab_address, timestamp DESC)
-
 -- Bug Reports
 idx_bug_reports_status ON bug_reports(status)
 idx_bug_reports_severity ON bug_reports(severity)
@@ -217,7 +201,7 @@ Returns: (insurance_deleted, oi_deleted)
 
 ## Schema Versioning
 
-Current schema version: **020** (as of 2026-02-16)
+Current schema version: **023** (as of 2026-02-19)
 
 Migrations are applied sequentially and should NEVER be modified after being deployed to production.
 New schema changes must be added as new migration files with the next sequential number.

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -109,30 +109,9 @@ VALUES (
 ON CONFLICT DO NOTHING;
 
 -- ============================================================================
--- 4. Example Simulation Session (for testing simulation UI)
+-- 4. Simulation tables removed (PRs #225-#227, 2026-02-19)
 -- ============================================================================
-
-INSERT INTO simulation_sessions (
-  slab_address,
-  scenario,
-  model,
-  start_price_e6,
-  current_price_e6,
-  status,
-  updates_count,
-  config
-)
-VALUES (
-  'DevMarket1111111111111111111111111111111',
-  'calm',
-  'random-walk',
-  100000000,
-  100500000,
-  'completed',
-  100,
-  '{"volatility": 0.02, "drift": 0.0001}'::jsonb
-)
-ON CONFLICT DO NOTHING;
+-- simulation_sessions and simulation_price_history no longer exist
 
 -- ============================================================================
 -- 5. Solana Program IDs (Reference Data - if needed by the app)


### PR DESCRIPTION
## What changed
- **Migration 023**: Drops `simulation_sessions` and `simulation_price_history` tables. The simulator feature was removed in PRs #225-#227, but migrations 011-013 (which created these tables) were deleted instead of adding a proper DROP migration. This ensures any environment that ran those migrations gets cleaned up.
- **seed.sql**: Removed INSERT into `simulation_sessions` which would fail since the table no longer exists.
- **README.md**: Added migrations 021-023 to the table, removed simulation table documentation, bumped schema version to 023.

## Why
During the simulator removal sprint, the migration files were deleted but no cleanup migration was added. This means:
- `supabase db reset` works (skips deleted migrations) but production DBs that ran 011-013 still have orphaned tables
- `seed.sql` would error on the simulation INSERT
- README was stale (said version 020, missing 3 migrations)

## How to test
```bash
supabase db reset  # Should complete without errors
```

## Notes
- 4 pre-existing test failures in `useTrade.test.ts` (stale preview prevention tests) — unrelated to this PR
- Schema.sql is still stale (only reflects migration 001) — separate task to regenerate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed simulator feature and cleaned up associated database infrastructure, including tables, indexes, and seed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->