### PR TITLE
fix(CI): pass Supabase env vars to E2E job — fix console error flake

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,6 +136,8 @@ jobs:
       RPC_URL: ${{ secrets.DEVNET_RPC_URL || 'https://api.devnet.solana.com' }}
       TEST_WALLET_PRIVATE_KEY: ${{ secrets.TEST_WALLET_PRIVATE_KEY }}
       BASE_URL: http://localhost:3000
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
     
     steps:
       - name: Checkout code


### PR DESCRIPTION
The E2E test suite was failing with `Failed to load market stats: Error: Supabase env vars not set`. The e2e-tests CI job was not passing `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` to the `pnpm run build` step, so the Next.js bundle had no Supabase config.\n\nFix: add both vars to the e2e-tests job env section (sourced from GitHub Secrets, now set).\n\nFixes the homepage console error E2E flake.