### PR TITLE
fix: eliminate act() test warnings in WarmupProgress, OpenInterestCard, InsuranceDashboard

### DIFF
--- a/app/__tests__/components/InsuranceDashboard.test.tsx
+++ b/app/__tests__/components/InsuranceDashboard.test.tsx
@@ -1,5 +1,5 @@
-import { vi, describe, it, expect, beforeEach } from "vitest";
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, fireEvent, act, cleanup } from "@testing-library/react";
 import { InsuranceDashboard } from "@/components/market/InsuranceDashboard";
 import "@testing-library/jest-dom";
 
@@ -16,6 +16,10 @@ global.fetch = vi.fn();
 describe("InsuranceDashboard Component", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it("should render loading state initially", () => {
@@ -184,9 +188,11 @@ describe("InsuranceDashboard Component", () => {
       expect(screen.getAllByText("more")[0]).toBeInTheDocument();
     });
 
-    // Click one of the "more" buttons
+    // Click one of the "more" buttons — wrap in act for state update
     const learnMoreButtons = screen.getAllByText("more");
-    fireEvent.click(learnMoreButtons[0]);
+    await act(async () => {
+      fireEvent.click(learnMoreButtons[0]);
+    });
 
     // Modal should open (would need to verify modal content in real test)
   });
@@ -253,13 +259,17 @@ describe("InsuranceDashboard Component", () => {
       expect(global.fetch).toHaveBeenCalledTimes(1);
     });
 
-    // Fast-forward 30 seconds
-    await vi.advanceTimersByTimeAsync(30000);
+    // Fast-forward 30 seconds — wrap in act so state updates are flushed
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30000);
+    });
 
     await vi.waitFor(() => {
       expect(global.fetch).toHaveBeenCalledTimes(2);
     });
 
+    // Cleanup before restoring timers to prevent async state updates on unmounted component
+    cleanup();
     vi.useRealTimers();
   });
 });

--- a/app/__tests__/components/OpenInterestCard.test.tsx
+++ b/app/__tests__/components/OpenInterestCard.test.tsx
@@ -1,5 +1,5 @@
-import { vi, describe, it, expect, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, act, cleanup } from "@testing-library/react";
 import { OpenInterestCard } from "@/components/market/OpenInterestCard";
 import "@testing-library/jest-dom";
 
@@ -16,6 +16,10 @@ global.fetch = vi.fn();
 describe("OpenInterestCard Component", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it("should render loading state initially", () => {
@@ -321,13 +325,17 @@ describe("OpenInterestCard Component", () => {
       expect(global.fetch).toHaveBeenCalledTimes(1);
     });
 
-    // Fast-forward 30 seconds
-    await vi.advanceTimersByTimeAsync(30000);
+    // Fast-forward 30 seconds — wrap in act so state updates are flushed
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30000);
+    });
 
     await vi.waitFor(() => {
       expect(global.fetch).toHaveBeenCalledTimes(2);
     });
 
+    // Cleanup before restoring timers to prevent async state updates on unmounted component
+    cleanup();
     vi.useRealTimers();
   });
 


### PR DESCRIPTION
## Summary
Fixes React `act()` test warnings in three component test files that were polluting test output.

## Changes
- **WarmupProgress.test.tsx**: Wrap `vi.advanceTimersByTimeAsync(5000)` in `act()`, wrap click handler in `act()`, add `cleanup()` before `vi.useRealTimers()`
- **OpenInterestCard.test.tsx**: Wrap `vi.advanceTimersByTimeAsync(30000)` in `act()`, add `cleanup()` before `vi.useRealTimers()`
- **InsuranceDashboard.test.tsx**: Wrap `vi.advanceTimersByTimeAsync(30000)` in `act()`, wrap `fireEvent.click()` in `act()`, add `cleanup()` before `vi.useRealTimers()`

## Root Cause
When using fake timers, `vi.advanceTimersByTimeAsync()` triggers interval callbacks that resolve fetch promises, causing React state updates outside of `act()`. Similarly, click events that trigger `setState` need to be wrapped in `act()`.

## Test Results
- All 388 tests pass ✅
- Zero `act()` warnings in output ✅
- 3 files changed, +44 -16 lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for InsuranceDashboard, OpenInterestCard, and WarmupProgress components through enhanced state management and cleanup procedures in test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->