### PR TITLE
fix: indexer bigint overflow + FK constraint violations

### DIFF
--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -101,7 +101,8 @@ export async function upsertMarketStats(stats: Partial<MarketStatsRow> & { slab_
   const { error } = await getSupabase()
     .from("market_stats")
     .upsert(stats, { onConflict: "slab_address" });
-  if (error) throw error;
+  // Ignore FK violations (23503) — slab may not be in markets table yet
+  if (error && error.code !== "23503") throw error;
 }
 
 export async function insertTrade(trade: Omit<TradeRow, "id" | "created_at">): Promise<void> {
@@ -130,7 +131,8 @@ export async function insertOraclePrice(price: OraclePriceRow): Promise<void> {
     timestamp: price.timestamp,
     tx_signature: price.tx_signature ?? null,
   });
-  if (error) throw error;
+  // Ignore FK violations (23503) — market may not be in DB yet
+  if (error && error.code !== "23503") throw error;
 }
 
 export async function getRecentTrades(slabAddress: string, limit = 50): Promise<TradeRow[]> {

--- a/supabase/migrations/024_bigint_overflow_fix.sql
+++ b/supabase/migrations/024_bigint_overflow_fix.sql
@@ -1,0 +1,65 @@
+-- Migration 024: Fix bigint overflow for large u64 on-chain values
+-- Created: 2026-02-26
+-- Purpose: Change BIGINT columns that may receive values > PG BIGINT MAX (9.2e18)
+--          to NUMERIC type. On-chain u64 values can reach ~1.8e19 which overflows
+--          PG signed BIGINT (max ~9.2e18).
+--
+-- Affected columns:
+--   market_stats.lifetime_liquidations  (could be garbage from wrong slab layout)
+--   market_stats.lifetime_force_closes  (same)
+--
+-- Note: last_crank_slot, max_crank_staleness_slots, warmup_period_slots,
+--       liquidation_fee_bps, liquidation_buffer_bps stay BIGINT since their
+--       realistic values are always well within range. The TypeScript indexer
+--       now also clamps these at PG BIGINT MAX as a safety net.
+
+-- Drop dependent view first
+DROP VIEW IF EXISTS markets_with_stats;
+
+-- Alter columns that can receive large u64 values
+ALTER TABLE market_stats
+  ALTER COLUMN lifetime_liquidations TYPE NUMERIC USING lifetime_liquidations::NUMERIC,
+  ALTER COLUMN lifetime_force_closes TYPE NUMERIC USING lifetime_force_closes::NUMERIC;
+
+-- Recreate the view (same as migration 010)
+CREATE VIEW markets_with_stats AS
+SELECT 
+  m.*,
+  ms.last_price,
+  ms.mark_price,
+  ms.index_price,
+  ms.volume_24h,
+  ms.volume_total,
+  ms.open_interest_long,
+  ms.open_interest_short,
+  ms.insurance_fund,
+  ms.total_accounts,
+  ms.funding_rate,
+  ms.total_open_interest,
+  ms.net_lp_pos,
+  ms.lp_sum_abs,
+  ms.lp_max_abs,
+  ms.insurance_balance,
+  ms.insurance_fee_revenue,
+  ms.warmup_period_slots,
+  ms.vault_balance,
+  ms.lifetime_liquidations,
+  ms.lifetime_force_closes,
+  ms.c_tot,
+  ms.pnl_pos_tot,
+  ms.last_crank_slot,
+  ms.max_crank_staleness_slots,
+  ms.maintenance_fee_per_slot,
+  ms.liquidation_fee_bps,
+  ms.liquidation_fee_cap,
+  ms.liquidation_buffer_bps,
+  ms.updated_at AS stats_updated_at
+FROM markets m
+LEFT JOIN market_stats ms ON m.slab_address = ms.slab_address;
+
+COMMENT ON VIEW markets_with_stats IS 'Combined view of markets and their complete stats (all RiskEngine fields)';
+
+DO $$
+BEGIN
+  RAISE NOTICE 'Migration 024 completed: lifetime_liquidations and lifetime_force_closes changed from BIGINT to NUMERIC';
+END $$;


### PR DESCRIPTION
## Problem

Two production issues causing only 4/7 markets to update per indexer cycle:

### 1. Bigint overflow
Value `13292928068290159000` (valid u64, ~1.3e19) exceeds PostgreSQL signed BIGINT max (~9.2e18), causing `out-of-range for bigint` errors on slab A35wGP...

### 2. FK constraint violations  
3 FK violations from unknown slab addresses not in the `markets` table. History tables (`oi_history`, `insurance_history`, `funding_history`) FK to `market_stats(slab_address)` — if a market is discovered on-chain but not yet registered in DB, all history inserts fail.

## Fix

### StatsCollector (`packages/indexer/src/services/StatsCollector.ts`)
- **New `safePgBigint()`** function that caps values at PG BIGINT max (9223372036854775807) for BIGINT-typed columns
- **Expanded `isSaneEngine` check** to include `lifetimeLiquidations` and `lifetimeForceCloses` — catches garbage values from wrong slab layout parsing (threshold: 1e12)
- **Replaced raw `Number()`** calls in history table inserts with `safeBigNum()`/`safePgBigint()`
- **FK-safe history inserts**: Use Supabase error response to ignore FK violations (23503) and unique constraint violations (23505) gracefully instead of throwing

### Shared queries (`packages/shared/src/db/queries.ts`)
- `upsertMarketStats()` and `insertOraclePrice()` now tolerate FK violations (23503) — slab may not be in markets table yet

### Migration 024 (`supabase/migrations/024_bigint_overflow_fix.sql`)
- Changes `lifetime_liquidations` and `lifetime_force_closes` from BIGINT to NUMERIC (arbitrary precision — safely stores any u64 value)
- Recreates `markets_with_stats` view

## Tests
- 40/40 indexer tests pass ✅
- 266/266 shared tests pass ✅  
- 2 new tests for bigint overflow protection:
  - Values exceeding sane threshold are rejected by isSaneEngine
  - u64::MAX sentinel values are safely converted to 0

## Expected Result
All 7/7 markets should update per indexer cycle (was 4/7).