### PR TITLE
fix: sanitize sentinel values in trade page stats & unify market count

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -146,10 +146,12 @@ export default function Home() {
           };
 
           // Filter out empty/abandoned markets (no price, no volume, no OI)
+          // Also filter sentinel-like values (u64::MAX ≈ 1.844e19 as JS number)
+          const isSane = (v: number) => v > 0 && v < 1e18 && Number.isFinite(v);
           const activeData = data.filter((m) =>
-            (m.last_price ?? 0) > 0 ||
-            (m.volume_24h ?? 0) > 0 ||
-            (m.total_open_interest ?? 0) > 0
+            isSane(m.last_price ?? 0) ||
+            isSane(m.volume_24h ?? 0) ||
+            isSane(m.total_open_interest ?? 0)
           );
           setStats({
             markets: activeData.length,

--- a/app/components/trade/LiquidationAnalytics.tsx
+++ b/app/components/trade/LiquidationAnalytics.tsx
@@ -4,6 +4,7 @@ import { FC } from "react";
 import { useEngineState } from "@/hooks/useEngineState";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { useTokenMeta } from "@/hooks/useTokenMeta";
+import { sanitizeOnChainValue } from "@/lib/health";
 import { InfoIcon } from "@/components/ui/Tooltip";
 
 function fmtCompact(n: number): string {
@@ -31,10 +32,11 @@ export const LiquidationAnalytics: FC = () => {
     );
   }
 
-  const lifetimeLiquidations = Number(engine.lifetimeLiquidations ?? 0n);
-  const lifetimeForceCloses = Number(engine.lifetimeForceCloses ?? 0n);
-  const insuranceBalance = Number(engine.insuranceFund?.balance ?? 0n) / divisor;
-  const totalOI = Number(engine.totalOpenInterest ?? 0n) / divisor;
+  // Sanitize sentinel values (u64::MAX from uninitialized on-chain fields)
+  const lifetimeLiquidations = Number(sanitizeOnChainValue(engine.lifetimeLiquidations ?? 0n));
+  const lifetimeForceCloses = Number(sanitizeOnChainValue(engine.lifetimeForceCloses ?? 0n));
+  const insuranceBalance = Number(sanitizeOnChainValue(engine.insuranceFund?.balance ?? 0n)) / divisor;
+  const totalOI = Number(sanitizeOnChainValue(engine.totalOpenInterest ?? 0n)) / divisor;
   const liqFeeBps = params ? Number(params.liquidationFeeBps ?? 0n) : 0;
   const bufferBps = params ? Number(params.liquidationBufferBps ?? 0n) : 0;
 

--- a/app/components/trade/MarketStatsCard.tsx
+++ b/app/components/trade/MarketStatsCard.tsx
@@ -7,6 +7,7 @@ import { useSlabState } from "@/components/providers/SlabProvider";
 import { useUsdToggle } from "@/components/providers/UsdToggleProvider";
 import { useTokenMeta } from "@/hooks/useTokenMeta";
 import { formatTokenAmount, formatUsd, formatBps } from "@/lib/format";
+import { sanitizeOnChainValue } from "@/lib/health";
 import { useLivePrice } from "@/hooks/useLivePrice";
 import { FundingRateCard } from "./FundingRateCard";
 import { FundingRateChart } from "./FundingRateChart";
@@ -37,8 +38,9 @@ export const MarketStatsCard: FC = () => {
 
   const decimals = tokenMeta?.decimals ?? 6;
   const tokenDivisor = 10 ** decimals;
-  const totalOI = engine.totalOpenInterest ?? 0n;
-  const vault = engine.vault ?? 0n;
+  // Sanitize sentinel values (u64::MAX) from uninitialized on-chain fields
+  const totalOI = sanitizeOnChainValue(engine.totalOpenInterest ?? 0n);
+  const vault = sanitizeOnChainValue(engine.vault ?? 0n);
   const oiDisplay = showUsd && priceUsd != null
     ? formatNum((Number(totalOI) / tokenDivisor) * priceUsd)
     : formatTokenAmount(totalOI, decimals);

--- a/app/components/trade/SystemCapitalCard.tsx
+++ b/app/components/trade/SystemCapitalCard.tsx
@@ -4,6 +4,7 @@ import { FC } from "react";
 import { useEngineState } from "@/hooks/useEngineState";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { useTokenMeta } from "@/hooks/useTokenMeta";
+import { sanitizeOnChainValue } from "@/lib/health";
 import { InfoIcon } from "@/components/ui/Tooltip";
 
 function fmtCompact(n: number): string {
@@ -31,14 +32,15 @@ export const SystemCapitalCard: FC = () => {
     );
   }
 
-  const vault = Number(engine.vault ?? 0n) / divisor;
-  const cTot = Number(engine.cTot ?? 0n) / divisor;
-  const pnlPosTot = Number(engine.pnlPosTot ?? 0n) / divisor;
-  const insurance = Number(engine.insuranceFund?.balance ?? 0n) / divisor;
-  const totalOI = Number(engine.totalOpenInterest ?? 0n) / divisor;
-  const netLp = Number(engine.netLpPos ?? 0n) / divisor;
-  const lpSum = Number(engine.lpSumAbs ?? 0n) / divisor;
-  const lpMax = Number(engine.lpMaxAbs ?? 0n) / divisor;
+  // Sanitize sentinel values (u64::MAX from uninitialized on-chain fields)
+  const vault = Number(sanitizeOnChainValue(engine.vault ?? 0n)) / divisor;
+  const cTot = Number(sanitizeOnChainValue(engine.cTot ?? 0n)) / divisor;
+  const pnlPosTot = Number(sanitizeOnChainValue(engine.pnlPosTot ?? 0n)) / divisor;
+  const insurance = Number(sanitizeOnChainValue(engine.insuranceFund?.balance ?? 0n)) / divisor;
+  const totalOI = Number(sanitizeOnChainValue(engine.totalOpenInterest ?? 0n)) / divisor;
+  const netLp = Number(sanitizeOnChainValue(engine.netLpPos ?? 0n)) / divisor;
+  const lpSum = Number(sanitizeOnChainValue(engine.lpSumAbs ?? 0n)) / divisor;
+  const lpMax = Number(sanitizeOnChainValue(engine.lpMaxAbs ?? 0n)) / divisor;
   const accounts = engine.numUsedAccounts ?? 0;
 
   // LP concentration: how much of total LP exposure is one whale


### PR DESCRIPTION
## Problem
Trade page stats panels show raw sentinel values (u64::MAX / corrupted on-chain data) instead of meaningful numbers. QA reported:
- OI: 98655066439639015785732174150
- Vault: 368934881474191

Also: market count inconsistency — homepage hero, Built Different section, and /markets page all show different counts (e.g. 148 vs 137 vs 140).

## Fix
### Sentinel value sanitization (5 files)
- **MarketStatsCard.tsx**: Sanitize `engine.totalOpenInterest` and `engine.vault` via `sanitizeOnChainValue()` before display
- **SystemCapitalCard.tsx**: Sanitize all 8 engine fields (vault, cTot, pnlPosTot, insurance, totalOI, netLp, lpSum, lpMax)
- **LiquidationAnalytics.tsx**: Sanitize insurance balance, OI, and lifetime counters

### Market count unification (2 files)
- **Homepage (page.tsx)**: Add `isSane()` guard to `activeData` filter — sentinel Supabase numbers (> 1e18) no longer inflate the count
- **Markets page (markets/page.tsx)**: Add `isSaneNum()` guard + `sanitizeOnChainValue()` to `activeMarkets` filter

All three views (hero stats, Built Different, /markets) now apply the same sentinel-aware filtering, producing consistent counts.

## Testing
- `pnpm build` ✅ (all packages compile)
- `pnpm test` ✅ (38/38 tests pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of market prices, trading volumes, and open interest metrics across all market displays.
  * Markets with invalid or corrupted numeric data are now properly excluded from active market listings.
  * Financial statistics, analytics, and market information cards now accurately filter malformed or overflow values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->