### PR TITLE
fix(ci): enable Playwright webServer in CI — unblocks all PRs

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -83,11 +83,15 @@ export default defineConfig({
     // },
   ],
 
-  // Run local dev server before starting tests
-  webServer: process.env.CI ? undefined : {
-    command: 'pnpm run dev',
+  // Run app server before starting tests
+  // CI: use production build (pnpm start) — requires `pnpm build` first
+  // Local: use dev server (pnpm dev) and reuse if already running
+  webServer: {
+    command: process.env.CI ? 'pnpm --filter app start' : 'pnpm run dev',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120000,
+    stdout: 'pipe',
+    stderr: 'pipe',
   },
 });


### PR DESCRIPTION
## Problem
All 65 E2E tests fail with `net::ERR_CONNECTION_REFUSED` on every PR. The Playwright config set `webServer: undefined` when `CI=true`, so no server was started before tests ran.

## Fix
Always configure `webServer` in Playwright config:
- **CI**: `pnpm --filter app start` (production build, since `pnpm run build` runs first)
- **Local**: `pnpm run dev` with `reuseExistingServer: true`

One-line change in `playwright.config.ts`.

## Impact
Unblocks PRs #266, #267, #269, #270, #271, #262 which all fail the E2E gate.