### PR TITLE
fix(#341): Update Kani proofs for Sprint 2 struct changes

### DIFF
--- a/percolator/tests/kani.rs
+++ b/percolator/tests/kani.rs
@@ -47,6 +47,25 @@ fn test_params() -> RiskParams {
         liquidation_fee_cap: U128::new(10_000),
         liquidation_buffer_bps: 100,
         min_liquidation_abs: U128::new(100_000),
+        // PERC-121: Funding rate parameters (disabled by default)
+        funding_premium_weight_bps: 0,
+        funding_settlement_interval_slots: 0,
+        funding_premium_dampening_e6: 1_000_000,
+        funding_premium_max_bps_per_slot: 100,
+        // PERC-122: Partial liquidation parameters (disabled by default)
+        partial_liquidation_bps: 0,
+        partial_liquidation_cooldown_slots: 0,
+        use_mark_price_for_liquidation: false,
+        emergency_liquidation_margin_bps: 0,
+        // PERC-120: Dynamic fee parameters (disabled by default)
+        fee_tier2_bps: 0,
+        fee_tier3_bps: 0,
+        fee_tier2_threshold: 0,
+        fee_tier3_threshold: 0,
+        fee_split_lp_bps: 10_000,
+        fee_split_protocol_bps: 0,
+        fee_split_creator_bps: 0,
+        fee_utilization_surge_bps: 0,
     }
 }
 
@@ -66,6 +85,25 @@ fn test_params_with_floor() -> RiskParams {
         liquidation_fee_cap: U128::new(10_000),
         liquidation_buffer_bps: 100,
         min_liquidation_abs: U128::new(100_000),
+        // PERC-121: Funding rate parameters (disabled by default)
+        funding_premium_weight_bps: 0,
+        funding_settlement_interval_slots: 0,
+        funding_premium_dampening_e6: 1_000_000,
+        funding_premium_max_bps_per_slot: 100,
+        // PERC-122: Partial liquidation parameters (disabled by default)
+        partial_liquidation_bps: 0,
+        partial_liquidation_cooldown_slots: 0,
+        use_mark_price_for_liquidation: false,
+        emergency_liquidation_margin_bps: 0,
+        // PERC-120: Dynamic fee parameters (disabled by default)
+        fee_tier2_bps: 0,
+        fee_tier3_bps: 0,
+        fee_tier2_threshold: 0,
+        fee_tier3_threshold: 0,
+        fee_split_lp_bps: 10_000,
+        fee_split_protocol_bps: 0,
+        fee_split_creator_bps: 0,
+        fee_utilization_surge_bps: 0,
     }
 }
 
@@ -85,6 +123,25 @@ fn test_params_with_maintenance_fee() -> RiskParams {
         liquidation_fee_cap: U128::new(10_000),
         liquidation_buffer_bps: 100,
         min_liquidation_abs: U128::new(100_000),
+        // PERC-121: Funding rate parameters (disabled by default)
+        funding_premium_weight_bps: 0,
+        funding_settlement_interval_slots: 0,
+        funding_premium_dampening_e6: 1_000_000,
+        funding_premium_max_bps_per_slot: 100,
+        // PERC-122: Partial liquidation parameters (disabled by default)
+        partial_liquidation_bps: 0,
+        partial_liquidation_cooldown_slots: 0,
+        use_mark_price_for_liquidation: false,
+        emergency_liquidation_margin_bps: 0,
+        // PERC-120: Dynamic fee parameters (disabled by default)
+        fee_tier2_bps: 0,
+        fee_tier3_bps: 0,
+        fee_tier2_threshold: 0,
+        fee_tier3_threshold: 0,
+        fee_split_lp_bps: 10_000,
+        fee_split_protocol_bps: 0,
+        fee_split_creator_bps: 0,
+        fee_utilization_surge_bps: 0,
     }
 }
 
@@ -2036,6 +2093,7 @@ fn fast_account_equity_computes_correctly() {
         owner: [0; 32],
         fee_credits: I128::ZERO,
         last_fee_slot: 0,
+        last_partial_liquidation_slot: 0,
     };
 
     let equity = engine.account_equity(&account);

