### PR TITLE
ci: fix test.yml workflow file error — secrets context in step if

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      HAS_CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN != '' }}
     
     steps:
       - name: Checkout code
@@ -59,7 +61,7 @@ jobs:
 
       - name: Upload coverage (shared)
         uses: codecov/codecov-action@v4
-        if: always() && secrets.CODECOV_TOKEN != ''
+        if: always() && env.HAS_CODECOV_TOKEN == 'true'
         with:
           files: ./packages/shared/coverage/coverage-final.json
           flags: unit-shared
@@ -68,7 +70,7 @@ jobs:
 
       - name: Upload coverage (api)
         uses: codecov/codecov-action@v4
-        if: always() && secrets.CODECOV_TOKEN != ''
+        if: always() && env.HAS_CODECOV_TOKEN == 'true'
         with:
           files: ./packages/api/coverage/coverage-final.json
           flags: unit-api
@@ -83,6 +85,7 @@ jobs:
     env:
       RPC_URL: ${{ secrets.DEVNET_RPC_URL || 'https://api.devnet.solana.com' }}
       DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
+      HAS_CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN != '' }}
     
     steps:
       - name: Checkout code
@@ -117,7 +120,7 @@ jobs:
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4
-        if: always() && secrets.CODECOV_TOKEN != ''
+        if: always() && env.HAS_CODECOV_TOKEN == 'true'
         with:
           files: ./packages/api/coverage/coverage-final.json
           flags: integration


### PR DESCRIPTION
## 🚨 Hotfix: Test Suite workflow broken on main

PR #261 introduced `secrets.CODECOV_TOKEN != ''` directly in step-level `if:` conditions, which causes a GitHub Actions workflow file parsing error. The `secrets` context must be evaluated inside `${{ }}` expressions.

### Fix
- Added `HAS_CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN != '' }}` as a job-level env var
- Changed step `if:` conditions to use `env.HAS_CODECOV_TOKEN == 'true'` instead

### Impact
Test Suite workflow is currently broken on main (run #22214236291 failed with 'workflow file issue'). This PR restores it.