### PR TITLE
fix(ci): add missing logger import + fix monitor test threshold

### DIFF
--- a/packages/api/src/routes/oracle-router.ts
+++ b/packages/api/src/routes/oracle-router.ts
@@ -1,5 +1,8 @@
 import { Hono } from "hono";
 import { resolvePrice, type PriceRouterResult } from "@percolator/core";
+import { createLogger } from "@percolator/shared";
+
+const logger = createLogger("api:oracle-router");
 
 // Simple in-memory cache: mint → { result, expiresAt }
 const cache = new Map<string, { result: PriceRouterResult; expiresAt: number }>();

--- a/packages/shared/tests/monitor.test.ts
+++ b/packages/shared/tests/monitor.test.ts
@@ -50,7 +50,7 @@ describe("ServiceMonitor", () => {
     const strictMonitor = new ServiceMonitor("test", "strict", {
       maxConsecutiveFailures: 3,
       maxStalenessMs: 600_000, // 10 min — won't trigger in test
-      maxErrorRate: 1.0, // 100% — won't trigger
+      maxErrorRate: 1.1, // above 100% — won't trigger
       errorRateWindow: 10,
     });
     await strictMonitor.recordFailure("err1");


### PR DESCRIPTION
Quick CI fix for two issues blocking PR #285:

1. **oracle-router.ts**: Missing `createLogger` import — introduced in PERC-055 (PR #283) when I added `logger.error()` for error logging but forgot the import.
2. **monitor.test.ts**: Test set `maxErrorRate: 1.0` expecting it wouldn't trigger, but `>=` comparison means exactly 100% error rate (2/2 failures) does trigger. Changed to `1.1` so only `consecutiveFailures` is the trigger.

All 209 shared tests pass. All 106 API tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error logging infrastructure in the oracle router for improved observability.

* **Tests**
  * Updated monitor configuration threshold in test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->