### PR TITLE
fix: Trade page UI polish — stats contrast, empty positions, slider, banner (PERC-240)

### DIFF
--- a/app/app/globals.css
+++ b/app/app/globals.css
@@ -287,10 +287,14 @@ body::before {
 
 /* ─── Ticker Banner ─── */
 .ticker-banner {
-  height: 28px;
+  height: 32px;
   display: flex;
   align-items: center;
   white-space: nowrap;
+  padding: 0 4px;
+}
+@media (min-width: 768px) {
+  .ticker-banner { height: 28px; padding: 0; }
 }
 .ticker-track {
   display: inline-flex;

--- a/app/components/trade/MarketStatsCard.tsx
+++ b/app/components/trade/MarketStatsCard.tsx
@@ -64,8 +64,8 @@ export const MarketStatsCard: FC = () => {
         <div className="grid grid-cols-3 gap-px">
           {stats.map((s) => (
             <div key={s.label} className="px-1.5 py-1 border-b border-r border-[var(--border)]/20 last:border-r-0 [&:nth-child(3n)]:border-r-0 [&:nth-last-child(-n+3)]:border-b-0">
-              <p className="text-[8px] uppercase tracking-[0.1em] text-[var(--text-dim)] truncate">{s.label}</p>
-              <p className="text-[11px] font-medium text-[var(--text)] truncate" style={{ fontFamily: "var(--font-mono)" }}>{s.value}</p>
+              <p className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-muted)] truncate" title={s.label}>{s.label}</p>
+              <p className="text-[11px] font-medium text-[var(--text)] truncate" style={{ fontFamily: "var(--font-mono)" }} title={String(s.value)}>{s.value}</p>
             </div>
           ))}
         </div>

--- a/app/components/trade/PositionsTable.tsx
+++ b/app/components/trade/PositionsTable.tsx
@@ -45,7 +45,16 @@ export const PositionsTable: FC<{ slabAddress: string }> = ({ slabAddress }) => 
   }, [accounts]);
   const lpUnderfunded = lpEntry !== null && lpEntry.account.capital === 0n;
 
-  if (!userAccount) return null;
+  if (!userAccount) {
+    return (
+      <div className="border border-[var(--border)]/50 bg-[var(--bg)]/80">
+        <div className="py-10 text-center space-y-1">
+          <p className="text-[12px] text-[var(--text-muted)]">No positions yet</p>
+          <p className="text-[10px] text-[var(--text-dim)]">Connect your wallet and open a trade to get started</p>
+        </div>
+      </div>
+    );
+  }
 
   const { account } = userAccount;
   const hasPosition = account.positionSize !== 0n;

--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -364,7 +364,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
           style={{
             background: `linear-gradient(to right, var(--accent) 0%, var(--accent) ${maxLeverage > 1 ? ((leverage - 1) / (maxLeverage - 1)) * 100 : 100}%, rgba(255,255,255,0.03) ${maxLeverage > 1 ? ((leverage - 1) / (maxLeverage - 1)) * 100 : 100}%, rgba(255,255,255,0.03) 100%)`,
           }}
-          className="mb-3 h-1 w-full cursor-pointer appearance-none accent-[var(--accent)] [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:bg-[var(--accent)]"
+          className="mb-3 h-1.5 w-full cursor-pointer appearance-none rounded-full accent-[var(--accent)] [&::-webkit-slider-thumb]:h-5 [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-[var(--accent)] [&::-webkit-slider-thumb]:shadow-md [&::-moz-range-thumb]:h-5 [&::-moz-range-thumb]:w-5 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-[var(--accent)] [&::-moz-range-thumb]:border-0"
         />
         <div className="flex gap-1">
           {availableLeverage.map((l) => (


### PR DESCRIPTION
## PERC-240: Trade page visual fixes

### P1 Fixes
- **Stats headers low contrast**: Bumped label size 8px→9px, color from `text-dim` to `text-muted`
- **MY POSITIONS empty state**: Shows helpful message when wallet not connected (was blank)
- **Leverage slider thumb**: Enlarged from 12px to 20px with rounded corners + shadow for mobile touch

### P2 Fixes
- **Mobile ticker banner clipping**: Increased height 28px→32px on mobile with padding
- **Truncated values**: Added title tooltips on stat labels and values

### P3 (Deferred)
- ADMIN ACTIVE badge: Not yet in codebase, needs design spec
- Funding history pagination: Chart-based, no pagination exists yet

### How to test
1. Visit /trade/[slab] — check stats labels are readable
2. Disconnect wallet — 'My Positions' tab shows empty state
3. On mobile: leverage slider thumb is tappable, ticker banner text not clipped