--- a/program/tests/kani.rs
+++ b/program/tests/kani.rs
@@ -54,11 +54,11 @@ use percolator_prog::verify::{
     init_market_scale_ok,
     // PERC-117: Pyth oracle verification helpers
     is_pyth_pinned_mode, is_hyperp_mode_verify, pyth_price_is_fresh,
-    // PERC-118: Mark price EMA verification helpers
-    ema_mark_step, mark_cap_bound,
+    // PERC-118: Mark price EMA verification helpers (moved to program crate)
 };
 use percolator_prog::constants::MAX_UNIT_SCALE;
 use percolator_prog::oracle::clamp_toward_with_dt;
+use percolator_prog::LpRiskState;
 
 // Kani-specific bounds to avoid SAT explosion on division/modulo.
 // MAX_UNIT_SCALE (1 billion) is too large for bit-precise SAT solving.
@@ -3130,6 +3130,16 @@ fn kani_pyth_price_invert_zero_price_rejected() {
     assert_eq!(result, None, "inverting zero price must return None");
 }
 
+// Helper: compute max allowed deviation from mark_prev given cap and dt.
+// Replaces the removed `mark_cap_bound` from verify module.
+fn mark_cap_bound_inline(mark_prev: u64, cap_e2bps: u64, dt_slots: u64) -> u64 {
+    let max_delta = (mark_prev as u128)
+        .saturating_mul(cap_e2bps as u128)
+        .saturating_mul(dt_slots as u128)
+        / 1_000_000u128;
+    max_delta.min(mark_prev as u128) as u64
+}
+
 // PERC-118: Mark price EMA proofs
 // =========================================================================
 
