### PR TITLE
fix: make rpc proxy read-only allowlist

### DIFF
--- a/app/app/api/rpc/route.ts
+++ b/app/app/api/rpc/route.ts
@@ -44,9 +44,6 @@ const ALLOWED_RPC_METHODS = new Set([
   "getRecentPrioritizationFees",
   "getFeeForMessage",
   "isBlockhashValid",
-  // Transaction submission
-  "sendTransaction",
-  "simulateTransaction",
   // Misc read
   "getMinimumBalanceForRentExemption",
   "getSupply",


### PR DESCRIPTION
Issue summary: The RPC proxy allowed transaction-submission methods, enabling write-capable use through a public route.
What changed: Removed [sendTransaction] and simulateTransaction from [ALLOWED_RPC_METHODS in app/app/api/rpc/route.ts.
The endpoint now enforces read-only JSON-RPC forwarding, reducing abuse risk while preserving required read operations.
Risk level: low.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Removed transaction submission methods from available RPC operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->