### PR TITLE
ci: fix fuzz test pre-check — skip when script missing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -222,16 +222,12 @@ jobs:
       - name: Check for fuzz test script
         id: fuzz-check
         run: |
-          if cd packages/core && pnpm run --silent --if-present test:fuzz --help > /dev/null 2>&1; then
+          cd packages/core
+          if node -e "const p=require('./package.json'); if(!p.scripts?.['test:fuzz']) process.exit(1)" 2>/dev/null; then
             echo "has_fuzz=true" >> "$GITHUB_OUTPUT"
           else
-            # Check if the script exists in package.json
-            if node -e "const p=require('./package.json'); process.exit(p.scripts?.['test:fuzz'] ? 0 : 1)" 2>/dev/null; then
-              echo "has_fuzz=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "has_fuzz=false" >> "$GITHUB_OUTPUT"
-              echo "ℹ️  No test:fuzz script in packages/core — skipping"
-            fi
+            echo "has_fuzz=false" >> "$GITHUB_OUTPUT"
+            echo "ℹ️  No test:fuzz script in packages/core — skipping"
           fi
 
       - name: Run fuzz tests


### PR DESCRIPTION
## Fix: Fuzz Tests still failing after PR #261/#263

The fuzz pre-check used `pnpm run --if-present test:fuzz` which exits 0 when the script doesn't exist (that's what `--if-present` does!), so the fuzz step always ran and failed with exit 254.

### Fix
Simplified to a direct `node -e` check against `package.json` scripts — only runs fuzz tests when the `test:fuzz` script actually exists.

### Current main CI status
- Test Suite: Fuzz Tests ❌ (this fixes it)
- All other jobs: ✅