### PR TITLE
fix: add WebSocket endpoint for Solana Connection subscriptions

### DIFF
--- a/app/hooks/useWalletCompat.ts
+++ b/app/hooks/useWalletCompat.ts
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { usePrivy } from "@privy-io/react-auth";
 import { useWallets, useSignTransaction } from "@privy-io/react-auth/solana";
 import { Connection, PublicKey, Transaction } from "@solana/web3.js";
-import { getConfig } from "@/lib/config";
+import { getConfig, getWsEndpoint } from "@/lib/config";
 import { usePrivyAvailable } from "@/hooks/usePrivySafe";
 
 /**
@@ -92,7 +92,11 @@ function useWalletCompatInner() {
 export function useConnectionCompat() {
   const connection = useMemo(() => {
     const url = getConfig().rpcUrl;
-    return new Connection(url, "confirmed");
+    const wsEndpoint = getWsEndpoint();
+    return new Connection(url, {
+      commitment: "confirmed",
+      ...(wsEndpoint ? { wsEndpoint } : {}),
+    });
   }, []);
 
   return { connection };

--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -36,6 +36,22 @@ export function getRpcEndpoint(): string {
   return process.env.NEXT_PUBLIC_SOLANA_RPC_URL ?? "https://api.devnet.solana.com";
 }
 
+/**
+ * Get WebSocket endpoint for Solana Connection subscriptions.
+ * The HTTP proxy at /api/rpc doesn't support WebSocket upgrades,
+ * so we connect directly to Helius WSS for real-time subscriptions.
+ * Returns undefined if no Helius key is configured (disables WS subscriptions).
+ */
+export function getWsEndpoint(): string | undefined {
+  const apiKey = process.env.NEXT_PUBLIC_HELIUS_API_KEY ?? "";
+  if (!apiKey) return undefined;
+
+  const net = getNetwork();
+  return net === "mainnet"
+    ? `wss://mainnet.helius-rpc.com/?api-key=${apiKey}`
+    : `wss://devnet.helius-rpc.com/?api-key=${apiKey}`;
+}
+
 const CONFIGS = {
   mainnet: {
     get rpcUrl() { return getRpcEndpoint(); },


### PR DESCRIPTION
Closes #333

## Problem
`/api/rpc` proxy only handles HTTP POST. Solana `Connection` tries to open `wss://percolatorlaunch.com/api/rpc` for subscriptions → infinite reconnect loop, console spam, no real-time data.

## Fix
- Add `getWsEndpoint()` in `config.ts` — returns direct Helius WSS URL using `NEXT_PUBLIC_HELIUS_API_KEY`
- Pass `wsEndpoint` to `Connection` constructor in `useConnectionCompat`
- If no API key configured, WS subscriptions are disabled (no crash)

## Files
- `app/lib/config.ts` — new `getWsEndpoint()` function
- `app/hooks/useWalletCompat.ts` — pass wsEndpoint to Connection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WebSocket endpoint support for enhanced wallet connectivity configuration.
  * Connection now properly configures commitment settings across different networks.

* **Bug Fixes**
  * Improved connection initialization to use standardized configuration parameters for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->