### PR TITLE
fix: CSP blocking Privy and WalletConnect — site wallet connect broken

### DIFF
--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -88,8 +88,8 @@ function addSecurityHeaders(response: NextResponse, nonce?: string) {
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "font-src 'self' https://fonts.gstatic.com",
     "img-src 'self' data: https: blob:",
-    "connect-src 'self' https://*.solana.com wss://*.solana.com https://*.supabase.co wss://*.supabase.co https://*.vercel-insights.com https://api.coingecko.com https://*.helius-rpc.com wss://*.helius-rpc.com https://api.dexscreener.com https://hermes.pyth.network https://*.up.railway.app wss://*.up.railway.app https://token.jup.ag blob:",
-    "frame-src 'none'",
+    "connect-src 'self' https://*.solana.com wss://*.solana.com https://*.supabase.co wss://*.supabase.co https://*.vercel-insights.com https://api.coingecko.com https://*.helius-rpc.com wss://*.helius-rpc.com https://api.dexscreener.com https://hermes.pyth.network https://*.up.railway.app wss://*.up.railway.app https://token.jup.ag https://auth.privy.io https://*.rpc.privy.systems https://explorer-api.walletconnect.com wss://relay.walletconnect.com wss://relay.walletconnect.org wss://www.walletlink.org blob:",
+    "frame-src https://auth.privy.io https://verify.walletconnect.com https://verify.walletconnect.org",
     "object-src 'none'",
     "base-uri 'self'",
   ].join("; ");


### PR DESCRIPTION
## Problem
percolatorlaunch.com wallet connect is broken. Console shows CSP violations:
- `auth.privy.io` blocked by `connect-src` — Privy SDK can't authenticate
- `explorer-api.walletconnect.com` blocked — wallet list won't load
- `relay.walletconnect.com` blocked — WalletConnect relay can't connect

## Root Cause
`middleware.ts` CSP `connect-src` didn't include Privy or WalletConnect domains. `frame-src` was set to `'none'`, blocking Privy auth iframes.

## Fix
Added domains per [official Privy CSP docs](https://docs.privy.io/security/implementation-guide/content-security-policy):
- `connect-src`: `auth.privy.io`, `*.rpc.privy.systems`, `explorer-api.walletconnect.com`, `wss://relay.walletconnect.com`, `wss://relay.walletconnect.org`, `wss://www.walletlink.org`
- `frame-src`: `auth.privy.io`, `verify.walletconnect.com`, `verify.walletconnect.org`

## Testing
- `pnpm build` passes
- CSP domains match official Privy documentation exactly

🔴 **P0 — merge ASAP, wallet connect is non-functional on prod**