### PR TITLE
feat(PERC-110): Add wrapper tags 30+31 — SetInsuranceWithdrawPolicy + WithdrawInsuranceLimited

### DIFF
--- a/program/src/tags.rs
+++ b/program/src/tags.rs
@@ -41,9 +41,9 @@ pub const TAG_UNPAUSE_MARKET: u8 = 28;
 // ═══════════════════════════════════════════════════════════════
 /// Two-step admin transfer: new admin accepts the proposal.
 pub const TAG_ACCEPT_ADMIN: u8 = 29;
-/// Reserved for percolator-stake CPI — not yet implemented.
+/// Set insurance withdrawal policy on a resolved market (PERC-110).
 pub const TAG_SET_INSURANCE_WITHDRAW_POLICY: u8 = 30;
-/// Reserved for percolator-stake CPI — not yet implemented.
+/// Withdraw limited amount from insurance fund per policy (PERC-110).
 pub const TAG_WITHDRAW_INSURANCE_LIMITED: u8 = 31;
 
 #[cfg(test)]
@@ -67,6 +67,7 @@ mod tests {
             TAG_CREATE_INSURANCE_MINT, TAG_DEPOSIT_INSURANCE_LP,
             TAG_WITHDRAW_INSURANCE_LP, TAG_PAUSE_MARKET, TAG_UNPAUSE_MARKET,
             TAG_ACCEPT_ADMIN,
+            TAG_SET_INSURANCE_WITHDRAW_POLICY, TAG_WITHDRAW_INSURANCE_LIMITED,
         ];
 
         for i in 0..tags.len() {
@@ -93,6 +94,7 @@ mod tests {
             TAG_CREATE_INSURANCE_MINT, TAG_DEPOSIT_INSURANCE_LP,
             TAG_WITHDRAW_INSURANCE_LP, TAG_PAUSE_MARKET, TAG_UNPAUSE_MARKET,
             TAG_ACCEPT_ADMIN,
+            TAG_SET_INSURANCE_WITHDRAW_POLICY, TAG_WITHDRAW_INSURANCE_LIMITED,
         ];
 
         for (i, &tag) in tags.iter().enumerate() {


### PR DESCRIPTION
## Critical Fix — CPI Tag Numbering Divergence

### Tag Assignment (updated to match tags.rs canonical numbering from PR #304)
- **Tag 29** = AcceptAdmin (PERC-112, PR #304)
- **Tag 30** = SetInsuranceWithdrawPolicy ← this PR
- **Tag 31** = WithdrawInsuranceLimited ← this PR

### The Bug
percolator-stake/cpi.rs was calling wrapper tags 22/23 for these instructions. In percolator-launch those tags are UpdateRiskParams(22) and RenounceAdmin(23). Calling AdminWithdrawInsurance from the stake program would have **invoked RenounceAdmin** — permanently removing the admin.

### The Fix
Added Tag 30 (SetInsuranceWithdrawPolicy) and Tag 31 (WithdrawInsuranceLimited). Policy state stored in PDA [ins_policy, slab_key] — no state migration needed.

### Security review items addressed
- epoch_cap saturating_mul was already correct
- All unwrap() replaced with .map_err(|_| ProgramError::Invalid*)?

### Merge order
1. PR #304 (PERC-112, AcceptAdmin tag 29) must merge first
2. Then this PR (#302, tags 30+31)
3. Then percolator-stake PR #2 (cpi.rs 22→30, 23→31)

cargo check passes on all branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Insurance fund administrators can now configure withdrawal policies with customizable parameters including minimum withdrawal amounts, per-epoch limits, and cooldown periods.
* Added limited insurance fund withdrawal functionality with enforcement of configured policy constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->