### PR TITLE
fix: OI Cap meter unit mismatch — convert totalOI to USD (#489)

### DIFF
--- a/app/hooks/useEarnStats.ts
+++ b/app/hooks/useEarnStats.ts
@@ -199,9 +199,11 @@ export function useEarnStats() {
       const markets: MarketVaultInfo[] = data
         .filter((m) => m.status === 'active' || m.status === 'Active')
         .map((m) => {
-          const oiLong = m.open_interest_long ?? 0;
-          const oiShort = m.open_interest_short ?? 0;
-          const totalOI = m.total_open_interest ?? oiLong + oiShort;
+          const oiLongRaw = m.open_interest_long ?? 0;
+          const oiShortRaw = m.open_interest_short ?? 0;
+          const totalOIRaw = m.total_open_interest ?? oiLongRaw + oiShortRaw;
+          // OI values are stored in USDC micro-units (6 decimals) — convert to USD
+          const totalOI = totalOIRaw / 1e6;
           const maxLeverage = m.max_leverage ?? 10;
           const vaultBalance = m.lp_collateral ?? 0;
           const tradingFeeBps = m.trading_fee_bps ?? 10;


### PR DESCRIPTION
## Summary
Fixes the P2 display bug where the OI Capacity meter on `/earn` showed:
> **Near Capacity — Current: $47,529,476.98M  Max: $60.10M  100.0%**

## Root Cause
`total_open_interest` (and `open_interest_long`/`open_interest_short`) from the `markets_with_stats` DB view are stored in USDC micro-units (6 decimal places), while `maxOI` was correctly converted to USD (`vaultBalance / 1e6 * maxLeverage`).

This meant `currentOI` was ~1,000,000× too large relative to `maxOI`, causing the meter to always show 100% / Near Capacity.

## Fix
Divide the raw OI value by `1e6` to convert from USDC micro-units to USD, matching the `maxOI` denomination.

## Testing
- All 12 existing tests pass (OiCapMeter + useEarnStats)
- TypeScript compiles cleanly
- The `[slab]/page.tsx` already had a `/ 1e6` conversion for the engine state path, confirming the DB stores values in micro-units

Closes #489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the calculation of total open interest per market to properly convert values to USD format for accurate reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->