### PR TITLE
PERC-150: Add detailed README + Apache 2.0 license

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,20 @@ solana program deploy target/deploy/percolator.so \
 
 ---
 
+## Related Repositories
+
+| Repository | Description |
+|-----------|-------------|
+| [percolator](https://github.com/dcccrypto/percolator) | Core risk engine crate (Rust) |
+| [percolator-prog](https://github.com/dcccrypto/percolator-prog) | Solana on-chain program (wrapper) |
+| [percolator-matcher](https://github.com/dcccrypto/percolator-matcher) | Reference matcher program for LP pricing |
+| [percolator-stake](https://github.com/dcccrypto/percolator-stake) | Insurance LP staking program |
+| [percolator-sdk](https://github.com/dcccrypto/percolator-sdk) | TypeScript SDK for client integration |
+| [percolator-ops](https://github.com/dcccrypto/percolator-ops) | Operations dashboard |
+| [percolator-mobile](https://github.com/dcccrypto/percolator-mobile) | Solana Seeker mobile trading app |
+
+---
+
 ## License
 
-MIT
+Apache 2.0 — see [LICENSE](LICENSE).


### PR DESCRIPTION
## PERC-150: Add detailed README + Apache 2.0 license

### Changes
- **README.md**: Comprehensive documentation with architecture diagrams, setup instructions, build/test commands, deployment notes, and cross-links to all related Percolator repositories
- **LICENSE**: Apache 2.0 license file (where missing)
- **Related Repositories**: Cross-linking table connecting all 8 project repos

### Repos covered (8 total)
- percolator (core risk engine)
- percolator-prog (Solana program)
- percolator-matcher (reference matcher)
- percolator-stake (insurance staking)
- percolator-sdk (TypeScript SDK)
- percolator-ops (operations dashboard)
- percolator-mobile (Solana Seeker app)
- percolator-launch (full-stack monorepo)