### PR TITLE
feat(keeper): PERC-204 Solana latency optimizations

### DIFF
--- a/packages/keeper/tests/services/liquidation.test.ts
+++ b/packages/keeper/tests/services/liquidation.test.ts
@@ -95,6 +95,7 @@ vi.mock('@percolator/shared', () => ({
     };
   }),
   sendWithRetry: vi.fn(async () => 'mock-signature'),
+  sendWithRetryKeeper: vi.fn(async () => 'mock-keeper-signature'),
   pollSignatureStatus: vi.fn(async () => true),
   getRecentPriorityFees: vi.fn(async () => ({
     priorityFeeMicroLamports: 5000,


### PR DESCRIPTION
## PERC-204: Zero-cost Solana latency optimizations

### Changes

**1. Multi-RPC parallel broadcast** (`broadcastToMultipleRpcs`)
- Sends every transaction to primary + fallback + up to 3 extra RPC endpoints simultaneously
- First confirmation wins; Solana network de-dupes by signature
- Configure via `EXTRA_RPC_URLS` env var (comma-separated)
- Expected: +20-40% landing rate

**2. Dynamic compute budget**
- Simulates transaction to get actual CU consumption, sets tight limit (actual + 10% buffer)
- Queries recent priority fees, uses 75th-percentile for dynamic pricing
- Better queue position under congestion vs hardcoded 400k CU

**3. Pyth Pull Oracle bundling**
- Bundles oracle price push instruction directly into crank transaction
- Eliminates separate oracle update round-trip
- Falls back gracefully if price fetch fails

**4. Parallel keeper cranks**
- Concurrency: 3 → 10 simultaneous market cranks
- Batch gap: 2000ms → 500ms
- Each market gets independent transaction, safe for parallel submission
- Massive throughput improvement with 137+ markets

**5. Liquidation service**
- Migrated from manual retry loop to `sendWithRetryKeeper` for same optimizations

### Testing
- All 41 keeper tests pass ✅
- All 266 shared tests pass ✅
- Pure code changes, zero infra cost

### How to test
- Set `EXTRA_RPC_URLS=https://rpc1.example.com,https://rpc2.example.com` for multi-RPC
- Monitor keeper logs for `[sendWithRetryKeeper]` entries
- Compare tx landing rate before/after

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Crank batch processing now executes in parallel for significantly faster throughput
  * Transactions broadcast across multiple RPC endpoints to improve reliability

* **New Features**
  * Oracle price updates automatically bundled with crank operations
  * Dynamic compute unit optimization reduces transaction failures and improves execution efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->