### PR TITLE
fix(PERC-252): change active filter pill text to var(--text) for WCAG AAA contrast

### DIFF
--- a/app/components/CommitHeatmap.tsx
+++ b/app/components/CommitHeatmap.tsx
@@ -163,7 +163,7 @@ export const CommitHeatmap: FC<Props> = ({ commitActivity }) => {
             className={[
               "rounded-full border px-3 py-1 text-[12px] transition-all duration-150",
               selectedRepo === "all"
-                ? "border-[rgb(124,58,237)] bg-[rgba(124,58,237,0.35)] text-white font-semibold shadow-[0_0_12px_rgba(124,58,237,0.25)]"
+                ? "border-[rgb(124,58,237)] bg-[rgba(124,58,237,0.35)] text-[var(--text)] font-semibold shadow-[0_0_12px_rgba(124,58,237,0.25)]"
                 : "border-white/[0.08] bg-white/[0.04] text-[var(--text-secondary)] hover:border-white/[0.16]",
             ].join(" ")}
             style={{ fontFamily: "var(--font-mono, 'JetBrains Mono')" }}
@@ -177,7 +177,7 @@ export const CommitHeatmap: FC<Props> = ({ commitActivity }) => {
               className={[
                 "rounded-full border px-3 py-1 text-[12px] transition-all duration-150",
                 selectedRepo === repo
-                  ? "border-[rgb(124,58,237)] bg-[rgba(124,58,237,0.35)] text-white font-semibold shadow-[0_0_12px_rgba(124,58,237,0.25)]"
+                  ? "border-[rgb(124,58,237)] bg-[rgba(124,58,237,0.35)] text-[var(--text)] font-semibold shadow-[0_0_12px_rgba(124,58,237,0.25)]"
                   : "border-white/[0.08] bg-white/[0.04] text-[var(--text-secondary)] hover:border-white/[0.16]",
               ].join(" ")}
               style={{ fontFamily: "var(--font-mono, 'JetBrains Mono')" }}

--- a/app/components/RepoGrid.tsx
+++ b/app/components/RepoGrid.tsx
@@ -41,7 +41,7 @@ export const RepoGrid: FC<Props> = ({ repos, isLive, ciStatuses }) => {
             className={[
               "rounded-full border px-4 py-1.5 font-mono text-[13px] transition-all duration-150",
               active === f
-                ? "border-[rgb(124,58,237)] bg-[rgba(124,58,237,0.35)] text-white font-semibold shadow-[0_0_12px_rgba(124,58,237,0.25)] ring-1 ring-[rgba(124,58,237,0.50)]"
+                ? "border-[rgb(124,58,237)] bg-[rgba(124,58,237,0.35)] text-[var(--text)] font-semibold shadow-[0_0_12px_rgba(124,58,237,0.25)] ring-1 ring-[rgba(124,58,237,0.50)]"
                 : "border-white/[0.08] bg-white/[0.04] text-[var(--text-secondary)] hover:border-white/[0.16] hover:text-[var(--text)]",
             ].join(" ")}
           >


### PR DESCRIPTION
## Summary

Replace `text-white` with `text-[var(--text)]` (`#E1E2E8`) on active filter pill backgrounds in **RepoGrid** and **CommitHeatmap**.

## Why

The design-system text color `--text` (#E1E2E8) provides a **12.39:1** contrast ratio against the purple accent fill (`rgba(124,58,237,0.35)`) — **WCAG AAA compliant**. The purple `accentPillBg` + border still carries brand color. This was agreed by the designer as a follow-up to PERC-251.

## Changes

| File | Change |
|------|--------|
| `app/components/RepoGrid.tsx` | Active pill: `text-white` → `text-[var(--text)]` |
| `app/components/CommitHeatmap.tsx` | Active pill (×2): `text-white` → `text-[var(--text)]` |

## Testing

- `pnpm build` passes ✅
- Visual: active pills now use `#E1E2E8` instead of `#FFFFFF` — subtle difference but design-system consistent

Closes PERC-252

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text color styling for active repository filter pills to use theme-aware colors, replacing hardcoded white text with a CSS variable reference for better theme consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->