### PR TITLE
test: fix 22 skipped useInsuranceLP tests (PERC-037)

### DIFF
--- a/app/hooks/useInsuranceLP.ts
+++ b/app/hooks/useInsuranceLP.ts
@@ -161,10 +161,10 @@ export function useInsuranceLP() {
   }, [refreshState]);
   
   useEffect(() => {
-    refreshStateRef.current();
-    const interval = setInterval(() => {
-      refreshStateRef.current();
-    }, 10_000);
+    // Call refreshState on mount and set up auto-refresh interval
+    const doRefresh = () => refreshStateRef.current();
+    doRefresh();
+    const interval = setInterval(doRefresh, 10_000);
     return () => clearInterval(interval);
   }, []); // Empty deps safe now — ref always points to latest refreshState
 


### PR DESCRIPTION
## PERC-037: Fix Skipped useInsuranceLP Tests

### Problem
The entire `useInsuranceLP` test suite (22 tests) was skipped via `describe.skip` + 3 individual `it.skip`. Tests had timer/async mock issues causing timeouts and unhandled rejections.

### Root Causes Fixed
1. **Missing `@percolator/core` mock** — PDA derivation failed in test env, making `lpMintInfo` null
2. **Fake timer conflicts** — `vi.useFakeTimers()` broke `waitFor()`. Fixed with `{ shouldAdvanceTime: true }`
3. **Guard check vs try/catch** — Hook throws before try block when wallet not connected
4. **RPC error assertions** — Tested wrong state; fixed to assert graceful handling
5. **React 18 batching** — Mid-flight loading state unobservable; split into success/failure tests
6. **sendTx mock type** — Hook expects string, not object

### Results
- **Before**: 181 passed, 55 skipped
- **After**: 204 passed, 34 skipped (+23 tests enabled)
- All 22 useInsuranceLP tests now pass
- Zero unhandled rejections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for insurance LP functionality with improved mock setup and comprehensive error handling scenarios.
  * Tests now validate graceful handling of wallet connection failures, RPC errors, and transaction failures.

* **Refactor**
  * Improved internal refresh logic structure for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->