### PR TITLE
fix: enforce circuit breaker cap for DEX oracle markets

### DIFF
--- a/program/src/percolator.rs
+++ b/program/src/percolator.rs
@@ -1686,6 +1686,7 @@ pub mod units {
 pub mod oracle {
     use solana_program::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey};
     use crate::error::PercolatorError;
+    use crate::constants::DEFAULT_DEX_ORACLE_PRICE_CAP_E2BPS;
 
     // SECURITY (H5): The "devnet" feature disables critical oracle safety checks:
     // - Staleness validation (stale prices accepted)
@@ -2910,7 +2911,7 @@ pub mod processor {
         constants::{MAGIC, VERSION, SLAB_LEN, CONFIG_LEN, MATCHER_CONTEXT_LEN, MATCHER_CALL_TAG, MATCHER_CALL_LEN, MATCHER_CONTEXT_PREFIX_LEN,
             DEFAULT_FUNDING_HORIZON_SLOTS, DEFAULT_FUNDING_K_BPS, DEFAULT_FUNDING_INV_SCALE_NOTIONAL_E6, DEFAULT_FUNDING_MAX_PREMIUM_BPS, DEFAULT_FUNDING_MAX_BPS_PER_SLOT,
             DEFAULT_THRESH_FLOOR, DEFAULT_THRESH_RISK_BPS, DEFAULT_THRESH_UPDATE_INTERVAL_SLOTS, DEFAULT_THRESH_STEP_BPS, DEFAULT_THRESH_ALPHA_BPS, DEFAULT_THRESH_MIN, DEFAULT_THRESH_MAX, DEFAULT_THRESH_MIN_STEP,
-            DEFAULT_HYPERP_PRICE_CAP_E2BPS},
+            DEFAULT_HYPERP_PRICE_CAP_E2BPS, DEFAULT_DEX_ORACLE_PRICE_CAP_E2BPS},
         error::{PercolatorError, map_risk_error},
         oracle,
         collateral,


### PR DESCRIPTION
## Summary
Mitigates the DEX oracle flash-loan vulnerability reported in #232.

## Changes
**`program/src/percolator.rs`:**

1. **New constant** `DEFAULT_DEX_ORACLE_PRICE_CAP_E2BPS = 50_000` (5% per slot max price change)

2. **InitMarket default changed**: Non-Hyperp markets now get the 5% cap instead of 0 (disabled). This is harmless for Pyth/Chainlink markets since they already have staleness/confidence checks.

3. **Runtime enforcement** in `read_price_clamped()`: Added `is_dex_oracle()` helper that detects PumpSwap/Raydium CLMM/Meteora DLMM oracle accounts. When a DEX oracle is detected and the market's cap is below the minimum, the minimum is enforced. This **retroactively protects existing markets** that were initialized with cap=0.

## How it works
The circuit breaker limits how much `last_effective_price_e6` can change per crank. With a 5% cap:
- Flash loan manipulates DEX pool price by 50% → crank only moves effective price by 5%
- Attacker needs multiple sequential cranks (each in separate slots) to move the price significantly
- This makes single-transaction flash-loan attacks uneconomical

## Limitations
- This is per-slot clamping, not true TWAP. A determined attacker with multiple slots could still manipulate over time.
- Recommend TWAP or multi-block sampling as a follow-up for high-TVL DEX oracle markets.
- UI warning for DEX oracle markets not included (separate task).

## Testing
⚠️ **Requires Rust/Solana toolchain to build.** No Rust installed on this machine — CI will verify compilation.

Closes #232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented circuit-breaker cap protection for DEX-based oracle price feeds to safeguard against extreme price volatility.

* **Bug Fixes**
  * Strengthened price clamping logic for decentralized exchange oracles (PumpSwap, Raydium CLMM, Meteora DLMM) with improved default cap configuration during market initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->