### PR TITLE
feat: nav restructure with dropdown groups + DEVNET badge (PERC-169)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ render-pdf.cjs
 render-pdf.mjs
 .worktrees/
 program/target/
+percolator/target/

--- a/app/__tests__/components/Header.test.tsx
+++ b/app/__tests__/components/Header.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 vi.mock("next/link", () => ({
   default: ({ href, children, ...props }: any) => (
@@ -37,9 +38,30 @@ vi.mock("@/lib/config", () => ({
 import { Header } from "@/components/layout/Header";
 
 describe("Header", () => {
-  it("includes a Wallet link", () => {
+  it("renders dropdown group triggers", () => {
     render(<Header />);
-    const walletLink = screen.getByRole("link", { name: /Wallet/i });
+    expect(screen.getByRole("button", { name: /Trade/i })).toBeDefined();
+    expect(screen.getByRole("button", { name: /Build/i })).toBeDefined();
+    expect(screen.getByRole("button", { name: /Community/i })).toBeDefined();
+  });
+
+  it("shows Wallet link inside Trade dropdown", async () => {
+    render(<Header />);
+    const tradeTrigger = screen.getByRole("button", { name: /Trade/i });
+    await userEvent.click(tradeTrigger);
+    const walletLink = screen.getByRole("menuitem", { name: /Wallet/i });
     expect(walletLink).toHaveAttribute("href", "/wallet");
+  });
+
+  it("renders DEVNET badge as non-interactive", () => {
+    render(<Header />);
+    const badge = screen.getByTitle(/devnet/i);
+    expect(badge.tagName).not.toBe("BUTTON");
+    expect(badge.className).toContain("pointer-events-none");
+  });
+
+  it("renders connect button", () => {
+    render(<Header />);
+    expect(screen.getByTestId("connect-button")).toBeDefined();
   });
 });

--- a/app/components/layout/NavDropdown.tsx
+++ b/app/components/layout/NavDropdown.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { FC, useState, useRef, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+export interface NavItem {
+  href: string;
+  label: string;
+}
+
+interface NavDropdownProps {
+  label: string;
+  items: NavItem[];
+}
+
+export const NavDropdown: FC<NavDropdownProps> = ({ label, items }) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const pathname = usePathname();
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const hasActive = items.some((item) => pathname === item.href);
+
+  const handleMouseEnter = useCallback(() => {
+    clearTimeout(timeoutRef.current);
+    setOpen(true);
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    timeoutRef.current = setTimeout(() => setOpen(false), 150);
+  }, []);
+
+  // Close on escape
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    if (open) {
+      document.addEventListener("keydown", onKey);
+      return () => document.removeEventListener("keydown", onKey);
+    }
+  }, [open]);
+
+  // Close on outside click
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    if (open) {
+      document.addEventListener("mousedown", onClick);
+      return () => document.removeEventListener("mousedown", onClick);
+    }
+  }, [open]);
+
+  return (
+    <div
+      ref={ref}
+      className="relative"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      <button
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        aria-haspopup="true"
+        className={[
+          "flex items-center gap-1 px-3 py-1.5 text-sm font-medium rounded-sm transition-colors duration-200",
+          hasActive || open
+            ? "text-white"
+            : "text-[#9ca3af] hover:text-white",
+        ].join(" ")}
+      >
+        {label}
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 10 10"
+          fill="none"
+          className={[
+            "transition-transform duration-150",
+            open ? "rotate-180" : "",
+          ].join(" ")}
+        >
+          <path
+            d="M2.5 3.75L5 6.25L7.5 3.75"
+            stroke="currentColor"
+            strokeWidth="1.25"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+
+      {/* Dropdown panel */}
+      <div
+        role="menu"
+        className={[
+          "absolute left-0 top-full mt-1 min-w-[200px] rounded-xl border border-white/[0.08] bg-[rgba(15,15,20,0.97)] py-2 shadow-[0_8px_32px_rgba(0,0,0,0.48)] transition-all duration-[120ms] ease-out",
+          open
+            ? "opacity-100 translate-y-0 pointer-events-auto"
+            : "opacity-0 -translate-y-1 pointer-events-none",
+        ].join(" ")}
+      >
+        {items.map((item) => {
+          const active = pathname === item.href;
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              role="menuitem"
+              onClick={() => setOpen(false)}
+              className={[
+                "block px-4 py-2.5 text-sm transition-colors duration-150",
+                active
+                  ? "text-[#22d3ee] bg-[rgba(34,211,238,0.08)]"
+                  : "text-[#d1d5db] hover:text-white hover:bg-white/[0.06]",
+              ].join(" ")}
+            >
+              {item.label}
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
Major navigation UX overhaul per designer spec. Restructures 12 flat nav items into 3 organized dropdown groups.

### Changes

**Nav Restructure (Audit #4)**
- 12 flat items → 3 dropdown groups: **Trade** (Markets/Dashboard/Portfolio/Wallet), **Build** (Create/Developers/Guide/Faucet), **Community** (Join Us/Agents/Report Bug)
- New `NavDropdown` component with hover + click, keyboard dismiss (Escape), outside-click close
- 120ms fade+slide animation, `12px` rounded panel, dark glass bg per spec
- Active route detection: cyan (`#22d3ee`) text + tinted background
- Mobile: accordion-style groups replacing flat list

**DEVNET Badge (Audit #11)**
- Changed from clickable `<button>` to non-interactive `<span>`
- Amber pill style: `rounded-full`, `pointer-events-none`, `cursor-default`
- Added tooltip: "You are on devnet — no real funds"

**Faucet Fix (Audit #5)**
- Moved from standalone purple-highlighted nav item into Build dropdown
- No longer has inconsistent magenta color

### How to Test
1. `pnpm dev` → check nav at 1440px: 3 dropdown triggers visible
2. Hover/click each dropdown — items appear with animation
3. Active route highlighted in cyan
4. Resize to mobile (≤768px) — groups become accordion
5. DEVNET badge: non-clickable amber pill with tooltip
6. Keyboard: press Escape to close open dropdown

### Related
- Task: PERC-169
- Designer spec: nav-restructure-and-contrast-fixes.md
- Depends on: PR #412 (PERC-168 layout voids)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Navigation reorganized into dropdown menus for Trade, Build, and Community sections
  * Mobile navigation redesigned with accordion-style expansion
  * Network badge updated to display-only (non-interactive)
  * Mobile menu now automatically closes upon navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->