### PR TITLE
fix: PERC-168/169 — eliminate layout voids + improve text contrast

### DIFF
--- a/app/app/create/loading.tsx
+++ b/app/app/create/loading.tsx
@@ -4,9 +4,9 @@ export default function CreateLoading() {
   return (
     <div className="min-h-[calc(100vh-48px)] relative">
       {/* Grid background */}
-      <div className="absolute inset-x-0 top-0 h-48 bg-grid pointer-events-none" />
+      <div className="absolute inset-x-0 top-0 h-32 bg-grid pointer-events-none" />
 
-      <div className="relative mx-auto max-w-4xl px-4 py-10">
+      <div className="relative mx-auto max-w-4xl px-4 pt-4 pb-10">
         {/* Page header skeleton */}
         <div className="mb-8">
           <ShimmerSkeleton className="h-3 w-16 mb-2" />

--- a/app/app/create/page.tsx
+++ b/app/app/create/page.tsx
@@ -36,9 +36,9 @@ function CreatePageInner() {
   return (
     <div className="min-h-[calc(100vh-48px)] relative">
       {/* Grid background */}
-      <div className="absolute inset-x-0 top-0 h-48 bg-grid pointer-events-none" />
+      <div className="absolute inset-x-0 top-0 h-32 bg-grid pointer-events-none" />
 
-      <div className="relative mx-auto max-w-4xl px-4 py-10">
+      <div className="relative mx-auto max-w-4xl px-4 pt-4 pb-10">
         {/* Page header */}
         <ScrollReveal>
           <div className="mb-8">

--- a/app/app/markets/loading.tsx
+++ b/app/app/markets/loading.tsx
@@ -4,9 +4,9 @@ export default function MarketsLoading() {
   return (
     <div className="min-h-[calc(100vh-48px)] relative">
       {/* Grid background */}
-      <div className="absolute inset-x-0 top-0 h-48 bg-grid pointer-events-none" />
+      <div className="absolute inset-x-0 top-0 h-32 bg-grid pointer-events-none" />
 
-      <div className="relative mx-auto max-w-4xl px-4 py-10">
+      <div className="relative mx-auto max-w-4xl px-4 pt-4 pb-10">
         {/* Header skeleton */}
         <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
           <div>

--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -257,9 +257,9 @@ function MarketsPageInner() {
   return (
     <div className="min-h-[calc(100vh-48px)] relative">
       {/* Grid background */}
-      <div className="absolute inset-x-0 top-0 h-48 bg-grid pointer-events-none" />
+      <div className="absolute inset-x-0 top-0 h-32 bg-grid pointer-events-none" />
 
-      <div className="relative mx-auto max-w-4xl px-4 py-10">
+      <div className="relative mx-auto max-w-4xl px-4 pt-4 pb-10">
         {/* Header */}
         <ScrollReveal>
           <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">

--- a/app/components/marketing/HeroCtaGroup.tsx
+++ b/app/components/marketing/HeroCtaGroup.tsx
@@ -47,16 +47,16 @@ export function HeroCtaGroup() {
 
       <Link
         href="/markets"
-        className={`hero-cta inline-flex items-center rounded-xl border border-white/20 bg-white/5 px-6 py-3 text-sm font-semibold text-white transition-colors hover:border-purple-400 hover:bg-white/10 ${prefersReduced ? '' : 'gsap-fade'}`}
+        className={`hero-cta inline-flex items-center rounded-xl border-[1.5px] border-white/20 bg-white/[0.06] px-6 py-3 text-[15px] font-semibold text-white transition-all hover:border-white/35 hover:bg-white/10 ${prefersReduced ? '' : 'gsap-fade'}`}
       >
         Trade Now
       </Link>
 
       <Link
         href="#how-it-works"
-        className={`hero-cta text-sm font-medium text-cyan-400 underline underline-offset-4 transition-colors hover:text-cyan-300 ${prefersReduced ? '' : 'gsap-fade'}`}
+        className={`hero-cta inline-flex items-center gap-1 text-[14px] font-medium text-[#22d3ee] border-b border-[#22d3ee]/40 pb-px transition-colors hover:text-[#67e8f9] hover:border-[#67e8f9]/70 ${prefersReduced ? '' : 'gsap-fade'}`}
       >
-        Earn as Creator
+        Earn as Creator <span aria-hidden="true">→</span>
       </Link>
     </div>
   );

--- a/app/components/marketing/HeroSection.tsx
+++ b/app/components/marketing/HeroSection.tsx
@@ -85,7 +85,7 @@ export function HeroSection() {
   return (
     <section
       ref={containerRef}
-      className="relative flex min-h-[100vh] items-center overflow-hidden"
+      className="relative flex min-h-[80vh] items-center overflow-hidden"
     >
       {/* ── Background layers ── */}
       <div className="absolute inset-x-0 top-0 h-full bg-grid pointer-events-none" />
@@ -115,7 +115,7 @@ export function HeroSection() {
       />
 
       {/* ── Content ── */}
-      <div className="relative z-10 mx-auto grid w-full max-w-[1280px] grid-cols-1 items-center gap-12 px-6 py-20 md:grid-cols-[55%_45%] lg:gap-16">
+      <div className="relative z-10 mx-auto grid w-full max-w-[1280px] grid-cols-1 items-center gap-12 px-6 pt-12 pb-16 md:grid-cols-[55%_45%] lg:gap-16">
         {/* LEFT COLUMN */}
         <div className="flex flex-col gap-6">
           {/* Eyebrow badge */}
@@ -147,13 +147,13 @@ export function HeroSection() {
 
           {/* Subheadline */}
           <p
-            className={`hero-fade max-w-[520px] text-base leading-relaxed text-white/60 sm:text-lg ${prefersReduced ? '' : 'gsap-fade'}`}
+            className={`hero-fade max-w-[520px] text-base leading-[1.6] text-[#d1d5db] sm:text-lg ${prefersReduced ? '' : 'gsap-fade'}`}
           >
             Deploy a perpetual futures market for any Solana token.
             <br />
             No permission. No admin key. No gatekeepers.
             <br />
-            <span className="text-white/40">
+            <span className="text-[#9ca3af]">
               Earn 8% of all trading fees as the market creator.
             </span>
           </p>
@@ -171,22 +171,22 @@ export function HeroSection() {
 
           {/* Social proof bar */}
           <div
-            className={`hero-fade flex flex-wrap items-center gap-4 text-[12px] text-white/30 ${prefersReduced ? '' : 'gsap-fade'}`}
+            className={`hero-fade flex flex-wrap items-center gap-4 text-[12px] text-[#6b7280] ${prefersReduced ? '' : 'gsap-fade'}`}
           >
             <span className="flex items-center gap-1.5">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" className="text-white/20">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" className="text-[#6b7280]">
                 <circle cx="12" cy="12" r="10" />
               </svg>
               Powered by Solana
             </span>
             <span className="flex items-center gap-1.5">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-white/20">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-[#6b7280]">
                 <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
               </svg>
               Open Source
             </span>
             <span className="flex items-center gap-1.5">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" className="text-white/20">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" className="text-[#6b7280]">
                 <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
               </svg>
               MIT License

--- a/app/components/marketing/HeroStats.tsx
+++ b/app/components/marketing/HeroStats.tsx
@@ -62,11 +62,11 @@ export function HeroStats({
       style={{ fontFamily: "var(--font-heading)" }}
     >
       {stats.map((s, i) => (
-        <div key={s.label} className="flex items-center gap-2 text-[13px]">
+        <div key={s.label} className="flex items-center gap-2 text-[13px] font-medium tracking-[0.01em]">
           {i > 0 && (
             <span className="mr-2 hidden text-white/10 md:inline">|</span>
           )}
-          <span className="text-white/40">{s.label}</span>
+          <span className="text-[#9ca3af]">{s.label}</span>
           {s.value}
         </div>
       ))}


### PR DESCRIPTION
## Summary

Addresses **PERC-168** (layout voids) and **PERC-169** (visual polish P0 contrast fixes) from designer's visual audit.

### Layout voids fixed
- **Homepage hero**: Reduced `min-h-[100vh]` → `min-h-[80vh]` to eliminate the ~600px empty gap below hero content. Tightened vertical padding from `py-20` to `pt-12 pb-16`.
- **Markets page**: Reduced decorative bg-grid from `h-48` → `h-32`, changed content padding from `py-10` → `pt-4 pb-10` to close the top void.
- **Create page**: Same bg-grid and padding adjustments as markets.
- **Loading states**: Markets and Create loading skeletons match their page counterparts.

### Text contrast improvements (WCAG AA)
- **Hero subheadline**: `text-white/60` → `#d1d5db` (light gray, ~4.8:1 ratio on dark bg)
- **Hero stats labels**: `text-white/40` → `#9ca3af` with `font-medium` tracking
- **Social proof bar**: `text-white/30` → `#6b7280` with matching icon colors
- **Trade Now CTA**: `border-[1.5px]` + `text-[15px]` for better visibility
- **Earn as Creator**: Replaced subtle underline with solid border-bottom + arrow indicator

### Files changed (7)
- `app/components/marketing/HeroSection.tsx`
- `app/components/marketing/HeroStats.tsx`
- `app/components/marketing/HeroCtaGroup.tsx`
- `app/app/markets/page.tsx` + `loading.tsx`
- `app/app/create/page.tsx` + `loading.tsx`

Build passes ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for passing mint parameter via URL to pre-populate market creation form.

* **Style**
  * Updated color scheme to gray palette across hero section and stats.
  * Adjusted vertical spacing and hero section height for improved layout.
  * Enhanced button and link styling with updated colors, borders, and transitions.
  * Refined typography with improved font weights and letter spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->