### PR TITLE
fix: use /api/rpc proxy instead of falling back to public devnet

### DIFF
--- a/app/components/providers/PrivyProviderClient.tsx
+++ b/app/components/providers/PrivyProviderClient.tsx
@@ -17,7 +17,7 @@ const PrivyProviderClient: FC<{ appId: string; children: ReactNode }> = ({
 }) => {
   const rpcUrl = useMemo(() => {
     const url = getConfig().rpcUrl;
-    if (!url || !url.startsWith("http")) return "https://api.devnet.solana.com";
+    if (!url) return "https://api.devnet.solana.com";
     return url;
   }, []);
 

--- a/app/hooks/useWalletCompat.ts
+++ b/app/hooks/useWalletCompat.ts
@@ -93,7 +93,7 @@ export function useConnectionCompat() {
   const connection = useMemo(() => {
     const url = getConfig().rpcUrl;
     const rpc =
-      !url || !url.startsWith("http")
+      !url
         ? "https://api.devnet.solana.com"
         : url;
     return new Connection(rpc, "confirmed");


### PR DESCRIPTION
## Problem
Client-side code was **always falling back to public devnet RPC** (`https://api.devnet.solana.com`) because `useConnectionCompat` and `PrivyProviderClient` checked `url.startsWith('http')` — but the proxy URL `/api/rpc` is a relative path that doesn't start with `http`.

This caused **429 rate limiting** from Solana's public devnet endpoint.

## Fix
Remove the `startsWith('http')` guard. `getConfig().rpcUrl` already returns the correct value:
- Client-side: `/api/rpc` (proxy that uses Helius API key server-side)
- Server-side: direct Helius URL with API key

## Files Changed
- `app/hooks/useWalletCompat.ts` — remove http check in `useConnectionCompat`
- `app/components/providers/PrivyProviderClient.tsx` — remove http check in rpcUrl memo

## Testing
- TypeScript compiles clean
- All RPC calls now route through `/api/rpc` → Helius (no more public devnet 429s)

## Priority
**P0** — site was non-functional due to rate limiting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Refined URL validation to accept non-HTTP custom RPC endpoints without defaulting to fallback values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->