### PR TITLE
fix: NaN funding countdown, /faucet & /bugs 404s, WebSocket close warning

### DIFF
--- a/app/app/bugs/page.tsx
+++ b/app/app/bugs/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function BugsRedirect() {
+  redirect("/report-bug");
+}

--- a/app/app/faucet/page.tsx
+++ b/app/app/faucet/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function FaucetRedirect() {
+  redirect("/devnet-mint");
+}

--- a/app/app/not-found.tsx
+++ b/app/app/not-found.tsx
@@ -31,7 +31,7 @@ export default function NotFound() {
         </div>
         
         <h1 className="mb-3 text-2xl font-semibold text-white" style={{ fontFamily: "var(--font-heading)" }}>
-          Market Not Found
+          Page Not Found
         </h1>
         
         <p className="mb-8 text-[13px] leading-relaxed text-[var(--text-secondary)]">


### PR DESCRIPTION
## Summary
Fixes three UI bugs reported in #236, #237, #238.

### #236 — 'Next funding: NaNs' on trade page
- `formatCountdown()` now guards against `NaN`, non-finite, and `<= 0` slot values — returns '—' instead of 'NaNs'
- Countdown timer properly decrements (~2.5 slots/sec) instead of showing a static stale value
- On-chain fallback (slots = 0) gracefully shows '—' instead of '0s'

### #237 — /faucet and /bugs return 404
- Added redirect pages: `/faucet` → `/devnet-mint`, `/bugs` → `/report-bug`
- Fixed 404 page heading from 'Market Not Found' to 'Page Not Found' (was misleading for non-market routes)

### #238 — WebSocket 'closed before established' console warning
- `useLivePrice`: When cleaning up a WebSocket still in CONNECTING state, defer `.close()` to the `onopen` handler instead of calling it immediately
- Prevents the browser console warning on fast page navigation / component unmount

### Testing
- Visit any trade page → funding section should show '—' or a valid countdown, never 'NaNs'
- Navigate to `/faucet` → should redirect to `/devnet-mint`
- Navigate to `/bugs` → should redirect to `/report-bug`
- Open console, navigate between pages quickly → no WebSocket warnings

Closes #236
Closes #237
Closes #238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced funding rate countdown formatting and validation logic
  * Updated 404 error page heading
  * Improved WebSocket connection lifecycle handling to eliminate warnings and prevent memory leaks

* **New Features**
  * Added navigation redirects for bugs and faucet routes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->