### PR TITLE
test: add 187 unit tests for 7 untested lib modules

### DIFF
--- a/app/__tests__/lib/createMarketValidation.test.ts
+++ b/app/__tests__/lib/createMarketValidation.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect } from "vitest";
+import { validateCreateForm, type CreateFormValues } from "../../lib/createMarketValidation";
+
+/** Helper: returns a valid baseline form to mutate for individual tests */
+function validForm(overrides: Partial<CreateFormValues> = {}): CreateFormValues {
+  return {
+    mint: "So11111111111111111111111111111111111111112",
+    mintValid: true,
+    tokenMeta: { symbol: "SOL", name: "Solana", decimals: 9 },
+    oracleResolved: true,
+    oracleMode: "auto",
+    tradingFeeBps: 30,
+    initialMarginBps: 500,
+    lpCollateral: "100",
+    insuranceAmount: "10",
+    tokenBalance: 1_000_000_000_000n, // 1000 SOL
+    walletConnected: true,
+    decimals: 9,
+    ...overrides,
+  };
+}
+
+function fieldErrors(errors: ReturnType<typeof validateCreateForm>, field: string) {
+  return errors.filter((e) => e.field === field);
+}
+
+describe("validateCreateForm", () => {
+  // ── Happy path ──
+  it("returns no errors for a fully valid form", () => {
+    expect(validateCreateForm(validForm())).toEqual([]);
+  });
+
+  // ── Wallet ──
+  it("errors when wallet is not connected", () => {
+    const errors = validateCreateForm(validForm({ walletConnected: false }));
+    expect(fieldErrors(errors, "Wallet")).toHaveLength(1);
+    expect(fieldErrors(errors, "Wallet")[0].severity).toBe("error");
+  });
+
+  // ── Token Mint ──
+  it("errors when mint is empty", () => {
+    const errors = validateCreateForm(validForm({ mint: "" }));
+    expect(fieldErrors(errors, "Token Mint")).toHaveLength(1);
+  });
+
+  it("errors when mint is invalid", () => {
+    const errors = validateCreateForm(validForm({ mint: "invalidkey", mintValid: false }));
+    expect(fieldErrors(errors, "Token Mint")).toHaveLength(1);
+    expect(fieldErrors(errors, "Token Mint")[0].message).toContain("Invalid base58");
+  });
+
+  // ── Token Decimals overflow ──
+  it("errors when token decimals exceed max (12)", () => {
+    const errors = validateCreateForm(
+      validForm({ tokenMeta: { symbol: "X", name: "X", decimals: 18 } })
+    );
+    expect(fieldErrors(errors, "Token Decimals")).toHaveLength(1);
+    expect(fieldErrors(errors, "Token Decimals")[0].message).toContain("overflow");
+  });
+
+  it("allows tokens with exactly 12 decimals", () => {
+    const errors = validateCreateForm(
+      validForm({ tokenMeta: { symbol: "X", name: "X", decimals: 12 } })
+    );
+    expect(fieldErrors(errors, "Token Decimals")).toHaveLength(0);
+  });
+
+  // ── Oracle ──
+  it("errors when oracle not resolved in auto mode", () => {
+    const errors = validateCreateForm(validForm({ oracleResolved: false, oracleMode: "auto" }));
+    expect(fieldErrors(errors, "Oracle")).toHaveLength(1);
+    expect(fieldErrors(errors, "Oracle")[0].message).toContain("DEX Pool or Pyth");
+  });
+
+  it("errors when oracle not resolved in pyth mode", () => {
+    const errors = validateCreateForm(validForm({ oracleResolved: false, oracleMode: "pyth" }));
+    expect(fieldErrors(errors, "Oracle")).toHaveLength(1);
+    expect(fieldErrors(errors, "Oracle")[0].message).toContain("Pyth feed ID");
+  });
+
+  it("errors when oracle not resolved in dex mode", () => {
+    const errors = validateCreateForm(validForm({ oracleResolved: false, oracleMode: "dex" }));
+    expect(fieldErrors(errors, "Oracle")).toHaveLength(1);
+    expect(fieldErrors(errors, "Oracle")[0].message).toContain("DEX pool address");
+  });
+
+  it("skips oracle check if mint is empty", () => {
+    const errors = validateCreateForm(validForm({ mint: "", oracleResolved: false }));
+    expect(fieldErrors(errors, "Oracle")).toHaveLength(0);
+  });
+
+  it("skips oracle check if mint is invalid", () => {
+    const errors = validateCreateForm(validForm({ mintValid: false, oracleResolved: false }));
+    expect(fieldErrors(errors, "Oracle")).toHaveLength(0);
+  });
+
+  // ── Trading Fee ──
+  it("errors when trading fee is 0 bps", () => {
+    const errors = validateCreateForm(validForm({ tradingFeeBps: 0 }));
+    expect(fieldErrors(errors, "Trading Fee").some((e) => e.message.includes("at least 1 bps"))).toBe(true);
+  });
+
+  it("errors when trading fee exceeds 100 bps", () => {
+    const errors = validateCreateForm(validForm({ tradingFeeBps: 101 }));
+    expect(fieldErrors(errors, "Trading Fee").some((e) => e.message.includes("100 bps or less"))).toBe(true);
+  });
+
+  it("accepts trading fee of exactly 1 bps", () => {
+    const errors = validateCreateForm(validForm({ tradingFeeBps: 1 }));
+    expect(fieldErrors(errors, "Trading Fee")).toHaveLength(0);
+  });
+
+  it("accepts trading fee of exactly 100 bps", () => {
+    const errors = validateCreateForm(validForm({ tradingFeeBps: 100, initialMarginBps: 5000 }));
+    expect(fieldErrors(errors, "Trading Fee")).toHaveLength(0);
+  });
+
+  // ── Initial Margin ──
+  it("errors when margin below 100 bps", () => {
+    const errors = validateCreateForm(validForm({ initialMarginBps: 99 }));
+    expect(fieldErrors(errors, "Initial Margin").some((e) => e.message.includes("at least 100 bps"))).toBe(true);
+  });
+
+  it("errors when margin above 5000 bps", () => {
+    const errors = validateCreateForm(validForm({ initialMarginBps: 5001 }));
+    expect(fieldErrors(errors, "Initial Margin").some((e) => e.message.includes("5000 bps or less"))).toBe(true);
+  });
+
+  it("accepts margin of exactly 100 bps", () => {
+    const errors = validateCreateForm(validForm({ initialMarginBps: 100, tradingFeeBps: 10 }));
+    expect(fieldErrors(errors, "Initial Margin")).toHaveLength(0);
+  });
+
+  it("accepts margin of exactly 5000 bps", () => {
+    const errors = validateCreateForm(validForm({ initialMarginBps: 5000 }));
+    expect(fieldErrors(errors, "Initial Margin")).toHaveLength(0);
+  });
+
+  // ── Fee vs Margin ──
+  it("errors when fee equals margin (would consume entire margin)", () => {
+    const errors = validateCreateForm(validForm({ tradingFeeBps: 100, initialMarginBps: 100 }));
+    expect(fieldErrors(errors, "Trading Fee").some((e) => e.message.includes("consume the entire margin"))).toBe(true);
+  });
+
+  it("errors when fee exceeds margin", () => {
+    const errors = validateCreateForm(validForm({ tradingFeeBps: 100, initialMarginBps: 50 }));
+    // Should get both the margin-too-low error and the fee-vs-margin error
+    const feeErrors = fieldErrors(errors, "Trading Fee");
+    expect(feeErrors.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // ── LP Collateral ──
+  it("errors when LP collateral is empty", () => {
+    const errors = validateCreateForm(validForm({ lpCollateral: "" }));
+    expect(fieldErrors(errors, "LP Collateral")).toHaveLength(1);
+  });
+
+  it("errors when LP collateral is 0", () => {
+    const errors = validateCreateForm(validForm({ lpCollateral: "0" }));
+    expect(fieldErrors(errors, "LP Collateral")).toHaveLength(1);
+  });
+
+  it("errors when LP collateral is NaN", () => {
+    const errors = validateCreateForm(validForm({ lpCollateral: "abc" }));
+    expect(fieldErrors(errors, "LP Collateral")).toHaveLength(1);
+  });
+
+  it("warns when LP collateral below minimum for 6-decimal tokens", () => {
+    const errors = validateCreateForm(validForm({ lpCollateral: "5", decimals: 6 }));
+    const lpWarnings = fieldErrors(errors, "LP Collateral").filter((e) => e.severity === "warning");
+    expect(lpWarnings).toHaveLength(1);
+    expect(lpWarnings[0].message).toContain("10 tokens");
+  });
+
+  it("warns when LP collateral below minimum for 9-decimal tokens", () => {
+    const errors = validateCreateForm(validForm({ lpCollateral: "0.005", decimals: 9 }));
+    const lpWarnings = fieldErrors(errors, "LP Collateral").filter((e) => e.severity === "warning");
+    expect(lpWarnings).toHaveLength(1);
+    expect(lpWarnings[0].message).toContain("0.01 tokens");
+  });
+
+  it("defaults to 1 token minimum for unknown decimal values", () => {
+    const errors = validateCreateForm(validForm({ lpCollateral: "0.5", decimals: 8 }));
+    const lpWarnings = fieldErrors(errors, "LP Collateral").filter((e) => e.severity === "warning");
+    expect(lpWarnings).toHaveLength(1);
+    expect(lpWarnings[0].message).toContain("1 tokens");
+  });
+
+  // ── Insurance Fund ──
+  it("errors when insurance amount is empty", () => {
+    const errors = validateCreateForm(validForm({ insuranceAmount: "" }));
+    expect(fieldErrors(errors, "Insurance Fund")).toHaveLength(1);
+  });
+
+  it("errors when insurance amount is 0", () => {
+    const errors = validateCreateForm(validForm({ insuranceAmount: "0" }));
+    expect(fieldErrors(errors, "Insurance Fund")).toHaveLength(1);
+  });
+
+  it("warns when insurance is below 5% of LP collateral", () => {
+    const errors = validateCreateForm(validForm({ lpCollateral: "100", insuranceAmount: "2" }));
+    const insWarnings = fieldErrors(errors, "Insurance Fund").filter((e) => e.severity === "warning");
+    expect(insWarnings).toHaveLength(1);
+    expect(insWarnings[0].message).toContain("5%");
+  });
+
+  it("no warning when insurance is exactly 5% of LP collateral", () => {
+    const errors = validateCreateForm(validForm({ lpCollateral: "100", insuranceAmount: "5" }));
+    const insWarnings = fieldErrors(errors, "Insurance Fund").filter((e) => e.severity === "warning");
+    expect(insWarnings).toHaveLength(0);
+  });
+
+  // ── Token Balance ──
+  it("errors when balance is zero", () => {
+    const errors = validateCreateForm(validForm({ tokenBalance: 0n }));
+    expect(fieldErrors(errors, "Token Balance")).toHaveLength(1);
+    expect(fieldErrors(errors, "Token Balance")[0].message).toContain("no tokens");
+  });
+
+  it("errors when combined LP + insurance exceeds balance", () => {
+    // 100 + 10 = 110 tokens needed, balance = 100 tokens (100 * 10^9 native)
+    const errors = validateCreateForm(
+      validForm({
+        lpCollateral: "100",
+        insuranceAmount: "10",
+        tokenBalance: 100_000_000_000n, // 100 tokens with 9 decimals
+        decimals: 9,
+      })
+    );
+    expect(fieldErrors(errors, "Token Balance").some((e) => e.severity === "error")).toBe(true);
+  });
+
+  it("warns when combined LP + insurance exceeds 90% of balance", () => {
+    // 90 + 5 = 95 tokens needed, balance = 100 tokens
+    const errors = validateCreateForm(
+      validForm({
+        lpCollateral: "90",
+        insuranceAmount: "5",
+        tokenBalance: 100_000_000_000n, // 100 tokens with 9 decimals
+        decimals: 9,
+      })
+    );
+    expect(fieldErrors(errors, "Token Balance").some((e) => e.severity === "warning")).toBe(true);
+  });
+
+  it("skips balance check when wallet not connected", () => {
+    const errors = validateCreateForm(
+      validForm({ walletConnected: false, tokenBalance: 0n })
+    );
+    // Should get wallet error but not balance error
+    expect(fieldErrors(errors, "Token Balance")).toHaveLength(0);
+  });
+
+  it("skips balance check when tokenBalance is null", () => {
+    const errors = validateCreateForm(validForm({ tokenBalance: null }));
+    expect(fieldErrors(errors, "Token Balance")).toHaveLength(0);
+  });
+
+  it("skips balance check when mint is invalid", () => {
+    const errors = validateCreateForm(validForm({ mintValid: false, tokenBalance: 0n }));
+    expect(fieldErrors(errors, "Token Balance")).toHaveLength(0);
+  });
+
+  // ── Multiple errors ──
+  it("returns multiple errors for a completely invalid form", () => {
+    const errors = validateCreateForm({
+      mint: "",
+      mintValid: false,
+      tokenMeta: null,
+      oracleResolved: false,
+      oracleMode: "auto",
+      tradingFeeBps: 0,
+      initialMarginBps: 0,
+      lpCollateral: "",
+      insuranceAmount: "",
+      tokenBalance: null,
+      walletConnected: false,
+      decimals: 6,
+    });
+    // Should have errors for wallet, mint, fee, margin, LP, insurance (not oracle since mint is empty)
+    expect(errors.length).toBeGreaterThanOrEqual(5);
+  });
+});

--- a/app/__tests__/lib/errorMessages.test.ts
+++ b/app/__tests__/lib/errorMessages.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi } from "vitest";
+import { humanizeError, isTransientError, isOracleStaleError, withTransientRetry } from "../../lib/errorMessages";
+
+describe("humanizeError", () => {
+  // ── Known error codes via hex format ──
+  it("maps hex error code 0x0 to invalid market magic", () => {
+    expect(humanizeError("custom program error: 0x0")).toContain("Invalid market magic");
+  });
+
+  it("maps hex error code 0x1 to version mismatch", () => {
+    expect(humanizeError("custom program error: 0x1")).toContain("Version mismatch");
+  });
+
+  it("maps hex error code 0xE (14) to undercollateralized", () => {
+    expect(humanizeError("custom program error: 0xE")).toContain("Undercollateralized");
+  });
+
+  it("maps hex error code 0x21 (33) to market is paused", () => {
+    expect(humanizeError("custom program error: 0x21")).toContain("paused");
+  });
+
+  // ── Custom(N) format ──
+  it("parses Custom(6) as oracle stale", () => {
+    expect(humanizeError("Custom(6)")).toContain("Oracle price is stale");
+  });
+
+  it("parses Custom(14) as undercollateralized", () => {
+    expect(humanizeError("Custom(14)")).toContain("Undercollateralized");
+  });
+
+  // ── JSON format: {"Custom":N} ──
+  it('parses {"Custom":14} from getSignatureStatuses', () => {
+    expect(humanizeError('"Custom":14')).toContain("Undercollateralized");
+  });
+
+  it('parses {"Custom":6} as oracle stale', () => {
+    expect(humanizeError('"Custom": 6')).toContain("Oracle price is stale");
+  });
+
+  // ── Instruction index hint ──
+  it("appends instruction hint when InstructionError is present", () => {
+    const msg = '{"InstructionError": [4, {"Custom": 14}]}';
+    const result = humanizeError(msg);
+    expect(result).toContain("Undercollateralized");
+    expect(result).toContain("(in trade)");
+  });
+
+  it("appends oracle push hint for instruction index 2", () => {
+    const msg = '{"InstructionError": [2, {"Custom": 6}]}';
+    const result = humanizeError(msg);
+    expect(result).toContain("Oracle price is stale");
+    expect(result).toContain("(in oracle push)");
+  });
+
+  // ── Special messages ──
+  it("humanizes Blockhash not found", () => {
+    expect(humanizeError("Blockhash not found")).toContain("expired");
+  });
+
+  it("humanizes block height exceeded", () => {
+    expect(humanizeError("block height exceeded")).toContain("expired");
+  });
+
+  it("humanizes 'has expired' messages", () => {
+    expect(humanizeError("Transaction has expired")).toContain("expired");
+  });
+
+  it("humanizes insufficient funds", () => {
+    expect(humanizeError("insufficient funds for transfer")).toContain("Insufficient token balance");
+  });
+
+  it("humanizes Insufficient (capital I)", () => {
+    expect(humanizeError("Insufficient balance for CPI")).toContain("Insufficient token balance");
+  });
+
+  it("humanizes user rejection", () => {
+    expect(humanizeError("User rejected the request")).toBe("Transaction cancelled.");
+  });
+
+  it("humanizes timeout", () => {
+    expect(humanizeError("Transaction timeout after 30s")).toContain("timed out");
+  });
+
+  it("humanizes Timeout (capital T)", () => {
+    expect(humanizeError("Timeout waiting for confirmation")).toContain("timed out");
+  });
+
+  // ── Unknown program error codes ──
+  it("shows raw Custom(N) for unknown codes", () => {
+    expect(humanizeError("Custom(999)")).toContain("Custom(999)");
+  });
+
+  it("shows raw hex code for unknown custom program error", () => {
+    // 0xFFF = 4095 — not in our map
+    expect(humanizeError("custom program error: 0xFFF")).toContain("Program error");
+  });
+
+  // ── Fallback ──
+  it("returns truncated message for completely unknown errors", () => {
+    const msg = "x".repeat(100);
+    const result = humanizeError(msg);
+    expect(result).toContain("Transaction failed:");
+    expect(result).toContain("...");
+  });
+
+  it("returns short messages without truncation", () => {
+    const msg = "Something broke";
+    expect(humanizeError(msg)).toBe(`Transaction failed: ${msg}`);
+  });
+});
+
+describe("isTransientError", () => {
+  it("returns true for oracle stale (code 6)", () => {
+    expect(isTransientError("Custom(6)")).toBe(true);
+  });
+
+  it("returns true for oracle invalid (code 12)", () => {
+    expect(isTransientError("Custom(12)")).toBe(true);
+  });
+
+  it("returns true for Blockhash not found", () => {
+    expect(isTransientError("Blockhash not found")).toBe(true);
+  });
+
+  it("returns true for block height exceeded", () => {
+    expect(isTransientError("block height exceeded")).toBe(true);
+  });
+
+  it("returns true for 'has expired'", () => {
+    expect(isTransientError("Transaction has expired")).toBe(true);
+  });
+
+  it("returns false for undercollateralized (code 14)", () => {
+    expect(isTransientError("Custom(14)")).toBe(false);
+  });
+
+  it("returns false for non-transient messages", () => {
+    expect(isTransientError("User rejected")).toBe(false);
+  });
+
+  it("returns false for empty strings", () => {
+    expect(isTransientError("")).toBe(false);
+  });
+});
+
+describe("isOracleStaleError", () => {
+  it("returns true for code 6", () => {
+    expect(isOracleStaleError("Custom(6)")).toBe(true);
+  });
+
+  it("returns true for code 12", () => {
+    expect(isOracleStaleError("Custom(12)")).toBe(true);
+  });
+
+  it("returns false for code 14", () => {
+    expect(isOracleStaleError("Custom(14)")).toBe(false);
+  });
+
+  it("returns false for Blockhash not found", () => {
+    expect(isOracleStaleError("Blockhash not found")).toBe(false);
+  });
+});
+
+describe("withTransientRetry", () => {
+  it("returns result on first success", async () => {
+    const fn = vi.fn().mockResolvedValue(42);
+    const result = await withTransientRetry(fn);
+    expect(result).toBe(42);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on transient error and succeeds", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Custom(6)"))
+      .mockResolvedValueOnce("ok");
+    const result = await withTransientRetry(fn, { delayMs: 0 });
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries up to maxRetries on transient errors then throws", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("Blockhash not found"));
+    await expect(withTransientRetry(fn, { maxRetries: 2, delayMs: 0 })).rejects.toThrow(
+      "Blockhash not found"
+    );
+    expect(fn).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+
+  it("does not retry non-transient errors", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("User rejected"));
+    await expect(withTransientRetry(fn, { maxRetries: 3, delayMs: 0 })).rejects.toThrow(
+      "User rejected"
+    );
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles non-Error throws", async () => {
+    const fn = vi.fn().mockRejectedValue("string error");
+    await expect(withTransientRetry(fn, { delayMs: 0 })).rejects.toBe("string error");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/__tests__/lib/format-extended.test.ts
+++ b/app/__tests__/lib/format-extended.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatTokenAmount,
+  formatPriceE6,
+  formatBps,
+  formatUsd,
+  formatLiqPrice,
+  LIQ_PRICE_UNLIQUIDATABLE,
+  shortenAddress,
+  formatSlotAge,
+  formatI128Amount,
+  formatPnl,
+  formatMarginPct,
+  formatPercent,
+  formatFundingRate,
+} from "../../lib/format";
+
+describe("formatTokenAmount (extended)", () => {
+  it("handles null", () => expect(formatTokenAmount(null)).toBe("0"));
+  it("handles undefined", () => expect(formatTokenAmount(undefined)).toBe("0"));
+  it("handles negative values", () => expect(formatTokenAmount(-1_500_000n)).toBe("-1.5"));
+  it("handles large values", () => expect(formatTokenAmount(1_000_000_000_000n)).toBe("1000000"));
+  it("handles 9 decimals", () => expect(formatTokenAmount(1_500_000_000n, 9)).toBe("1.5"));
+  it("handles sub-unit with 9 decimals", () => expect(formatTokenAmount(1n, 9)).toBe("0.000000001"));
+});
+
+describe("formatPriceE6", () => {
+  it("delegates to formatTokenAmount with 6 decimals", () => {
+    expect(formatPriceE6(1_000_000n)).toBe("1");
+  });
+  it("formats fractional prices", () => {
+    expect(formatPriceE6(1_500_000n)).toBe("1.5");
+  });
+  it("formats sub-dollar prices", () => {
+    expect(formatPriceE6(500n)).toBe("0.0005");
+  });
+});
+
+describe("formatUsd (extended)", () => {
+  it("returns $0.00 for null", () => expect(formatUsd(null)).toBe("$0.00"));
+  it("returns $0.00 for undefined", () => expect(formatUsd(undefined)).toBe("$0.00"));
+  it("formats zero", () => expect(formatUsd(0n)).toBe("$0.00"));
+  it("formats large amounts", () => {
+    const result = formatUsd(1_000_000_000_000n); // $1,000,000
+    expect(result).toContain("$");
+    expect(result).toContain("1");
+  });
+});
+
+describe("formatLiqPrice", () => {
+  it("returns '-' for null", () => expect(formatLiqPrice(null)).toBe("-"));
+  it("returns '-' for undefined", () => expect(formatLiqPrice(undefined)).toBe("-"));
+  it("returns '-' for zero", () => expect(formatLiqPrice(0n)).toBe("-"));
+  it("returns '∞' for unliquidatable sentinel", () => {
+    expect(formatLiqPrice(LIQ_PRICE_UNLIQUIDATABLE)).toBe("∞");
+  });
+  it("returns '∞' for values >= sentinel", () => {
+    expect(formatLiqPrice(LIQ_PRICE_UNLIQUIDATABLE + 1n)).toBe("∞");
+  });
+  it("delegates to formatUsd for normal values", () => {
+    const result = formatLiqPrice(1_000_000n);
+    expect(result).toContain("$");
+    expect(result).toContain("1");
+  });
+});
+
+describe("LIQ_PRICE_UNLIQUIDATABLE", () => {
+  it("equals max u64", () => {
+    expect(LIQ_PRICE_UNLIQUIDATABLE).toBe(18446744073709551615n);
+    expect(LIQ_PRICE_UNLIQUIDATABLE).toBe(2n ** 64n - 1n);
+  });
+});
+
+describe("shortenAddress (extended)", () => {
+  it("shortens with default chars=4", () => {
+    expect(shortenAddress("1234567890abcdef")).toBe("1234...cdef");
+  });
+  it("shortens with custom chars", () => {
+    expect(shortenAddress("1234567890abcdef", 6)).toBe("123456...abcdef");
+  });
+  it("handles short addresses", () => {
+    expect(shortenAddress("abcd", 4)).toBe("abcd...abcd");
+  });
+});
+
+describe("formatSlotAge (extended)", () => {
+  it("returns '—' for null currentSlot", () => {
+    expect(formatSlotAge(null, 100n)).toBe("—");
+  });
+  it("returns '—' for null targetSlot", () => {
+    expect(formatSlotAge(100n, null)).toBe("—");
+  });
+  it("returns '—' for undefined slots", () => {
+    expect(formatSlotAge(undefined, undefined)).toBe("—");
+  });
+  it("returns '0s' when target > current", () => {
+    expect(formatSlotAge(50n, 100n)).toBe("0s");
+  });
+  it("formats minutes", () => {
+    // 500 slots / 2.5 = 200 seconds = 3.33 min
+    expect(formatSlotAge(600n, 100n)).toBe("3.3m");
+  });
+  it("formats hours", () => {
+    // 36000 slots / 2.5 = 14400 seconds = 4 hours
+    expect(formatSlotAge(36100n, 100n)).toBe("4.0h");
+  });
+});
+
+describe("formatI128Amount", () => {
+  it("formats positive value", () => {
+    expect(formatI128Amount(1_500_000n)).toBe("1");
+  });
+  it("formats negative value", () => {
+    expect(formatI128Amount(-2_000_000n)).toBe("-2");
+  });
+  it("formats zero", () => {
+    expect(formatI128Amount(0n)).toBe("0");
+  });
+  it("respects custom decimals", () => {
+    expect(formatI128Amount(1_500_000_000n, 9)).toBe("1");
+  });
+});
+
+describe("formatPnl (extended)", () => {
+  it("returns '0' for null", () => expect(formatPnl(null)).toBe("0"));
+  it("returns '0' for undefined", () => expect(formatPnl(undefined)).toBe("0"));
+  it("formats large positive PnL", () => {
+    expect(formatPnl(100_500_000n)).toBe("+100.5");
+  });
+  it("formats large negative PnL", () => {
+    expect(formatPnl(-100_500_000n)).toBe("-100.5");
+  });
+  it("formats with custom decimals", () => {
+    expect(formatPnl(1_500_000_000n, 9)).toBe("+1.5");
+  });
+});
+
+describe("formatMarginPct", () => {
+  it("formats 100 bps as 1.0%", () => {
+    expect(formatMarginPct(100)).toBe("1.0%");
+  });
+  it("formats 500 bps as 5.0%", () => {
+    expect(formatMarginPct(500)).toBe("5.0%");
+  });
+  it("formats 10000 bps as 100.0%", () => {
+    expect(formatMarginPct(10000)).toBe("100.0%");
+  });
+  it("formats 50 bps as 0.5%", () => {
+    expect(formatMarginPct(50)).toBe("0.5%");
+  });
+});
+
+describe("formatPercent", () => {
+  it("formats positive percentage with + sign", () => {
+    expect(formatPercent(12.34)).toBe("+12.34%");
+  });
+  it("formats negative percentage with - sign", () => {
+    expect(formatPercent(-5.67)).toBe("-5.67%");
+  });
+  it("formats zero without sign", () => {
+    expect(formatPercent(0)).toBe("0.00%");
+  });
+  it("respects custom decimal places", () => {
+    expect(formatPercent(12.3456, 1)).toBe("+12.3%");
+    expect(formatPercent(12.3456, 4)).toBe("+12.3456%");
+  });
+});
+
+describe("formatFundingRate", () => {
+  it("formats zero rate", () => {
+    expect(formatFundingRate(0n)).toBe("0.00%");
+  });
+  it("formats positive funding rate", () => {
+    const result = formatFundingRate(1n); // 1 bps/slot
+    expect(result).toMatch(/^\+/);
+    expect(result).toMatch(/%$/);
+  });
+  it("formats negative funding rate", () => {
+    const result = formatFundingRate(-1n);
+    expect(result).toMatch(/^-/);
+    expect(result).toMatch(/%$/);
+  });
+  it("calculates annualized rate correctly", () => {
+    // 1 bps/slot × (2.5 * 60 * 60 * 24 * 365) slots/yr / 100
+    const slotsPerYear = 2.5 * 60 * 60 * 24 * 365;
+    const expected = slotsPerYear / 100; // 1 bps/slot annualized to %
+    const result = formatFundingRate(1n);
+    const numericPart = parseFloat(result.replace("+", "").replace("%", ""));
+    expect(numericPart).toBeCloseTo(expected, 0);
+  });
+});

--- a/app/__tests__/lib/formatters.test.ts
+++ b/app/__tests__/lib/formatters.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { formatCompact } from "../../lib/formatters";
+
+describe("formatCompact", () => {
+  it("formats trillions", () => {
+    expect(formatCompact(1.5e12)).toBe("1.50T");
+  });
+
+  it("formats billions", () => {
+    expect(formatCompact(2.3e9)).toBe("2.30B");
+  });
+
+  it("formats millions", () => {
+    expect(formatCompact(5.67e6)).toBe("5.67M");
+  });
+
+  it("formats thousands", () => {
+    expect(formatCompact(1234)).toBe("1.23K");
+  });
+
+  it("formats small numbers as-is", () => {
+    expect(formatCompact(999)).toBe("999.00");
+  });
+
+  it("formats zero", () => {
+    expect(formatCompact(0)).toBe("0.00");
+  });
+
+  it("formats exactly 1000 as K", () => {
+    expect(formatCompact(1000)).toBe("1.00K");
+  });
+
+  it("formats exactly 1e6 as M", () => {
+    expect(formatCompact(1e6)).toBe("1.00M");
+  });
+
+  it("formats exactly 1e9 as B", () => {
+    expect(formatCompact(1e9)).toBe("1.00B");
+  });
+
+  it("formats exactly 1e12 as T", () => {
+    expect(formatCompact(1e12)).toBe("1.00T");
+  });
+
+  it("formats fractional numbers", () => {
+    expect(formatCompact(0.5)).toBe("0.50");
+  });
+});

--- a/app/__tests__/lib/health.test.ts
+++ b/app/__tests__/lib/health.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import { computeMarketHealth } from "../../lib/health";
+import type { HealthLevel } from "../../lib/health";
+
+/** Stub EngineState with only the fields computeMarketHealth uses */
+function makeEngine(overrides: {
+  totalOpenInterest?: bigint;
+  cTot?: bigint;
+  insuranceFundBalance?: bigint;
+}) {
+  return {
+    totalOpenInterest: overrides.totalOpenInterest ?? 0n,
+    cTot: overrides.cTot ?? 1_000_000n,
+    insuranceFund: { balance: overrides.insuranceFundBalance ?? 100_000n },
+  } as any;
+}
+
+describe("computeMarketHealth", () => {
+  // ── Empty states ──
+  it('returns "empty" when capital is zero', () => {
+    const result = computeMarketHealth(makeEngine({ cTot: 0n }));
+    expect(result.level).toBe("empty");
+    expect(result.label).toBe("Empty");
+    expect(result.insuranceRatio).toBe(0);
+    expect(result.capitalRatio).toBe(0);
+  });
+
+  it('returns "empty" when insurance is zero', () => {
+    const result = computeMarketHealth(makeEngine({ insuranceFundBalance: 0n }));
+    expect(result.level).toBe("empty");
+  });
+
+  it('returns "empty" when both capital and insurance are zero', () => {
+    const result = computeMarketHealth(makeEngine({ cTot: 0n, insuranceFundBalance: 0n }));
+    expect(result.level).toBe("empty");
+  });
+
+  // ── No open interest ──
+  it('returns "healthy" with Infinity ratios when OI is zero', () => {
+    const result = computeMarketHealth(
+      makeEngine({ cTot: 1_000_000n, insuranceFundBalance: 100_000n, totalOpenInterest: 0n })
+    );
+    expect(result.level).toBe("healthy");
+    expect(result.insuranceRatio).toBe(Infinity);
+    expect(result.capitalRatio).toBe(Infinity);
+  });
+
+  // ── Healthy market ──
+  it('returns "healthy" when both ratios are above thresholds', () => {
+    // insurance >= 5% of OI, capital >= 80% of OI
+    const result = computeMarketHealth(
+      makeEngine({
+        totalOpenInterest: 1_000_000n,
+        cTot: 1_000_000n,        // 100% capital ratio
+        insuranceFundBalance: 100_000n, // 10% insurance ratio
+      })
+    );
+    expect(result.level).toBe("healthy");
+    expect(result.label).toBe("Healthy");
+    expect(result.insuranceRatio).toBeCloseTo(0.1, 5);
+    expect(result.capitalRatio).toBeCloseTo(1.0, 5);
+  });
+
+  // ── Caution market ──
+  it('returns "caution" when insurance ratio is between 2% and 5%', () => {
+    const result = computeMarketHealth(
+      makeEngine({
+        totalOpenInterest: 1_000_000n,
+        cTot: 1_000_000n,        // 100% capital ratio → healthy
+        insuranceFundBalance: 30_000n,  // 3% insurance ratio → caution
+      })
+    );
+    expect(result.level).toBe("caution");
+    expect(result.label).toBe("Caution");
+  });
+
+  it('returns "caution" when capital ratio is between 50% and 80%', () => {
+    const result = computeMarketHealth(
+      makeEngine({
+        totalOpenInterest: 1_000_000n,
+        cTot: 600_000n,           // 60% capital ratio → caution
+        insuranceFundBalance: 100_000n, // 10% insurance ratio → healthy
+      })
+    );
+    expect(result.level).toBe("caution");
+  });
+
+  // ── Warning market ──
+  it('returns "warning" when insurance ratio < 2%', () => {
+    const result = computeMarketHealth(
+      makeEngine({
+        totalOpenInterest: 1_000_000n,
+        cTot: 1_000_000n,        // 100% capital → healthy
+        insuranceFundBalance: 10_000n,  // 1% insurance → warning
+      })
+    );
+    expect(result.level).toBe("warning");
+    expect(result.label).toBe("Low Liquidity");
+  });
+
+  it('returns "warning" when capital ratio < 50%', () => {
+    const result = computeMarketHealth(
+      makeEngine({
+        totalOpenInterest: 1_000_000n,
+        cTot: 400_000n,           // 40% capital → warning
+        insuranceFundBalance: 100_000n, // 10% insurance → healthy
+      })
+    );
+    expect(result.level).toBe("warning");
+  });
+
+  // ── Edge cases ──
+  it("returns correct ratios for large numbers", () => {
+    const result = computeMarketHealth(
+      makeEngine({
+        totalOpenInterest: 1_000_000_000_000n,
+        cTot: 500_000_000_000n,
+        insuranceFundBalance: 50_000_000_000n,
+      })
+    );
+    expect(result.capitalRatio).toBeCloseTo(0.5, 3);
+    expect(result.insuranceRatio).toBeCloseTo(0.05, 3);
+  });
+
+  it('considers insurance=0 as "empty" even with high capital', () => {
+    const result = computeMarketHealth(
+      makeEngine({
+        totalOpenInterest: 100n,
+        cTot: 1_000_000n,
+        insuranceFundBalance: 0n,
+      })
+    );
+    expect(result.level).toBe("empty");
+  });
+});

--- a/app/__tests__/lib/mock-mode.test.ts
+++ b/app/__tests__/lib/mock-mode.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+describe("isMockMode", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    // Restore original env
+    process.env = { ...originalEnv };
+    vi.resetModules();
+  });
+
+  async function loadMockMode() {
+    // Dynamic import to re-evaluate the module with new env
+    const mod = await import("../../lib/mock-mode");
+    return mod.isMockMode;
+  }
+
+  it('returns true when NEXT_PUBLIC_MOCK_MODE is "true"', async () => {
+    process.env.NEXT_PUBLIC_MOCK_MODE = "true";
+    const isMockMode = await loadMockMode();
+    expect(isMockMode()).toBe(true);
+  });
+
+  it('returns true when NEXT_PUBLIC_MOCK_MODE is "1"', async () => {
+    process.env.NEXT_PUBLIC_MOCK_MODE = "1";
+    const isMockMode = await loadMockMode();
+    expect(isMockMode()).toBe(true);
+  });
+
+  it("returns false when NEXT_PUBLIC_MOCK_MODE is not set", async () => {
+    delete process.env.NEXT_PUBLIC_MOCK_MODE;
+    const isMockMode = await loadMockMode();
+    expect(isMockMode()).toBe(false);
+  });
+
+  it('returns false when NEXT_PUBLIC_MOCK_MODE is "false"', async () => {
+    process.env.NEXT_PUBLIC_MOCK_MODE = "false";
+    const isMockMode = await loadMockMode();
+    expect(isMockMode()).toBe(false);
+  });
+
+  it("returns false when NEXT_PUBLIC_MOCK_MODE is empty string", async () => {
+    process.env.NEXT_PUBLIC_MOCK_MODE = "";
+    const isMockMode = await loadMockMode();
+    expect(isMockMode()).toBe(false);
+  });
+});

