### PR TITLE
fix: always render ContributorStatsBar with — fallback on null API

### DIFF
--- a/app/app/developers/DevelopersClient.tsx
+++ b/app/app/developers/DevelopersClient.tsx
@@ -89,10 +89,8 @@ export const DevelopersClient: FC<Props> = ({
           </a>
         </header>
 
-        {/* ★ Contributor Stats Bar */}
-        {contributorStats && (
-          <ContributorStatsBar stats={contributorStats} />
-        )}
+        {/* ★ Contributor Stats Bar — always render; shows — values when API returns null */}
+        <ContributorStatsBar stats={contributorStats} />
 
         {/* Repo Grid (with CI statuses for health badges) */}
         <RepoGrid repos={repos} isLive={isLive} ciStatuses={ciStatuses} />


### PR DESCRIPTION
## Summary
Fixes a minor UX issue on the /developers page where the ContributorStatsBar was hidden entirely when the GitHub API returned null data.

## Problem
The component was conditionally rendered: `{contributorStats && <ContributorStatsBar ... />}`. When the API failed or returned null, the entire stats bar disappeared from the page.

## Fix
Removed the conditional wrapper. The component already handles `stats === null` gracefully by displaying `—` placeholders for all values. This matches the design spec (per designer feedback on PERC-188 review).

## Testing
- `pnpm build` passes
- Component renders with `—` values when stats is null
- Component renders normally with real data

**Design review requested from designer.**