### PR TITLE
fix(keeper): guard SUPABASE_KEY misconfiguration (#249)

### DIFF
--- a/packages/keeper/src/env-guards.ts
+++ b/packages/keeper/src/env-guards.ts
@@ -1,0 +1,11 @@
+export function validateKeeperEnvGuards(env: NodeJS.ProcessEnv = process.env): void {
+  const supabaseKey = env.SUPABASE_KEY?.trim();
+  const serviceRoleKey = env.SUPABASE_SERVICE_ROLE_KEY?.trim();
+
+  if (supabaseKey && serviceRoleKey && supabaseKey === serviceRoleKey) {
+    throw new Error(
+      "Keeper misconfiguration: SUPABASE_KEY must not equal SUPABASE_SERVICE_ROLE_KEY. " +
+      "Set SUPABASE_KEY to the anon key for keeper runtime."
+    );
+  }
+}

--- a/packages/keeper/src/index.ts
+++ b/packages/keeper/src/index.ts
@@ -4,6 +4,7 @@ import { config, createLogger, initSentry, captureException, sendInfoAlert, crea
 import { OracleService } from "./services/oracle.js";
 import { CrankService } from "./services/crank.js";
 import { LiquidationService } from "./services/liquidation.js";
+import { validateKeeperEnvGuards } from "./env-guards.js";
 
 // Monitoring — alerts to Discord on threshold breaches
 export const monitors = createServiceMonitors("Keeper");
@@ -16,6 +17,8 @@ const logger = createLogger("keeper");
 if (!process.env.CRANK_KEYPAIR) {
   throw new Error("CRANK_KEYPAIR must be set for keeper service");
 }
+
+validateKeeperEnvGuards();
 
 logger.info("Keeper service starting");
 

--- a/packages/keeper/tests/env-guards.test.ts
+++ b/packages/keeper/tests/env-guards.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { validateKeeperEnvGuards } from "../src/env-guards.js";
+
+describe("validateKeeperEnvGuards", () => {
+  it("throws when SUPABASE_KEY equals SUPABASE_SERVICE_ROLE_KEY", () => {
+    const env = {
+      SUPABASE_KEY: "same-key",
+      SUPABASE_SERVICE_ROLE_KEY: "same-key",
+    } as NodeJS.ProcessEnv;
+
+    expect(() => validateKeeperEnvGuards(env)).toThrow(
+      "Keeper misconfiguration: SUPABASE_KEY must not equal SUPABASE_SERVICE_ROLE_KEY"
+    );
+  });
+
+  it("does not throw when keys differ", () => {
+    const env = {
+      SUPABASE_KEY: "anon-key",
+      SUPABASE_SERVICE_ROLE_KEY: "service-role-key",
+    } as NodeJS.ProcessEnv;
+
+    expect(() => validateKeeperEnvGuards(env)).not.toThrow();
+  });
+
+  it("does not throw when one key is missing", () => {
+    const env = {
+      SUPABASE_KEY: "anon-key",
+    } as NodeJS.ProcessEnv;
+
+    expect(() => validateKeeperEnvGuards(env)).not.toThrow();
+  });
+});


### PR DESCRIPTION
What the issue was
- Issue #249 tracks secret-handling hardening and specifically flags that keeper can be misconfigured with SUPABASE_KEY set to the service_role key.
- That configuration grants keeper unnecessary full database privileges.

What was changed
- Added a keeper-only startup guard that throws if SUPABASE_KEY equals SUPABASE_SERVICE_ROLE_KEY.
- Wired the guard into keeper startup before services begin.
- Added targeted unit tests for equal-key rejection and valid cases.

Why the fix is safe and minimal
- Changes are scoped to keeper env validation only.
- No runtime behavior changes when keys are configured correctly.
- Prevents a known high-impact misconfiguration without touching unrelated services or deployments.
- Focused tests pass: pnpm --filter @percolator/keeper test -- tests/env-guards.test.ts