### PR TITLE
fix: remove InitVamm Tag 2 — new matcher has no such instruction

### DIFF
--- a/scripts/e2e-devnet-test.ts
+++ b/scripts/e2e-devnet-test.ts
@@ -217,7 +217,12 @@ async function main() {
     payer.publicKey, slabKp.publicKey, payerAta, vaultAta, WELL_KNOWN.tokenProgram,
   ]);
 
-  // Create matcher context account (owned by matcher program)
+  // Create matcher context account (owned by matcher program).
+  // The new reference AMM matcher (FmTx5yi...) does NOT require an InitVamm
+  // instruction — it only has one instruction (Tag 0, the CPI matcher call).
+  // The AMM reads LP config from the context account's user-data region
+  // (bytes 64..320) and falls back to defaults (30 bps spread, 100% fill)
+  // when the account is zeroed. So we just allocate it.
   const createMatcherTx = new Transaction().add(
     ComputeBudgetProgram.setComputeUnitLimit({ units: 50_000 }),
     SystemProgram.createAccount({
@@ -229,32 +234,6 @@ async function main() {
     })
   );
   await send(createMatcherTx, [payer, matcherCtxKp], "Create matcher ctx");
-
-  // Initialize vAMM matcher (Tag 2) — required before TradeCpi (#382)
-  // Without this, the matcher context is zeroed and the matcher rejects CPI trade calls
-  const vammData = new Uint8Array(66);
-  const vammDv = new DataView(vammData.buffer);
-  let vOff = 0;
-  vammData[vOff] = 2; vOff += 1;                                          // Tag 2 = InitVamm
-  vammData[vOff] = 0; vOff += 1;                                          // mode 0 = passive
-  vammDv.setUint32(vOff, 50, true); vOff += 4;                            // tradingFeeBps
-  vammDv.setUint32(vOff, 50, true); vOff += 4;                            // baseSpreadBps
-  vammDv.setUint32(vOff, 200, true); vOff += 4;                           // maxTotalBps
-  vammDv.setUint32(vOff, 0, true); vOff += 4;                             // impactKBps
-  vammDv.setBigUint64(vOff, 10_000_000_000_000n, true); vOff += 8;        // virtualBase
-  vammDv.setBigUint64(vOff, 0n, true); vOff += 8;                         // (unused)
-  vammDv.setBigUint64(vOff, 1_000_000_000_000n, true); vOff += 8;         // minLiquidity
-  vammDv.setBigUint64(vOff, 0n, true); vOff += 8;                         // (unused)
-  vammDv.setBigUint64(vOff, 0n, true); vOff += 8;                         // (unused)
-  vammDv.setBigUint64(vOff, 0n, true); vOff += 8;                         // (unused)
-  const initVammTx = new Transaction().add(
-    ComputeBudgetProgram.setComputeUnitLimit({ units: 50_000 }),
-    { programId: MATCHER_PROGRAM_ID, keys: [
-      { pubkey: lpPda, isSigner: false, isWritable: false },
-      { pubkey: matcherCtxKp.publicKey, isSigner: false, isWritable: true },
-    ], data: Buffer.from(vammData) }
-  );
-  await send(initVammTx, [payer], "Init matcher vAMM (Tag 2)");
 
   // Init LP in percolator
   const initLpTx = new Transaction().add(

--- a/tests/devnet-e2e.ts
+++ b/tests/devnet-e2e.ts
@@ -8,7 +8,6 @@ import {
   encodeSetOracleAuthority,
   encodePushOraclePrice,
   encodeKeeperCrank,
-  encodeInitVamm,
   encodeInitLP,
   encodeDepositCollateral,
   encodeInitUser,
@@ -17,7 +16,6 @@ import {
   ACCOUNTS_SET_ORACLE_AUTHORITY,
   ACCOUNTS_PUSH_ORACLE_PRICE,
   ACCOUNTS_KEEPER_CRANK,
-  ACCOUNTS_INIT_VAMM,
   ACCOUNTS_INIT_LP,
   ACCOUNTS_DEPOSIT_COLLATERAL,
   ACCOUNTS_INIT_USER,
@@ -150,11 +148,8 @@ async function main() {
     programId: MATCHER_ID,
   });
 
-  const initVammData = encodeInitVamm({});
-  const initVammKeys = buildAccountMetas(ACCOUNTS_INIT_VAMM, [
-    DEPLOYER_KP.publicKey, matcherCtxKeypair.publicKey,
-  ]);
-  const initVammIx = buildIx({ programId: MATCHER_ID, keys: initVammKeys, data: initVammData });
+  // NOTE: The new reference AMM matcher does NOT have an InitVamm instruction.
+  // It reads LP config from context bytes 64..68, using defaults when zeroed.
 
   const userAta = await getAta(DEPLOYER_KP.publicKey, MINT);
   const initLpData = encodeInitLP({ feePayment: "1000000" });
@@ -165,7 +160,7 @@ async function main() {
   ]);
   const initLpIx = buildIx({ programId: PROGRAM_ID, keys: initLpKeys, data: initLpData });
 
-  sig = await sendTx([createMatcherIx, initVammIx, initLpIx], [DEPLOYER_KP, matcherCtxKeypair]);
+  sig = await sendTx([createMatcherIx, initLpIx], [DEPLOYER_KP, matcherCtxKeypair]);
   console.log(`✅ Step 3 OK: ${sig}`);
 
   // Step 4: Deposit + Insurance + Delegate to crank

--- a/tests/t6-risk-gate.ts
+++ b/tests/t6-risk-gate.ts
@@ -228,31 +228,9 @@ async function main() {
       programId: MATCHER_PROGRAM_ID,
     }));
 
