### PR TITLE
security: fix 3 pentest findings — error disclosure, rate limit, CORS (PERC-055)

### DIFF
--- a/packages/api/src/routes/funding.ts
+++ b/packages/api/src/routes/funding.ts
@@ -59,7 +59,7 @@ export function fundingRoutes(): Hono {
       logger.error("Error fetching global funding data", { error: err });
       return c.json({ 
         error: "Failed to fetch global funding data",
-        details: err instanceof Error ? err.message : String(err)
+        ...(process.env.NODE_ENV !== "production" && { details: err instanceof Error ? err.message : String(err) })
       }, 500);
     }
   });
@@ -161,7 +161,7 @@ export function fundingRoutes(): Hono {
       logger.error("Error fetching funding data", { slab, error: err });
       return c.json({ 
         error: "Failed to fetch funding data",
-        details: err instanceof Error ? err.message : String(err)
+        ...(process.env.NODE_ENV !== "production" && { details: err instanceof Error ? err.message : String(err) })
       }, 500);
     }
   });
@@ -205,7 +205,7 @@ export function fundingRoutes(): Hono {
       logger.error("Error fetching funding history", { slab, error: err });
       return c.json({ 
         error: "Failed to fetch funding history",
-        details: err instanceof Error ? err.message : String(err)
+        ...(process.env.NODE_ENV !== "production" && { details: err instanceof Error ? err.message : String(err) })
       }, 500);
     }
   });

--- a/packages/api/src/routes/insurance.ts
+++ b/packages/api/src/routes/insurance.ts
@@ -80,7 +80,7 @@ export function insuranceRoutes(): Hono {
       logger.error("Error fetching insurance data", { slab, error: err });
       return c.json({ 
         error: "Failed to fetch insurance data",
-        details: err instanceof Error ? err.message : String(err)
+        ...(process.env.NODE_ENV !== "production" && { details: err instanceof Error ? err.message : String(err) })
       }, 500);
     }
   });

--- a/packages/api/src/routes/markets.ts
+++ b/packages/api/src/routes/markets.ts
@@ -122,7 +122,9 @@ export function marketRoutes(): Hono {
         },
       });
     } catch (err) {
-      return c.json({ error: err instanceof Error ? err.message : "Unknown error" }, 400);
+      const detail = err instanceof Error ? err.message : "Unknown error";
+      logger.error("Market fetch error", { detail, path: c.req.path });
+      return c.json({ error: "Failed to fetch market data" }, 400);
     }
   });
 

--- a/packages/api/src/routes/open-interest.ts
+++ b/packages/api/src/routes/open-interest.ts
@@ -84,7 +84,7 @@ export function openInterestRoutes(): Hono {
       logger.error("Error fetching OI data", { slab, error: err });
       return c.json({ 
         error: "Failed to fetch open interest data",
-        details: err instanceof Error ? err.message : String(err)
+        ...(process.env.NODE_ENV !== "production" && { details: err instanceof Error ? err.message : String(err) })
       }, 500);
     }
   });

--- a/packages/api/src/routes/oracle-router.ts
+++ b/packages/api/src/routes/oracle-router.ts
@@ -43,7 +43,9 @@ export function oracleRouterRoutes(): Hono {
 
       return c.json({ ...result, cached: false });
     } catch (err: any) {
-      return c.json({ error: err.message || "Failed to resolve oracle sources" }, 500);
+      const detail = err instanceof Error ? err.message : String(err);
+      logger.error("Oracle resolve error", { detail, path: c.req.path });
+      return c.json({ error: "Failed to resolve oracle sources" }, 500);
     }
   });
 

--- a/packages/api/src/routes/stats.ts
+++ b/packages/api/src/routes/stats.ts
@@ -78,7 +78,7 @@ export function statsRoutes(): Hono {
       logger.error("Error fetching platform stats", { error: err });
       return c.json({ 
         error: "Failed to fetch platform statistics",
-        details: err instanceof Error ? err.message : String(err)
+        ...(process.env.NODE_ENV !== "production" && { details: err instanceof Error ? err.message : String(err) })
       }, 500);
     }
   });

--- a/packages/api/tests/routes/markets.test.ts
+++ b/packages/api/tests/routes/markets.test.ts
@@ -343,7 +343,8 @@ describe("markets routes", () => {
 
       expect(res.status).toBe(400);
       const data = await res.json();
-      expect(data.error).toBe("Account not found");
+      // In production, error details are hidden; generic message returned
+      expect(data.error).toBe("Failed to fetch market data");
     });
   });
 });


### PR DESCRIPTION
## Pentest Remediation (PERC-049 findings)

### 1. Error Disclosure — MEDIUM (#278)
6 API routes leaked `err.message` in responses, exposing Supabase schema, RPC URLs, and library details.

**Fix:** Error details now only included when `NODE_ENV !== 'production'`. In production, generic messages returned; details logged server-side only.

**Affected routes:** stats, open-interest, insurance, funding (×3), oracle-router, markets

### 2. Rate Limiter IP Bypass — MEDIUM (#279)
Rate limiter used last IP in `X-Forwarded-For` chain, which is spoofable without a trusted proxy.

**Fix:** Added `TRUSTED_PROXY_DEPTH` env var (default 1):
- `0`: Ignore `X-Forwarded-For` entirely (safe for direct exposure)
- `1`: One reverse proxy (Vercel/Cloudflare) — default
- `2+`: Multiple proxy layers

Applied to both HTTP rate limiter and WebSocket IP extraction.

### 3. CORS + Dead Auth — LOW (#280)
CORS allowed POST/PUT/DELETE methods to routes that don't exist, and `requireApiKey()` middleware was defined but never applied.

**Fix:**
- CORS `allowMethods` restricted to `GET + OPTIONS`
- Default-deny middleware rejects POST/PUT/DELETE/PATCH with 405
- Comment trail for future mutation routes to apply `requireApiKey()`

### Testing
- All 106 API tests pass (updated market error expectation)
- Pre-existing shared/monitor test failure unrelated

Closes #278, closes #279, closes #280

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a default read-only guard that blocks write operations until authenticated endpoints are implemented.

* **Improvements**
  * Enhanced security by hiding sensitive error details in production environments.
  * Improved rate limiting and WebSocket client IP detection for proxy configurations.
  * Refined error responses with generic messages to prevent information disclosure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->