### PR TITLE
fix(a11y): NavDropdown timeout leak, keyboard trap, and reduced-motion mobile menu

### DIFF
--- a/app/__tests__/components/Header.test.tsx
+++ b/app/__tests__/components/Header.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 vi.mock("next/link", () => ({
@@ -45,12 +45,38 @@ describe("Header", () => {
     expect(screen.getByRole("button", { name: /Community/i })).toBeDefined();
   });
 
-  it("shows Wallet link inside Trade dropdown", async () => {
+  it("shows Wallet link inside Trade dropdown", () => {
     render(<Header />);
     const tradeTrigger = screen.getByRole("button", { name: /Trade/i });
-    await userEvent.click(tradeTrigger);
+    // Click to open (fireEvent avoids mouseenter/leave side-effects)
+    fireEvent.click(tradeTrigger);
+    expect(tradeTrigger.getAttribute("aria-expanded")).toBe("true");
+    // menuitem should be accessible when open
     const walletLink = screen.getByRole("menuitem", { name: /Wallet/i });
     expect(walletLink).toHaveAttribute("href", "/wallet");
+  });
+
+  it("dismisses Trade dropdown on Escape", () => {
+    render(<Header />);
+    const tradeTrigger = screen.getByRole("button", { name: /Trade/i });
+    fireEvent.click(tradeTrigger);
+    expect(screen.getByRole("menuitem", { name: /Wallet/i })).toBeDefined();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    // After Escape, dropdown closed — menuitem hidden from accessibility tree
+    expect(screen.queryByRole("menuitem", { name: /Wallet/i })).toBeNull();
+  });
+
+  it("dismisses Trade dropdown on outside click", () => {
+    render(<Header />);
+    const tradeTrigger = screen.getByRole("button", { name: /Trade/i });
+    fireEvent.click(tradeTrigger);
+    expect(screen.getByRole("menuitem", { name: /Wallet/i })).toBeDefined();
+
+    // Click outside the dropdown
+    fireEvent.mouseDown(document.body);
+    // After outside click, dropdown closed — menuitem hidden from accessibility tree
+    expect(screen.queryByRole("menuitem", { name: /Wallet/i })).toBeNull();
   });
 
   it("renders DEVNET badge as non-interactive", () => {

--- a/app/components/layout/Header.tsx
+++ b/app/components/layout/Header.tsx
@@ -66,7 +66,15 @@ export const Header: FC = () => {
   // Mobile menu animation
   useEffect(() => {
     const menu = mobileMenuRef.current;
-    if (!menu || prefersReduced) return;
+    if (!menu) return;
+
+    if (prefersReduced) {
+      // Skip animation but still toggle visibility for reduced-motion users
+      menu.style.display = mobileOpen ? "block" : "none";
+      menu.style.height = mobileOpen ? "auto" : "0px";
+      menu.style.opacity = mobileOpen ? "1" : "0";
+      return;
+    }
 
     if (mobileOpen) {
       menu.style.display = "block";

--- a/app/components/layout/NavDropdown.tsx
+++ b/app/components/layout/NavDropdown.tsx
@@ -28,7 +28,15 @@ export const NavDropdown: FC<NavDropdownProps> = ({ label, items }) => {
   }, []);
 
   const handleMouseLeave = useCallback(() => {
+    clearTimeout(timeoutRef.current);
     timeoutRef.current = setTimeout(() => setOpen(false), 150);
+  }, []);
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      clearTimeout(timeoutRef.current);
+    };
   }, []);
 
   // Close on escape
@@ -97,6 +105,7 @@ export const NavDropdown: FC<NavDropdownProps> = ({ label, items }) => {
       {/* Dropdown panel */}
       <div
         role="menu"
+        aria-hidden={!open || undefined}
         className={[
           "absolute left-0 top-full mt-1 min-w-[200px] rounded-xl border border-white/[0.08] bg-[rgba(15,15,20,0.97)] py-2 shadow-[0_8px_32px_rgba(0,0,0,0.48)] transition-all duration-[120ms] ease-out",
           open
@@ -111,6 +120,7 @@ export const NavDropdown: FC<NavDropdownProps> = ({ label, items }) => {
               key={item.href}
               href={item.href}
               role="menuitem"
+              tabIndex={open ? 0 : -1}
               onClick={() => setOpen(false)}
               className={[
                 "block px-4 py-2.5 text-sm transition-colors duration-150",


### PR DESCRIPTION
## Summary

Fixes three accessibility issues identified by CodeRabbit in PR #413:

### NavDropdown
- **Timeout leak on unmount**: `setTimeout` stored in `timeoutRef` was never cleared on unmount, causing potential late state updates on unmounted components. Added cleanup `useEffect`.
- **Keyboard trap when closed**: Dropdown menu items remained keyboard-focusable (`tabIndex=0`) even when visually hidden. Added `aria-hidden` on the menu container and `tabIndex={-1}` on links when closed.
- **Extra timeout safety**: Clear any pending timeout before scheduling a new one in `handleMouseLeave`.

### Header (Mobile Menu)  
- **Reduced-motion users locked out**: The mobile menu animation `useEffect` returned early when `prefersReduced` was true, but the menu was initialized with `display: 'none'`. This meant users with reduced motion preferences could never open the mobile menu. Now toggles visibility instantly without GSAP animation.

### Tests
- Added Escape key dismissal test
- Added outside-click dismissal test  
- Switched dropdown tests to `fireEvent` to avoid mouseenter/click race condition in JSDOM

**521 tests pass, build clean.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive dropdown interaction tests for keyboard (Escape key) and click-outside dismissal scenarios.

* **Improvements**
  * Mobile menu animations now respect reduced-motion system preferences, providing a non-animated fallback.
  * Dropdowns feature improved keyboard navigation with better focus control and ARIA accessibility support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->