### PR TITLE
feat: loading skeletons for all pages + reusable PageSkeleton (PERC-050)

### DIFF
--- a/app/app/agents/loading.tsx
+++ b/app/app/agents/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/components/ui/PageSkeleton";
+
+export default function AgentsLoading() {
+  return <PageSkeleton titleWidth="w-52" subtitleWidth="w-80" cards={6} />;
+}

--- a/app/app/bugs/loading.tsx
+++ b/app/app/bugs/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/components/ui/PageSkeleton";
+
+export default function BugsLoading() {
+  return <PageSkeleton titleWidth="w-40" subtitleWidth="w-72" rows={8} />;
+}

--- a/app/app/devnet-mint/loading.tsx
+++ b/app/app/devnet-mint/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/components/ui/PageSkeleton";
+
+export default function DevnetMintLoading() {
+  return <PageSkeleton titleWidth="w-44" subtitleWidth="w-72" cards={2} />;
+}

--- a/app/app/faucet/loading.tsx
+++ b/app/app/faucet/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/components/ui/PageSkeleton";
+
+export default function FaucetLoading() {
+  return <PageSkeleton titleWidth="w-36" subtitleWidth="w-64" cards={3} />;
+}

--- a/app/app/guide/loading.tsx
+++ b/app/app/guide/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/components/ui/PageSkeleton";
+
+export default function GuideLoading() {
+  return <PageSkeleton titleWidth="w-32" subtitleWidth="w-56" rows={10} />;
+}

--- a/app/app/join/loading.tsx
+++ b/app/app/join/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/components/ui/PageSkeleton";
+
+export default function JoinLoading() {
+  return <PageSkeleton titleWidth="w-36" subtitleWidth="w-72" form />;
+}

--- a/app/app/launch/loading.tsx
+++ b/app/app/launch/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/components/ui/PageSkeleton";
+
+export default function LaunchLoading() {
+  return <PageSkeleton titleWidth="w-40" subtitleWidth="w-72" rows={6} />;
+}

--- a/app/app/my-markets/loading.tsx
+++ b/app/app/my-markets/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/components/ui/PageSkeleton";
+
+export default function MyMarketsLoading() {
+  return <PageSkeleton titleWidth="w-44" subtitleWidth="w-56" rows={5} />;
+}

