### PR TITLE
feat: OI utilization bar label + branded onboarding SVG icons

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -11,6 +11,7 @@ import { ScrollReveal } from "@/components/ui/ScrollReveal";
 import { GradientText } from "@/components/ui/GradientText";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
+import { OnboardingIcon } from "@/components/icons/OnboardingIcons";
 
 /** Format large numbers compactly: 1.2T / 3.4B / 5.6M / 7.8K */
 function formatCompact(n: number): string {
@@ -28,18 +29,21 @@ const HOW_STEPS = [
     title: "Paste a Token Address",
     desc: "Any Solana token. We auto-detect everything. No approval needed.",
     icon: "M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5",
+    brandIcon: "perps" as const,
   },
   {
     number: "02",
     title: "Set Your Terms",
     desc: "Leverage, fees, initial liquidity. Smart defaults if you don't care.",
     icon: "M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z",
+    brandIcon: "onchain" as const,
   },
   {
     number: "03",
     title: "Market Goes Live",
     desc: "Your market is deployed instantly on-chain. Share the link. Done.",
     icon: "M13 10V3L4 14h7v7l9-11h-7z",
+    brandIcon: "deploy" as const,
   },
 ];
 
@@ -66,10 +70,8 @@ function HowItWorks() {
                 className="group relative bg-[var(--panel-bg)] p-4 sm:p-5 transition-colors duration-200 hover:bg-[var(--bg-elevated)]"
               >
                 <div className="mb-4 flex items-start justify-between">
-                  <div className="flex h-10 w-10 items-center justify-center border border-[var(--accent)]/15 bg-[var(--accent)]/[0.04] transition-colors duration-200 group-hover:border-[var(--accent)]/30 group-hover:bg-[var(--accent)]/[0.08]">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" className="text-[var(--accent)]">
-                      <path d={step.icon} stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                    </svg>
+                  <div className="flex h-12 w-12 items-center justify-center border border-[var(--accent)]/15 bg-[var(--accent)]/[0.04] transition-colors duration-200 group-hover:border-[var(--accent)]/30 group-hover:bg-[var(--accent)]/[0.08]">
+                    <OnboardingIcon type={step.brandIcon} size={32} />
                   </div>
                   <span className="text-[20px] font-normal tracking-tight text-[var(--border)] transition-colors duration-200 group-hover:text-[var(--accent)]/20" style={{ fontFamily: "var(--font-heading)" }}>
                     {step.number}

--- a/app/components/icons/OnboardingIcons.tsx
+++ b/app/components/icons/OnboardingIcons.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { FC } from "react";
+
+type IconType = "perps" | "onchain" | "deploy";
+
+interface OnboardingIconProps {
+  type: IconType;
+  size?: number;
+  className?: string;
+}
+
+/**
+ * Brand SVG icons for onboarding/landing sections.
+ * Replaces generic emoji with Percolator-themed illustrations.
+ *
+ * Colors:
+ *   cyan  = #22d3ee (var(--cyan))
+ *   accent = #7c3aed (var(--accent))
+ *
+ * Adapted from designer spec (mobile-oi-bar-and-onboarding-icons-spec.md)
+ * for Next.js/web SVG rendering.
+ */
+export const OnboardingIcon: FC<OnboardingIconProps> = ({ type, size = 64, className }) => {
+  if (type === "perps") {
+    return (
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 64 64"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        className={className}
+        aria-label="Permissionless Perps icon"
+        role="img"
+      >
+        {/* Circular arc (perpetual loop) */}
+        <circle
+          cx="32" cy="32" r="24"
+          stroke="#22d3ee" strokeWidth="1.5"
+          strokeDasharray="40 30" strokeLinecap="round"
+          opacity="0.4"
+        />
+        {/* Glow halo */}
+        <circle cx="32" cy="32" r="18" fill="#22d3ee" opacity="0.06" />
+        {/* Lightning bolt body */}
+        <path
+          d="M36 8 L22 34 H31 L28 56 L46 28 H36 L40 8 Z"
+          fill="#22d3ee" opacity="0.9"
+        />
+        {/* Lightning bolt inner highlight */}
+        <path
+          d="M36 14 L27 32 H33 L30 46 L41 30 H35 L38 14 Z"
+          fill="#7c3aed" opacity="0.6"
+        />
+      </svg>
+    );
+  }
+
+  if (type === "onchain") {
+    return (
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 64 64"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        className={className}
+        aria-label="Fully On-Chain icon"
+        role="img"
+      >
+        {/* Outer glow */}
+        <ellipse cx="32" cy="32" rx="22" ry="16" fill="#7c3aed" opacity="0.05" />
+        {/* Left hexagon block */}
+        <path
+          d="M12 32 L20 18 L36 18 L44 32 L36 46 L20 46 Z"
+          stroke="#7c3aed" strokeWidth="1.5"
+          fill="rgba(124,58,237,0.08)" strokeLinejoin="round"
+        />
+        {/* Right hexagon block (overlapping) */}
+        <path
+          d="M28 32 L36 18 L52 18 L60 32 L52 46 L36 46 Z"
+          stroke="#22d3ee" strokeWidth="1.5"
+          fill="rgba(34,211,238,0.08)" strokeLinejoin="round"
+        />
+        {/* Center link highlights */}
+        <path
+          d="M36 22 L40 32 L36 42"
+          stroke="#22d3ee" strokeWidth="2" strokeLinecap="round" opacity="0.7"
+        />
+        <path
+          d="M28 22 L24 32 L28 42"
+          stroke="#7c3aed" strokeWidth="2" strokeLinecap="round" opacity="0.7"
+        />
+      </svg>
+    );
+  }
+
+  // type === "deploy"
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 64 64"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-label="Deploy in 60s icon"
+      role="img"
+    >
+      {/* Exhaust glow */}
+      <ellipse cx="32" cy="48" rx="6" ry="10" fill="#7c3aed" opacity="0.2" />
+      {/* Exhaust trail */}
+      <path
+        d="M28 46 Q32 54 36 46"
+        stroke="#7c3aed" strokeWidth="2" strokeLinecap="round" opacity="0.6"
+      />
+      <path
+        d="M30 48 Q32 58 34 48"
+        stroke="#22d3ee" strokeWidth="1.5" strokeLinecap="round" opacity="0.4"
+      />
+      {/* Rocket body */}
+      <path
+        d="M32 8 C32 8 22 22 22 36 L32 40 L42 36 C42 22 32 8 32 8 Z"
+        fill="#22d3ee" opacity="0.9"
+      />
+      {/* Rocket window */}
+      <circle cx="32" cy="28" r="5" fill="#06060c" opacity="0.8" />
+      <circle cx="32" cy="28" r="3" fill="#7c3aed" opacity="0.9" />
+      <circle cx="30.5" cy="26.5" r="1" fill="white" opacity="0.5" />
+      {/* Rocket fins */}
+      <path d="M22 36 L16 44 L24 40 Z" fill="#7c3aed" opacity="0.7" />
+      <path d="M42 36 L48 44 L40 40 Z" fill="#7c3aed" opacity="0.7" />
+    </svg>
+  );
+};
+
+export default OnboardingIcon;


