### PR TITLE
fix: improve homepage stats error handling for Markets 0 debug

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -125,8 +125,12 @@ export default function Home() {
       }
 
       try {
-        const { data } = await getSupabase().from("markets_with_stats").select("slab_address, symbol, volume_24h, insurance_balance, last_price, total_open_interest, decimals") as { data: { slab_address: string; symbol: string | null; volume_24h: number | null; insurance_balance: number | null; last_price: number | null; total_open_interest: number | null; decimals: number | null }[] | null };
-        if (data) {
+        const { data, error: dbError } = await getSupabase().from("markets_with_stats").select("slab_address, symbol, volume_24h, insurance_balance, last_price, total_open_interest, decimals") as { data: { slab_address: string; symbol: string | null; volume_24h: number | null; insurance_balance: number | null; last_price: number | null; total_open_interest: number | null; decimals: number | null }[] | null; error: { message: string } | null };
+        if (dbError) {
+          console.error("Failed to query markets_with_stats:", dbError.message);
+          throw new Error(dbError.message);
+        }
+        if (data && data.length > 0) {
           // Sanitize a raw token amount → USD, with guards against corrupted data:
           // 1. Reject sentinel values (u64::MAX ≈ 1.844e19, or u128 overflow)
           // 2. Clamp decimals to sane range (0-18) — some on-chain mints have garbage


### PR DESCRIPTION
## Context
QA reports homepage shows 'Markets 0' despite 7 markets existing.

## Changes
- Destructure and log Supabase query errors from `markets_with_stats`
- Add explicit error handling to surface PostgREST errors in console
- Check `data.length > 0` before setting stats

## Related issues (need investigation)
1. **$13T token price** — likely on-chain data issue for specific market; need to identify which market
2. **/api/funding/:slab 404** — API deployment issue; rewrites exist in next.config.ts but backend may not be deployed with funding routes
3. **Market names = truncated addresses** — indexer uses `mintAddress.substring(0,8)` as symbol; needs Jupiter/token registry lookup

These are deployment/infra issues that need devops attention.