### PR TITLE
fix: replace remaining hardcoded /1e6 with dynamic token decimals (PERC-167)

### DIFF
--- a/app/components/market/OpenInterestCard.tsx
+++ b/app/components/market/OpenInterestCard.tsx
@@ -2,6 +2,8 @@
 
 import { FC, useState, useEffect, useMemo } from "react";
 import { useEngineState } from "@/hooks/useEngineState";
+import { useSlabState } from "@/components/providers/SlabProvider";
+import { useTokenMeta } from "@/hooks/useTokenMeta";
 import { InfoIcon } from "@/components/ui/Tooltip";
 import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab } from "@/lib/mock-trade-data";
@@ -32,18 +34,18 @@ const MOCK_OI: OpenInterestData = {
   ],
 };
 
-function formatUsdAmount(amountE6: string | bigint): string {
-  const num = typeof amountE6 === "string" ? BigInt(amountE6) : amountE6;
-  const usd = Number(num) / 1e6;
+function formatTokenUsd(amountRaw: string | bigint, decimals: number = 6): string {
+  const num = typeof amountRaw === "string" ? BigInt(amountRaw) : amountRaw;
+  const usd = Number(num) / 10 ** decimals;
   return usd.toLocaleString(undefined, {
     minimumFractionDigits: 0,
     maximumFractionDigits: 0,
   });
 }
 
-function formatSignedUsdAmount(amountE6: string): string {
-  const num = BigInt(amountE6 ?? "0");
-  const usd = Number(num) / 1e6;
+function formatSignedTokenUsd(amountRaw: string, decimals: number = 6): string {
+  const num = BigInt(amountRaw ?? "0");
+  const usd = Number(num) / 10 ** decimals;
   const formatted = Math.abs(usd).toLocaleString(undefined, {
     minimumFractionDigits: 0,
     maximumFractionDigits: 0,
@@ -56,6 +58,9 @@ export const OpenInterestCard: FC<{ slabAddress: string }> = ({
 }) => {
   const mockMode = isMockMode() && isMockSlab(slabAddress);
   const { engine } = useEngineState();
+  const { config } = useSlabState();
+  const tokenMeta = useTokenMeta(config?.collateralMint ?? null);
+  const decimals = tokenMeta?.decimals ?? 6;
 
   const [oiData, setOiData] = useState<OpenInterestData | null>(
     mockMode ? MOCK_OI : null
@@ -197,10 +202,10 @@ export const OpenInterestCard: FC<{ slabAddress: string }> = ({
     );
   }
 
-  const totalOiUsd = formatUsdAmount(oiData.totalOi);
-  const longOiUsd = formatUsdAmount(oiData.longOi);
-  const shortOiUsd = formatUsdAmount(oiData.shortOi);
-  const lpNetUsd = formatSignedUsdAmount(oiData.netLpPosition);
+  const totalOiUsd = formatTokenUsd(oiData.totalOi, decimals);
+  const longOiUsd = formatTokenUsd(oiData.longOi, decimals);
+  const shortOiUsd = formatTokenUsd(oiData.shortOi, decimals);
+  const lpNetUsd = formatSignedTokenUsd(oiData.netLpPosition, decimals);
   const lpDirection = BigInt(oiData.netLpPosition ?? "0") >= 0n ? "long" : "short";
 
   return (

--- a/app/components/trade/ClosePositionModal.tsx
+++ b/app/components/trade/ClosePositionModal.tsx
@@ -101,8 +101,9 @@ export const ClosePositionModal: FC<ClosePositionModalProps> = ({
     const rawReceive = closeCapital + pnl;
     const receive = rawReceive > 0n ? rawReceive : 0n;
 
+    const divisor = 10 ** decimals;
     const pnlUsd = priceUsd !== null && currentPrice > 0n
-      ? (Number(pnl) / 1e6) * priceUsd
+      ? (Number(pnl) / divisor) * priceUsd
       : null;
 
     return { closeAbs, remainingAbs, pnl, pnlUsd, receive };

--- a/app/components/trade/EngineHealthCard.tsx
+++ b/app/components/trade/EngineHealthCard.tsx
@@ -5,6 +5,7 @@ import { useEngineState } from "@/hooks/useEngineState";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { useUsdToggle } from "@/components/providers/UsdToggleProvider";
 import { useLivePrice } from "@/hooks/useLivePrice";
+import { useTokenMeta } from "@/hooks/useTokenMeta";
 import { computeMarketHealth } from "@/lib/health";
 import { formatTokenAmount, formatSlotAge } from "@/lib/format";
 
@@ -23,9 +24,12 @@ const HEALTH_COLORS: Record<string, string> = {
 
 export const EngineHealthCard: FC = () => {
   const { engine, loading } = useEngineState();
-  const { accounts } = useSlabState();
+  const { accounts, config } = useSlabState();
   const { showUsd } = useUsdToggle();
   const { priceUsd } = useLivePrice();
+  const tokenMeta = useTokenMeta(config?.collateralMint ?? null);
+  const decimals = tokenMeta?.decimals ?? 6;
+  const divisor = 10 ** decimals;
 
   if (loading || !engine) {
     return (
@@ -48,17 +52,17 @@ export const EngineHealthCard: FC = () => {
     : "0%";
 
   const netLpPosDisplay = showUsd && priceUsd != null
-    ? formatNum((Number(netLpPos < 0n ? -netLpPos : netLpPos) / 1e6) * priceUsd)
-    : formatTokenAmount(netLpPos < 0n ? -netLpPos : netLpPos);
+    ? formatNum((Number(netLpPos < 0n ? -netLpPos : netLpPos) / divisor) * priceUsd)
+    : formatTokenAmount(netLpPos < 0n ? -netLpPos : netLpPos, decimals);
   const lpSumAbsDisplay = showUsd && priceUsd != null
-    ? formatNum((Number(lpSumAbs) / 1e6) * priceUsd)
-    : formatTokenAmount(lpSumAbs);
+    ? formatNum((Number(lpSumAbs) / divisor) * priceUsd)
+    : formatTokenAmount(lpSumAbs, decimals);
   const cTotDisplay = showUsd && priceUsd != null
-    ? formatNum((Number(cTot) / 1e6) * priceUsd)
-    : formatTokenAmount(cTot);
+    ? formatNum((Number(cTot) / divisor) * priceUsd)
+    : formatTokenAmount(cTot, decimals);
   const pnlPosTotDisplay = showUsd && priceUsd != null
-    ? formatNum((Number(pnlPosTot) / 1e6) * priceUsd)
-    : formatTokenAmount(pnlPosTot);
+    ? formatNum((Number(pnlPosTot) / divisor) * priceUsd)
+    : formatTokenAmount(pnlPosTot, decimals);
 
   const metrics = [
     { label: "Crank Age", value: formatSlotAge(engine.currentSlot ?? 0n, engine.lastCrankSlot ?? 0n) },

--- a/app/components/trade/PositionPanel.tsx
+++ b/app/components/trade/PositionPanel.tsx
@@ -72,8 +72,9 @@ export const PositionPanel: FC<{ slabAddress: string }> = ({ slabAddress }) => {
     account.entryPrice,
     currentPriceE6,
   ) : 0n;
+  const divisor = 10 ** decimals;
   const pnlUsd =
-    priceUsd !== null && currentPriceE6 > 0n ? (Number(pnlTokens) / 1e6) * priceUsd : null;
+    priceUsd !== null && currentPriceE6 > 0n ? (Number(pnlTokens) / divisor) * priceUsd : null;
   const roe = currentPriceE6 > 0n ? computePnlPercent(pnlTokens, account.capital) : 0;
 
   const maintenanceBps = params?.maintenanceMarginBps ?? 500n;

--- a/app/components/trade/PositionsTable.tsx
+++ b/app/components/trade/PositionsTable.tsx
@@ -70,8 +70,9 @@ export const PositionsTable: FC<{ slabAddress: string }> = ({ slabAddress }) => 
   const pnlTokens = currentPriceE6 > 0n
     ? computeMarkPnl(account.positionSize, entryPriceE6, currentPriceE6)
     : 0n;
+  const divisor = 10 ** decimals;
   const pnlUsd = priceUsd !== null && currentPriceE6 > 0n
-    ? (Number(pnlTokens) / 1e6) * priceUsd
+    ? (Number(pnlTokens) / divisor) * priceUsd
     : null;
   const roe = currentPriceE6 > 0n ? computePnlPercent(pnlTokens, account.capital) : 0;
 

--- a/app/components/trade/WarmupProgress.tsx
+++ b/app/components/trade/WarmupProgress.tsx
@@ -2,6 +2,8 @@
 
 import { FC, useState, useEffect } from "react";
 import { WarmupExplainerModal } from "./WarmupExplainerModal";
+import { useSlabState } from "@/components/providers/SlabProvider";
+import { useTokenMeta } from "@/hooks/useTokenMeta";
 import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab } from "@/lib/mock-trade-data";
 
@@ -34,9 +36,9 @@ function formatCountdown(slots: number): string {
   return `${secs}s`;
 }
 
-function formatUsdAmount(amountE6: string | bigint): string {
-  const num = typeof amountE6 === "string" ? BigInt(amountE6) : amountE6;
-  const usd = Number(num) / 1e6;
+function formatTokenUsd(amountRaw: string | bigint, decimals: number = 6): string {
+  const num = typeof amountRaw === "string" ? BigInt(amountRaw) : amountRaw;
+  const usd = Number(num) / 10 ** decimals;
   return usd.toLocaleString(undefined, {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
@@ -48,6 +50,9 @@ export const WarmupProgress: FC<{
   accountIdx: number;
 }> = ({ slabAddress, accountIdx }) => {
   const mockMode = isMockMode() && isMockSlab(slabAddress);
+  const { config } = useSlabState();
+  const tokenMeta = useTokenMeta(config?.collateralMint ?? null);
+  const decimals = tokenMeta?.decimals ?? 6;
 
   const [warmupData, setWarmupData] = useState<WarmupData | null>(
     mockMode ? MOCK_WARMUP : null
@@ -175,11 +180,11 @@ export const WarmupProgress: FC<{
         {/* Amounts row — compact */}
         <div className="mt-1 flex items-center gap-3 pl-0">
           <span className="text-[9px] text-[var(--text-dim)]">
-            <span className="text-[var(--text-muted)]" style={{ fontFamily: "var(--font-mono)" }}>${formatUsdAmount(warmupData.unlockedAmount)}</span> available
+            <span className="text-[var(--text-muted)]" style={{ fontFamily: "var(--font-mono)" }}>${formatTokenUsd(warmupData.unlockedAmount, decimals)}</span> available
           </span>
           <span className="text-[var(--border)]">·</span>
           <span className="text-[9px] text-[var(--text-dim)]">
-            <span className="text-[var(--text-muted)]" style={{ fontFamily: "var(--font-mono)" }}>${formatUsdAmount(warmupData.lockedAmount)}</span> locked
+            <span className="text-[var(--text-muted)]" style={{ fontFamily: "var(--font-mono)" }}>${formatTokenUsd(warmupData.lockedAmount, decimals)}</span> locked
           </span>
           <button
             onClick={() => setShowExplainer(true)}


### PR DESCRIPTION
## Summary
Follow-up to PR #408 (PERC-166). Replaces all remaining hardcoded `/1e6` token amount conversions with dynamic decimals from `useTokenMeta` in 6 components:

### Changes
| Component | What changed |
|-----------|-------------|
| **PositionsTable** | PnL USD calculation now uses `divisor` |
| **PositionPanel** | PnL USD calculation now uses `divisor` |
| **ClosePositionModal** | Preview PnL USD calculation uses `decimals` prop |
| **EngineHealthCard** | 4 USD display values + added `useTokenMeta` hook |
| **WarmupProgress** | Unlocked/locked amount formatting + added `useTokenMeta` |
| **OpenInterestCard** | Total OI, long/short OI, LP net position + added `useTokenMeta` |

### Pattern
```ts
// Before (hardcoded)
(Number(value) / 1e6) * priceUsd

// After (dynamic)
const divisor = 10 ** decimals;
(Number(value) / divisor) * priceUsd
```

### Testing
- `pnpm build` passes clean
- No remaining `/1e6` in any of the 6 target files
- Default fallback remains `6` so existing behavior unchanged for USDC markets

Closes PERC-167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Token amount and USD value formatting now uses actual token decimals instead of fixed scaling, ensuring accurate display across trading dashboards and position tracking.
  * Profit/loss calculations updated to apply correct decimal scaling based on token metadata.
  * Open interest data loading enhanced with automatic fallback to on-chain data when API requests fail, ensuring data availability in all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->