### PR TITLE
fix: use absolute URL for /api/rpc proxy (fixes Connection crash)

### DIFF
--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -18,8 +18,9 @@ function getNetwork(): Network {
 /** Get RPC URL — uses /api/rpc proxy on client, direct Helius on server */
 function getRpcUrl(network: Network): string {
   // Client-side: use RPC proxy (API key stays server-side)
+  // Must be absolute URL — Solana Connection constructor rejects relative paths
   if (typeof window !== "undefined") {
-    return "/api/rpc";
+    return `${window.location.origin}/api/rpc`;
   }
   
   // Server-side: use direct Helius URL (for SSR/SSG)


### PR DESCRIPTION
## Context
PR #329 caused a P0 outage — Solana `Connection` constructor requires absolute URLs but `/api/rpc` is relative. Reverted in fa0a75d.

## Fix
Change `getRpcUrl()` in `config.ts` to return `${window.location.origin}/api/rpc` on client side. This:
- Gives `Connection` a valid absolute URL
- Keeps Helius API key server-side (proxied)
- Stops client RPC from hitting public devnet (fixing original 429s)

## Single file changed
`app/lib/config.ts` — 1 line in `getRpcUrl()`