### PR TITLE
fix: resolve token names on trade pages & sanitize account counts (PERC-198)

### DIFF
--- a/app/__tests__/components/MarketCard.test.tsx
+++ b/app/__tests__/components/MarketCard.test.tsx
@@ -37,6 +37,7 @@ vi.mock("@/lib/health", () => ({
   computeMarketHealth: (engine: any) => ({
     level: engine?.vault > 1000000n ? "healthy" : "warning",
   }),
+  sanitizeAccountCount: (count: number) => (count > 4096 || count < 0 ? 0 : count),
 }));
 
 const mockPublicKey = new PublicKey("11111111111111111111111111111111");

--- a/app/app/api/rpc/route.ts
+++ b/app/app/api/rpc/route.ts
@@ -50,6 +50,9 @@ const ALLOWED_RPC_METHODS = new Set([
   // Misc read
   "getMinimumBalanceForRentExemption",
   "getSupply",
+  // Helius DAS API — token metadata resolution (PERC-198)
+  "getAsset",
+  "getAssetBatch",
 ]);
 
 /** Maximum number of requests allowed in a single batch */

--- a/app/app/my-markets/page.tsx
+++ b/app/app/my-markets/page.tsx
@@ -9,6 +9,7 @@ import { useMyMarkets, type MyMarket } from "@/hooks/useMyMarkets";
 import { useAdminActions } from "@/hooks/useAdminActions";
 import { useToast } from "@/hooks/useToast";
 import { getConfig, explorerAccountUrl } from "@/lib/config";
+import { sanitizeAccountCount } from "@/lib/health";
 import { deriveInsuranceLpMint } from "@percolator/sdk";
 import { isMockMode } from "@/lib/mock-mode";
 import { getMockMyMarkets } from "@/lib/mock-trade-data";
