### PR TITLE
fix: bigint overflow causing $368T insurance display on homepage

### DIFF
--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -525,7 +525,8 @@ function MarketsPageInner() {
                   // Price: prefer Supabase, fall back to oracle-mode-aware on-chain price
                   const onChainPriceE6 = m.onChain ? resolveMarketPriceE6(m.onChain.config) : 0n;
                   const lastPrice = m.supabase?.last_price ?? priceE6ToUsd(onChainPriceE6);
-                  const mintDecimals = tokenMetaMap.get(m.mintAddress)?.decimals ?? (m.supabase?.decimals ?? 6);
+                  const rawDecimals = tokenMetaMap.get(m.mintAddress)?.decimals ?? (m.supabase?.decimals ?? 6);
+                  const mintDecimals = Math.min(Math.max(rawDecimals, 0), 18); // clamp to sane range
                   const tokenDivisor = 10 ** mintDecimals;
                   
                   // Token amounts: prefer on-chain, fall back to Supabase


### PR DESCRIPTION
## Problem
Homepage insurance fund stat displayed $368T instead of correct value.

## Root Cause
1. **u128 sentinel values**: On-chain insurance balances using u128 can contain u64::MAX sentinel values (≈1.844e19). `Number(bigint)` in the indexer stored these as large floats in Supabase.
2. **Corrupted decimals**: Many spam/test mint accounts have garbage `decimals` values (1, 169, 207, 240). With decimals=1 and a large raw balance, the USD conversion produces trillions.
3. **Insufficient filtering**: Frontend sentinel filter (`> 1e18`) caught the biggest values but not the combination of low decimals + moderate raw balances.

## Fixes
### Indexer (`StatsCollector.ts`)
- Add `safeBigNum()` helper that converts bigint→number, treating `≥ u64::MAX` as 0
- Clamp mint decimals to 0–18 range at write time (prevents garbage from on-chain)

### Frontend (`page.tsx` homepage)
- New `toUsd()` helper with: sentinel filtering, decimals clamping (0–18), price validation, and per-market $10B USD cap
- Replace duplicated inline sanitization logic with single helper

### Frontend (`markets/page.tsx`)
- Clamp decimals to 0–18 in display calculations

## Testing
- `pnpm test`: 548 passed
- `pnpm --filter indexer test`: 38 passed
- `pnpm build`: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to clamp token decimal precision to a safe range (0–18)
  * Enhanced USD conversion pipeline with guards against invalid or corrupted market data
  * Implemented safe conversion for large number calculations to prevent overflow issues
  * Introduced maximum USD cap for market data validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->