### PR TITLE
fix: replace last hardcoded /1e6 in PositionPanel + WarmupProgress (PERC-167)

### DIFF
--- a/app/components/trade/PositionPanel.tsx
+++ b/app/components/trade/PositionPanel.tsx
@@ -73,7 +73,7 @@ export const PositionPanel: FC<{ slabAddress: string }> = ({ slabAddress }) => {
     currentPriceE6,
   ) : 0n;
   const pnlUsd =
-    priceUsd !== null && currentPriceE6 > 0n ? (Number(pnlTokens) / 1e6) * priceUsd : null;
+    priceUsd !== null && currentPriceE6 > 0n ? (Number(pnlTokens) / 10 ** decimals) * priceUsd : null;
   const roe = currentPriceE6 > 0n ? computePnlPercent(pnlTokens, account.capital) : 0;
 
   const maintenanceBps = params?.maintenanceMarginBps ?? 500n;
@@ -214,7 +214,8 @@ export const PositionPanel: FC<{ slabAddress: string }> = ({ slabAddress }) => {
           <div className="mt-3 border-t border-[var(--border)] pt-3">
             <WarmupProgress 
               slabAddress={slabAddress} 
-              accountIdx={userAccount.idx} 
+              accountIdx={userAccount.idx}
+              tokenDecimals={decimals}
             />
           </div>
 

--- a/app/components/trade/WarmupProgress.tsx
+++ b/app/components/trade/WarmupProgress.tsx
@@ -34,9 +34,9 @@ function formatCountdown(slots: number): string {
   return `${secs}s`;
 }
 
-function formatUsdAmount(amountE6: string | bigint): string {
-  const num = typeof amountE6 === "string" ? BigInt(amountE6) : amountE6;
-  const usd = Number(num) / 1e6;
+function formatUsdAmount(amountRaw: string | bigint, tokenDecimals: number): string {
+  const num = typeof amountRaw === "string" ? BigInt(amountRaw) : amountRaw;
+  const usd = Number(num) / 10 ** tokenDecimals;
   return usd.toLocaleString(undefined, {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
@@ -46,7 +46,8 @@ function formatUsdAmount(amountE6: string | bigint): string {
 export const WarmupProgress: FC<{
   slabAddress: string;
   accountIdx: number;
-}> = ({ slabAddress, accountIdx }) => {
+  tokenDecimals?: number;
+}> = ({ slabAddress, accountIdx, tokenDecimals = 6 }) => {
   const mockMode = isMockMode() && isMockSlab(slabAddress);
 
   const [warmupData, setWarmupData] = useState<WarmupData | null>(
@@ -175,11 +176,11 @@ export const WarmupProgress: FC<{
         {/* Amounts row — compact */}
         <div className="mt-1 flex items-center gap-3 pl-0">
           <span className="text-[9px] text-[var(--text-dim)]">
-            <span className="text-[var(--text-muted)]" style={{ fontFamily: "var(--font-mono)" }}>${formatUsdAmount(warmupData.unlockedAmount)}</span> available
+            <span className="text-[var(--text-muted)]" style={{ fontFamily: "var(--font-mono)" }}>${formatUsdAmount(warmupData.unlockedAmount, tokenDecimals)}</span> available
           </span>
           <span className="text-[var(--border)]">·</span>
           <span className="text-[9px] text-[var(--text-dim)]">
-            <span className="text-[var(--text-muted)]" style={{ fontFamily: "var(--font-mono)" }}>${formatUsdAmount(warmupData.lockedAmount)}</span> locked
+            <span className="text-[var(--text-muted)]" style={{ fontFamily: "var(--font-mono)" }}>${formatUsdAmount(warmupData.lockedAmount, tokenDecimals)}</span> locked
           </span>
           <button
             onClick={() => setShowExplainer(true)}


### PR DESCRIPTION
## Summary
Fixes the 2 remaining hardcoded `/1e6` token-amount conversions flagged by QA:

### Changes
- **PositionPanel.tsx:76** — `pnlUsd` calculation now uses `10 ** decimals` from `useTokenMeta` instead of hardcoded `1e6`
- **WarmupProgress.tsx:39** — `formatUsdAmount` now accepts a `tokenDecimals` parameter (defaults to 6 for backward compat)
- **WarmupProgress** component accepts optional `tokenDecimals` prop, passed from PositionPanel

### Testing
- All 8 WarmupProgress tests pass ✅
- TypeScript compiles clean ✅
- Default fallback of 6 maintains backward compatibility for tests/mock data

### Context
Follow-up to PR #410 which fixed the majority of `/1e6` → dynamic decimals conversions. These 2 were flagged by QA as remaining instances.

Closes PERC-167 (final cleanup)