### PR TITLE
test: T10 pricing engine edge-case tests (PERC-105)

### DIFF
--- a/tests/t10-pricing-edge-cases.ts
+++ b/tests/t10-pricing-edge-cases.ts
@@ -69,8 +69,9 @@ const PROGRAM_ID = new PublicKey(
 );
 const SLAB_SIZE = Number(process.env.SLAB_SIZE ?? 62_808);
 
+// Load deployer wallet — set DEPLOYER_KP env var to override
 const DEPLOYER_KP_PATH = process.env.DEPLOYER_KP ??
-  "/Users/khubair/.openclaw/percolator/pm/qa-wallet.json";
+  `${process.env.HOME}/.config/solana/id.json`;
 
 interface TestResult { name: string; passed: boolean; error?: string; duration: number }
 const results: TestResult[] = [];


### PR DESCRIPTION
## Summary
Adds **21 new edge-case tests** for the pricing engine (T10), covering areas flagged by PM for deeper coverage.

### Test Categories

#### (a) Oracle Staleness Rejection (4 tests)
- Stale timestamp push behavior
- `maxCrankStalenessSlots=1`: crank failure after slot advance
- Fresh price push resets staleness
- `maxStalenessSecs=0`: disables staleness check

#### (b) Confidence Interval Boundaries (4 tests)
- `confFilterBps=0`: zero confidence filter
- `confFilterBps=10000`: 100% max filter
- `confFilterBps=1`: minimum non-zero
- Persistence through price pushes/cranks

#### (c) Hyperp EMA Warm-up Edge Cases (6 tests)
- `warmupPeriodSlots=0`: instant warm-up
- `warmupPeriodSlots=1`: minimal warm-up
- `warmupPeriodSlots=1000000`: very long warm-up
- LP/User account `warmupStartedAtSlot` verification
- Linear price tracking during warm-up

#### (d) Oracle Price Circuit Breaker (4 tests)
- `SetOraclePriceCap` write/read
- Disable (`cap=0`)
- Price within cap succeeds
- Price exceeding cap is rejected/clamped

#### (e) Extreme Price Values (5 tests)
- Near-zero (`priceE6=1`)
- Near-u64 max ($1B in E6)
- Rapid oscillation (5 alternating pushes)
- $1M initial price market
- Idempotent same-price pushes

#### (f) Funding Rate + Warm-up Interaction (1 test)
- Funding settlement during active warm-up period

### Also in this PR
- Closed #380 (already fixed in PR #381)

### How to run
```bash
HELIUS_API_KEY=xxx npx tsx tests/t10-pricing-edge-cases.ts
```

Part of PERC-105.