--- a/app/__tests__/lib/parseAmount.test.ts
+++ b/app/__tests__/lib/parseAmount.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "vitest";
+import { parseHumanAmount, formatHumanAmount } from "../../lib/parseAmount";
+
+describe("parseHumanAmount", () => {
+  // ── Basic parsing ──
+  it("parses whole number", () => {
+    expect(parseHumanAmount("100", 6)).toBe(100_000_000n);
+  });
+
+  it("parses decimal number", () => {
+    expect(parseHumanAmount("100.5", 6)).toBe(100_500_000n);
+  });
+
+  it("parses small decimal", () => {
+    expect(parseHumanAmount("0.000001", 6)).toBe(1n);
+  });
+
+  it("parses max precision for 6 decimals", () => {
+    expect(parseHumanAmount("1.123456", 6)).toBe(1_123_456n);
+  });
+
+  it("parses with 9 decimals (SOL)", () => {
+    expect(parseHumanAmount("1.5", 9)).toBe(1_500_000_000n);
+  });
+
+  it("parses zero", () => {
+    expect(parseHumanAmount("0", 6)).toBe(0n);
+  });
+
+  it("parses '0.0'", () => {
+    expect(parseHumanAmount("0.0", 6)).toBe(0n);
+  });
+
+  // ── Negative numbers ──
+  it("parses negative number", () => {
+    expect(parseHumanAmount("-100", 6)).toBe(-100_000_000n);
+  });
+
+  it("parses negative decimal", () => {
+    expect(parseHumanAmount("-1.5", 6)).toBe(-1_500_000n);
+  });
+
+  // ── Edge cases ──
+  it("returns 0n for empty string", () => {
+    expect(parseHumanAmount("", 6)).toBe(0n);
+  });
+
+  it("returns 0n for just a dot", () => {
+    expect(parseHumanAmount(".", 6)).toBe(0n);
+  });
+
+  it("returns 0n for whitespace only", () => {
+    expect(parseHumanAmount("   ", 6)).toBe(0n);
+  });
+
+  it("returns 0n for '-.'", () => {
+    expect(parseHumanAmount("-.", 6)).toBe(0n);
+  });
+
+  it("returns 0n for '-'", () => {
+    expect(parseHumanAmount("-", 6)).toBe(0n);
+  });
+
+  it("returns 0n for double dots (1.2.3)", () => {
+    expect(parseHumanAmount("1.2.3", 6)).toBe(0n);
+  });
+
+  it("trims whitespace", () => {
+    expect(parseHumanAmount("  100  ", 6)).toBe(100_000_000n);
+  });
+
+  // ── Precision overflow ──
+  it("throws when input exceeds token precision", () => {
+    expect(() => parseHumanAmount("1.1234567", 6)).toThrow("7 decimals");
+  });
+
+  it("allows exactly token precision", () => {
+    expect(parseHumanAmount("1.123456", 6)).toBe(1_123_456n);
+  });
+
+  // ── 0 decimals ──
+  it("works with 0 decimals", () => {
+    expect(parseHumanAmount("42", 0)).toBe(42n);
+  });
+
+  it("throws for decimals with 0-decimal token", () => {
+    expect(() => parseHumanAmount("1.5", 0)).toThrow();
+  });
+
+  // ── Leading zeros ──
+  it("handles leading zeros in whole part", () => {
+    expect(parseHumanAmount("001", 6)).toBe(1_000_000n);
+  });
+
+  // ── Large numbers ──
+  it("handles large numbers", () => {
+    expect(parseHumanAmount("1000000000", 6)).toBe(1_000_000_000_000_000n);
+  });
+});
+
+describe("formatHumanAmount", () => {
+  // ── Basic formatting ──
+  it("formats zero", () => {
+    expect(formatHumanAmount(0n, 6)).toBe("0");
+  });
+
+  it("formats whole number", () => {
+    expect(formatHumanAmount(1_000_000n, 6)).toBe("1");
+  });
+
+  it("formats decimal number", () => {
+    expect(formatHumanAmount(1_500_000n, 6)).toBe("1.5");
+  });
+
+  it("formats sub-unit amount", () => {
+    expect(formatHumanAmount(1n, 6)).toBe("0.000001");
+  });
+
+  it("strips trailing zeros", () => {
+    expect(formatHumanAmount(1_500_000n, 6)).toBe("1.5");
+    expect(formatHumanAmount(1_100_000n, 6)).toBe("1.1");
+  });
+
+  // ── Negative numbers ──
+  it("formats negative whole number", () => {
+    expect(formatHumanAmount(-1_000_000n, 6)).toBe("-1");
+  });
+
+  it("formats negative decimal number", () => {
+    expect(formatHumanAmount(-1_500_000n, 6)).toBe("-1.5");
+  });
+
+  // ── Different decimal counts ──
+  it("works with 9 decimals", () => {
+    expect(formatHumanAmount(1_500_000_000n, 9)).toBe("1.5");
+  });
+
+  it("works with 0 decimals", () => {
+    expect(formatHumanAmount(42n, 0)).toBe("42");
+  });
+
+  // ── Round-trip ──
+  it("round-trips parseHumanAmount → formatHumanAmount", () => {
+    const values = ["0", "1", "1.5", "0.000001", "100.123456", "999999999"];
+    for (const v of values) {
+      expect(formatHumanAmount(parseHumanAmount(v, 6), 6)).toBe(v);
+    }
+  });
+
+  it("round-trips negative values", () => {
+    expect(formatHumanAmount(parseHumanAmount("-1.5", 6), 6)).toBe("-1.5");
+  });
+});


