### PR TITLE
fix: pre-mainnet safety — tx simulation before signing + Math.round() insurance display

### DIFF
--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -483,14 +483,14 @@ function MarketsPageInner() {
                   
                   // Display values (USD or tokens)
                   const oiDisplay = showUsd && lastPrice != null
-                    ? formatNum((Number(oiTokensRaw) / 1e6) * lastPrice)
+                    ? formatNum(Math.round((Number(oiTokensRaw) / 1e6) * lastPrice * 100) / 100)
                     : formatTokenAmount(oiTokensRaw);
                   const insuranceDisplay = showUsd && lastPrice != null
-                    ? formatNum((Number(insuranceTokensRaw) / 1e6) * lastPrice)
+                    ? formatNum(Math.round((Number(insuranceTokensRaw) / 1e6) * lastPrice * 100) / 100)
                     : formatTokenAmount(insuranceTokensRaw);
                   const volumeDisplay = volume24hRaw != null
                     ? (showUsd && lastPrice != null
-                        ? formatNum((Number(volume24hRaw) / 1e6) * lastPrice)
+                        ? formatNum(Math.round((Number(volume24hRaw) / 1e6) * lastPrice * 100) / 100)
                         : formatTokenAmount(volume24hRaw))
                     : null;
 

--- a/app/components/market/InsuranceTopUpModal.tsx
+++ b/app/components/market/InsuranceTopUpModal.tsx
@@ -291,11 +291,11 @@ export const InsuranceTopUpModal: FC<InsuranceTopUpModalProps> = ({
                         style={{ fontFamily: "var(--font-mono)" }}
                       >
                         {lpState.lpSupply > 0n
-                          ? (
+                          ? Math.round(
                               (parseFloat(amount) * 1e6 * Number(lpState.lpSupply)) /
                               Number(lpState.insuranceBalance || 1n)
                             ).toLocaleString(undefined, { maximumFractionDigits: 2 })
-                          : (parseFloat(amount) * 1e6).toLocaleString()}{" "}
+                          : Math.round(parseFloat(amount) * 1e6).toLocaleString()}{" "}
                         LP
                       </span>
                     </div>


### PR DESCRIPTION
## Pre-mainnet Safety Follow-up

Items flagged by QA and Security during mobile PR review:

### 1. Pre-sign Transaction Simulation (`app/lib/tx.ts`)
- Added `connection.simulateTransaction()` call **before** requesting wallet signature
- Catches program errors early with clear, actionable error messages
- Non-blocking: if RPC simulation fails, falls through to normal `skipPreflight: false` behavior
- Passes existing signers for account-creation txs (so createAccount can be simulated)

### 2. Math.round() on Insurance Display Calculations
- **`app/app/markets/page.tsx`**: Wrapped OI, insurance, and volume USD display calculations with `Math.round()` (to 2 decimal places) to prevent floating-point artifacts like `489.99999`
- **`app/components/market/InsuranceTopUpModal.tsx`**: Wrapped LP token estimate calculation with `Math.round()` to prevent fractional LP token display

### Testing
- ✅ `pnpm build` passes (all packages)
- ✅ `pnpm test` — 206 passed, 34 skipped, 2 pre-existing failures (mainnet config tests, unrelated)
- No new dependencies

### Files Changed (3)
- `app/lib/tx.ts` — pre-sign simulation logic
- `app/app/markets/page.tsx` — Math.round() on display values  
- `app/components/market/InsuranceTopUpModal.tsx` — Math.round() on LP estimate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved USD value display precision by rounding open interest, insurance, and 24h volume amounts to two decimal places
  * Enhanced LP token estimate accuracy in insurance pool interactions with refined calculation logic
  * Added transaction error detection before signing to prevent failed blockchain submissions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->