### PR TITLE
fix(trade): P1/P2 visual polish — contrast, empty states, slider, symbol sanitization

### DIFF
--- a/app/app/trade/[slab]/page.tsx
+++ b/app/app/trade/[slab]/page.tsx
@@ -29,6 +29,7 @@ import { computeMarketHealth } from "@/lib/health";
 import { useLivePrice } from "@/hooks/useLivePrice";
 import { useTokenMeta } from "@/hooks/useTokenMeta";
 import { useToast } from "@/hooks/useToast";
+import { isPlaceholderSymbol } from "@/lib/symbol-utils";
 
 /* ── Reusable tiny components ─────────────────────────────── */
 
@@ -130,19 +131,6 @@ function CopyButton({ text }: { text: string }) {
       )}
     </button>
   );
-}
-
-/* ── Helper: detect placeholder/truncated-address symbols ── */
-
-function isPlaceholderSymbol(sym: string | null | undefined, mint: string): boolean {
-  if (!sym) return true;
-  // Reject if it's the first N chars of the mint address (StatsCollector default)
-  if (mint.startsWith(sym)) return true;
-  // Reject pure hex-like strings (8 chars)
-  if (/^[0-9a-fA-F]{8}$/.test(sym)) return true;
-  // Reject if it looks like a truncated address with ellipsis
-  if (/^[A-Za-z0-9]{3,6}[\u2026.]{1,3}[A-Za-z0-9]{3,6}$/.test(sym)) return true;
-  return false;
 }
 
 /* ── Main inner page ──────────────────────────────────────── */
