### PR TITLE
fix(admin): make right-side detail panel sticky on scroll

### DIFF
--- a/app/app/admin/page.tsx
+++ b/app/app/admin/page.tsx
@@ -919,9 +919,9 @@ export default function AdminDashboard() {
           </div>
         </div>
 
-        {/* Detail panel — scrollable, not sticky */}
+        {/* Detail panel — sticky on desktop so it stays visible while scrolling the bug list */}
         <div
-          className={`${card} lg:w-[400px] lg:shrink-0 overflow-y-auto max-h-[calc(100vh-200px)] lg:self-start`}
+          className={`${card} lg:w-[400px] lg:shrink-0 overflow-y-auto max-h-[calc(100vh-6rem)] lg:sticky lg:top-[5rem]`}
         >
           {!selectedBug ? (
             <div className="text-center text-[var(--text-muted)] text-[12px] py-12 px-4">


### PR DESCRIPTION
## PERC-217

**Problem:** On the admin dashboard, the bug report detail panel on the right side scrolls out of view when scrolling the bug list, making it hard to review bug details while scanning through reports.

**Fix:** Applied `position: sticky` with appropriate `top` offset to the detail panel container on desktop viewports (`lg:`+).

### Changes
- Added `lg:sticky lg:top-[5rem]` to the detail panel — `5rem` clears the sticky header (`h-14` = 3.5rem) plus 1.5rem breathing room
- Adjusted `max-height` to `calc(100vh - 6rem)` so the panel fits within the viewport when stuck
- Replaced `lg:self-start` (redundant with sticky which implicitly aligns to start)

### How it works
- On `lg`+ screens: the detail panel sticks just below the header as the user scrolls the left-side bug list
- On smaller screens: layout is stacked vertically (no change)
- The panel remains internally scrollable via `overflow-y-auto` for long bug reports

**Build:** ✅ passes  
**Testing:** Visual — desktop viewport, scroll the bug list and verify panel stays pinned

Closes PERC-217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Detail panel now remains visible while scrolling on desktop, keeping important information accessible alongside the main content list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->