### PR TITLE
fix: one-time migration to correct USDC market decimals

### DIFF
--- a/supabase/migrations/025_fix_usdc_market_decimals.sql
+++ b/supabase/migrations/025_fix_usdc_market_decimals.sql
@@ -1,0 +1,42 @@
+-- Migration 025: Fix USDC market decimals
+-- 
+-- Context: The indexer's auto-registration (StatsCollector.syncMarkets) used a
+-- fallback of decimals=9 when it couldn't fetch on-chain mint info. Markets using
+-- USDC as collateral (mint EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v) should
+-- have decimals=6 since USDC is a 6-decimal SPL token.
+--
+-- This caused the frontend to display incorrect Insurance Fund / vault values
+-- (off by 10^3 = 1000x, showing ~$1T instead of ~$1B type errors).
+--
+-- This is a one-time fix. Going forward, the indexer reads decimals from on-chain
+-- mint data at offset 44 (SPL Token Mint layout).
+
+-- Fix all USDC-collateral markets to decimals=6
+UPDATE markets
+SET decimals = 6,
+    updated_at = NOW()
+WHERE mint_address = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+  AND decimals != 6;
+
+-- Also fix devnet USDC variants (common devnet faucet mints)
+-- Devnet USDC: 4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU
+UPDATE markets
+SET decimals = 6,
+    updated_at = NOW()
+WHERE mint_address = '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU'
+  AND decimals != 6;
+
+-- Log how many rows were affected (visible in migration output)
+DO $$
+DECLARE
+  affected_count INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO affected_count
+  FROM markets
+  WHERE mint_address IN (
+    'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+    '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU'
+  ) AND decimals = 6;
+  
+  RAISE NOTICE 'USDC markets with correct decimals=6: %', affected_count;
+END $$;


### PR DESCRIPTION
## Problem

Existing USDC-collateral markets were auto-registered by the indexer with `decimals=9` (fallback) instead of the correct `6`. This caused the frontend to display incorrect Insurance Fund / vault values (off by 1000x, showing ~$1T instead of correct amounts).

Flagged by QA during Insurance Fund verification.

## Solution

**Migration 025** sets `decimals=6` for all markets using:
- Mainnet USDC: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
- Devnet USDC: `4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU`

## Testing

- Idempotent: safe to run multiple times (only updates where `decimals != 6`)
- No data loss: only modifies the `decimals` and `updated_at` columns
- A companion indexer PR adds self-healing logic to prevent this from recurring

## Related
- Companion: indexer PR (self-healing decimals correction on every discovery cycle)
- PR #417 (per-market decimals display fix)
- Indexer PR #5 (on-chain mint decimals for new markets)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected decimal precision for USDC markets to align with on-chain values, ensuring accurate market data representation across mainnet and devnet environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->