### PR TITLE
fix: Correct slab rent calculation + unify balance check (PERC-236)

### DIFF
--- a/app/components/create/CostEstimate.tsx
+++ b/app/components/create/CostEstimate.tsx
@@ -13,8 +13,8 @@ interface CostEstimateProps {
   className?: string;
 }
 
-/** Lamports per byte for rent exemption (approximation: 6.96 lamports/byte + 128 bytes overhead) */
-const RENT_PER_BYTE = 6.96;
+/** Lamports per byte for rent exemption (approximation: 6960 lamports/byte + 128 bytes overhead) */
+const RENT_PER_BYTE = 6960;
 const RENT_OVERHEAD_BYTES = 128;
 const LAMPORTS_PER_SOL = 1_000_000_000;
 

--- a/app/components/create/StepReview.tsx
+++ b/app/components/create/StepReview.tsx
@@ -24,6 +24,7 @@ interface StepReviewProps {
   walletConnected: boolean;
   walletBalanceSol: number | null;
   hasSufficientBalance: boolean;
+  requiredSol?: number;
   hasTokens: boolean;
   feeConflict: boolean;
   // Actions
@@ -60,6 +61,7 @@ export const StepReview: FC<StepReviewProps> = ({
   walletConnected,
   walletBalanceSol,
   hasSufficientBalance,
+  requiredSol,
   hasTokens,
   feeConflict,
   onBack,
@@ -150,7 +152,7 @@ export const StepReview: FC<StepReviewProps> = ({
             <>
               <span className="text-[var(--short)]">✗</span>
               <span className="text-[var(--short)]">
-                Insufficient SOL — balance: {walletBalanceSol.toFixed(4)} SOL
+                Insufficient SOL — balance: {walletBalanceSol.toFixed(4)} SOL{requiredSol ? `, need ~${requiredSol.toFixed(4)} SOL` : ""}
               </span>
             </>
           )}


### PR DESCRIPTION
## P0 Fix — Market creation blocked

### Problem
1. **Slab rent displayed as 0.0005 SOL** — should be ~0.45 SOL for Small tier. `RENT_PER_BYTE` was 6.96 instead of 6960 (off by 1000x).
2. **False 'Insufficient SOL' error** — balance check used hardcoded `>= 0.5 SOL` while display showed ~0.025 SOL total.

### Fix
- Correct `RENT_PER_BYTE` from 6.96 → 6960 in CostEstimate
- Replace hardcoded 0.5 SOL threshold with dynamic calculation matching CostEstimate
- Show required amount in 'Insufficient SOL' message

### Actual costs (corrected)
| Tier | Slab Rent | Total Required |
|------|-----------|---------------|
| Small (256 slots) | 0.4539 SOL | ~0.48 SOL |
| Medium (1024 slots) | 1.7909 SOL | ~1.82 SOL |
| Large (4096 slots) | 7.1362 SOL | ~7.17 SOL |

### Impact
Khubair has 0.4992 SOL — with the fix, Small tier creation will work (needs ~0.48 SOL).

### How to test
1. Go to market creation wizard, select Small tier
2. Verify cost estimate shows ~0.45 SOL for slab rent
3. With 0.5+ SOL balance, verify no 'Insufficient SOL' error
4. With < 0.48 SOL, verify error shows actual required amount