### PR TITLE
Validate idx as an integer in isAccountUsed function

### DIFF
--- a/packages/core/src/solana/slab.ts
+++ b/packages/core/src/solana/slab.ts
@@ -638,7 +638,7 @@ export function parseUsedIndices(data: Uint8Array): number[] {
 export function isAccountUsed(data: Uint8Array, idx: number): boolean {
   const layout = detectLayout(data.length);
   const maxAcc = layout ? layout.maxAccounts : DEFAULT_MAX_ACCOUNTS;
-  if (idx < 0 || idx >= maxAcc) return false;
+  if (!Number.isInteger(idx) || idx < 0 || idx >= maxAcc) return false;
   const base = ENGINE_OFF + ENGINE_BITMAP_OFF;
   const word = Math.floor(idx / 64);
   const bit = idx % 64;


### PR DESCRIPTION
This pull request makes a small but important improvement to the `isAccountUsed` function in `slab.ts` by adding a check to ensure that the `idx` argument is an integer before proceeding. This helps prevent potential bugs caused by passing non-integer values.

- Validation improvement:
  * Added a check to verify that `idx` is an integer in the `isAccountUsed` function, enhancing input validation and preventing invalid accesses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced input validation for account operations. The system now performs stricter validation checks before processing account-related requests, ensuring that invalid inputs are properly detected and rejected. This improvement increases system reliability and prevents edge cases that could negatively impact account management functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->