### PR TITLE
fix: relax base58 address length validation (closes #361)

### DIFF
--- a/app/__tests__/lib/config.test.ts
+++ b/app/__tests__/lib/config.test.ts
@@ -46,7 +46,8 @@ describe("Mainnet Configuration Validation", () => {
     
     const config = getConfig();
     expect(config.crankWallet).toBeTruthy();
-    expect(config.crankWallet).toHaveLength(44); // Base58 address length
+    expect(config.crankWallet.length).toBeGreaterThanOrEqual(32); // Base58 address: 32-44 chars
+    expect(config.crankWallet.length).toBeLessThanOrEqual(44);
   });
 
   it("should have valid devnet matcherProgramId", () => {
@@ -56,7 +57,8 @@ describe("Mainnet Configuration Validation", () => {
     
     const config = getConfig();
     expect(config.matcherProgramId).toBeTruthy();
-    expect(config.matcherProgramId).toHaveLength(44); // Base58 address length
+    expect(config.matcherProgramId.length).toBeGreaterThanOrEqual(32); // Base58 address: 32-44 chars
+    expect(config.matcherProgramId.length).toBeLessThanOrEqual(44);
   });
 });
 


### PR DESCRIPTION
## What
Relaxes base58 address length assertions in `config.test.ts` from strict `toHaveLength(44)` to `>= 32 && <= 44`.

## Why
Solana base58 public keys can be 32-44 characters. The devnet matcher ID `FmTx5yi62Y3h1ATkxm8ujLNNCwYcc2LTmWRFFWN31Af` is 43 chars — valid on-chain but failed the old assertion.

## Changes
- `matcherProgramId`: length range check (32-44)
- `crankWallet`: same fix applied proactively

## Testing
```
pnpm test:app — 7/7 config tests pass
```

Closes #361

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated configuration validation to accept a broader range of valid input lengths for wallet and program identifiers (32-44 characters instead of exactly 44 characters) across mainnet and devnet environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->