### PR TITLE
fix(PERC-244): Homepage design polish — contrast, whitespace, CTA hierarchy

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -48,7 +48,7 @@ const HOW_STEPS = [
 
 function HowItWorks() {
   return (
-    <section className="relative overflow-hidden py-16">
+    <section className="relative overflow-hidden py-10">
       <div className="mx-auto max-w-[1100px] px-6">
         <ScrollReveal>
           <div className="mb-10 text-center">
@@ -66,13 +66,13 @@ function HowItWorks() {
             {HOW_STEPS.map((step, i) => (
               <article
                 key={step.number}
-                className="group relative bg-[var(--panel-bg)] p-4 sm:p-5 transition-colors duration-200 hover:bg-[var(--bg-elevated)]"
+                className="group relative bg-[var(--panel-bg)] p-4 sm:p-5 transition-colors duration-200 hover:bg-[var(--bg-elevated)] min-h-[160px]"
               >
                 <div className="mb-4 flex items-start justify-between">
                   <div className="flex h-12 w-12 items-center justify-center border border-[var(--accent)]/15 bg-[var(--accent)]/[0.04] transition-colors duration-200 group-hover:border-[var(--accent)]/30 group-hover:bg-[var(--accent)]/[0.08]">
                     <OnboardingIcon type={step.brandIcon} size={32} />
                   </div>
-                  <span className="text-[20px] font-normal tracking-tight text-[var(--border)] transition-colors duration-200 group-hover:text-[var(--accent)]/20" style={{ fontFamily: "var(--font-heading)" }}>
+                  <span className="text-[20px] font-normal tracking-tight text-[var(--text-muted)] transition-colors duration-200 group-hover:text-[var(--accent)]/20" style={{ fontFamily: "var(--font-heading)" }}>
                     {step.number}
                   </span>
                 </div>
@@ -188,7 +188,7 @@ export default function Home() {
 
       {/* ═══════════════════════ STATS ═══════════════════════ */}
       <ErrorBoundary label="Stats Section">
-        <section className="relative py-16">
+        <section className="relative py-10">
           <div className="mx-auto max-w-[1100px] px-6">
             <ScrollReveal>
               <div className="mb-10 text-center">
@@ -210,7 +210,7 @@ export default function Home() {
                   { label: "Access", value: "Open", color: "text-[var(--long)]" },
                 ].map((stat) => (
                   <div key={stat.label} className="bg-[var(--panel-bg)] p-4 sm:p-5 transition-colors duration-200 hover:bg-[var(--bg-elevated)]">
-                    <p className="mb-2 text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-dim)]">{stat.label}</p>
+                    <p className="mb-2 text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-secondary)]">{stat.label}</p>
                     <p className={`text-lg sm:text-xl font-semibold tracking-tight tabular-nums ${stat.color}`} style={{ fontFamily: "var(--font-heading)" }}>
                       {stat.value}
                     </p>
@@ -229,7 +229,7 @@ export default function Home() {
 
       {/* ═══════════════════════ FEATURES ═══════════════════════ */}
       <ErrorBoundary label="Features Section">
-        <section className="relative overflow-hidden py-16">
+        <section className="relative overflow-hidden py-10">
           <div className="mx-auto max-w-[1100px] px-6">
             <ScrollReveal>
               <div className="mb-10 text-center">
@@ -253,7 +253,7 @@ export default function Home() {
                         <path d="M12 21a9.004 9.004 0 0 0 8.716-6.747M12 21a9.004 9.004 0 0 1-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 0 1 7.843 4.582M12 3a8.997 8.997 0 0 0-7.843 4.582m15.686 0A11.953 11.953 0 0 1 12 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0 1 21 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0 1 12 16.5a17.92 17.92 0 0 1-8.716-2.247m0 0A9 9 0 0 1 3 12c0-1.47.353-2.856.978-4.082" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
                       </svg>
                     </div>
-                    <span className="text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-dim)]">
+                    <span className="text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-secondary)]">
                       PERMISSIONLESS
                     </span>
                   </div>
@@ -320,7 +320,7 @@ export default function Home() {
                         <path d={f.icon} stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
                       </svg>
                     </div>
-                    <span className="text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-dim)] transition-colors duration-200 group-hover:text-[var(--accent)]/40">
+                    <span className="text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-secondary)] transition-colors duration-200 group-hover:text-[var(--accent)]/40">
                       {f.tag}
                     </span>
                   </div>
@@ -338,7 +338,7 @@ export default function Home() {
       {/* ═══════════════════════ FEATURED MARKETS ═══════════════════════ */}
       {hasMarkets && (
         <ErrorBoundary label="Featured Markets Section">
-        <section className="relative py-16">
+        <section className="relative py-10">
           <div className="mx-auto max-w-[1100px] px-6">
             <ScrollReveal>
               <div className="mb-10 text-center">

--- a/app/components/marketing/HeroCtaGroup.tsx
+++ b/app/components/marketing/HeroCtaGroup.tsx
@@ -47,9 +47,22 @@ export function HeroCtaGroup() {
 
       <Link
         href="/markets"
-        className={`hero-cta inline-flex items-center rounded-xl border-[1.5px] border-white/20 bg-white/[0.06] px-6 py-3 text-[15px] font-semibold text-white transition-all hover:border-white/35 hover:bg-white/10 ${prefersReduced ? '' : 'gsap-fade'}`}
+        className={`hero-cta group inline-flex items-center gap-2 rounded-xl border-[1.5px] border-green-400/30 bg-green-500/15 px-6 py-3 text-[15px] font-semibold text-green-400 transition-all hover:border-green-400/50 hover:bg-green-500/20 ${prefersReduced ? '' : 'gsap-fade'}`}
       >
         Trade Now
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="transition-transform group-hover:translate-x-0.5"
+        >
+          <path d="M5 12h14M12 5l7 7-7 7" />
+        </svg>
       </Link>
 
       <Link


### PR DESCRIPTION
## PERC-244: Homepage Design Polish

Addresses designer audit findings (Feb 27) for the homepage.

### P1 — Contrast (WCAG AA)
- **Metrics card labels** ('MARKETS LIVE', '24H VOLUME', etc.): Changed from `--text-dim` (`#2A2E3D`, ~1.5:1 ratio) to `--text-secondary` (`#7a7f96`, ~4.5:1 ratio) — now passes WCAG AA
- **Architecture section tags** ('PERMISSIONLESS', 'VERIFIED', 'ACTIVE', 'NOVEL'): Same fix
- **How It Works step numbers** (01, 02, 03): Changed from `--border` (`#1c1f2e`) to `--text-muted` (`#454b5f`) — visible but still subtle

### P2 — Whitespace  
- Added `min-h-[160px]` to How It Works cards so bottoms align consistently regardless of text length
- Reduced section spacing from `py-16` (128px gap) to `py-10` (80px gap) across all homepage sections — tighter, more cohesive flow

### P2 — CTA Hierarchy
- Elevated **Trade Now** button from ghost style (white/20 border) to green accent (`border-green-400/30 bg-green-500/15`) with arrow icon
- Visual weight now: **Launch** (purple filled) ≈ **Trade** (green accent) > **Earn** (text link)

### Verification
- ✅ Build passes (`pnpm build`)
- ✅ 2 files changed, surgical CSS-only edits
- ✅ No functional changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing and visual hierarchy across multiple page sections for better overall flow
  * Enhanced text color contrast for improved readability and visual organization
  * Redesigned the Trade Now call-to-action button with vibrant green styling
  * Added animated chevron icon with smooth hover effects to increase user engagement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->