### PR TITLE
Fix NaN bypasses bounds check in parseAccount

### DIFF
--- a/packages/core/src/solana/slab.ts
+++ b/packages/core/src/solana/slab.ts
@@ -662,7 +662,7 @@ export function maxAccountIndex(dataLen: number): number {
  */
 export function parseAccount(data: Uint8Array, idx: number): Account {
   const maxIdx = maxAccountIndex(data.length);
-  if (idx < 0 || idx >= maxIdx) {
+  if (!Number.isInteger(idx) || idx < 0 || idx >= maxIdx) {
     throw new Error(`Account index out of range: ${idx} (max: ${maxIdx - 1})`);
   }
 


### PR DESCRIPTION
This pull request makes a small but important improvement to input validation in the `parseAccount` function. The change ensures that only integer indices are accepted, preventing potential errors from non-integer values.

- Improved input validation:
  * [`packages/core/src/solana/slab.ts`](diffhunk://#diff-734c7c1830b551d776596214559a6983ecaba1d7f44130d74b6396316af69b99L665-R665): Updated the `parseAccount` function to check that `idx` is an integer using `Number.isInteger`, in addition to the existing range validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced input validation to catch and reject previously undetected invalid entries, preventing potential processing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->