### PR TITLE
fix: PERC-212 — Fix 4 mobile/UX bounty bugs

### DIFF
--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -546,13 +546,13 @@ function MarketsPageInner() {
             <>
               <div className="relative rounded-sm border border-[var(--border)] hud-corners overflow-x-auto">
                 {/* Header row - responsive grid columns */}
-                <div className="grid min-w-[500px] sm:min-w-[700px] grid-cols-[minmax(140px,2fr)_minmax(70px,1fr)_minmax(70px,1fr)_minmax(70px,1fr)_minmax(50px,0.7fr)] sm:grid-cols-[minmax(140px,2fr)_minmax(70px,1fr)_minmax(70px,1fr)_minmax(70px,1fr)_minmax(70px,1fr)_minmax(50px,0.7fr)_minmax(50px,0.7fr)] gap-3 border-b border-[var(--border)] bg-[var(--bg-surface)] px-4 py-2.5 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">
+                <div className="grid min-w-[600px] sm:min-w-[700px] grid-cols-[minmax(120px,2fr)_minmax(60px,1fr)_minmax(60px,1fr)_minmax(60px,1fr)_minmax(55px,0.8fr)_minmax(40px,0.5fr)_minmax(45px,0.7fr)] sm:grid-cols-[minmax(140px,2fr)_minmax(70px,1fr)_minmax(70px,1fr)_minmax(70px,1fr)_minmax(70px,1fr)_minmax(50px,0.7fr)_minmax(50px,0.7fr)] gap-3 border-b border-[var(--border)] bg-[var(--bg-surface)] px-4 py-2.5 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">
                   <div>token</div>
                   <div className="text-right">price</div>
                   <div className="text-right">OI</div>
                   <div className="text-right">volume</div>
-                  <div className="text-right hidden sm:block">insurance</div>
-                  <div className="text-right hidden sm:block">max lev</div>
+                  <div className="text-right"><span className="sm:hidden">ins</span><span className="hidden sm:inline">insurance</span></div>
+                  <div className="text-right"><span className="sm:hidden">lev</span><span className="hidden sm:inline">max lev</span></div>
                   <div className="text-right">health</div>
                 </div>
 
@@ -609,7 +609,7 @@ function MarketsPageInner() {
                       key={m.slabAddress}
                       href={`/trade/${m.slabAddress}`}
                       className={[
-                        "grid min-w-[500px] sm:min-w-[700px] grid-cols-[minmax(140px,2fr)_minmax(70px,1fr)_minmax(70px,1fr)_minmax(70px,1fr)_minmax(50px,0.7fr)] sm:grid-cols-[minmax(140px,2fr)_minmax(70px,1fr)_minmax(70px,1fr)_minmax(70px,1fr)_minmax(70px,1fr)_minmax(50px,0.7fr)_minmax(50px,0.7fr)] gap-3 items-center px-4 py-3 transition-all duration-200 hover:bg-[var(--accent)]/[0.04] hover:border-l-2 hover:border-l-[var(--accent)]/30",
+                        "grid min-w-[600px] sm:min-w-[700px] grid-cols-[minmax(120px,2fr)_minmax(60px,1fr)_minmax(60px,1fr)_minmax(60px,1fr)_minmax(55px,0.8fr)_minmax(40px,0.5fr)_minmax(45px,0.7fr)] sm:grid-cols-[minmax(140px,2fr)_minmax(70px,1fr)_minmax(70px,1fr)_minmax(70px,1fr)_minmax(70px,1fr)_minmax(50px,0.7fr)_minmax(50px,0.7fr)] gap-3 items-center px-4 py-3 transition-all duration-200 hover:bg-[var(--accent)]/[0.04] hover:border-l-2 hover:border-l-[var(--accent)]/30",
                         i > 0 ? "border-t border-[var(--border)]" : "",
                       ].join(" ")}
                     >
@@ -670,8 +670,8 @@ function MarketsPageInner() {
                       <div className="text-right text-sm text-[var(--text-secondary)] truncate" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
                         {volumeDisplay ?? "\u2014"}
                       </div>
-                      <div className="text-right text-sm text-[var(--text)] truncate hidden sm:block" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>{insuranceDisplay}</div>
-                      <div className="text-right text-sm text-[var(--text-secondary)] hidden sm:block">{m.maxLeverage}x</div>
+                      <div className="text-right text-sm text-[var(--text)] truncate" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>{insuranceDisplay}</div>
+                      <div className="text-right text-sm text-[var(--text-secondary)]">{m.maxLeverage}x</div>
                       <div className="text-right"><HealthBadge level={health.level} /></div>
                     </Link>
                   );

--- a/app/components/market/ShareCard.tsx
+++ b/app/components/market/ShareCard.tsx
@@ -117,7 +117,7 @@ export const ShareButton: FC<Omit<ShareCardProps, "change24h"> & { change24h?: n
         Share
       </button>
       {open && (
-        <div ref={dropdownRef} className="absolute right-0 top-full z-50 mt-2 w-72">
+        <div ref={dropdownRef} className="fixed sm:absolute right-4 sm:right-0 top-auto sm:top-full z-50 mt-2 w-[calc(100vw-2rem)] sm:w-72">
           <ShareCard {...props} />
         </div>
       )}


### PR DESCRIPTION
## Summary
1. **Mobile table columns** (5d527304): Insurance + max leverage visible on mobile with abbreviated headers
2. **Share dropdown** (d3311f3d): Fixed positioning on mobile prevents off-screen clipping
3. **Loading indicator** (dd59626c): Already fixed (ShimmerSkeleton)
4. **Invalid market 404** (ce6bf66f): Already fixed (InvalidAddressPage)

579 tests passing.