### PR TITLE
fix(PERC-276): Seed vault before InitMarket — fix error 36 InsufficientSeed

### DIFF
--- a/app/components/create/CostEstimate.tsx
+++ b/app/components/create/CostEstimate.tsx
@@ -49,10 +49,11 @@ export const CostEstimate: FC<CostEstimateProps> = ({
     // Total SOL cost
     const totalSolCost = slabRentSol + tokenAccountRentSol + TX_FEE_ESTIMATE_SOL;
 
-    // Token costs
+    // Token costs (vault seed is 500_000_000 raw = 500 at 6 decimals)
+    const seedAmount = 500_000_000 / Math.pow(10, tokenDecimals);
     const lpNum = parseFloat(lpCollateral) || 0;
     const insNum = parseFloat(insuranceAmount) || 0;
-    const totalTokens = lpNum + insNum;
+    const totalTokens = seedAmount + lpNum + insNum;
 
     // USD values if price available
     const tokenUsdValue = tokenPriceUsd ? totalTokens * tokenPriceUsd : null;
@@ -62,6 +63,7 @@ export const CostEstimate: FC<CostEstimateProps> = ({
       tokenAccountRentSol: tokenAccountRentSol.toFixed(4),
       txFeeSol: TX_FEE_ESTIMATE_SOL.toFixed(4),
       totalSolCost: totalSolCost.toFixed(4),
+      seedTokens: seedAmount,
       lpTokens: lpNum,
       insTokens: insNum,
       totalTokens,
@@ -106,6 +108,12 @@ export const CostEstimate: FC<CostEstimateProps> = ({
 
       {/* Token Costs */}
       <div className="px-4 py-3 space-y-2">
+        <div className="flex items-center justify-between text-[11px]">
+          <span className="text-[var(--text-muted)]">Vault Seed (required)</span>
+          <span className="font-mono text-[var(--text)]">
+            {estimate.seedTokens.toLocaleString()} {tokenSymbol}
+          </span>
+        </div>
         <div className="flex items-center justify-between text-[11px]">
           <span className="text-[var(--text-muted)]">LP Collateral</span>
           <span className="font-mono text-[var(--text)]">

--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -3,7 +3,7 @@
 import { FC, useState, useMemo, useCallback, useEffect } from "react";
 import { PublicKey } from "@solana/web3.js";
 import { useWalletCompat, useConnectionCompat } from "@/hooks/useWalletCompat";
-import { useCreateMarket, type CreateMarketParams } from "@/hooks/useCreateMarket";
+import { useCreateMarket, MIN_INIT_MARKET_SEED, type CreateMarketParams } from "@/hooks/useCreateMarket";
 import { useQuickLaunch } from "@/hooks/useQuickLaunch";
 import { type DexPoolResult } from "@/hooks/useDexPoolSearch";
 import { parseHumanAmount, formatHumanAmount } from "@/lib/parseAmount";
@@ -108,6 +108,7 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
   const maxLeverage = Math.floor(10000 / wizard.initialMarginBps);
   const feeConflict = wizard.tradingFeeBps >= wizard.initialMarginBps;
   const hasTokens = wizard.walletBalance !== null && wizard.walletBalance > 0n;
+  const hasSufficientTokensForSeed = wizard.walletBalance !== null && wizard.walletBalance >= MIN_INIT_MARKET_SEED;
   const decimals = wizard.tokenMeta?.decimals ?? 6;
   const symbol = wizard.tokenMeta?.symbol ?? "Token";
 
@@ -138,7 +139,7 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
     return slabRentSol + tokenAccountRentSol + TX_FEE_ESTIMATE_SOL;
   }, [wizard.slabTier]);
   const hasSufficientSol = solBalance !== null && solBalance >= requiredSol;
-  const allValid = step1Valid && step2Valid && step3Valid && hasTokens && hasSufficientSol;
+  const allValid = step1Valid && step2Valid && step3Valid && hasTokens && hasSufficientTokensForSeed && hasSufficientSol;
 
   // Navigation
   const goToStep = useCallback((step: WizardStep) => {
@@ -481,6 +482,7 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
             hasSufficientBalance={hasSufficientSol}
             requiredSol={requiredSol}
             hasTokens={hasTokens}
+            hasSufficientTokensForSeed={hasSufficientTokensForSeed}
             feeConflict={feeConflict}
             onBack={goBack}
             onLaunch={handleLaunch}

--- a/app/components/create/StepReview.tsx
+++ b/app/components/create/StepReview.tsx
@@ -26,6 +26,7 @@ interface StepReviewProps {
   hasSufficientBalance: boolean;
   requiredSol?: number;
   hasTokens: boolean;
+  hasSufficientTokensForSeed: boolean;
   feeConflict: boolean;
   // Actions
   onBack: () => void;
@@ -63,6 +64,7 @@ export const StepReview: FC<StepReviewProps> = ({
   hasSufficientBalance,
   requiredSol,
   hasTokens,
+  hasSufficientTokensForSeed,
   feeConflict,
   onBack,
   onLaunch,
@@ -81,10 +83,11 @@ export const StepReview: FC<StepReviewProps> = ({
   const launchButtonLabel = useMemo(() => {
     if (!walletConnected) return "Connect Wallet to Launch";
     if (!hasTokens) return "No Tokens — Mint First";
+    if (!hasSufficientTokensForSeed) return "Insufficient Tokens for Vault Seed (500)";
     if (feeConflict) return "Fix Parameters to Continue";
     if (!hasSufficientBalance) return "Insufficient SOL";
     return "LAUNCH MARKET";
-  }, [walletConnected, hasTokens, feeConflict, hasSufficientBalance]);
+  }, [walletConnected, hasTokens, hasSufficientTokensForSeed, feeConflict, hasSufficientBalance]);
 
   return (
     <div className="space-y-5">


### PR DESCRIPTION
## What

P0 fix: Market creation was failing at step 1 with program error code 36 (InsufficientSeed).

## Root Cause

`useCreateMarket.ts` sent `[createAccountIx, createAtaIx, initMarketIx]` atomically but never funded the vault. The program requires vault balance >= 500,000,000 tokens (MIN_INIT_MARKET_SEED) before InitMarket. A freshly created empty ATA has 0 tokens — instant reject.

Tests were patched (PERC-214) but the frontend was never updated.

## Fix

1. Added `createTransferInstruction` for MIN_INIT_MARKET_SEED (500M raw tokens) between `createAtaIx` and `initMarketIx` in both:
   - Fresh creation path (atomic bundle now: `createAccount → createATA → seedTransfer → initMarket`)
   - Stuck-slab recovery path (same missing seed transfer)
2. Exported `MIN_INIT_MARKET_SEED` constant
3. Added pre-check in wizard: blocks launch if wallet token balance < seed amount
4. Updated CostEstimate to show vault seed as a line item
5. Updated launch button label to show clear error when tokens insufficient

## How to Test

1. Connect wallet with collateral tokens
2. Go through market creation wizard
3. Verify cost estimate shows "Vault Seed (required): 500 TOKEN"
4. Verify market creation succeeds at step 1 (no more error 36)
5. Verify insufficient token balance shows clear error before review step

Tag: PERC-276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vault seed tokens now calculated and displayed in cost estimate breakdown
  * Added minimum token balance requirement validation for vault initialization
  * Launch button provides feedback when insufficient tokens for vault seeding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->