### PR TITLE
fix: P0 markets page — .2T price, missing names, 7/144 count, skeleton band (PERC-190)

### DIFF
--- a/app/__tests__/lib/oraclePrice.test.ts
+++ b/app/__tests__/lib/oraclePrice.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { PublicKey } from "@solana/web3.js";
+import { detectOracleMode, resolveMarketPriceE6, priceE6ToUsd } from "../../lib/oraclePrice";
+
+const ZERO_KEY = new PublicKey(new Uint8Array(32));
+const NON_ZERO_KEY = new PublicKey("SysvarC1ock11111111111111111111111111111111");
+const ANOTHER_KEY = new PublicKey("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
+
+describe("detectOracleMode", () => {
+  it("returns 'hyperp' when indexFeedId is zero", () => {
+    expect(detectOracleMode({
+      oracleAuthority: NON_ZERO_KEY,
+      indexFeedId: ZERO_KEY,
+    })).toBe("hyperp");
+  });
+
+  it("returns 'pyth-pinned' when oracleAuthority is zero and indexFeedId is non-zero", () => {
+    expect(detectOracleMode({
+      oracleAuthority: ZERO_KEY,
+      indexFeedId: NON_ZERO_KEY,
+    })).toBe("pyth-pinned");
+  });
+
+  it("returns 'admin' when both are non-zero", () => {
+    expect(detectOracleMode({
+      oracleAuthority: NON_ZERO_KEY,
+      indexFeedId: ANOTHER_KEY,
+    })).toBe("admin");
+  });
+
+  it("returns 'hyperp' when both are zero (indexFeedId check takes priority)", () => {
+    expect(detectOracleMode({
+      oracleAuthority: ZERO_KEY,
+      indexFeedId: ZERO_KEY,
+    })).toBe("hyperp");
+  });
+});
+
+describe("resolveMarketPriceE6", () => {
+  it("uses lastEffectivePriceE6 for pyth-pinned markets", () => {
+    const result = resolveMarketPriceE6({
+      oracleAuthority: ZERO_KEY,
+      indexFeedId: NON_ZERO_KEY,
+      lastEffectivePriceE6: 150_000_000n,
+      authorityPriceE6: 999_999_999_999n, // stale/garbage — should be ignored
+    });
+    expect(result).toBe(150_000_000n);
+  });
+
+  it("uses lastEffectivePriceE6 for hyperp markets", () => {
+    const result = resolveMarketPriceE6({
+      oracleAuthority: NON_ZERO_KEY,
+      indexFeedId: ZERO_KEY,
+      lastEffectivePriceE6: 4_190_000n,
+      authorityPriceE6: 4_187_729_446_681_120_000n, // inflated mark price — should be ignored
+    });
+    expect(result).toBe(4_190_000n);
+  });
+
+  it("uses authorityPriceE6 for admin oracle markets", () => {
+    const result = resolveMarketPriceE6({
+      oracleAuthority: NON_ZERO_KEY,
+      indexFeedId: ANOTHER_KEY,
+      lastEffectivePriceE6: 1_000_000n,
+      authorityPriceE6: 1_500_000n,
+    });
+    expect(result).toBe(1_500_000n);
+  });
+
+  it("falls back to lastEffectivePriceE6 for admin markets when authorityPriceE6 is 0", () => {
+    const result = resolveMarketPriceE6({
+      oracleAuthority: NON_ZERO_KEY,
+      indexFeedId: ANOTHER_KEY,
+      lastEffectivePriceE6: 2_000_000n,
+      authorityPriceE6: 0n,
+    });
+    expect(result).toBe(2_000_000n);
+  });
+
+  it("returns 0n when no valid price is available", () => {
+    const result = resolveMarketPriceE6({
+      oracleAuthority: NON_ZERO_KEY,
+      indexFeedId: ANOTHER_KEY,
+      lastEffectivePriceE6: 0n,
+      authorityPriceE6: 0n,
+    });
+    expect(result).toBe(0n);
+  });
+});
+
+describe("priceE6ToUsd", () => {
+  it("converts E6 to USD", () => {
+    expect(priceE6ToUsd(1_500_000n)).toBe(1.5);
+    expect(priceE6ToUsd(150_000_000n)).toBe(150);
+    expect(priceE6ToUsd(1_000n)).toBe(0.001);
+  });
+
+  it("returns null for 0 or negative", () => {
+    expect(priceE6ToUsd(0n)).toBeNull();
+    expect(priceE6ToUsd(-1n)).toBeNull();
+  });
+});

--- a/app/app/create/page.tsx
+++ b/app/app/create/page.tsx
@@ -35,8 +35,8 @@ function CreatePageInner() {
 
   return (
     <div className="min-h-[calc(100vh-48px)] relative">
-      {/* Grid background */}
-      <div className="absolute inset-x-0 top-0 h-32 bg-grid pointer-events-none" />
+      {/* Grid background — subtle decorative element */}
+      <div className="absolute inset-x-0 top-0 h-16 bg-grid pointer-events-none opacity-50" />
 
       <div className="relative mx-auto max-w-4xl px-4 pt-4 pb-10">
         {/* Page header */}

--- a/app/lib/oraclePrice.ts
+++ b/app/lib/oraclePrice.ts
@@ -1,0 +1,82 @@
+import { PublicKey } from "@solana/web3.js";
+
+/**
+ * Oracle mode for a Percolator market.
+ *
+ * - 'pyth-pinned': oracleAuthority == [0;32] && indexFeedId != [0;32]
+ *   → staleness enforced on-chain by Pyth CPI; use lastEffectivePriceE6
+ *
+ * - 'hyperp': indexFeedId == [0;32]
+ *   → DEX oracle mode; authorityPriceE6 is mark price, lastEffectivePriceE6 is index price
+ *   → authorityTimestamp stores funding rate, NOT a real timestamp
+ *   → use lastEffectivePriceE6 for display
+ *
+ * - 'admin': oracleAuthority != [0;32] && indexFeedId != [0;32]
+ *   → off-chain authority pushes prices; authorityPriceE6 is the latest pushed price
+ *   → use authorityPriceE6 (with optional staleness check via authorityTimestamp)
+ */
+export type OracleMode = "pyth-pinned" | "hyperp" | "admin";
+
+const ZERO_KEY = new PublicKey(new Uint8Array(32));
+
+/**
+ * Detect oracle mode from market config keys.
+ * Centralizes mode detection for consistent behavior across the app.
+ */
+export function detectOracleMode(cfg: {
+  oracleAuthority: PublicKey;
+  indexFeedId: PublicKey;
+}): OracleMode {
+  if (cfg.indexFeedId.equals(ZERO_KEY)) return "hyperp";
+  if (cfg.oracleAuthority.equals(ZERO_KEY)) return "pyth-pinned";
+  return "admin";
+}
+
+/**
+ * Resolve the correct USD price (in E6 format) for a market based on its oracle mode.
+ *
+ * For display purposes (markets page, trade page), this returns the best available
+ * price from on-chain data. The caller should divide by 1_000_000 to get USD.
+ *
+ * @returns priceE6 (bigint) or 0n if no valid price available
+ */
+export function resolveMarketPriceE6(cfg: {
+  oracleAuthority: PublicKey;
+  indexFeedId: PublicKey;
+  lastEffectivePriceE6: bigint;
+  authorityPriceE6: bigint;
+  authorityTimestamp?: bigint;
+}): bigint {
+  const mode = detectOracleMode(cfg);
+
+  switch (mode) {
+    case "pyth-pinned":
+      // Pyth-pinned: lastEffectivePriceE6 is the on-chain resolved price
+      // authorityPriceE6 may be stale/garbage — never use it
+      return cfg.lastEffectivePriceE6;
+
+    case "hyperp":
+      // Hyperp (DEX oracle): lastEffectivePriceE6 is the index price from on-chain crank
+      // authorityPriceE6 is the mark price — use index price for display
+      // Note: authorityTimestamp stores funding rate, NOT a real timestamp
+      return cfg.lastEffectivePriceE6;
+
+    case "admin":
+      // Admin oracle: authorityPriceE6 is the latest pushed price
+      // Fall back to lastEffectivePriceE6 if authority price is 0
+      if (cfg.authorityPriceE6 > 0n) return cfg.authorityPriceE6;
+      return cfg.lastEffectivePriceE6;
+
+    default:
+      return 0n;
+  }
+}
+
+/**
+ * Convert an E6 price to USD number.
+ * Returns null if priceE6 is 0 or negative.
+ */
+export function priceE6ToUsd(priceE6: bigint): number | null {
+  if (priceE6 <= 0n) return null;
+  return Number(priceE6) / 1_000_000;
+}

--- a/packages/indexer/tests/services/StatsCollector.test.ts
+++ b/packages/indexer/tests/services/StatsCollector.test.ts
@@ -22,6 +22,8 @@ vi.mock('@percolator/shared', () => ({
   getConnection: vi.fn(() => ({
     getAccountInfo: mockGetAccountInfo,
     getMultipleAccountsInfo: mockGetMultipleAccountsInfo,
+    getParsedAccountInfo: vi.fn().mockResolvedValue({ value: null }),
+    rpcEndpoint: 'https://api.devnet.solana.com',
   })),
   upsertMarketStats: vi.fn(),
   insertOraclePrice: vi.fn(),
@@ -85,6 +87,9 @@ function makeConfig(overrides: Record<string, any> = {}) {
     collateralMint: new PublicKey('So11111111111111111111111111111111111111112'),
     oracleAuthority: new PublicKey('SysvarC1ock11111111111111111111111111111111'),
     authorityPriceE6: 1_500_000n,
+    lastEffectivePriceE6: 1_500_000n,
+    // Non-zero indexFeedId = admin oracle mode (not hyperp)
+    indexFeedId: new PublicKey('SysvarC1ock11111111111111111111111111111111'),
     ...overrides,
   } as any;
 }
@@ -98,7 +103,9 @@ function makeMockMarket(slabAddress: string) {
         collateralMint: new PublicKey('So11111111111111111111111111111111111111112'),
         oracleAuthority: new PublicKey('SysvarC1ock11111111111111111111111111111111'),
         authorityPriceE6: 1_500_000n,
-        indexFeedId: { toBytes: () => new Uint8Array(32) },
+        lastEffectivePriceE6: 1_500_000n,
+        // Non-zero indexFeedId = admin oracle mode (uses authorityPriceE6)
+        indexFeedId: new PublicKey('SysvarC1ock11111111111111111111111111111111'),
       },
       params: { maintenanceMarginBps: 500n, initialMarginBps: 1000n },
       header: { admin: new PublicKey('ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL') },


### PR DESCRIPTION
## PERC-190: Markets Page Regressions (P0)

### 1. Price shows $4.2T on manual-oracle markets
**Root cause**: Both the frontend and StatsCollector used `authorityPriceE6` for all oracle types. For hyperp-mode markets (`indexFeedId == [0;32]`), this field stores the mark price which can be inflated/garbage. The correct field for these markets is `lastEffectivePriceE6` (the on-chain crank-resolved index price).

**Fix**: New `detectOracleMode()` and `resolveMarketPriceE6()` helpers in `app/lib/oraclePrice.ts`:
- **pyth-pinned** (oracleAuthority=zero): uses `lastEffectivePriceE6`
- **hyperp** (indexFeedId=zero): uses `lastEffectivePriceE6`
- **admin** (both non-zero): uses `authorityPriceE6`, falls back to `lastEffectivePriceE6`

Applied to: markets page, `useLivePrice` hook, and StatsCollector.

### 2. Token names show truncated addresses
**Root cause**: StatsCollector auto-registers markets with `symbol = mintAddress.substring(0,8)` — a base58 fragment that passes the old hex-only filter. Frontend showed these as `H23ShTgd/USD`.

**Fix**: Improved placeholder detection: check if symbol is a prefix of the mint address, plus pattern matching for auto-generated names (`Market XXXXXXXX`). StatsCollector now resolves real token metadata via Helius DAS + `getParsedAccountInfo`.

### 3. Only 7 of 144 markets visible
**Root cause**: Markets page only showed on-chain discovered markets (limited by RPC's `getProgramAccounts`). Supabase had 144 active markets but the discovery hook only found 7.

**Fix**: Hybrid merge — on-chain discovered markets are enriched with Supabase stats, then Supabase-only markets (not found on-chain) are appended. `MergedMarket.onChain` is now nullable; all access points are guarded.

### 4. ~200px empty skeleton band
**Fix**: Reduced decorative `bg-grid` height from `h-32` (128px) to `h-16` (64px), added `opacity-50`. Applied to both /markets and /create pages.

## Testing
- 11 new tests for `oraclePrice.ts` (all pass ✅)
- Updated StatsCollector tests with proper oracle mode config
- Full suite: 570+ tests pass ✅
- TypeScript: clean ✅
- Build: passes ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Markets page now displays additional markets from alternate data sources alongside on-chain markets.

* **Improvements**
  * Enhanced token metadata resolution with improved fallback handling for better data accuracy.
  * Refined price resolution logic to better handle different market configurations.

* **UI/UX**
  * Minor visual adjustment to the grid background element on the create page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->