### PR TITLE
fix: set InitLP feePayment to match newAccountFee in e2e test

### DIFF
--- a/app/scripts/e2e-devnet-test.ts
+++ b/app/scripts/e2e-devnet-test.ts
@@ -208,10 +208,11 @@ async function main() {
   const lpIdx = 0;
   const [lpPda] = deriveLpPda(PROGRAM_ID, slabKp.publicKey, lpIdx);
 
+  // feePayment must be >= newAccountFee (1_000_000) set in InitMarket
   const initLpData = encodeInitLP({
     matcherProgram: MATCHER_PROGRAM_ID,
     matcherContext: matcherCtxKp.publicKey,
-    feePayment: "0",
+    feePayment: "1000000",
   });
   const initLpKeys = buildAccountMetas(ACCOUNTS_INIT_LP, [
     payer.publicKey, slabKp.publicKey, payerAta, vaultAta, WELL_KNOWN.tokenProgram,

--- a/scripts/e2e-devnet-test.ts
+++ b/scripts/e2e-devnet-test.ts
@@ -207,10 +207,11 @@ async function main() {
   const lpIdx = 0;
   const [lpPda] = deriveLpPda(PROGRAM_ID, slabKp.publicKey, lpIdx);
 
+  // feePayment must be >= newAccountFee (1_000_000) set in InitMarket
   const initLpData = encodeInitLP({
     matcherProgram: MATCHER_PROGRAM_ID,
     matcherContext: matcherCtxKp.publicKey,
-    feePayment: "0",
+    feePayment: "1000000",
   });
   const initLpKeys = buildAccountMetas(ACCOUNTS_INIT_LP, [
     payer.publicKey, slabKp.publicKey, payerAta, vaultAta, WELL_KNOWN.tokenProgram,


### PR DESCRIPTION
## Problem

E2E devnet test Step 6 (InitLP) fails with error `0xd` (`EngineInsufficientBalance`).

## Root Cause

The program's `add_lp()` function requires `fee_payment >= new_account_fee`. The `InitMarket` call sets `newAccountFee: 1_000_000`, but `InitLP` was passing `feePayment: 0`. This means the LP creation fee check fails immediately.

## Fix

Changed `feePayment` from `"0"` to `"1000000"` in both copies of the E2E test:
- `scripts/e2e-devnet-test.ts`
- `app/scripts/e2e-devnet-test.ts`

## Testing

- All 491 app tests pass ✅
- All 49 SDK tests pass ✅
- Rust unit tests pass ✅

Reported by QA (message #1234).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test initialization to properly validate fee payment constraints and ensure compliance with account creation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->