### PR TITLE
fix: PERC-211 — Fix 10 high/medium frontend bounty bugs

### DIFF
--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -123,6 +123,7 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
     wizard.tradingFeeBps <= 1000 &&
     wizard.initialMarginBps >= 100 &&
     !feeConflict &&
+    parseFloat(wizard.lpCollateral || "0") > 0 &&
     parseFloat(wizard.insuranceAmount) >= 100;
   const hasSufficientSol = solBalance !== null && solBalance >= 0.5;
   const allValid = step1Valid && step2Valid && step3Valid && hasTokens && hasSufficientSol;

--- a/app/components/trade/PositionPanel.tsx
+++ b/app/components/trade/PositionPanel.tsx
@@ -72,8 +72,9 @@ export const PositionPanel: FC<{ slabAddress: string }> = ({ slabAddress }) => {
     account.entryPrice,
     currentPriceE6,
   ) : 0n;
-  const pnlUsd =
+  const pnlUsdRaw =
     priceUsd !== null && currentPriceE6 > 0n ? (Number(pnlTokens) / 10 ** decimals) * priceUsd : null;
+  const pnlUsd = pnlUsdRaw !== null && Number.isFinite(pnlUsdRaw) ? pnlUsdRaw : null;
   const roe = currentPriceE6 > 0n ? computePnlPercent(pnlTokens, account.capital) : 0;
 
   const maintenanceBps = params?.maintenanceMarginBps ?? 500n;

--- a/app/components/trade/PositionsTable.tsx
+++ b/app/components/trade/PositionsTable.tsx
@@ -70,9 +70,10 @@ export const PositionsTable: FC<{ slabAddress: string }> = ({ slabAddress }) => 
   const pnlTokens = currentPriceE6 > 0n
     ? computeMarkPnl(account.positionSize, entryPriceE6, currentPriceE6)
     : 0n;
-  const pnlUsd = priceUsd !== null && currentPriceE6 > 0n
+  const pnlUsdRaw = priceUsd !== null && currentPriceE6 > 0n
     ? (Number(pnlTokens) / (10 ** decimals)) * priceUsd
     : null;
+  const pnlUsd = pnlUsdRaw !== null && Number.isFinite(pnlUsdRaw) ? pnlUsdRaw : null;
   const roe = currentPriceE6 > 0n ? computePnlPercent(pnlTokens, account.capital) : 0;
 
   const liqPriceE6 = computeLiqPrice(

--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -154,6 +154,16 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
     return () => { cancelled = true; };
   }, [publicKey, mktConfig?.collateralMint, connection, mockMode]);
 
+  // Reset form state when switching markets (bug #1a12dab5)
+  useEffect(() => {
+    setDirection("long");
+    setMarginInput("");
+    setLeverage(1);
+    setLastSig(null);
+    setHumanError(null);
+    setTradePhase("idle");
+  }, [slabAddress]);
+
   // Direction toggle GSAP bounce
   useEffect(() => {
     if (prefersReduced) return;

--- a/app/hooks/usePortfolio.ts
+++ b/app/hooks/usePortfolio.ts
@@ -251,5 +251,25 @@ export function usePortfolio(): PortfolioData {
 
   const refresh = () => setRefreshCounter((c) => c + 1);
 
+  // Auto-refresh when tab becomes visible (e.g., after closing position on trade page)
+  // and every 30s while visible
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState === "visible") {
+        setRefreshCounter((c) => c + 1);
+      }
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    const interval = setInterval(() => {
+      if (document.visibilityState === "visible") {
+        setRefreshCounter((c) => c + 1);
+      }
+    }, 30_000);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisible);
+      clearInterval(interval);
+    };
+  }, []);
+
   return { positions, totalPnl, totalDeposited, totalValue, totalUnrealizedPnl, atRiskCount, loading, refresh };
 }

--- a/app/hooks/useToast.ts
+++ b/app/hooks/useToast.ts
@@ -26,9 +26,17 @@ export function ToastProvider({ children }: { children: ReactNode }) {
     setToasts((prev) => prev.filter((t) => t.id !== id));
   }, []);
 
+  const MAX_TOASTS = 5;
+
   const toast = useCallback((message: string, type: ToastItem["type"] = "info") => {
     const id = `toast-${++counter}-${Date.now()}`;
-    setToasts((prev) => [...prev, { id, message, type }]);
+    setToasts((prev) => {
+      // Deduplicate: skip if same message+type already visible
+      if (prev.some((t) => t.message === message && t.type === type)) return prev;
+      // Cap at MAX_TOASTS — remove oldest first
+      const updated = [...prev, { id, message, type }];
+      return updated.length > MAX_TOASTS ? updated.slice(-MAX_TOASTS) : updated;
+    });
     // Auto-dismiss after 5 seconds
     setTimeout(() => {
       setToasts((prev) => prev.filter((t) => t.id !== id));


### PR DESCRIPTION
## Summary
Fixes 10 high/medium-severity bugs from the bug bounty program.

### Actually Fixed (code changes)
1. **PnL NaN guard** (24dae681): Added `Number.isFinite()` guard on pnlUsd in PositionsTable/PositionPanel
6. **Trade state reset** (1a12dab5): TradeForm resets direction/margin/leverage when market changes via URL
7. **Toast stack limit** (930c1a3f): Capped at 5 toasts max + dedup by message+type
8. **Create market validation** (0aa98a90): Added lpCollateral > 0 to step3Valid
9. **Portfolio stale data** (a75804ea): Auto-refresh on visibility change + 30s interval

### Already Fixed (no changes needed)
2. Markets pagination — IntersectionObserver infinite scroll already in place
3. Markets loading state — ShimmerSkeleton already shows during fetch
4. Oracle cache — No frontend cache; prices come from on-chain subscription
5. MAX_SAFE_INTEGER — computePnlPercent already uses BigInt scaling
10. Referrer-Policy — Already set in next.config.ts and middleware.ts

## Testing
- 579 unit tests passing
- No test changes needed