-    // Init vAMM (Tag 2)
-    const vammData = new Uint8Array(66);
-    const dv = new DataView(vammData.buffer);
-    let off = 0;
-    vammData[off] = 2; off += 1;
-    vammData[off] = 0; off += 1;
-    dv.setUint32(off, 50, true); off += 4;
-    dv.setUint32(off, 50, true); off += 4;
-    dv.setUint32(off, 200, true); off += 4;
-    dv.setUint32(off, 0, true); off += 4;
-    dv.setBigUint64(off, 10_000_000_000_000n, true); off += 8;
-    dv.setBigUint64(off, 0n, true); off += 8;
-    dv.setBigUint64(off, 1_000_000_000_000n, true); off += 8;
-    dv.setBigUint64(off, 0n, true); off += 8;
-    dv.setBigUint64(off, 0n, true); off += 8;
-    dv.setBigUint64(off, 0n, true); off += 8;
-
-    instructions.push(new TransactionInstruction({
-      programId: MATCHER_PROGRAM_ID,
-      keys: [
-        { pubkey: lpPda, isSigner: false, isWritable: false },
-        { pubkey: matcherCtxKp.publicKey, isSigner: false, isWritable: true },
-      ],
-      data: Buffer.from(vammData),
-    }));
+    // NOTE: The new reference AMM matcher does NOT have an InitVamm (Tag 2)
+    // instruction. It reads LP config from context bytes 64..68, defaulting
+    // to 30 bps spread and 100% fill when zeroed.
 
     // Init LP
     const initLpData = encodeInitLP({


### PR DESCRIPTION
## Fixes #384 — P0 E2E blocker

### Root Cause
The new reference AMM matcher (`FmTx5yi...`, 356KB) only has **one instruction**: Tag 0 (CPI matcher call). It does **NOT** have the `InitVamm` (Tag 2) instruction that the old matcher (`4HcGCsy...`, 44KB) had.

PR #382/#383 added a Tag 2 InitVamm call assuming the new matcher had the same instruction set as the old one. But the new matcher is a completely different program — a simple oracle-anchored AMM that reads LP config from the context account's user-data region (bytes 64..68: `spread_bps` u16 + `max_fill_pct` u16), falling back to defaults (30 bps spread, 100% fill) when zeroed.

### Fix
Remove all InitVamm (Tag 2) instruction construction from **8 files**:
- `scripts/e2e-devnet-test.ts` — E2E test
- `app/scripts/e2e-devnet-test.ts` — E2E test (app copy)
- `app/scripts/deploy-all-tiers.ts` — Multi-tier deploy script
- `app/hooks/useCreateMarket.ts` — **Production UI hook**
- `app/hooks/useVAMM.ts` — **Production UI hook**
- `tests/devnet-e2e.ts` — Devnet test
- `tests/t4-liquidation.ts` — Liquidation test
- `tests/t6-risk-gate.ts` — Risk gate test

The matcher context account just needs to be allocated (`createAccount`) — no separate initialization instruction is required.

### Why This Works
From the Rust source (`percolator-matcher/matcher-program/src/`):
- **Entrypoint** (`lib.rs`): Only parses `MatcherRequest::from_bytes(instruction_data)` which requires `data[0] == CALL_TAG (0x00)` and exactly 67 bytes. Tag 2 fails immediately with `InvalidInstructionData`.
- **ABI** (`matcher-abi/src/lib.rs`): Defines only `CALL_TAG = 0`, `CALL_LEN = 67`.
- **AMM** (`amm.rs`): Reads config from context bytes 64..68 (`LpConfig::from_context`), defaults to 30 bps spread + 100% fill when all zeros.

### Impact
- Unblocks E2E Steps 6-11
- Fixes production market creation from the UI
- 8 files changed, **196 deletions**, 45 insertions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the initialization process by removing an unnecessary vAMM setup step. The system now uses a streamlined two-step initialization flow instead of the previous three-step process, with configuration automatically read from defaults.

* **Tests**
  * Updated test suites to reflect the simplified initialization flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->