### PR TITLE
fix: Jupiter token fallback, disable insurance top-up, sanitize admin placeholder

### DIFF
--- a/app/app/admin/login/page.tsx
+++ b/app/app/admin/login/page.tsx
@@ -60,7 +60,7 @@ export default function AdminLoginPage() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               className={inputStyle}
-              placeholder="admin@percolator.com"
+              placeholder="email@example.com"
               required
             />
           </div>

--- a/app/components/market/InsuranceDashboard.tsx
+++ b/app/components/market/InsuranceDashboard.tsx
@@ -290,10 +290,11 @@ export const InsuranceDashboard: FC<{ slabAddress: string }> = ({
         {/* Action Buttons */}
         <div className="flex gap-2">
           <button
-            onClick={() => setShowTopUp(true)}
-            className="flex-1 rounded-none border border-[var(--accent)]/30 bg-[var(--accent)]/10 py-2 text-[10px] font-medium text-[var(--accent)] transition-colors hover:bg-[var(--accent)]/20"
+            disabled
+            title="Insurance top-up coming soon — requires on-chain instruction support"
+            className="flex-1 cursor-not-allowed rounded-none border border-[var(--border)]/30 bg-[var(--bg-elevated)]/50 py-2 text-[10px] font-medium text-[var(--text-dim)] opacity-50"
           >
-            Top Up Insurance
+            Top Up (Coming Soon)
           </button>
           <button
             onClick={() => setShowExplainer(true)}

--- a/app/lib/tokenMeta.ts
+++ b/app/lib/tokenMeta.ts
@@ -8,6 +8,39 @@ export interface TokenMeta {
 
 const cache = new Map<string, TokenMeta>();
 
+// Jupiter token list cache (populated lazily on first miss)
+let jupiterTokenMap: Map<string, { symbol: string; name: string }> | null = null;
+let jupiterFetchPromise: Promise<void> | null = null;
+
+async function loadJupiterTokenList(): Promise<Map<string, { symbol: string; name: string }>> {
+  if (jupiterTokenMap) return jupiterTokenMap;
+  if (jupiterFetchPromise) {
+    await jupiterFetchPromise;
+    return jupiterTokenMap ?? new Map();
+  }
+  jupiterFetchPromise = (async () => {
+    try {
+      const res = await fetch("https://token.jup.ag/all", {
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!res.ok) throw new Error(`Jupiter API ${res.status}`);
+      const tokens = (await res.json()) as Array<{ address: string; symbol: string; name: string }>;
+      jupiterTokenMap = new Map();
+      for (const t of tokens) {
+        jupiterTokenMap.set(t.address, { symbol: t.symbol, name: t.name });
+      }
+    } catch {
+      // Jupiter unavailable — use empty map, retry next time
+      jupiterTokenMap = new Map();
+      // Allow retry after 60s
+      setTimeout(() => { jupiterTokenMap = null; jupiterFetchPromise = null; }, 60_000);
+    }
+  })();
+  await jupiterFetchPromise;
+  jupiterFetchPromise = null;
+  return jupiterTokenMap ?? new Map();
+}
+
 /** Strip unsafe characters from token metadata strings */
 function sanitizeTokenString(input: string, maxLen: number): string {
   // M6: Allow alphanumeric, spaces, dashes, dots, underscores, parentheses, $, #, &, and emoji
@@ -41,8 +74,8 @@ export async function fetchTokenMeta(
 
   // Check well-known tokens first
   const known = KNOWN_TOKENS[key];
-  let symbol = known?.symbol ?? key.slice(0, 4) + "...";
-  let name = known?.name ?? "Unknown Token";
+  let symbol = known?.symbol ?? "";
+  let name = known?.name ?? "";
 
   if (!known) {
     // Try on-chain Metaplex metadata (works for most SPL tokens)
@@ -88,8 +121,26 @@ export async function fetchTokenMeta(
         }
       }
     } catch {
-      // Use fallback defaults (truncated mint address)
+      // Metaplex lookup failed — will try Jupiter next
     }
+
+    // If Metaplex didn't resolve, try Jupiter token list
+    if (!symbol || !name) {
+      try {
+        const jupTokens = await loadJupiterTokenList();
+        const jupMeta = jupTokens.get(key);
+        if (jupMeta) {
+          symbol = symbol || jupMeta.symbol;
+          name = name || jupMeta.name;
+        }
+      } catch {
+        // Jupiter unavailable — continue to fallback
+      }
+    }
+
+    // Final fallback: show truncated mint address instead of "Unknown Token"
+    if (!symbol) symbol = key.slice(0, 4) + "…" + key.slice(-4);
+    if (!name) name = key.slice(0, 4) + "…" + key.slice(-4);
   }
 
   // R2-S14: Sanitize metadata — strip unsafe characters, limit length


### PR DESCRIPTION
## Summary
Fixes three bugs: #241, #243, #247. Also closes duplicates #242 and #246.

### #241 — 'Unknown Token' for ~20 markets
- Added Jupiter token list (`token.jup.ag/all`) as fallback when Metaplex metadata lookup fails
- Resolution order: well-known tokens → Metaplex on-chain → Jupiter token list → truncated mint address
- Jupiter list is fetched lazily on first miss and cached in-memory (with 60s retry on failure)
- Final fallback now shows truncated mint address (`ABCD…WXYZ`) instead of 'Unknown Token'

### #243 — Insurance top-up modal throws on click
- Disabled the 'Top Up Insurance' button with a 'Coming Soon' label and tooltip
- The on-chain instruction for insurance deposits doesn't exist yet — showing a broken modal was worse than disabling the button

### #247 — Admin login placeholder leaks email
- Changed `admin@percolator.com` → `email@example.com` in the admin login form placeholder

### Testing
- Markets page should show token names/symbols for all markets (Jupiter resolves what Metaplex can't)
- Insurance dashboard: top-up button should be disabled and greyed out
- Admin login: placeholder should show `email@example.com`

Closes #241
Closes #243
Closes #247