@@ -3152,10 +3162,10 @@ fn kani_mark_price_bounded_by_cap() {
     kani::assume(alpha_e6 <= 1_000_000);
     kani::assume(cap_e2bps > 0 && cap_e2bps <= 1_000_000); // up to 100%/slot
 
-    let mark_new = ema_mark_step(mark_prev, oracle, dt_slots, alpha_e6, cap_e2bps);
+    let mark_new = LpRiskState::compute_ema_mark_price(mark_prev, oracle, dt_slots, alpha_e6, cap_e2bps);
 
     // Compute the allowed bound
-    let bound = mark_cap_bound(mark_prev, cap_e2bps, dt_slots);
+    let bound = mark_cap_bound_inline(mark_prev, cap_e2bps, dt_slots);
 
     let lo = mark_prev.saturating_sub(bound);
     let hi = mark_prev.saturating_add(bound);
@@ -3184,7 +3194,7 @@ fn kani_hyperp_ema_converges_full_alpha() {
 
     // With alpha=1_000_000 (100%), one step converges fully to oracle
     // (no cap, so oracle passes through unmodified)
-    let mark_new = ema_mark_step(
+    let mark_new = LpRiskState::compute_ema_mark_price(
         mark_prev,
         oracle,
         1,           // dt=1 slot
@@ -3206,7 +3216,7 @@ fn kani_hyperp_ema_monotone_up() {
     kani::assume(mark_prev <= 1_000_000_000u64 && oracle <= 1_000_000_000u64);
     kani::assume(alpha_e6 > 0 && alpha_e6 <= 1_000_000);
 
-    let mark_new = ema_mark_step(mark_prev, oracle, 1, alpha_e6, 0 /* no cap */);
+    let mark_new = LpRiskState::compute_ema_mark_price(mark_prev, oracle, 1, alpha_e6, 0 /* no cap */);
 
     // With oracle > mark_prev and alpha > 0, mark_new >= mark_prev
     assert!(
@@ -3231,7 +3241,7 @@ fn kani_hyperp_ema_monotone_down() {
     kani::assume(mark_prev <= 1_000_000_000u64);
     kani::assume(alpha_e6 > 0 && alpha_e6 <= 1_000_000);
 
-    let mark_new = ema_mark_step(mark_prev, oracle, 1, alpha_e6, 0);
+    let mark_new = LpRiskState::compute_ema_mark_price(mark_prev, oracle, 1, alpha_e6, 0);
 
     assert!(
         mark_new <= mark_prev,
@@ -3256,7 +3266,7 @@ fn kani_ema_mark_identity_at_equilibrium() {
     kani::assume(dt_slots > 0 && dt_slots <= 10_000);
 
     // No cap
-    let mark_new = ema_mark_step(price, price, dt_slots, alpha_e6, 0);
+    let mark_new = LpRiskState::compute_ema_mark_price(price, price, dt_slots, alpha_e6, 0);
 
     assert_eq!(
         mark_new, price,
@@ -3276,8 +3286,8 @@ fn kani_mark_cap_bound_monotone_in_dt() {
     kani::assume(cap_e2bps > 0 && cap_e2bps <= 1_000_000);
     kani::assume(dt_a <= dt_b && dt_b <= 100_000);
 
-    let bound_a = mark_cap_bound(mark_prev, cap_e2bps, dt_a);
-    let bound_b = mark_cap_bound(mark_prev, cap_e2bps, dt_b);
+    let bound_a = mark_cap_bound_inline(mark_prev, cap_e2bps, dt_a);
+    let bound_b = mark_cap_bound_inline(mark_prev, cap_e2bps, dt_b);
 
     // Larger dt allows at least as much movement
     assert!(
@@ -3298,7 +3308,7 @@ fn kani_ema_mark_bootstrap() {
     kani::assume(alpha_e6 <= 1_000_000);
     kani::assume(dt_slots > 0 && dt_slots <= 10_000);
 
-    let mark_new = ema_mark_step(0 /* mark_prev=0 */, oracle, dt_slots, alpha_e6, 1_000);
+    let mark_new = LpRiskState::compute_ema_mark_price(0 /* mark_prev=0 */, oracle, dt_slots, alpha_e6, 1_000);
 
     assert_eq!(
         mark_new, oracle,
@@ -3316,7 +3326,7 @@ fn kani_ema_mark_no_cap_full_oracle() {
     kani::assume(oracle > 0 && oracle <= 1_000_000_000u64);
 
     // alpha=1_000_000 (full), cap=0 (disabled), dt=1
-    let mark_new = ema_mark_step(mark_prev, oracle, 1, 1_000_000, 0);
+    let mark_new = LpRiskState::compute_ema_mark_price(mark_prev, oracle, 1, 1_000_000, 0);
 
     // With cap disabled and alpha=100%, result is exactly the oracle
     assert_eq!(mark_new, oracle, "no-cap + full-alpha must return oracle unchanged");
@@ -3359,7 +3369,7 @@ fn kani_hyperp_pipeline_bounded_when_bootstrapped() {
     kani::assume(cap_e2bps > 0);
     kani::assume(cap_e2bps <= 100_000); // up to 10% per slot
 
-    let new_mark = compute_ema_mark_price(prev_mark, dex_price, dt_slots, alpha_e6, cap_e2bps);
+    let new_mark = LpRiskState::compute_ema_mark_price(prev_mark, dex_price, dt_slots, alpha_e6, cap_e2bps);
 
     // New mark must be > 0 (can't go to zero from positive prev_mark with EMA)
     assert!(new_mark > 0, "EMA mark must be positive when prev_mark > 0");


### PR DESCRIPTION
## Problem
Both Kani proof files (~306 proofs) fail to compile on current main due to missing struct fields added by Sprint 2 PRs (#315, #317, #319, #322).

## Changes

### percolator/tests/kani.rs
- Added 17 new `RiskParams` fields to all 3 helper constructors (`test_params`, `test_params_with_floor`, `test_params_with_maintenance_fee`) with safe disabled-by-default values
- Added `last_partial_liquidation_slot: 0` to the `Account` initializer

### program/tests/kani.rs
- Replaced removed `ema_mark_step` → `LpRiskState::compute_ema_mark_price` (same signature)
- Replaced removed `mark_cap_bound` → inline `mark_cap_bound_inline` helper (same formula)
- Updated imports accordingly

## Testing
- ✅ All 145 percolator unit tests pass
- ✅ 35 program unit tests pass (3 pre-existing failures on main, unrelated)
- Kani proofs require `cargo kani` to run (not available in CI)

Closes #341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test coverage for funding premium management, partial liquidation mechanics, tiered fee structures, and emergency liquidation scenarios.

* **Refactor**
  * Centralized EMA mark price computation logic for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->