### PR TITLE
fix: /api/markets perf (#459) + insurance fund display (#460)

### DIFF
--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -14,7 +14,12 @@ export async function GET() {
     const supabase = getServiceClient();
     const { data, error } = await supabase
       .from("markets_with_stats")
-      .select("*");
+      .select(
+        "slab_address,mint_address,symbol,name,decimals,deployer,logo_url,max_leverage,trading_fee_bps," +
+        "last_price,mark_price,volume_24h,open_interest_long,open_interest_short,total_open_interest," +
+        "insurance_fund,insurance_balance,total_accounts,funding_rate,net_lp_pos,lp_sum_abs,c_tot," +
+        "vault_balance,created_at,stats_updated_at"
+      );
 
     if (error) {
       Sentry.captureException(error, {
@@ -23,7 +28,11 @@ export async function GET() {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
 
-    return NextResponse.json({ markets: data });
+    return NextResponse.json({ markets: data }, {
+      headers: {
+        "Cache-Control": "public, s-maxage=10, stale-while-revalidate=30",
+      },
+    });
   } catch (error) {
     Sentry.captureException(error, {
       tags: { endpoint: "/api/markets", method: "GET" },

--- a/app/app/api/stats/route.ts
+++ b/app/app/api/stats/route.ts
@@ -57,5 +57,9 @@ export async function GET() {
     totalTraders: uniqueTraders,
     trades24h,
     updatedAt: new Date().toISOString(),
+  }, {
+    headers: {
+      "Cache-Control": "public, s-maxage=15, stale-while-revalidate=45",
+    },
   });
 }


### PR DESCRIPTION
## Fixes
- **#459** — /api/markets response time exceeds 500ms target
- **#460** — Insurance fund values truncated/unreadable in /markets table

## Changes

### Performance (#459)
- Select only needed columns from markets_with_stats view (was SELECT *)
- Add Cache-Control headers to /api/markets and /api/stats for CDN edge caching

### Display (#460)
- Add maxDisplayDecimals parameter to formatTokenAmount() in lib/format.ts
- Cap insurance fund and OI token display to 2 decimal places in markets table

## How to test
1. curl /api/markets — check Cache-Control header present, response faster
2. Visit /markets — insurance fund column shows clean values (e.g. 100.00)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized token amount display formatting for open interest and insurance values to consistently show 2-decimal precision across the markets interface.

* **Performance**
  * Implemented HTTP caching headers on markets and stats API endpoints to reduce load times and improve overall application responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->