### PR TITLE
fix(PERC-129): serialize Error objects properly in all keeper catch blocks

### DIFF
--- a/packages/keeper/src/index.ts
+++ b/packages/keeper/src/index.ts
@@ -121,7 +121,7 @@ async function start() {
 }
 
 start().catch((err) => {
-  logger.error("Failed to start keeper", { error: err });
+  logger.error("Failed to start keeper", { error: err instanceof Error ? err.message : String(err), stack: err instanceof Error ? err.stack : undefined });
   process.exit(1);
 });
 
@@ -157,7 +157,7 @@ async function shutdown(signal: string): Promise<void> {
     logger.info("Shutdown complete");
     process.exit(0);
   } catch (err) {
-    logger.error("Error during shutdown", { error: err });
+    logger.error("Error during shutdown", { error: err instanceof Error ? err.message : String(err), stack: err instanceof Error ? err.stack : undefined });
     process.exit(1);
   }
 }

--- a/packages/keeper/src/services/crank.ts
+++ b/packages/keeper/src/services/crank.ts
@@ -225,12 +225,13 @@ export class CrankService {
         state.isActive = false;
       }
       
-      logger.error("Crank failed", { 
-        slabAddress, 
-        error: err,
+      logger.error("Crank failed", {
+        slabAddress,
+        error: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
         consecutiveFailures: state.consecutiveFailures,
         market: market.slabAddress.toBase58(),
-        programId: market.programId.toBase58()
+        programId: market.programId.toBase58(),
       });
       
       // Alert on 5+ consecutive failures
@@ -308,7 +309,7 @@ export class CrankService {
     this.discover().then(markets => {
       logger.info("Initial discovery complete", { marketCount: markets.length });
     }).catch(err => {
-      logger.error("Initial discovery failed", { error: err });
+      logger.error("Initial discovery failed", { error: err instanceof Error ? err.message : String(err), stack: err instanceof Error ? err.stack : undefined });
     });
 
     this.timer = setInterval(async () => {

--- a/packages/keeper/src/services/liquidation.ts
+++ b/packages/keeper/src/services/liquidation.ts
@@ -203,7 +203,11 @@ export class LiquidationService {
 
       return candidates;
     } catch (err) {
-      logger.error("Market scan failed", { slabAddress, error: err });
+      logger.error("Market scan failed", {
+        slabAddress,
+        error: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
+      });
       return [];
     }
   }
@@ -387,12 +391,13 @@ export class LiquidationService {
       
       return sig!;
     } catch (err) {
-      logger.error("Liquidation failed", { 
-        error: err,
+      logger.error("Liquidation failed", {
+        error: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
         slabAddress: slabAddress.toBase58(),
         accountIdx,
         market: slabAddress.toBase58(),
-        programId: market.programId.toBase58()
+        programId: market.programId.toBase58(),
       });
       
       eventBus.publish("liquidation.failure", slabAddress.toBase58(), {
@@ -475,7 +480,10 @@ export class LiquidationService {
           });
         }
       } catch (err) {
-        logger.error("Liquidation cycle failed", { error: err });
+        logger.error("Liquidation cycle failed", {
+          error: err instanceof Error ? err.message : String(err),
+          stack: err instanceof Error ? err.stack : undefined,
+        });
       } finally {
         this._scanning = false;
       }

--- a/packages/keeper/src/services/oracle.ts
+++ b/packages/keeper/src/services/oracle.ts
@@ -324,12 +324,13 @@ export class OracleService {
       });
       return true;
     } catch (err) {
-      logger.error("Failed to push oracle price", { 
-        slabAddress, 
-        error: err,
+      logger.error("Failed to push oracle price", {
+        slabAddress,
+        error: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
         mint,
         priceE6: priceEntry?.priceE6.toString(),
-        source: priceEntry?.source
+        source: priceEntry?.source,
       });
       
       return false;


### PR DESCRIPTION
## P0 Production Fix

### Problem
All keeper catch blocks logged `error: err` directly. JavaScript Error objects have non-enumerable properties — JSON.stringify serializes them as `{}`. The liquidation scanner was silently failing on 30+ markets every 60s with zero diagnostic info.

### Fix
Replace all bare `error: err` with:
```ts
error: err instanceof Error ? err.message : String(err),
stack: err instanceof Error ? err.stack : undefined,
```

### Files
- `liquidation.ts` — 3 catch blocks (market scan, liquidate(), cycle loop)
- `oracle.ts` — push oracle price catch block  
- `crank.ts` — crank() + initial discovery
- `index.ts` — startup + shutdown

### Next Steps
After keeper1 redeploy, real error messages will reveal the root cause (likely slab parsing failure from program upgrade tier size change). Follow-up fix in PERC-129.