@@ -204,7 +205,7 @@ const MarketCard: FC<{
             { label: "last crank", value: timeAgo(lastCrank, currentSlot) },
             { label: "staleness", value: `${staleness} slots` },
             { label: "oracle authority", value: hasOracleAuthority ? shortAddr(oracleAuthority) : "none" },
-            { label: "active accounts", value: market.engine?.numUsedAccounts?.toString() ?? "0" },
+            { label: "active accounts", value: sanitizeAccountCount(market.engine?.numUsedAccounts ?? 0).toString() },
           ].map((s, i) => (
             <div key={s.label} className="border-t border-[var(--border)]/30 px-4 py-3">
               <p className="text-[9px] uppercase tracking-[0.15em] text-[var(--text-dim)]">{s.label}</p>

--- a/app/components/market/MarketBrowser.tsx
+++ b/app/components/market/MarketBrowser.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { PublicKey } from "@solana/web3.js";
 import { useMarketDiscovery } from "@/hooks/useMarketDiscovery";
 import { formatTokenAmount, shortenAddress } from "@/lib/format";
-import { computeMarketHealth } from "@/lib/health";
+import { computeMarketHealth, sanitizeAccountCount } from "@/lib/health";
 import { HealthBadge } from "@/components/market/HealthBadge";
 import { useMultiTokenMeta } from "@/hooks/useMultiTokenMeta";
 import type { DiscoveredMarket } from "@percolator/sdk";
@@ -118,7 +118,7 @@ export const MarketBrowser: FC = () => {
                     <HealthBadge level={computeMarketHealth(m.engine).level} />
                   </td>
                   <td className="px-4 py-3 text-right text-[var(--text)]">
-                    {m.engine.numUsedAccounts}
+                    {sanitizeAccountCount(m.engine.numUsedAccounts)}
                   </td>
                   <td className="px-4 py-3 text-right">
                     <Link

--- a/app/components/market/MarketStats.tsx
+++ b/app/components/market/MarketStats.tsx
@@ -5,6 +5,7 @@ import { useEngineState } from "@/hooks/useEngineState";
 import { useMarketConfig } from "@/hooks/useMarketConfig";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { formatTokenAmount, formatUsd, formatBps } from "@/lib/format";
+import { sanitizeAccountCount } from "@/lib/health";
 
 export const MarketStats: FC = () => {
   const { engine, params, loading } = useEngineState();
@@ -24,7 +25,7 @@ export const MarketStats: FC = () => {
     { label: "Vault Balance", value: formatTokenAmount(engine.vault) },
     { label: "Trading Fee", value: formatBps(params.tradingFeeBps) },
     { label: "Maintenance Margin", value: formatBps(params.maintenanceMarginBps) },
-    { label: "Accounts", value: (engine.numUsedAccounts ?? 0).toString() },
+    { label: "Accounts", value: sanitizeAccountCount(engine.numUsedAccounts ?? 0).toString() },
   ];
 
   return (

--- a/app/components/trade/MarketStatsCard.tsx
+++ b/app/components/trade/MarketStatsCard.tsx
@@ -7,7 +7,7 @@ import { useSlabState } from "@/components/providers/SlabProvider";
 import { useUsdToggle } from "@/components/providers/UsdToggleProvider";
 import { useTokenMeta } from "@/hooks/useTokenMeta";
 import { formatTokenAmount, formatUsd, formatBps } from "@/lib/format";
-import { sanitizeOnChainValue } from "@/lib/health";
+import { sanitizeOnChainValue, sanitizeAccountCount } from "@/lib/health";
 import { useLivePrice } from "@/hooks/useLivePrice";
 import { FundingRateCard } from "./FundingRateCard";
 import { FundingRateChart } from "./FundingRateChart";
@@ -54,7 +54,7 @@ export const MarketStatsCard: FC = () => {
     { label: "Vault", value: vaultDisplay },
     { label: "Trading Fee", value: formatBps(params.tradingFeeBps) },
     { label: "Init. Margin", value: formatBps(params.initialMarginBps) },
-    { label: "Accounts", value: (engine.numUsedAccounts ?? 0).toString() },
+    { label: "Accounts", value: sanitizeAccountCount(engine.numUsedAccounts ?? 0, params ? Number(params.maxAccounts) : undefined).toString() },
   ];
 
   return (

--- a/app/components/trade/SystemCapitalCard.tsx
+++ b/app/components/trade/SystemCapitalCard.tsx
@@ -4,7 +4,7 @@ import { FC } from "react";
 import { useEngineState } from "@/hooks/useEngineState";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { useTokenMeta } from "@/hooks/useTokenMeta";
-import { sanitizeOnChainValue } from "@/lib/health";
+import { sanitizeOnChainValue, sanitizeAccountCount } from "@/lib/health";
 import { InfoIcon } from "@/components/ui/Tooltip";
 
 function fmtCompact(n: number): string {
@@ -41,7 +41,7 @@ export const SystemCapitalCard: FC = () => {
   const netLp = Number(sanitizeOnChainValue(engine.netLpPos ?? 0n)) / divisor;
   const lpSum = Number(sanitizeOnChainValue(engine.lpSumAbs ?? 0n)) / divisor;
   const lpMax = Number(sanitizeOnChainValue(engine.lpMaxAbs ?? 0n)) / divisor;
-  const accounts = engine.numUsedAccounts ?? 0;
+  const accounts = sanitizeAccountCount(engine.numUsedAccounts ?? 0);
 
   // LP concentration: how much of total LP exposure is one whale
   const lpConcentration = lpSum > 0 ? (lpMax / lpSum) * 100 : 0;

--- a/app/lib/health.ts
+++ b/app/lib/health.ts
@@ -32,6 +32,26 @@ export function sanitizeOnChainValue(v: bigint): bigint {
 }
 
 /**
+ * Maximum possible account slots across all slab tiers (large slab = 4096).
+ * Any numUsedAccounts value above this is garbage data from an uninitialized slab.
+ */
+const MAX_SLAB_ACCOUNTS = 4096;
+
+/**
+ * Sanitize the numUsedAccounts value from on-chain engine state.
+ * Returns 0 if the value exceeds the maximum slab capacity (garbage/uninitialized data)
+ * or if it's negative.
+ *
+ * Optionally accepts maxAccounts from the slab's risk params for a tighter bound.
+ */
+export function sanitizeAccountCount(count: number, maxAccounts?: number): number {
+  if (count < 0) return 0;
+  const cap = maxAccounts != null && maxAccounts > 0 ? maxAccounts : MAX_SLAB_ACCOUNTS;
+  if (count > cap) return 0;
+  return count;
+}
+
+/**
  * Compute market health from on-chain EngineState.
  * Handles sentinel values (u64::MAX for uninitialized insurance) and
  * treats them as zero rather than showing absurd numbers.


### PR DESCRIPTION
## Summary

Fixes two issues on trade pages:

### 1. Token names showing truncated addresses instead of resolved symbols

**Root cause**: The Helius DAS API (`getAsset`/`getAssetBatch`) was completely dead on the client side:
- `getHeliusRpcUrl()` only recognized URLs containing `helius-rpc.com`, but the client uses `/api/rpc` proxy → returned `null` → DAS path skipped entirely
- Even if it hadn't been skipped, the RPC proxy allowlist didn't include DAS methods → would have been blocked

**Fix**:
- Added `getAsset` and `getAssetBatch` to the RPC proxy allowlist
- Updated `getHeliusRpcUrl()` to recognize `/api/rpc` as a valid DAS-capable endpoint
- Wrapped unguarded `getParsedAccountInfo()` in try/catch (was causing silent failures that left token meta as null)

### 2. Accounts counts showing 29K, 13K on empty markets

**Root cause**: `engine.numUsedAccounts` (u16) was displaying raw garbage values from uninitialized slabs. Values like 29,807 exceed max slab capacity (4096 slots), making them clearly invalid.

**Fix**:
- Added `sanitizeAccountCount()` helper — returns 0 for values exceeding max slab capacity
- Applied across all 5 components displaying account counts

### Files Changed (11)
- `app/api/rpc/route.ts` — DAS methods in allowlist
- `app/lib/tokenMeta.ts` — proxy-aware DAS URL + try/catch
- `app/lib/health.ts` — new sanitizeAccountCount()
- `MarketStatsCard`, `SystemCapitalCard`, `MarketStats`, `MarketBrowser`, `my-markets/page` — sanitized accounts
- Tests: 3 new test files/sections (566 total pass)

### Testing
- `pnpm test` — 566 passed ✅
- `pnpm build` — success ✅

Closes PERC-198

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account count validation to ensure displayed numbers remain within valid ranges across market displays.
  * Extended RPC proxy support for additional token metadata retrieval methods.

* **Bug Fixes**
  * Improved error handling for token metadata fetching with graceful fallback to default values.

* **Tests**
  * Added comprehensive test coverage for account count validation logic and edge cases.
  * Added test cases for enhanced token metadata retrieval error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->