### PR TITLE
fix: e2e devnet test falls back to public RPC when HELIUS_API_KEY is unset

### DIFF
--- a/app/scripts/e2e-devnet-test.ts
+++ b/app/scripts/e2e-devnet-test.ts
@@ -61,7 +61,10 @@ import {
   SLAB_TIERS,
 } from "../../packages/core/dist/index.js";
 
-const RPC = `https://devnet.helius-rpc.com/?api-key=${process.env.HELIUS_API_KEY ?? ""}`;
+const HELIUS_KEY = process.env.HELIUS_API_KEY;
+const RPC = HELIUS_KEY
+  ? `https://devnet.helius-rpc.com/?api-key=${HELIUS_KEY}`
+  : "https://api.devnet.solana.com";
 const PROGRAM_ID = new PublicKey("FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD");
 const MATCHER_PROGRAM_ID = new PublicKey("FmTx5yi62Y3h1ATkxm8ujLNNCwYcc2LTmWRFFWN31Af");
 const MATCHER_CTX_SIZE = 320;
@@ -91,6 +94,7 @@ async function send(tx: Transaction, signers: Keypair[], label: string): Promise
 
 async function main() {
   console.log("🧪 E2E Devnet Test");
+  console.log(`   RPC: ${HELIUS_KEY ? "Helius (devnet)" : "Public Solana devnet"}`);
   console.log(`   Payer: ${payer.publicKey.toBase58()}`);
   console.log(`   Balance: ${(await conn.getBalance(payer.publicKey)) / LAMPORTS_PER_SOL} SOL`);
   console.log(`   Program: ${PROGRAM_ID.toBase58()}`);

--- a/scripts/e2e-devnet-test.ts
+++ b/scripts/e2e-devnet-test.ts
@@ -61,7 +61,10 @@ import {
   SLAB_TIERS,
 } from "@percolator/sdk";
 
-const RPC = `https://devnet.helius-rpc.com/?api-key=${process.env.HELIUS_API_KEY ?? ""}`;
+const HELIUS_KEY = process.env.HELIUS_API_KEY;
+const RPC = HELIUS_KEY
+  ? `https://devnet.helius-rpc.com/?api-key=${HELIUS_KEY}`
+  : "https://api.devnet.solana.com";
 const PROGRAM_ID = new PublicKey("FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD");
 const MATCHER_PROGRAM_ID = new PublicKey("FmTx5yi62Y3h1ATkxm8ujLNNCwYcc2LTmWRFFWN31Af");
 const MATCHER_CTX_SIZE = 320;
@@ -91,6 +94,7 @@ async function send(tx: Transaction, signers: Keypair[], label: string): Promise
 
 async function main() {
   console.log("🧪 E2E Devnet Test");
+  console.log(`   RPC: ${HELIUS_KEY ? "Helius (devnet)" : "Public Solana devnet"}`);
   console.log(`   Payer: ${payer.publicKey.toBase58()}`);
   console.log(`   Balance: ${(await conn.getBalance(payer.publicKey)) / LAMPORTS_PER_SOL} SOL`);
   console.log(`   Program: ${PROGRAM_ID.toBase58()}`);


### PR DESCRIPTION
## Summary

When `HELIUS_API_KEY` is not set in the environment, the e2e-devnet-test script was constructing a broken Helius RPC URL with an empty key, making the test impossible to run without a Helius account.

## Changes

- **scripts/e2e-devnet-test.ts** + **app/scripts/e2e-devnet-test.ts**: If `HELIUS_API_KEY` is set, use Helius devnet RPC; otherwise fall back to `https://api.devnet.solana.com`
- Added RPC indicator line to test output so it's clear which endpoint is in use

## Testing

- `pnpm build` passes ✅
- Without `HELIUS_API_KEY`: script will connect to public Solana devnet RPC
- With `HELIUS_API_KEY`: script uses Helius as before (no change)

## Related

- Unblocks QA on-chain E2E testing (PERC-131)
- Reported by QA agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved E2E testing infrastructure with conditional RPC endpoint selection. When a Helius API key is configured, the system uses the Helius devnet RPC; otherwise, it defaults to the public Solana devnet RPC. Added logging to display the active RPC source during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->