### PR TITLE
fix: base58 regex missing lowercase chars in PROGRAM_ID validation

### DIFF
--- a/packages/shared/src/networkValidation.ts
+++ b/packages/shared/src/networkValidation.ts
@@ -81,7 +81,7 @@ export function validateNetworkConfig(env: {
   }
 
   // 5. Validate program ID looks like a valid Solana address (base58, ~44 chars)
-  if (!/[1-9A-HJ-NP-Z]{40,45}/.test(programIdEnv)) {
+  if (!/[1-9A-HJ-NP-Za-km-z]{40,45}/.test(programIdEnv)) {
     throw new Error(
       `❌ PROGRAM_ID does not look like a valid Solana address.\n` +
       `Got: ${programIdEnv}\n` +


### PR DESCRIPTION
## CRITICAL — Railway API is DOWN

The PROGRAM_ID validation regex `/[1-9A-HJ-NP-Z]{40,45}/` only matches uppercase base58 characters. Solana addresses use full base58: `[1-9A-HJ-NP-Za-km-z]`.

This causes percolator-api1 to crash immediately on startup because our program ID `FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD` contains lowercase letters.

### Fix
Change the regex to include lowercase base58 characters: `/[1-9A-HJ-NP-Za-km-z]{40,45}/`

This matches the fix already applied in dcccrypto/percolator-shared#4.

### Impact
- **percolator-api1 is currently CRASHED in Railway production**
- Merge immediately to restore service

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Solana program ID validation to correctly accept a broader range of valid addresses, resolving cases where valid identifiers were previously rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->