### PR TITLE
fix(PERC-234): /markets bigint formatting + homepage GSAP void at 1440px

### DIFF
--- a/app/components/ui/ScrollReveal.tsx
+++ b/app/components/ui/ScrollReveal.tsx
@@ -60,9 +60,11 @@ export function ScrollReveal({
       scale: scale ?? 1,
     });
 
-    // Safety net: if observer doesn't fire within 2s (e.g. element is
-    // already in the viewport but rootMargin clips it), reveal anyway.
-    // This prevents invisible "gap" sections at certain viewport sizes.
+    // Safety net: if observer doesn't fire quickly (e.g. element is
+    // near the viewport edge but rootMargin clips it), reveal anyway.
+    // PERC-234: Reduced from 2000ms to 600ms — at 1440px desktop the
+    // below-hero sections were invisible for too long, creating a
+    // visible "void" on fresh load.
     const safetyTimer = setTimeout(() => {
       if (!hasAnimated.current) {
         hasAnimated.current = true;
@@ -76,7 +78,7 @@ export function ScrollReveal({
           ease: "power3.out",
         });
       }
-    }, 2000);
+    }, 600);
 
     const observer = new IntersectionObserver(
       (entries) => {
@@ -123,7 +125,7 @@ export function ScrollReveal({
           }
         }
       },
-      { threshold: 0.05, rootMargin: "0px 0px -30px 0px" }
+      { threshold: 0.01, rootMargin: "0px 0px 50px 0px" }
     );
 
     observer.observe(el);


### PR DESCRIPTION
## Bug 1: /markets OI & Insurance showing raw bigints

**Root cause:** The StatsCollector stores raw on-chain values via `safeBigNum(engine.totalOpenInterest)` — these are NOT human-readable floats. The markets page had an incorrect comment saying `Supabase values are already in human-readable token units (floats)` and multiplied by `tokenDivisor` before passing to `formatTokenAmount`.

This double-counted the decimals:
- Supabase stores: `113997366982` (raw, meaning 113,997 tokens with 6 decimals)
- Code did: `BigInt(113997366982 * 10^6)` = `113997366982000000`
- `formatTokenAmount(113997366982000000, 6, 2)` = `"113997366982"` — raw bigint displayed!

**Fix:** Use Supabase values directly as BigInt (they're already raw, same as the on-chain path). Applied to OI, insurance, and volume columns.

## Bug 2: Homepage GSAP void at 1440px

**Root cause:** ScrollReveal component starts elements at `opacity: 0`. At 1440px desktop, below-hero content sits just outside the IntersectionObserver detection zone (negative rootMargin of -30px). The 2-second safety timer was too slow — users saw a black void.

**Fix:**
- Reduced safety timer from 2000ms → 600ms
- Changed rootMargin from `0px 0px -30px 0px` → `0px 0px 50px 0px` (triggers 50px before element enters viewport)
- Reduced threshold from 0.05 → 0.01 for faster trigger

Existing tests pass (format, health, oraclePrice).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined on-chain market data calculations for Supabase-backed markets, affecting open interest, insurance balance, and 24-hour trading volume

* **Performance**
  * Enhanced scroll reveal with faster response time and improved viewport edge detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->