### PR TITLE
fix: Insurance Fund showing $1018110.5T — convert raw token amounts on homepage

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -129,17 +129,20 @@ export default function Home() {
         if (data) {
           setStats({
             markets: data.length,
-            volume: data.reduce((s, m) => s + Number(m.volume_24h || 0), 0),
-            insurance: data.reduce((s, m) => s + Number(m.insurance_balance || 0), 0),
+            // volume_24h is stored as raw token units (e6) — convert to human-readable
+            volume: data.reduce((s, m) => s + Number(m.volume_24h || 0) / 1e6, 0),
+            // insurance_balance is stored as raw token units (e6 for USDC) — convert to human-readable
+            insurance: data.reduce((s, m) => s + Number(m.insurance_balance || 0) / 1e6, 0),
           });
           setStatsLoaded(true);
           const sorted = [...data].sort((a, b) => (b.volume_24h || 0) - (a.volume_24h || 0)).slice(0, 5);
           setFeatured(sorted.map((m) => ({
             slab_address: m.slab_address,
             symbol: m.symbol,
-            volume_24h: m.volume_24h || 0,
+            // volume_24h and total_open_interest are stored as raw token units (e6) — convert
+            volume_24h: (m.volume_24h || 0) / 1e6,
             last_price: m.last_price,
-            total_open_interest: m.total_open_interest || 0,
+            total_open_interest: (m.total_open_interest || 0) / 1e6,
           })));
         }
       } catch (err) {


### PR DESCRIPTION
## Problem
The Insurance Fund stat on the homepage was displaying **$1018110.5T** instead of the correct amount.

## Root Cause
`insurance_balance` in the `market_stats` table (written by the indexer's StatsCollector) is stored as **raw token units** (e.g., with 6 decimal places for USDC). The homepage was summing these raw values directly and passing them to `formatCompact()`, which treats the input as human-readable dollars.

Example: Insurance fund of $1,018.11 USDC is stored as `1018110000` (raw). Summed across markets, this easily exceeds `1e12`, triggering the `T` (trillion) suffix.

## Fix
- Divide `insurance_balance` by `1e6` when aggregating for the homepage stats display
- Applied the same fix to `volume_24h` and `total_open_interest` in the featured markets table, which had the identical raw-value bug
- Build clean ✅, all 521 tests pass ✅

## Note
This is a display-only fix in `app/app/page.tsx`. The underlying database storage (raw token units) is unchanged — other consumers like InsuranceDashboard and SystemCapitalCard already handle the conversion correctly via `useTokenMeta` decimals.