@@ -278,11 +266,11 @@ function TradePageInner({ slab }: { slab: string }) {
               </h1>
             </div>
           </div>
-          <div className="flex items-center gap-1.5 min-w-0 shrink-0">
+          <div className="flex items-center gap-1.5 min-w-0 overflow-hidden">
             <UsdToggleButton />
             {health && <HealthBadge level={health.level} />}
             {priceDisplay && (
-              <span className="truncate text-sm font-bold text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>{priceDisplay}</span>
+              <span className="shrink-0 text-sm font-bold text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>{priceDisplay}</span>
             )}
           </div>
         </div>

--- a/app/components/trade/MarketStatsCard.tsx
+++ b/app/components/trade/MarketStatsCard.tsx
@@ -11,6 +11,7 @@ import { sanitizeOnChainValue, sanitizeAccountCount } from "@/lib/health";
 import { useLivePrice } from "@/hooks/useLivePrice";
 import { FundingRateCard } from "./FundingRateCard";
 import { FundingRateChart } from "./FundingRateChart";
+import { sanitizeSymbol } from "@/lib/symbol-utils";
 
 function formatNum(n: number): string {
   if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(1)}M`;
@@ -25,7 +26,8 @@ export const MarketStatsCard: FC = () => {
   const { priceE6: livePriceE6, priceUsd } = useLivePrice();
   const { showUsd } = useUsdToggle();
   const tokenMeta = useTokenMeta(mktConfig?.collateralMint ?? null);
-  const symbol = tokenMeta?.symbol ?? "Token";
+  const mintAddress = mktConfig?.collateralMint?.toBase58() ?? "";
+  const symbol = sanitizeSymbol(tokenMeta?.symbol, mintAddress);
   const [showFundingChart, setShowFundingChart] = useState(false);
 
   if (loading || !engine || !config || !params) {
@@ -64,7 +66,7 @@ export const MarketStatsCard: FC = () => {
         <div className="grid grid-cols-3 gap-px">
           {stats.map((s) => (
             <div key={s.label} className="px-1.5 py-1 border-b border-r border-[var(--border)]/20 last:border-r-0 [&:nth-child(3n)]:border-r-0 [&:nth-last-child(-n+3)]:border-b-0">
-              <p className="text-[8px] uppercase tracking-[0.1em] text-[var(--text-dim)] truncate">{s.label}</p>
+              <p className="text-[8px] uppercase tracking-[0.1em] text-[var(--text-muted)] truncate">{s.label}</p>
               <p className="text-[11px] font-medium text-[var(--text)] truncate" style={{ fontFamily: "var(--font-mono)" }}>{s.value}</p>
             </div>
           ))}

--- a/app/components/trade/PositionPanel.tsx
+++ b/app/components/trade/PositionPanel.tsx
@@ -18,6 +18,7 @@ import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab, getMockUserAccount } from "@/lib/mock-trade-data";
 import { WarmupProgress } from "./WarmupProgress";
 import { ClosePositionModal } from "./ClosePositionModal";
+import { sanitizeSymbol } from "@/lib/symbol-utils";
 
 function abs(n: bigint): bigint {
   return n < 0n ? -n : n;
@@ -31,7 +32,8 @@ export const PositionPanel: FC<{ slabAddress: string }> = ({ slabAddress }) => {
   const { accounts, config: mktConfig, params } = useSlabState();
   const { priceE6: livePriceE6, priceUsd } = useLivePrice();
   const tokenMeta = useTokenMeta(mktConfig?.collateralMint ?? null);
-  const symbol = tokenMeta?.symbol ?? "Token";
+  const mintAddress = mktConfig?.collateralMint?.toBase58() ?? "";
+  const symbol = sanitizeSymbol(tokenMeta?.symbol, mintAddress);
   const decimals = tokenMeta?.decimals ?? 6;
 
   const { closePosition, loading: closeLoading, error: closeError } = useClosePosition(slabAddress);

--- a/app/components/trade/PositionsTable.tsx
+++ b/app/components/trade/PositionsTable.tsx
@@ -20,6 +20,7 @@ import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab, getMockUserAccount } from "@/lib/mock-trade-data";
 import { ClosePositionModal } from "./ClosePositionModal";
 import { WarmupProgress } from "./WarmupProgress";
+import { sanitizeSymbol } from "@/lib/symbol-utils";
 
 function abs(n: bigint): bigint {
   return n < 0n ? -n : n;
@@ -33,7 +34,8 @@ export const PositionsTable: FC<{ slabAddress: string }> = ({ slabAddress }) => 
   const { accounts, config: mktConfig, params } = useSlabState();
   const { priceE6: livePriceE6, priceUsd } = useLivePrice();
   const tokenMeta = useTokenMeta(mktConfig?.collateralMint ?? null);
-  const symbol = tokenMeta?.symbol ?? "Token";
+  const mintAddress = mktConfig?.collateralMint?.toBase58() ?? "";
+  const symbol = sanitizeSymbol(tokenMeta?.symbol, mintAddress);
   const decimals = tokenMeta?.decimals ?? 6;
 
   const { closePosition, loading: closeLoading, error: closeError, phase: closePhase } = useClosePosition(slabAddress);
@@ -45,7 +47,23 @@ export const PositionsTable: FC<{ slabAddress: string }> = ({ slabAddress }) => 
   }, [accounts]);
   const lpUnderfunded = lpEntry !== null && lpEntry.account.capital === 0n;
 
-  if (!userAccount) return null;
+  if (!userAccount) {
+    return (
+      <div className="border border-[var(--border)]/50 bg-[var(--bg)]/80">
+        <div className="py-10 text-center">
+          <div className="mx-auto mb-2 flex h-8 w-8 items-center justify-center rounded-full border border-[var(--border)]/30">
+            <svg className="h-4 w-4 text-[var(--text-dim)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5" />
+            </svg>
+          </div>
+          <p className="text-[11px] font-medium text-[var(--text-muted)]">No open positions</p>
+          <p className="mt-1 text-[10px] text-[var(--text-dim)] max-w-[220px] mx-auto leading-relaxed">
+            Connect your wallet and deposit collateral to start trading.
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   const { account } = userAccount;
   const hasPosition = account.positionSize !== 0n;
@@ -53,8 +71,16 @@ export const PositionsTable: FC<{ slabAddress: string }> = ({ slabAddress }) => 
   if (!hasPosition) {
     return (
       <div className="border border-[var(--border)]/50 bg-[var(--bg)]/80">
-        <div className="py-8 text-center">
-          <p className="text-[11px] text-[var(--text-muted)]">No open positions</p>
+        <div className="py-10 text-center">
+          <div className="mx-auto mb-2 flex h-8 w-8 items-center justify-center rounded-full border border-[var(--border)]/30">
+            <svg className="h-4 w-4 text-[var(--text-dim)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5" />
+            </svg>
+          </div>
+          <p className="text-[11px] font-medium text-[var(--text-muted)]">No open positions</p>
+          <p className="mt-1 text-[10px] text-[var(--text-dim)] max-w-[220px] mx-auto leading-relaxed">
+            Use the trade form to open a position.
+          </p>
         </div>
       </div>
     );
@@ -121,7 +147,7 @@ export const PositionsTable: FC<{ slabAddress: string }> = ({ slabAddress }) => 
       <div className="overflow-x-auto">
         <table className="min-w-full text-[10px]">
           <thead>
-            <tr className="border-b border-[var(--border)]/30 text-[8px] uppercase tracking-[0.15em] text-[var(--text-dim)]">
+            <tr className="border-b border-[var(--border)]/30 text-[8px] uppercase tracking-[0.15em] text-[var(--text-muted)]">
               <th className="whitespace-nowrap px-4 py-2 text-left font-medium">Market</th>
               <th className="whitespace-nowrap px-3 py-2 text-left font-medium">Side</th>
               <th className="whitespace-nowrap px-3 py-2 text-right font-medium">Size</th>

--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -20,6 +20,7 @@ import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
 import { usePrivyLogin } from "@/hooks/usePrivySafe";
 import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab, getMockUserAccountIdle } from "@/lib/mock-trade-data";
+import { sanitizeSymbol } from "@/lib/symbol-utils";
 
 const LEVERAGE_PRESETS = [1, 2, 3, 5, 10];
 const MARGIN_PRESETS = [25, 50, 75, 100];
@@ -58,7 +59,8 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
   const tokenMeta = useTokenMeta(mktConfig?.collateralMint ?? null);
   const { priceUsd } = useLivePrice();
   const openWalletModal = usePrivyLogin();
-  const symbol = tokenMeta?.symbol ?? "Token";
+  const mintAddress = mktConfig?.collateralMint?.toBase58() ?? "";
+  const symbol = sanitizeSymbol(tokenMeta?.symbol, mintAddress);
   
   // BUG FIX: Fetch on-chain decimals from token account (like DepositWithdrawCard)
   // Don't rely solely on tokenMeta which may fail for cross-network tokens
@@ -364,7 +366,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
           style={{
             background: `linear-gradient(to right, var(--accent) 0%, var(--accent) ${maxLeverage > 1 ? ((leverage - 1) / (maxLeverage - 1)) * 100 : 100}%, rgba(255,255,255,0.03) ${maxLeverage > 1 ? ((leverage - 1) / (maxLeverage - 1)) * 100 : 100}%, rgba(255,255,255,0.03) 100%)`,
           }}
-          className="mb-3 h-1 w-full cursor-pointer appearance-none accent-[var(--accent)] [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:bg-[var(--accent)]"
+          className="mb-3 h-1.5 w-full cursor-pointer appearance-none accent-[var(--accent)] [&::-webkit-slider-thumb]:h-5 [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-[var(--accent)] [&::-webkit-slider-thumb]:shadow-[0_0_6px_rgba(153,69,255,0.4)] [&::-moz-range-thumb]:h-5 [&::-moz-range-thumb]:w-5 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-[var(--accent)]"
         />
         <div className="flex gap-1">
           {availableLeverage.map((l) => (
@@ -472,11 +474,11 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
 
       {/* Coin-margined info */}
       <div className="mt-3 rounded-none border border-[var(--border)]/20 bg-[var(--bg)]/50 p-2.5">
-        <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">
+        <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-muted)]">
           Coin-Margined Market
         </p>
         <p className="mt-1 text-[9px] leading-relaxed text-[var(--text-muted)]">
-          Margined in <strong className="text-[var(--text-secondary)]">{symbol}</strong>, not USD. Position value and liquidation risk are affected by {symbol} price movements.
+          Margined in <strong className="text-[var(--text-secondary)]">{symbol}</strong>, not USD. Position value and liquidation risk are affected by the collateral token&apos;s price movements.
           Effective USD leverage: <span className="font-mono text-[var(--text-secondary)]">{leverage > 0 ? `~${leverage * 2}x` : "—"}</span> (nominal {leverage}x × 2 for coin exposure).
         </p>
       </div>

--- a/app/lib/symbol-utils.ts
+++ b/app/lib/symbol-utils.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared utilities for token symbol resolution.
+ * Prevents truncated on-chain addresses from leaking into UI labels.
+ */
+
+/**
+ * Returns true if the given symbol looks like a placeholder / truncated address
+ * rather than a real human-readable token name.
+ */
+export function isPlaceholderSymbol(sym: string | null | undefined, mint: string): boolean {
+  if (!sym) return true;
+  // Reject if it's the first N chars of the mint address (StatsCollector default)
+  if (mint.startsWith(sym)) return true;
+  // Reject pure hex-like strings (8 chars)
+  if (/^[0-9a-fA-F]{8}$/.test(sym)) return true;
+  // Reject if it looks like a truncated address with ellipsis
+  if (/^[A-Za-z0-9]{3,6}[\u2026.]{1,3}[A-Za-z0-9]{3,6}$/.test(sym)) return true;
+  return false;
+}
+
+/**
+ * Sanitize a symbol for display in labels. If the on-chain symbol looks like a
+ * placeholder / truncated address, fall back to a generic "Token" label.
+ */
+export function sanitizeSymbol(sym: string | null | undefined, mintAddress?: string): string {
+  if (!sym) return "Token";
+  if (mintAddress && isPlaceholderSymbol(sym, mintAddress)) return "Token";
+  return sym;
+}


### PR DESCRIPTION
## PERC-240: Trade Page UI Polish

Addresses P1/P2 visual issues from designer's visual audit (PERC-237 review).

### P1 Fixes (Critical)

**Stats & table header contrast** — Headers used `--text-dim` (#2A2E3D) which is nearly invisible against the dark background. Bumped to `--text-muted` (#454B5F) for readable contrast while preserving hierarchy.

**MY POSITIONS empty state** — The PositionsTable returned `null` when no user account existed, showing a blank void under the tab. Now renders a proper empty state with icon, heading, and guidance text. Also added an empty state for connected users with no positions.

**Leverage slider thumb** — Was 12x12px (h-3 w-3), far below mobile touch target minimums. Enlarged to 20x20px rounded with accent glow. Added Firefox (::-moz-range-thumb) support.

### P2 Fixes

**Truncated token addresses in labels** — Token symbols from on-chain metadata sometimes resolve to truncated mint addresses. Extracted isPlaceholderSymbol from the trade page into shared lib/symbol-utils.ts with a new sanitizeSymbol() helper. Applied across TradeForm, PositionsTable, PositionPanel, and MarketStatsCard.

**Coin-Margined explanation** — Replaced {symbol} reference in the explanation text with generic collateral token wording so it reads naturally even with placeholder symbols.

**Mobile header clipping** — Right-aligned header container used shrink-0 preventing content from fitting in narrow viewports. Replaced with overflow-hidden + min-w-0 to allow graceful truncation.

### P3 Notes (Not in scope)
- Funding history pagination: no pagination controls exist yet (chart renders all data inline)
- ADMIN ACTIVE badge: intentional transparency feature — shows users whether the market admin has been renounced

### Testing
- 695/695 tests pass
- TypeScript clean (tsc --noEmit)
- No regressions to existing components