--- a/app/app/portfolio/loading.tsx
+++ b/app/app/portfolio/loading.tsx
@@ -1,0 +1,75 @@
+import { ShimmerSkeleton } from "@/components/ui/ShimmerSkeleton";
+
+export default function PortfolioLoading() {
+  return (
+    <div className="min-h-[calc(100vh-48px)] relative">
+      <div className="absolute inset-x-0 top-0 h-48 bg-grid pointer-events-none" />
+
+      <div className="relative mx-auto max-w-4xl px-4 py-10 space-y-8">
+        {/* Header */}
+        <div>
+          <ShimmerSkeleton className="h-3 w-16 mb-2" />
+          <ShimmerSkeleton className="h-7 w-40 mb-2" />
+          <ShimmerSkeleton className="h-4 w-56" />
+        </div>
+
+        {/* Summary stat cards */}
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+          {[1, 2, 3, 4].map((i) => (
+            <div
+              key={i}
+              className="rounded-sm border border-[var(--border)] bg-[var(--bg-surface)] p-4 hud-corners accent-top"
+            >
+              <ShimmerSkeleton className="h-3 w-20 mb-3" />
+              <ShimmerSkeleton className="h-6 w-28 mb-2" />
+              <ShimmerSkeleton className="h-3 w-16" />
+            </div>
+          ))}
+        </div>
+
+        {/* Position cards */}
+        <div>
+          <ShimmerSkeleton className="h-4 w-32 mb-4" />
+          <div className="space-y-3">
+            {[1, 2, 3].map((i) => (
+              <div
+                key={i}
+                className="rounded-sm border border-[var(--border)] bg-[var(--bg-surface)] p-4 hud-corners"
+              >
+                <div className="flex items-center justify-between mb-3">
+                  <div className="flex items-center gap-2">
+                    <ShimmerSkeleton className="h-8 w-8 rounded-full" />
+                    <ShimmerSkeleton className="h-5 w-32" />
+                  </div>
+                  <ShimmerSkeleton className="h-6 w-16 rounded-sm" />
+                </div>
+                <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+                  {[1, 2, 3, 4].map((j) => (
+                    <div key={j}>
+                      <ShimmerSkeleton className="h-3 w-14 mb-1.5" />
+                      <ShimmerSkeleton className="h-4 w-20" />
+                    </div>
+                  ))}
+                </div>
+                <div className="mt-3 flex gap-2">
+                  <ShimmerSkeleton className="h-8 w-24" />
+                  <ShimmerSkeleton className="h-8 w-24" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Trade history */}
+        <div>
+          <ShimmerSkeleton className="h-4 w-28 mb-4" />
+          <div className="space-y-2">
+            {[1, 2, 3, 4, 5].map((i) => (
+              <ShimmerSkeleton key={i} className="h-[44px]" />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/app/report-bug/loading.tsx
+++ b/app/app/report-bug/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/components/ui/PageSkeleton";
+
+export default function ReportBugLoading() {
+  return <PageSkeleton titleWidth="w-44" subtitleWidth="w-80" form />;
+}

--- a/app/components/ui/PageSkeleton.tsx
+++ b/app/components/ui/PageSkeleton.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { ShimmerSkeleton } from "./ShimmerSkeleton";
+
+interface PageSkeletonProps {
+  /** Heading label width (e.g., "w-16") */
+  labelWidth?: string;
+  /** Heading title width (e.g., "w-48") */
+  titleWidth?: string;
+  /** Subtitle width */
+  subtitleWidth?: string;
+  /** Number of content block rows */
+  rows?: number;
+  /** Show a form layout */
+  form?: boolean;
+  /** Show card grid (2-col or 3-col) */
+  cards?: number;
+}
+
+/**
+ * Reusable page-level loading skeleton that matches the Percolator
+ * design system. Used in Next.js loading.tsx files for instant
+ * visual feedback while the page chunk loads.
+ */
+export function PageSkeleton({
+  labelWidth = "w-16",
+  titleWidth = "w-48",
+  subtitleWidth = "w-64",
+  rows = 6,
+  form = false,
+  cards = 0,
+}: PageSkeletonProps) {
+  return (
+    <div className="min-h-[calc(100vh-48px)] relative">
+      <div className="absolute inset-x-0 top-0 h-48 bg-grid pointer-events-none" />
+
+      <div className="relative mx-auto max-w-4xl px-4 py-10 space-y-8">
+        {/* Page header */}
+        <div>
+          <ShimmerSkeleton className={`h-3 ${labelWidth} mb-2`} />
+          <ShimmerSkeleton className={`h-7 ${titleWidth} mb-2`} />
+          <ShimmerSkeleton className={`h-4 ${subtitleWidth}`} />
+        </div>
+
+        {/* Card grid */}
+        {cards > 0 && (
+          <div className={`grid gap-3 ${cards >= 3 ? "md:grid-cols-3" : "md:grid-cols-2"}`}>
+            {Array.from({ length: cards }).map((_, i) => (
+              <div
+                key={i}
+                className="rounded-sm border border-[var(--border)] bg-[var(--bg-surface)] p-5 hud-corners"
+              >
+                <ShimmerSkeleton className="h-4 w-24 mb-3" />
+                <ShimmerSkeleton className="h-3 w-full mb-2" />
+                <ShimmerSkeleton className="h-3 w-3/4" />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Form layout */}
+        {form && (
+          <div className="rounded-sm border border-[var(--border)] bg-[var(--bg-surface)] p-6 hud-corners space-y-4">
+            {[1, 2, 3, 4].map((i) => (
+              <div key={i}>
+                <ShimmerSkeleton className="h-3 w-20 mb-2" />
+                <ShimmerSkeleton className="h-10 w-full" />
+              </div>
+            ))}
+            <ShimmerSkeleton className="h-10 w-32 mt-2" />
+          </div>
+        )}
+
+        {/* Content rows */}
+        {!form && rows > 0 && (
+          <div className="space-y-2">
+            {Array.from({ length: rows }).map((_, i) => (
+              <ShimmerSkeleton key={i} className="h-[48px]" />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Adds Next.js `loading.tsx` instant loading skeletons to every page that was missing one, giving users immediate visual feedback during chunk loads.

### New Component
- **`PageSkeleton`**: Reusable skeleton with configurable layout (header, card grid, form, content rows). Uses `ShimmerSkeleton` with HUD corners and `bg-grid`.

### Pages Updated (11 files)
| Page | Skeleton Type |
|------|--------------|
| `/portfolio` | Custom — position cards, stat cards, trade history |
| `/bugs` | Row list (8 rows) |
| `/report-bug` | Form layout |
| `/guide` | Row list (10 rows) |
| `/join` | Form layout |
| `/faucet` | Card grid (3 cards) |
| `/my-markets` | Row list (5 rows) |
| `/devnet-mint` | Card grid (2 cards) |
| `/agents` | Card grid (6 cards) |
| `/launch` | Row list (6 rows) |

### Already Done (not changed)
- `/markets` — custom skeleton ✅
- `/trade/[slab]` — custom skeleton (desktop + mobile) ✅
- `/create` — custom skeleton ✅
- Trade form — optimistic UI with phase states (idle → submitting → confirming) ✅

### Testing
- All 237 unit tests pass
- TypeScript clean
- Skeletons are static (no data fetching) so zero risk of runtime errors

PERC-050

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added skeleton loading screens across multiple pages (Agents, Bugs, Devnet Mint, Faucet, Guide, Join, Launch, My Markets, Portfolio, and Report Bug) to provide visual feedback while page content loads. Users will see animated placeholders that match the structure of the final page layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->