### PR TITLE
fix(PERC-134): Fix BigInt serialization in keeper logger

### DIFF
--- a/packages/keeper/src/services/liquidation.ts
+++ b/packages/keeper/src/services/liquidation.ts
@@ -118,7 +118,7 @@ export class LiquidationService {
       if (priceAge > 60n) {
         // Only log for markets with actual positions (reduce noise)
         if (engine.totalOpenInterest > 0n) {
-          logger.warn("Stale oracle price, skipping", { slabAddress, priceAgeSeconds: priceAge, maxAge: 60 });
+          logger.warn("Stale oracle price, skipping", { slabAddress, priceAgeSeconds: Number(priceAge), maxAge: 60 });
         }
         return []; // Don't liquidate with stale prices
       }

--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -28,6 +28,9 @@ const isProd = process.env.NODE_ENV === "production";
  * message, name, stack, and cause into a plain object.
  */
 function serializeValue(value: unknown): unknown {
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
   if (value instanceof Error) {
     const obj: Record<string, unknown> = {
       message: value.message,


### PR DESCRIPTION
## Problem
Production keeper logs show `Do not know how to serialize a BigInt` errors during liquidation scans, causing the entire scan to fail.

## Fix
- **packages/shared/src/logger.ts**: Add BigInt → string conversion in `serializeValue()`
- **packages/keeper/src/services/liquidation.ts**: Convert `priceAge` BigInt to Number before logging

## Impact
Fixes keeper scan failures. Should be deployed ASAP.