### PR TITLE
hotfix: Graceful Privy fallback — prevent site crash on missing app ID

### DIFF
--- a/app/components/providers/WalletProvider.tsx
+++ b/app/components/providers/WalletProvider.tsx
@@ -1,12 +1,84 @@
 "use client";
 
-import { FC, ReactNode, useMemo } from "react";
-import { PrivyProvider } from "@privy-io/react-auth";
+import { Component, FC, ReactNode, useMemo } from "react";
+import { PrivyProvider, usePrivy } from "@privy-io/react-auth";
 import { toSolanaWalletConnectors } from "@privy-io/react-auth/solana";
 import { SentryUserContext } from "@/components/providers/SentryUserContext";
+import { PrivyAvailableContext, PrivyLoginContext } from "@/hooks/usePrivySafe";
 import { getConfig } from "@/lib/config";
 
+/**
+ * Error boundary that catches PrivyProvider crashes and renders children
+ * without wallet capability. This prevents the entire app from being
+ * unusable when Privy SDK fails (invalid app ID, network issues, etc.).
+ */
+class PrivyErrorBoundary extends Component<
+  { children: ReactNode; fallback: ReactNode },
+  { hasError: boolean }
+> {
+  constructor(props: { children: ReactNode; fallback: ReactNode }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): { hasError: boolean } {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error) {
+    console.warn(
+      "[WalletProvider] Privy initialization failed, running in read-only mode:",
+      error.message
+    );
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+    return this.props.children;
+  }
+}
+
 export const WalletProvider: FC<{ children: ReactNode }> = ({ children }) => {
+  const appId = process.env.NEXT_PUBLIC_PRIVY_APP_ID;
+
+  // If no Privy app ID is configured, skip PrivyProvider entirely.
+  // The app runs in read-only mode (no wallet connection).
+  // PrivyAvailableContext = false tells all hooks to return defaults.
+  if (!appId) {
+    return (
+      <PrivyAvailableContext.Provider value={false}>
+        {children}
+      </PrivyAvailableContext.Provider>
+    );
+  }
+
+  const readOnlyFallback = (
+    <PrivyAvailableContext.Provider value={false}>
+      {children}
+    </PrivyAvailableContext.Provider>
+  );
+
+  return (
+    <PrivyErrorBoundary fallback={readOnlyFallback}>
+      <PrivyAvailableContext.Provider value={true}>
+        <PrivyProviderWrapper appId={appId}>
+          {children}
+        </PrivyProviderWrapper>
+      </PrivyAvailableContext.Provider>
+    </PrivyErrorBoundary>
+  );
+};
+
+/**
+ * Inner component that initializes Privy. Separated so the error boundary
+ * can catch any errors thrown during PrivyProvider initialization or rendering.
+ */
+const PrivyProviderWrapper: FC<{ appId: string; children: ReactNode }> = ({
+  appId,
+  children,
+}) => {
   const rpcUrl = useMemo(() => {
     const url = getConfig().rpcUrl;
     if (!url || !url.startsWith("http")) return "https://api.devnet.solana.com";
@@ -15,16 +87,9 @@ export const WalletProvider: FC<{ children: ReactNode }> = ({ children }) => {
 
   const solanaConnectors = useMemo(() => toSolanaWalletConnectors(), []);
 
-  // Fall back to a 25-char placeholder in test/CI environments where the secret
-  // is not set. Privy validates appId.length === 25 so this must be exact.
-  // The provider will still refuse auth connections, but the server won't crash.
-  const privyAppId =
-    process.env.NEXT_PUBLIC_PRIVY_APP_ID ||
-    "cltestappid00000000000000";
-
   return (
     <PrivyProvider
-      appId={privyAppId}
+      appId={appId as string}
       config={{
         appearance: {
           walletChainType: "solana-only",
@@ -44,7 +109,20 @@ export const WalletProvider: FC<{ children: ReactNode }> = ({ children }) => {
       }}
     >
       <SentryUserContext />
-      {children}
+      <PrivyLoginBridge>{children}</PrivyLoginBridge>
     </PrivyProvider>
+  );
+};
+
+/**
+ * Bridge component that exposes Privy's login function via context.
+ * Must be rendered inside PrivyProvider.
+ */
+const PrivyLoginBridge: FC<{ children: ReactNode }> = ({ children }) => {
+  const { login } = usePrivy();
+  return (
+    <PrivyLoginContext.Provider value={login}>
+      {children}
+    </PrivyLoginContext.Provider>
   );
 };

--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -17,7 +17,7 @@ import { PreTradeSummary } from "@/components/trade/PreTradeSummary";
 import { TradeConfirmationModal } from "@/components/trade/TradeConfirmationModal";
 import { InfoIcon } from "@/components/ui/Tooltip";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
-import { usePrivy } from "@privy-io/react-auth";
+import { usePrivyLogin } from "@/hooks/usePrivySafe";
 import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab, getMockUserAccountIdle } from "@/lib/mock-trade-data";
 
@@ -57,7 +57,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
   const { accounts, config: mktConfig, header } = useSlabState();
   const tokenMeta = useTokenMeta(mktConfig?.collateralMint ?? null);
   const { priceUsd } = useLivePrice();
-  const { login: openWalletModal } = usePrivy();
+  const openWalletModal = usePrivyLogin();
   const symbol = tokenMeta?.symbol ?? "Token";
   
   // BUG FIX: Fetch on-chain decimals from token account (like DepositWithdrawCard)

--- a/app/components/wallet/ConnectButton.tsx
+++ b/app/components/wallet/ConnectButton.tsx
@@ -3,12 +3,35 @@
 import { FC, useCallback, useMemo, useState, useRef, useEffect } from "react";
 import { usePrivy } from "@privy-io/react-auth";
 import { useWallets } from "@privy-io/react-auth/solana";
+import { usePrivyAvailable } from "@/hooks/usePrivySafe";
 
 /**
  * Privy-backed wallet connect button — replaces WalletMultiButton.
  * Shows truncated address when connected, opens Privy modal when not.
+ * Gracefully degrades when Privy is not available (no app ID).
  */
 export const ConnectButton: FC = () => {
+  const privyAvailable = usePrivyAvailable();
+
+  if (!privyAvailable) {
+    return (
+      <button
+        disabled
+        className="rounded-sm px-4 py-1.5 text-[13px] font-medium text-[var(--text-muted)] border border-[var(--border)] opacity-50"
+        aria-label="Wallet unavailable"
+      >
+        Connect
+      </button>
+    );
+  }
+
+  return <ConnectButtonInner />;
+};
+
+/**
+ * Inner component that uses Privy hooks. Only rendered when PrivyProvider is mounted.
+ */
+const ConnectButtonInner: FC = () => {
   const { ready, authenticated, login, logout } = usePrivy();
   const { wallets } = useWallets();
   const [menuOpen, setMenuOpen] = useState(false);

--- a/app/hooks/usePrivySafe.ts
+++ b/app/hooks/usePrivySafe.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { createContext, useCallback, useContext } from "react";
+
+/**
+ * Context to indicate whether Privy is available.
+ * Set to true by WalletProvider when PrivyProvider is mounted.
+ */
+export const PrivyAvailableContext = createContext<boolean>(false);
+
+/**
+ * Context holding Privy's login function.
+ * Provided by WalletProvider when Privy is available.
+ */
+export const PrivyLoginContext = createContext<(() => void) | null>(null);
+
+/**
+ * Returns true if PrivyProvider is in the component tree.
+ * Components should check this before calling usePrivy() or useWallets().
+ */
+export function usePrivyAvailable(): boolean {
+  return useContext(PrivyAvailableContext);
+}
+
+/**
+ * Safe hook that returns Privy's login function, or a no-op if unavailable.
+ * Use this instead of `usePrivy().login` in components that need to trigger
+ * the wallet connect modal but should work without Privy.
+ */
+export function usePrivyLogin(): () => void {
+  const login = useContext(PrivyLoginContext);
+  return useCallback(() => {
+    if (login) {
+      login();
+    } else {
+      console.warn("[Privy] Wallet connection unavailable");
+    }
+  }, [login]);
+}


### PR DESCRIPTION
CRITICAL HOTFIX: Site 500ing because Privy SDK crashes on missing/invalid app ID. Fix: error boundary + conditional PrivyProvider + safe hook defaults. App degrades to read-only mode when Privy unavailable.