### PR DESCRIPTION
## Summary

Adds **187 new unit tests** across **7 previously untested lib modules**, significantly expanding test coverage for the app's core utilities.

### New Test Files

| File | Tests | Module Covered |
|------|-------|----------------|
| `createMarketValidation.test.ts` | 38 | Market creation form validation — wallet, mint, oracle, fees, margin, LP collateral, insurance, balance checks |
| `errorMessages.test.ts` | 39 | Error humanization (hex/Custom/JSON formats), transient error detection, oracle stale detection, retry logic |
| `parseAmount.test.ts` | 33 | Human↔native amount parsing/formatting, precision overflow, negative numbers, edge cases |
| `format-extended.test.ts` | 50 | All previously untested `format.ts` exports: formatPriceE6, formatLiqPrice, formatI128Amount, formatMarginPct, formatPercent, formatFundingRate, extended edge cases |
| `formatters.test.ts` | 11 | Compact number formatting (K/M/B/T suffixes) |
| `health.test.ts` | 11 | Market health computation — empty/healthy/caution/warning thresholds |
| `mock-mode.test.ts` | 5 | Environment flag detection for mock mode |

### Coverage Gap Closed

Before: 3 lib modules had tests (`config`, `solflare`, `wallets`)
After: 10 lib modules have tests — the remaining untested modules are either type-only (`database.types.ts`), thin re-exports (`trading.ts`), or require network mocking (`tokenMeta.ts`, `supabase.ts`, `connection.ts`).

All 187 tests pass. No production code changes.