### PR TITLE
feat(PERC-119): Hyperp EMA oracle — permissionless perps via DEX-as-oracle

### DIFF
--- a/program/src/tags.rs
+++ b/program/src/tags.rs
@@ -47,6 +47,10 @@ pub const TAG_SET_INSURANCE_WITHDRAW_POLICY: u8 = 30;
 pub const TAG_WITHDRAW_INSURANCE_LIMITED: u8 = 31;
 /// Configure on-chain Pyth oracle for a market (PERC-117).
 pub const TAG_SET_PYTH_ORACLE: u8 = 32;
+/// Update mark price EMA (PERC-118, reserved).
+pub const TAG_UPDATE_MARK_PRICE: u8 = 33;
+/// Update Hyperp mark from DEX oracle (PERC-119).
+pub const TAG_UPDATE_HYPERP_MARK: u8 = 34;
 
 #[cfg(test)]
 mod tests {
@@ -70,6 +74,7 @@ mod tests {
             TAG_WITHDRAW_INSURANCE_LP, TAG_PAUSE_MARKET, TAG_UNPAUSE_MARKET,
             TAG_ACCEPT_ADMIN,
             TAG_SET_INSURANCE_WITHDRAW_POLICY, TAG_WITHDRAW_INSURANCE_LIMITED,
+            TAG_SET_PYTH_ORACLE, TAG_UPDATE_MARK_PRICE, TAG_UPDATE_HYPERP_MARK,
         ];
 
         for i in 0..tags.len() {
@@ -97,6 +102,7 @@ mod tests {
             TAG_WITHDRAW_INSURANCE_LP, TAG_PAUSE_MARKET, TAG_UNPAUSE_MARKET,
             TAG_ACCEPT_ADMIN,
             TAG_SET_INSURANCE_WITHDRAW_POLICY, TAG_WITHDRAW_INSURANCE_LIMITED,
+            TAG_SET_PYTH_ORACLE, TAG_UPDATE_MARK_PRICE, TAG_UPDATE_HYPERP_MARK,
         ];
 
         for (i, &tag) in tags.iter().enumerate() {


### PR DESCRIPTION
## The Percolator Differentiator

### UpdateHyperpMark (Tag 34) — Permissionless DEX Oracle for Any Token

Perps for ANY Solana token, no Pyth/Chainlink needed. The DEX AMM IS the oracle.

**Flow:** Caller provides PumpSwap/Raydium/Meteora pool account → on-chain owner validation → spot price read → 8h EMA smoothing → circuit breaker → new mark written to `authority_price_e6`

**Security:**
- DEX program owner validated (prevents substitution attacks)
- Circuit breaker BEFORE EMA (rugpull can't instantly move mark)
- Only Hyperp markets (`index_feed_id == [0;32]`)
- Resolved/paused/same-slot = no-op

**Also:** `compute_ema_mark_price()`, EMA constants, tags 32-34 in tags.rs, TS SDK.

`cargo check`: zero errors. Tag tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Permissionless Hyperp update flow to refresh mark price from DEX pricing (Hyperp-only markets).
  * EMA smoothing applied to mark price with an ~8-hour window and circuit-breaker limits.

* **Bug Fixes / Validation**
  * Bootstrap guard requiring an initial authority price before permissionless updates.
  * Hyperp-mode gate rejects non-Hyperp markets for this update path.

* **Documentation**
  * Added docs describing the update flow, required accounts, and effects.

* **Tests**
  * Added formal proofs validating EMA bootstrap, bounds, and gate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->