### PR TITLE
fix(api): return HTTP 200 for JSON-RPC error responses in /api/rpc

### DIFF
--- a/app/app/api/rpc/route.ts
+++ b/app/app/api/rpc/route.ts
@@ -236,8 +236,9 @@ export async function POST(req: NextRequest) {
     }
 
     const result = await processSingleRequest(body as JsonRpcRequest);
-    const hasError = (result as Record<string, unknown>).error;
-    return NextResponse.json(result, { status: hasError ? 400 : 200 });
+    // JSON-RPC errors are application-level, not transport-level — always return HTTP 200.
+    // Returning 400 for RPC errors breaks @solana/web3.js which treats non-2xx as network failures.
+    return NextResponse.json(result, { status: 200 });
   } catch (error) {
     console.error("[/api/rpc] Error:", error);
     return NextResponse.json(


### PR DESCRIPTION
## Fix: /api/rpc returning 400 for RPC error responses

### Problem
QA reported multiple `/api/rpc` 400 errors in the browser console on trade page load (post-PERC-203 deploy).

### Root Cause
The RPC proxy was returning HTTP 400 when the upstream Solana RPC response contained a JSON-RPC error field. This is incorrect per the JSON-RPC spec — application-level errors should be HTTP 200. The HTTP status should only reflect transport-level issues.

This caused:
- `@solana/web3.js` treating valid RPC error responses as network failures
- Console errors on trade page load (e.g., when `getAsset` returns unknown token errors)
- Potential data loading issues for market pages

### Fix
Single-request path now always returns HTTP 200 for successfully proxied responses (matching batch request behavior which already returned 200).

Proxy-level validation errors (missing method, disallowed method) still return 400/403.

### Testing
- TypeScript compiles cleanly
- One-line change, low risk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JSON-RPC API responses now consistently return HTTP 200 status codes instead of 400 for application-level errors, improving client compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->