### PR TITLE
🚨 hotfix: Disable Privy SSR — fix production 500

### DIFF
--- a/app/components/providers/PrivyProviderClient.tsx
+++ b/app/components/providers/PrivyProviderClient.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { FC, ReactNode, useMemo } from "react";
+import { PrivyProvider, usePrivy } from "@privy-io/react-auth";
+import { toSolanaWalletConnectors } from "@privy-io/react-auth/solana";
+import { SentryUserContext } from "@/components/providers/SentryUserContext";
+import { PrivyLoginContext } from "@/hooks/usePrivySafe";
+import { getConfig } from "@/lib/config";
+
+/**
+ * Client-only Privy provider wrapper. Loaded via next/dynamic with ssr:false
+ * to prevent Privy SDK from crashing during server-side rendering.
+ */
+const PrivyProviderClient: FC<{ appId: string; children: ReactNode }> = ({
+  appId,
+  children,
+}) => {
+  const rpcUrl = useMemo(() => {
+    const url = getConfig().rpcUrl;
+    if (!url || !url.startsWith("http")) return "https://api.devnet.solana.com";
+    return url;
+  }, []);
+
+  const solanaConnectors = useMemo(() => toSolanaWalletConnectors(), []);
+
+  return (
+    <PrivyProvider
+      appId={appId}
+      config={{
+        appearance: {
+          walletChainType: "solana-only",
+          showWalletLoginFirst: true,
+        },
+        loginMethods: ["wallet", "email"],
+        externalWallets: {
+          solana: {
+            connectors: solanaConnectors,
+          },
+        },
+        embeddedWallets: {
+          solana: {
+            createOnLogin: "users-without-wallets",
+          },
+        },
+      }}
+    >
+      <SentryUserContext />
+      <PrivyLoginBridge>{children}</PrivyLoginBridge>
+    </PrivyProvider>
+  );
+};
+
+/**
+ * Bridge that exposes Privy's login function via context so components
+ * outside the Privy tree can trigger wallet connection safely.
+ */
+const PrivyLoginBridge: FC<{ children: ReactNode }> = ({ children }) => {
+  const { login } = usePrivy();
+  return (
+    <PrivyLoginContext.Provider value={login}>
+      {children}
+    </PrivyLoginContext.Provider>
+  );
+};
+
+export default PrivyProviderClient;


### PR DESCRIPTION
## 🚨 CRITICAL — Site still 500ing after PR #326

PR #326's error boundary only catches client-side errors. The Privy SDK crashes during **server-side rendering** because it accesses browser-only APIs (`window`, `localStorage`). SSR errors bypass React error boundaries.

### Fix
Split Privy into a separate `PrivyProviderClient.tsx` and load it via `next/dynamic({ ssr: false })`:
- During SSR: children render without wallet → page loads successfully
- After hydration: Privy loads client-side → wallet connection available
- Error boundary still catches runtime Privy crashes

### Files
- **New:** `PrivyProviderClient.tsx` — all Privy SDK imports isolated here
- **Modified:** `WalletProvider.tsx` — uses `dynamic()` import, no direct Privy SDK import

### Verification
`pnpm build` passes ✅ — all pages render as dynamic (server-rendered on demand)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved wallet provider initialization with better client-side handling and error resilience.
  * Added graceful fallback to read-only mode when wallet configuration is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->