### PR TITLE
security: fix PII exposure via Supabase anon key (3 HIGH + 2 MEDIUM)

### DIFF
--- a/app/app/api/ideas/route.ts
+++ b/app/app/api/ideas/route.ts
@@ -24,30 +24,6 @@ function sanitize(str: string): string {
 
 const TABLE = "ideas";
 
-async function ensureTable() {
-  const sb = getServiceClient();
-  // Try a simple query — if it fails, table doesn't exist
-  const { error } = await (sb.from as any)(TABLE).select("id").limit(1);
-  if (error?.code === "42P01") {
-    // table doesn't exist — create it via raw SQL
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await (sb.rpc as any)("exec_sql", {
-      query: `
-        CREATE TABLE IF NOT EXISTS public.ideas (
-          id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
-          handle text NOT NULL,
-          idea text NOT NULL,
-          contact text,
-          ip text,
-          created_at timestamptz DEFAULT now()
-        );
-        ALTER TABLE public.ideas ENABLE ROW LEVEL SECURITY;
-        CREATE POLICY "ideas_read" ON public.ideas FOR SELECT USING (true);
-      `,
-    });
-  }
-}
-
 export async function GET() {
   try {
     const sb = getServiceClient();
@@ -100,8 +76,6 @@ export async function POST(req: NextRequest) {
         { status: 400 }
       );
     }
-
-    await ensureTable();
 
     const sb = getServiceClient();
     const { error } = await (sb.from as any)(TABLE)

--- a/supabase/migrations/024_fix_pii_exposure.sql
+++ b/supabase/migrations/024_fix_pii_exposure.sql
@@ -1,0 +1,101 @@
+-- Migration 024: Fix PII Exposure via Anon Key
+-- Security: GitHub issue #260 / PERC-031
+--
+-- Problem: bug_reports, job_applications, and ideas tables have
+-- USING(true) SELECT policies that expose sensitive columns
+-- (IP addresses, admin notes, emails, CV files) to anyone with
+-- the public anon key, bypassing the API's column filtering.
+--
+-- Fix: Use column-level GRANTs to restrict which columns the
+-- anon role can read. RLS row-level policies remain USING(true)
+-- but the column-level grants prevent reading sensitive fields.
+-- Service role (used by API routes) retains full access.
+
+-- ═══════════════════════════════════════════════════════════════
+-- 1. BUG_REPORTS — hide ip and admin_notes from anon
+-- ═══════════════════════════════════════════════════════════════
+
+-- Revoke blanket SELECT, then grant only safe columns
+REVOKE SELECT ON bug_reports FROM anon;
+
+GRANT SELECT (
+  id, twitter_handle, title, description, severity, page, page_url,
+  bounty_wallet, transaction_wallet, browser, status, created_at
+) ON bug_reports TO anon;
+
+-- Ensure service_role retains full access
+GRANT ALL ON bug_reports TO service_role;
+
+-- ═══════════════════════════════════════════════════════════════
+-- 2. JOB_APPLICATIONS — hide email, ip, admin_notes, cv_data
+-- ═══════════════════════════════════════════════════════════════
+
+REVOKE SELECT ON job_applications FROM anon;
+
+GRANT SELECT (
+  id, name, twitter_handle, desired_role, experience_level,
+  about, portfolio_links, cv_filename, availability, solana_wallet,
+  status, created_at
+) ON job_applications TO anon;
+
+-- Ensure service_role retains full access
+GRANT ALL ON job_applications TO service_role;
+
+-- ═══════════════════════════════════════════════════════════════
+-- 3. IDEAS — hide ip, admin_notes, contact from anon
+-- ═══════════════════════════════════════════════════════════════
+
+REVOKE SELECT ON ideas FROM anon;
+
+GRANT SELECT (
+  id, handle, idea, status, created_at
+) ON ideas TO anon;
+
+-- Ensure service_role retains full access
+GRANT ALL ON ideas TO service_role;
+
+-- ═══════════════════════════════════════════════════════════════
+-- 4. LOCK DOWN exec_sql RPC FUNCTION
+-- ═══════════════════════════════════════════════════════════════
+-- The exec_sql function (if it exists) should only be callable
+-- by service_role. If callable by anon, it's a SQL injection vector.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON p.pronamespace = n.oid
+    WHERE n.nspname = 'public' AND p.proname = 'exec_sql'
+  ) THEN
+    -- Revoke execute from anon and authenticated
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION public.exec_sql FROM anon';
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION public.exec_sql FROM authenticated';
+    -- Only service_role should call this
+    EXECUTE 'GRANT EXECUTE ON FUNCTION public.exec_sql TO service_role';
+    RAISE NOTICE 'exec_sql: locked down to service_role only';
+  ELSE
+    RAISE NOTICE 'exec_sql: function does not exist, skipping';
+  END IF;
+END
+$$;
+
+-- ═══════════════════════════════════════════════════════════════
+-- 5. ENSURE AUTHENTICATED (ADMIN) ROLE RETAINS FULL ACCESS
+-- ═══════════════════════════════════════════════════════════════
+-- Admin users authenticate via Supabase auth and use the
+-- authenticated role. They need full column access for the
+-- admin dashboard.
+
+GRANT SELECT ON bug_reports TO authenticated;
+GRANT SELECT ON job_applications TO authenticated;
+GRANT SELECT ON ideas TO authenticated;
+
+-- ═══════════════════════════════════════════════════════════════
+-- VERIFICATION COMMENTS
+-- ═══════════════════════════════════════════════════════════════
+COMMENT ON POLICY "Anyone can view bugs" ON bug_reports IS
+  'Row-level: allows all rows. Column access restricted via GRANT (migration 024)';
+COMMENT ON POLICY "Applications readable by all (limited fields)" ON job_applications IS
+  'Row-level: allows all rows. Column access restricted via GRANT (migration 024)';
+COMMENT ON POLICY "Ideas readable by all" ON ideas IS
+  'Row-level: allows all rows. Column access restricted via GRANT (migration 024)';


### PR DESCRIPTION
## Security Fix — Issue #260

### 3 HIGH Severity (PII Exposure)

The public Supabase anon key allowed direct queries to read sensitive columns that the API routes properly filtered:

| Table | Exposed Columns | Risk |
|-------|----------------|------|
| `bug_reports` | `ip`, `admin_notes` | IP address disclosure |
| `job_applications` | `email`, `ip`, `admin_notes`, `cv_data` | **GDPR** — full CVs readable |
| `ideas` | `ip`, `admin_notes`, `contact` | IP + contact disclosure |

**Fix:** Column-level `GRANT` — revoke blanket `SELECT` from `anon`, grant only safe columns. Service role and authenticated (admin) roles retain full access.

### 2 MEDIUM Severity

1. **`exec_sql` RPC function** — locked down to `service_role` only. Previously could be callable by anon (SQL injection vector). Also removed dynamic DDL `exec_sql` call from ideas route.

2. **RPC proxy method allowlist** — added explicit set of 30 permitted Solana JSON-RPC methods. Previously forwarded ANY method to Helius, enabling API key abuse.

### Files Changed
- `supabase/migrations/024_fix_pii_exposure.sql` — column-level grants + exec_sql lockdown
- `app/app/api/rpc/route.ts` — method allowlist
- `app/app/api/ideas/route.ts` — removed exec_sql call

### Testing
- All 237 tests pass
- TypeScript clean
- API routes unaffected (use service_role, not anon)
- Migration is additive — safe to run on existing DB

### ⚠️ Deployment Note
Migration 024 must be run on Supabase before or alongside this deploy. Run via Supabase dashboard SQL editor or CLI.

Closes #260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Implemented validation for JSON-RPC method requests to restrict unauthorized API access
  * Enhanced database security to prevent unauthorized exposure of sensitive user information
  * Restricted administrative function access to authorized accounts only

<!-- end of auto-generated comment: release notes by coderabbit.ai -->