### PR DESCRIPTION
## Summary

Implements the designer's OI bar label + onboarding icons spec (adapted from mobile to web).

### Changes

**1. OI Utilization Bar (`OpenInterestCard.tsx`)**
- Added labeled 'OI Utilization' progress bar above the Long/Short breakdown
- Dynamic color based on capacity:
  - `var(--accent)` (purple) at 0–49%
  - `var(--warning)` (yellow) at 50–79%  
  - `var(--short)` (red) at 80–100%
- Uses $5M placeholder max capacity until `market.maxOpenInterest` is available on-chain
- Tabular-nums font variant for stable percentage display
- Smooth 500ms transition on bar width changes

**2. Onboarding SVG Icons (`OnboardingIcons.tsx`)**
- New component: `OnboardingIcon` with 3 variants: `perps`, `onchain`, `deploy`
- Each icon uses brand colors (cyan `#22d3ee`, purple `#7c3aed`) with glow halos
- Proper `aria-label` and `role='img'` for accessibility
- Replaces generic SVG path icons in the homepage How It Works section

**3. Homepage Update (`page.tsx`)**
- HowItWorks cards now render `OnboardingIcon` at 32px inside 48px containers
- Brand visual identity replaces generic stroke icons

### Design Spec
From `designer/specs/mobile-oi-bar-and-onboarding-icons-spec.md`, adapted for Next.js/Tailwind.

### Testing
- ✅ TypeScript compiles clean (`tsc --noEmit`)
- ✅ All 516 tests pass (0 failures)
- ✅ `next build` succeeds