### PR TITLE
PERC-140: Fresh devnet program deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,10 +16,10 @@ SUPABASE_SERVICE_ROLE_KEY=
 
 # Program IDs
 # Primary program ID for this deployment
-PROGRAM_ID=FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD
+PROGRAM_ID=4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih
 
 # All program IDs to monitor (comma-separated)
-ALL_PROGRAM_IDS=FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD,FwfBKZXbYr4vTK23bMFkbgKq3npJ3MSDxEaKmq9Aj4Qn,g9msRSV3RFRFSqMeyjmiSAHfKcLFqYSWB7YXZBhNb2V
+ALL_PROGRAM_IDS=4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih,p9F84kJm39fQP3AwZSta2tB7oudUKPQd7zFuNHR7vas,g9msRSV3RFRFSqMeyjmiSAHfKcLFqYSWB7YXZBhNb2V
 
 # Monitoring (Optional)
 # Sentry DSN for error tracking

--- a/app/__tests__/components/ConnectButton.test.tsx
+++ b/app/__tests__/components/ConnectButton.test.tsx
@@ -5,8 +5,8 @@ vi.mock("@/lib/config", () => ({
   getConfig: () => ({
     network: "devnet",
     rpcUrl: "https://api.devnet.solana.com",
-    programId: "FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD",
-    matcherProgramId: "4HcGCsyjAqnFua5ccuXyt8KRRQzKFbGTJkVChpS7Yfzy",
+    programId: "4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih",
+    matcherProgramId: "93BiJ7abUKwJmSvqqPJa7X7YqVCCt2Ai9u3wTxZJYevm",
     crankWallet: "2JaSzRYrf44fPpQBtRJfnCEgThwCmvpFd3FCXi45VXxm",
     explorerUrl: "https://explorer.solana.com",
     slabSize: 992560,

--- a/app/__tests__/components/WalletPage.test.tsx
+++ b/app/__tests__/components/WalletPage.test.tsx
@@ -6,8 +6,8 @@ vi.mock("@/lib/config", () => ({
   getConfig: () => ({
     network: "devnet",
     rpcUrl: "https://api.devnet.solana.com",
-    programId: "FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD",
-    matcherProgramId: "4HcGCsyjAqnFua5ccuXyt8KRRQzKFbGTJkVChpS7Yfzy",
+    programId: "4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih",
+    matcherProgramId: "93BiJ7abUKwJmSvqqPJa7X7YqVCCt2Ai9u3wTxZJYevm",
     crankWallet: "2JaSzRYrf44fPpQBtRJfnCEgThwCmvpFd3FCXi45VXxm",
     explorerUrl: "https://explorer.solana.com",
     slabSize: 992560,

--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -66,15 +66,15 @@ const CONFIGS = {
   },
   devnet: {
     get rpcUrl() { return getRpcEndpoint(); },
-    programId: "FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD",
-    matcherProgramId: "4HcGCsyjAqnFua5ccuXyt8KRRQzKFbGTJkVChpS7Yfzy",
+    programId: "4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih",
+    matcherProgramId: "93BiJ7abUKwJmSvqqPJa7X7YqVCCt2Ai9u3wTxZJYevm",
     crankWallet: "2JaSzRYrf44fPpQBtRJfnCEgThwCmvpFd3FCXi45VXxm",
     explorerUrl: "https://explorer.solana.com",
     // Multiple program deployments for different slab sizes
     programsBySlabTier: {
-      small: "FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD",   // 256 slots
-      medium: "FwfBKZXbYr4vTK23bMFkbgKq3npJ3MSDxEaKmq9Aj4Qn",  // 1024 slots
-      large: "g9msRSV3sJmmE3r5Twn9HuBsxzuuRGTjKCVTKudm9in",   // 4096 slots
+      small: "4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih",   // 256 slots
+      medium: "p9F84kJm39fQP3AwZSta2tB7oudUKPQd7zFuNHR7vas",  // 1024 slots
+      large: "6oLLu8wLe6tmEkcGhHfNXNEBZFgKBzcZFheNtgJvZQaS",   // 4096 slots
     } as Record<string, string>,
   },
 } as const;

--- a/app/scripts/deploy-all-tiers.ts
+++ b/app/scripts/deploy-all-tiers.ts
@@ -53,13 +53,13 @@ import {
 
 // Use public devnet RPC to avoid Helius rate limits (crank service uses the Helius key)
 const RPC = "https://api.devnet.solana.com";
-const MATCHER_PROGRAM_ID = new PublicKey("4HcGCsyjAqnFua5ccuXyt8KRRQzKFbGTJkVChpS7Yfzy");
+const MATCHER_PROGRAM_ID = new PublicKey("93BiJ7abUKwJmSvqqPJa7X7YqVCCt2Ai9u3wTxZJYevm");
 const MATCHER_CTX_SIZE = 320;
 
 const TIERS = [
-  { name: "Small",  programId: "FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD", maxAccounts: 256,  dataSize: 62_808 },
-  { name: "Medium", programId: "FwfBKZXbYr4vTK23bMFkbgKq3npJ3MSDxEaKmq9Aj4Qn", maxAccounts: 1024, dataSize: 248_760 },
-  { name: "Large",  programId: "g9msRSV3sJmmE3r5Twn9HuBsxzuuRGTjKCVTKudm9in", maxAccounts: 4096, dataSize: 992_568 },
+  { name: "Small",  programId: "4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih", maxAccounts: 256,  dataSize: 62_808 },
+  { name: "Medium", programId: "p9F84kJm39fQP3AwZSta2tB7oudUKPQd7zFuNHR7vas", maxAccounts: 1024, dataSize: 248_760 },
+  { name: "Large",  programId: "6oLLu8wLe6tmEkcGhHfNXNEBZFgKBzcZFheNtgJvZQaS", maxAccounts: 4096, dataSize: 992_568 },
 ];
 
 const conn = new Connection(RPC, "confirmed");

--- a/app/scripts/e2e-devnet-test.ts
+++ b/app/scripts/e2e-devnet-test.ts
@@ -62,8 +62,8 @@ import {
 } from "../../packages/core/dist/index.js";
 
 const RPC = `https://devnet.helius-rpc.com/?api-key=${process.env.HELIUS_API_KEY ?? ""}`;
-const PROGRAM_ID = new PublicKey("FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD");
-const MATCHER_PROGRAM_ID = new PublicKey("4HcGCsyjAqnFua5ccuXyt8KRRQzKFbGTJkVChpS7Yfzy");
+const PROGRAM_ID = new PublicKey("4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih");
+const MATCHER_PROGRAM_ID = new PublicKey("93BiJ7abUKwJmSvqqPJa7X7YqVCCt2Ai9u3wTxZJYevm");
 const MATCHER_CTX_SIZE = 320;
 
 const conn = new Connection(RPC, "confirmed");

--- a/app/scripts/test-insurance-lp-comprehensive.ts
+++ b/app/scripts/test-insurance-lp-comprehensive.ts
@@ -66,15 +66,15 @@ const RPC_URL = 'https://api.devnet.solana.com';
 // All 3 program tiers and their test markets
 const TIERS = {
   small: {
-    programId: 'FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD',
+    programId: '4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih',
     slab: 'ACp47TrdPCT5qH5pFUfpoavbsY8D8jSHQxRXnbUpLaCH',
   },
   medium: {
-    programId: 'FwfBKZXbYr4vTK23bMFkbgKq3npJ3MSDxEaKmq9Aj4Qn',
+    programId: 'p9F84kJm39fQP3AwZSta2tB7oudUKPQd7zFuNHR7vas',
     slab: '4xMdY8R1xRFYABBybcoJsyUVSkXdowSQ5yM5ytUopyF9',
   },
   large: {
-    programId: 'g9msRSV3sJmmE3r5Twn9HuBsxzuuRGTjKCVTKudm9in',
+    programId: '6oLLu8wLe6tmEkcGhHfNXNEBZFgKBzcZFheNtgJvZQaS',
     slab: '6rj9uzukVQmZuaUwDhmCoR77PfxadpqQP4w2zGvqwfqG',
   },
 };

--- a/packages/core/src/config/program-ids.ts
+++ b/packages/core/src/config/program-ids.ts
@@ -9,8 +9,8 @@ import { PublicKey } from "@solana/web3.js";
 
 export const PROGRAM_IDS = {
   devnet: {
-    percolator: "FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD",
-    matcher: "4HcGCsyjAqnFua5ccuXyt8KRRQzKFbGTJkVChpS7Yfzy",
+    percolator: "4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih",
+    matcher: "93BiJ7abUKwJmSvqqPJa7X7YqVCCt2Ai9u3wTxZJYevm",
   },
   mainnet: {
     percolator: "GM8zjJ8LTBMv9xEsverh6H6wLyevgMHEJXcEzyY3rY24",

--- a/packages/indexer/tests/services/StatsCollector.test.ts
+++ b/packages/indexer/tests/services/StatsCollector.test.ts
@@ -43,8 +43,8 @@ import type { MarketProvider } from '../../src/services/StatsCollector.js';
 import * as core from '@percolator/sdk';
 import * as shared from '@percolator/shared';
 
-const SLAB1 = 'FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD';
-const SLAB2 = 'FwfBKZXbYr4vTK23bMFkbgKq3npJ3MSDxEaKmq9Aj4Qn';
+const SLAB1 = '4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih';
+const SLAB2 = 'p9F84kJm39fQP3AwZSta2tB7oudUKPQd7zFuNHR7vas';
 
 function makeEngineState(overrides: Record<string, any> = {}) {
   return {

--- a/packages/indexer/tests/services/TradeIndexer.test.ts
+++ b/packages/indexer/tests/services/TradeIndexer.test.ts
@@ -10,7 +10,7 @@ vi.mock('@percolator/sdk', () => ({
 
 vi.mock('@percolator/shared', () => ({
   config: {
-    allProgramIds: ['FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD'],
+    allProgramIds: ['4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih'],
   },
   createLogger: vi.fn(() => ({
     info: vi.fn(),
@@ -60,8 +60,8 @@ vi.mock('@percolator/shared', () => ({
 import { TradeIndexerPolling } from '../../src/services/TradeIndexer.js';
 import * as shared from '@percolator/shared';
 
-const SLAB = 'FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD';
-const PROGRAM_ID = 'FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD';
+const SLAB = '4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih';
+const PROGRAM_ID = '4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih';
 const TRADER = 'So11111111111111111111111111111111111111112';
 // Valid base58 signature (88 chars)
 const VALID_SIG = '5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW';

--- a/packages/keeper/tests/services/oracle.test.ts
+++ b/packages/keeper/tests/services/oracle.test.ts
@@ -340,7 +340,7 @@ describe('OracleService', () => {
         }),
       } as any);
 
-      const slab = 'FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD';
+      const slab = '4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih';
 
       // First push should succeed
       const result1 = await oracleService.pushPrice(slab, mockMarketConfig);
@@ -364,7 +364,7 @@ describe('OracleService', () => {
         }),
       } as any);
 
-      const slab = 'FwfBKZXbYr4vTK23bMFkbgKq3npJ3MSDxEaKmq9Aj4Qn';
+      const slab = 'p9F84kJm39fQP3AwZSta2tB7oudUKPQd7zFuNHR7vas';
 
       // First push
       await oracleService.pushPrice(slab, mockMarketConfig);

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -6,12 +6,12 @@ const env = validateEnv();
 
 export const config = {
   rpcUrl: env.RPC_URL ?? `https://devnet.helius-rpc.com/?api-key=${env.HELIUS_API_KEY ?? ""}`,
-  programId: env.PROGRAM_ID ?? "FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD",
+  programId: env.PROGRAM_ID ?? "4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih",
   /** Comma-separated list of all program IDs to scan for markets */
   allProgramIds: (env.ALL_PROGRAM_IDS ?? [
-    "FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD",
-    "FwfBKZXbYr4vTK23bMFkbgKq3npJ3MSDxEaKmq9Aj4Qn",
-    "g9msRSV3sJmmE3r5Twn9HuBsxzuuRGTjKCVTKudm9in",
+    "4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih",
+    "p9F84kJm39fQP3AwZSta2tB7oudUKPQd7zFuNHR7vas",
+    "6oLLu8wLe6tmEkcGhHfNXNEBZFgKBzcZFheNtgJvZQaS",
   ].join(",")).split(",").filter(Boolean),
   crankKeypair: env.CRANK_KEYPAIR ?? "",
   supabaseUrl: env.SUPABASE_URL ?? "",

--- a/packages/shared/tests/config.test.ts
+++ b/packages/shared/tests/config.test.ts
@@ -38,11 +38,11 @@ describe("config", () => {
     const { config } = await import("../src/config.js");
 
     expect(config.rpcUrl).toBe("https://devnet.helius-rpc.com/?api-key=");
-    expect(config.programId).toBe("FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD");
+    expect(config.programId).toBe("4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih");
     expect(config.allProgramIds).toEqual([
-      "FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD",
-      "FwfBKZXbYr4vTK23bMFkbgKq3npJ3MSDxEaKmq9Aj4Qn",
-      "g9msRSV3sJmmE3r5Twn9HuBsxzuuRGTjKCVTKudm9in",
+      "4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih",
+      "p9F84kJm39fQP3AwZSta2tB7oudUKPQd7zFuNHR7vas",
+      "6oLLu8wLe6tmEkcGhHfNXNEBZFgKBzcZFheNtgJvZQaS",
     ]);
     expect(config.crankKeypair).toBe("");
     expect(config.supabaseUrl).toBe("");
@@ -156,9 +156,9 @@ describe("config", () => {
     // Default program IDs must be an array of 3 known program addresses
     expect(Array.isArray(config.allProgramIds)).toBe(true);
     expect(config.allProgramIds).toHaveLength(3);
-    expect(config.allProgramIds[0]).toBe("FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD");
-    expect(config.allProgramIds[1]).toBe("FwfBKZXbYr4vTK23bMFkbgKq3npJ3MSDxEaKmq9Aj4Qn");
-    expect(config.allProgramIds[2]).toBe("g9msRSV3sJmmE3r5Twn9HuBsxzuuRGTjKCVTKudm9in");
+    expect(config.allProgramIds[0]).toBe("4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih");
+    expect(config.allProgramIds[1]).toBe("p9F84kJm39fQP3AwZSta2tB7oudUKPQd7zFuNHR7vas");
+    expect(config.allProgramIds[2]).toBe("6oLLu8wLe6tmEkcGhHfNXNEBZFgKBzcZFheNtgJvZQaS");
   });
 
   it("should reject invalid NODE_ENV values with a clear validation error", async () => {

--- a/scripts/e2e-devnet-test.ts
+++ b/scripts/e2e-devnet-test.ts
@@ -62,8 +62,8 @@ import {
 } from "@percolator/sdk";
 
 const RPC = `https://devnet.helius-rpc.com/?api-key=${process.env.HELIUS_API_KEY ?? ""}`;
-const PROGRAM_ID = new PublicKey("FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD");
-const MATCHER_PROGRAM_ID = new PublicKey("4HcGCsyjAqnFua5ccuXyt8KRRQzKFbGTJkVChpS7Yfzy");
+const PROGRAM_ID = new PublicKey("4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih");
+const MATCHER_PROGRAM_ID = new PublicKey("93BiJ7abUKwJmSvqqPJa7X7YqVCCt2Ai9u3wTxZJYevm");
 const MATCHER_CTX_SIZE = 320;
 
 const conn = new Connection(RPC, "confirmed");

--- a/tests/devnet-e2e.ts
+++ b/tests/devnet-e2e.ts
@@ -40,7 +40,7 @@ const RPC_URL = `https://devnet.helius-rpc.com/?api-key=${process.env.HELIUS_API
 // Use centralized config instead of hard-coded ID
 import { getProgramId } from "../packages/core/src/config/program-ids.js";
 const PROGRAM_ID = getProgramId("devnet");
-const MATCHER_ID = new PublicKey("4HcGCsyjAqnFua5ccuXyt8KRRQzKFbGTJkVChpS7Yfzy");
+const MATCHER_ID = new PublicKey("93BiJ7abUKwJmSvqqPJa7X7YqVCCt2Ai9u3wTxZJYevm");
 const CRANK_WALLET = new PublicKey("2JaSzRYrf44fPpQBtRJfnCEgThwCmvpFd3FCXi45VXxm");
 const MINT = new PublicKey("DvH13uxzTzo1xVFwkbJ6YASkZWs6bm3vFDH4xu7kUYTs");
 const DEPLOYER_KP = Keypair.fromSecretKey(Uint8Array.from(JSON.parse(fs.readFileSync("/tmp/deployer.json", "utf8"))));

--- a/tests/t4-liquidation.ts
+++ b/tests/t4-liquidation.ts
@@ -62,8 +62,8 @@ import {
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 const RPC_URL = process.env.SOLANA_RPC_URL ?? "https://api.devnet.solana.com";
-const PROGRAM_ID = new PublicKey(process.env.PROGRAM_ID ?? "FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD");
-const MATCHER_PROGRAM_ID = new PublicKey(process.env.MATCHER_PROGRAM_ID ?? "4HcGCsyjAqnFua5ccuXyt8KRRQzKFbGTJkVChpS7Yfzy");
+const PROGRAM_ID = new PublicKey(process.env.PROGRAM_ID ?? "4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih");
+const MATCHER_PROGRAM_ID = new PublicKey(process.env.MATCHER_PROGRAM_ID ?? "93BiJ7abUKwJmSvqqPJa7X7YqVCCt2Ai9u3wTxZJYevm");
 const SLAB_SIZE = Number(process.env.SLAB_SIZE ?? 62_808);
 const MATCHER_CTX_SIZE = 320;
 

--- a/tests/t6-risk-gate.ts
+++ b/tests/t6-risk-gate.ts
@@ -56,8 +56,8 @@ import {
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 const RPC_URL = process.env.SOLANA_RPC_URL ?? "https://api.devnet.solana.com";
-const PROGRAM_ID = new PublicKey(process.env.PROGRAM_ID ?? "FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD");
-const MATCHER_PROGRAM_ID = new PublicKey(process.env.MATCHER_PROGRAM_ID ?? "4HcGCsyjAqnFua5ccuXyt8KRRQzKFbGTJkVChpS7Yfzy");
+const PROGRAM_ID = new PublicKey(process.env.PROGRAM_ID ?? "4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih");
+const MATCHER_PROGRAM_ID = new PublicKey(process.env.MATCHER_PROGRAM_ID ?? "93BiJ7abUKwJmSvqqPJa7X7YqVCCt2Ai9u3wTxZJYevm");
 const SLAB_SIZE = Number(process.env.SLAB_SIZE ?? 62_808);
 const MATCHER_CTX_SIZE = 320;
 

--- a/tests/t7-market-pause.ts
+++ b/tests/t7-market-pause.ts
@@ -58,8 +58,8 @@ import {
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 const RPC_URL = process.env.SOLANA_RPC_URL ?? "https://api.devnet.solana.com";
-const PROGRAM_ID = new PublicKey(process.env.PROGRAM_ID ?? "FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD");
-const MATCHER_PROGRAM_ID = new PublicKey(process.env.MATCHER_PROGRAM_ID ?? "4HcGCsyjAqnFua5ccuXyt8KRRQzKFbGTJkVChpS7Yfzy");
+const PROGRAM_ID = new PublicKey(process.env.PROGRAM_ID ?? "4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih");
+const MATCHER_PROGRAM_ID = new PublicKey(process.env.MATCHER_PROGRAM_ID ?? "93BiJ7abUKwJmSvqqPJa7X7YqVCCt2Ai9u3wTxZJYevm");
 const SLAB_SIZE = Number(process.env.SLAB_SIZE ?? 62_808);
 const MATCHER_CTX_SIZE = 320;
 

--- a/tests/t8-trading-fee-update.ts
+++ b/tests/t8-trading-fee-update.ts
@@ -45,7 +45,7 @@ import {
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 const RPC_URL = process.env.SOLANA_RPC_URL ?? "https://api.devnet.solana.com";
-const PROGRAM_ID = new PublicKey(process.env.PROGRAM_ID ?? "FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD");
+const PROGRAM_ID = new PublicKey(process.env.PROGRAM_ID ?? "4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih");
 const SLAB_SIZE = Number(process.env.SLAB_SIZE ?? 62_808);
 
 interface TestResult { name: string; passed: boolean; error?: string; duration: number }


### PR DESCRIPTION
## What
Redeployed all 5 programs to devnet from the qa-wallet (`GRMMNs...`).

## New Program IDs
| Program | ID |
|---------|-----|
| Wrapper Small (256) | `4dvCZrrPHmimQLDUBLme5CRqa81nGVLzGMwKUAPfXKih` |
| Wrapper Medium (1024) | `p9F84kJm39fQP3AwZSta2tB7oudUKPQd7zFuNHR7vas` |
| Wrapper Large (4096) | `6oLLu8wLe6tmEkcGhHfNXNEBZFgKBzcZFheNtgJvZQaS` |
| Matcher | `93BiJ7abUKwJmSvqqPJa7X7YqVCCt2Ai9u3wTxZJYevm` |
| Stake | `4mJ8CasrkLWebfYUrk6NZHXQmx9yQTbWqY3i2FDkM4n2` (redeployed) |

## Why
Old program authorities (`FF7K...`, `A3Mu...`) were not available on this machine. Fresh deploy with qa-wallet as authority.

## Changes
- Updated all 19 files referencing old program IDs
- All builds from latest `main`

## Testing
Markets need to be re-initialized on the new program IDs. QA blocked on PERC-124/116/131 can proceed after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated program identifiers across development and test environments to reference new on-chain addresses. All configuration files, test fixtures, and deployment scripts have been synchronized with the new program identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->