### PR TITLE
fix: insurance column decimal display for Supabase-fallback markets (PERC-223)

### DIFF
--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -579,16 +579,20 @@ function MarketsPageInner() {
                     ? sanitizeOnChainValue(m.onChain.engine.totalOpenInterest)
                     : (() => {
                         const v = m.supabase?.total_open_interest ?? ((m.supabase?.open_interest_long ?? 0) + (m.supabase?.open_interest_short ?? 0));
-                        return BigInt(isSentinelNum(v) ? 0 : Math.max(0, v));
+                        const safe = isSentinelNum(v) ? 0 : Math.max(0, v);
+                        return BigInt(Math.round(safe * tokenDivisor));
                       })();
                   const insuranceTokensRaw = m.onChain
                     ? sanitizeOnChainValue(m.onChain.engine.insuranceFund.balance)
                     : (() => {
                         const v = m.supabase?.insurance_balance ?? m.supabase?.insurance_fund ?? 0;
-                        return BigInt(isSentinelNum(v) ? 0 : Math.max(0, v));
+                        const safe = isSentinelNum(v) ? 0 : Math.max(0, v);
+                        // Supabase values are already in human-readable token units (floats).
+                        // Multiply by 10^decimals to convert back to raw token units for formatTokenAmount.
+                        return BigInt(Math.round(safe * tokenDivisor));
                       })();
                   const volume24hRaw = m.supabase?.volume_24h != null && !isSentinelNum(m.supabase.volume_24h) && m.supabase.volume_24h > 0
-                    ? BigInt(m.supabase.volume_24h)
+                    ? BigInt(Math.round(m.supabase.volume_24h * tokenDivisor))
                     : null;
                   
                   // Display values (USD or tokens) — cap token display at 2dp for table readability


### PR DESCRIPTION
## PERC-223

Supabase stores insurance_balance, total_open_interest, and volume_24h as human-readable floats (e.g. `113.997366982`), not raw token units. `BigInt(113.997)` truncated to `113n`, so `formatTokenAmount(113n, 6, 2)` displayed `0.00` instead of `113.99`.

**Fix:** Multiply by `10^decimals` before BigInt conversion so the values round-trip correctly through formatTokenAmount.

Affects all three Supabase-fallback columns: OI, insurance, volume.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of Open Interest, Insurance, and 24-hour volume token value conversions for Supabase-sourced market data.

* **Documentation**
  * Added clarifying comments about token unit conversion handling in market data calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->