### PR TITLE
fix: require auth for logo upload endpoints

### DIFF
--- a/app/app/api/markets/[slab]/logo/route.ts
+++ b/app/app/api/markets/[slab]/logo/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServiceClient } from "@/lib/supabase";
 import { PublicKey } from "@solana/web3.js";
+import { requireAuth, UNAUTHORIZED } from "@/lib/api-auth";
 
 export const dynamic = "force-dynamic";
 
@@ -34,6 +35,10 @@ export async function POST(
   req: NextRequest,
   { params }: { params: Promise<{ slab: string }> }
 ) {
+  if (!requireAuth(req)) {
+    return UNAUTHORIZED;
+  }
+
   const { slab } = await params;
 
   // Validate slab address

--- a/app/app/api/tokens/[mint]/logo/route.ts
+++ b/app/app/api/tokens/[mint]/logo/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServiceClient } from "@/lib/supabase";
 import { PublicKey } from "@solana/web3.js";
+import { requireAuth, UNAUTHORIZED } from "@/lib/api-auth";
 
 export const dynamic = "force-dynamic";
 
@@ -45,6 +46,10 @@ export async function POST(
   req: NextRequest,
   { params }: { params: Promise<{ mint: string }> }
 ) {
+  if (!requireAuth(req)) {
+    return UNAUTHORIZED;
+  }
+
   const { mint } = await params;
 
   try {


### PR DESCRIPTION
"fix: require auth for logo upload endpoints" --body "Issue summary:Unauthenticated clients could POST to logo upload endpoints and overwrite market/token logos. This allowed unauthorized mutation of user-facing branding assets.

What changed:- Added existing API auth guard to POST /api/markets/[slab]/logo- 
Added existing API auth guard to POST /api/tokens/[mint]/logo- Unauthorized requests now return the shared 401 response

Why this fix is correct:These endpoints are mutation routes and should not be publicly writable. Reusing the existing auth mechanism enforces consistent access control with minimal surface-area change while leaving read endpoints unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Market and token logo upload endpoints now require authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->