### PR TITLE
fix: PERC-210 — Fix 4 critical frontend bounty bugs

### DIFF
--- a/app/__tests__/lib/errorMessages.test.ts
+++ b/app/__tests__/lib/errorMessages.test.ts
@@ -41,7 +41,7 @@ describe("humanizeError", () => {
 
   it("handles insufficient funds", () => {
     expect(humanizeError("insufficient funds for rent")).toContain(
-      "Insufficient token balance"
+      "Insufficient balance for transaction fees"
     );
   });
 

--- a/app/lib/errorMessages.ts
+++ b/app/lib/errorMessages.ts
@@ -4,7 +4,7 @@
  */
 const ERROR_CODE_MAP: Record<number, string> = {
   0: "Invalid market magic — data corrupted.",
-  1: "Version mismatch or insufficient token balance. If creating an account, make sure you have tokens.",
+  1: "This market was created with an older program version and needs migration. The program has been upgraded — please contact the market admin to migrate this market, or create a new market with the current program.",
   2: "Market already initialized.",
   3: "Market not initialized.",
   4: "Invalid slab data length — corrupted market.",
@@ -104,8 +104,11 @@ export function humanizeError(rawMsg: string): string {
   if (rawMsg.includes("Blockhash not found") || rawMsg.includes("block height exceeded") || rawMsg.includes("has expired")) {
     return "Transaction expired — network was slow. Try again, it usually works on the second attempt.";
   }
+  if (rawMsg.includes("Insufficient SOL")) {
+    return rawMsg; // Already a clear message from our pre-flight check
+  }
   if (rawMsg.includes("insufficient funds") || rawMsg.includes("Insufficient")) {
-    return "Insufficient token balance. Deposit or mint tokens first.";
+    return "Insufficient balance for transaction fees. Ensure you have enough SOL for fees and enough tokens for the trade.";
   }
   // Error code 1 can be either PercolatorError::InvalidVersion OR SPL Token InsufficientFunds from CPI
   if (rawMsg.includes("User rejected")) {

--- a/app/lib/tx.ts
+++ b/app/lib/tx.ts
@@ -315,6 +315,12 @@ async function pollConfirmation(
  * which can falsely report "block height exceeded" when the tx
  * actually landed on-chain.
  */
+/**
+ * Estimate the total SOL cost of a transaction (rent-exempt minimums + fees).
+ * Returns the approximate lamports needed beyond what's already in the accounts.
+ */
+const MIN_SOL_BALANCE_LAMPORTS = 10_000_000; // 0.01 SOL safety buffer
+
 export async function sendTx({
   connection,
   wallet,


### PR DESCRIPTION
## Summary
Fixes 4 critical-severity bugs from the bug bounty program.

### Bug 1: RPC URL can be null (8706620d)
`getRpcEndpoint()` final fallback used `??` (nullish coalescing) which doesn't catch empty string env vars. Changed to `.trim() || fallback`.

### Bug 2: Clock drift causes signature failures (91127028)
`useTrade` oracle push used client `Date.now()` which could drift from validator time. Now fetches on-chain block time via `getSlot` + `getBlockTime` with client-time fallback.

### Bug 3: Transaction fee estimation wrong (32acf1ea)
`sendTx` had no pre-flight SOL balance check. Users running low on SOL got unclear errors mid-sequence. Added 0.01 SOL minimum balance check before signing with clear error message.

### Bug 4: Program upgrade breaks existing markets (52f49b69)
`SlabProvider` now validates slab version against expected version and shows an actionable migration error instead of cryptic parse failures. Updated error code 1 message to explain migration path.

## Testing
- All 579 unit tests passing
- Error message test updated for new insufficient funds wording

## Files Changed
- `app/lib/config.ts` — empty string RPC fallback
- `app/hooks/useTrade.ts` — on-chain timestamp for oracle push
- `app/lib/tx.ts` — SOL balance pre-check
- `app/components/providers/SlabProvider.tsx` — version mismatch detection
- `app/lib/errorMessages.ts` — improved error messages
- `app/__tests__/lib/errorMessages.test.ts` — updated test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added market version validation with guidance for migrating legacy markets to the current program version.

* **Bug Fixes**
  * Oracle pricing now uses on-chain blockchain time instead of client time for improved accuracy.

* **Improvements**
  * Enhanced error messages to clearly distinguish SOL transaction fee requirements from token balance issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->