### PR TITLE
fix(#491): sanitize corrupt insurance_fund values in earn display

### DIFF
--- a/app/hooks/useEarnStats.ts
+++ b/app/hooks/useEarnStats.ts
@@ -208,7 +208,10 @@ export function useEarnStats() {
           const vaultBalance = m.lp_collateral ?? 0;
           const tradingFeeBps = m.trading_fee_bps ?? 10;
           const volume24h = m.volume_24h ?? 0;
-          const insurance = m.insurance_fund ?? 0;
+          const insuranceRaw = m.insurance_fund ?? 0;
+          // Sanity cap: insurance_fund values > 10 billion USDC micro-units ($10M)
+          // are corrupt data from bad slab tier detection — clamp to 0
+          const insurance = insuranceRaw < 1e13 ? insuranceRaw : 0;
 
           // Max OI = vault collateral × max leverage (simplified)
           const vaultUsd = vaultBalance / 1e6; // collateral in USDC (6 decimals)

--- a/packages/indexer/src/services/StatsCollector.ts
+++ b/packages/indexer/src/services/StatsCollector.ts
@@ -325,8 +325,9 @@ export class StatsCollector {
             // Sanity-check parsed engine values: if the slab layout detection
             // failed (wrong tier), the parser reads garbage from wrong offsets.
             // Telltale sign: values like 9.8e34 OI or 1.8e25 insurance.
-            // Max sane value: 1e18 (u64::MAX ≈ 1.8e19, so anything near that is suspect)
-            const MAX_SANE_VALUE = 1e18;
+            // Max sane value: 1e13 (~$10M USD in micro-USDC). Previously 1e18 which
+            // let through corrupt values from wrong slab tier detection (see #491).
+            const MAX_SANE_VALUE = 1e13;
             // Max sane counter value: liquidation/force-close counts shouldn't exceed 1e12
             const MAX_SANE_COUNTER = 1e12;
             const isSaneEngine = (

--- a/supabase/migrations/025_cleanup_corrupt_insurance.sql
+++ b/supabase/migrations/025_cleanup_corrupt_insurance.sql
@@ -1,0 +1,28 @@
+-- Migration 025: Clean up corrupt insurance_fund and vault_balance values
+-- Created: 2026-02-28
+-- Purpose: Some markets have garbage insurance_fund values (up to 1e18) from
+--          bad slab tier detection in earlier indexer versions. These cause the
+--          /earn page to display ~$1T insurance instead of ~$1M.
+--
+-- Fix: Zero out insurance_fund, insurance_balance, and vault_balance values
+--      that exceed a sane maximum (1e13 micro-USDC = $10M USD).
+--      Real insurance funds on devnet are all < $200K.
+
+UPDATE market_stats
+SET insurance_fund = 0,
+    insurance_balance = 0
+WHERE insurance_fund > 1e13;
+
+UPDATE market_stats
+SET vault_balance = 0
+WHERE vault_balance > 1e13;
+
+DO $$
+DECLARE
+  ins_count INTEGER;
+  vault_count INTEGER;
+BEGIN
+  SELECT count(*) INTO ins_count FROM market_stats WHERE insurance_fund = 0;
+  SELECT count(*) INTO vault_count FROM market_stats WHERE vault_balance = 0;
+  RAISE NOTICE 'Migration 025: Cleaned corrupt insurance_fund and vault_balance values';
+END $$;


### PR DESCRIPTION
## Summary

Fixes #491 — Insurance fund total on /earn showing ~$1T instead of ~$1M.

## Root Cause

**Not** a missing /1e6 conversion (that was already correct). The actual issue: a few markets (DsSVgDP9, FWqfo2mw) have corrupt `insurance_fund` values (~1e18 micro-USDC) from bad slab tier detection in earlier indexer versions. After the correct /1e6 conversion, these still produce ~$1T values that dominate the total.

## Changes

1. **`app/hooks/useEarnStats.ts`** — Clamp per-market `insurance_fund` to 0 if raw value > 1e13 (~$10M USD). This is a frontend safety net.
2. **`packages/indexer/src/services/StatsCollector.ts`** — Tighten `MAX_SANE_VALUE` from 1e18 to 1e13 to prevent future corrupt writes.
3. **`supabase/migrations/025_cleanup_corrupt_insurance.sql`** — Zero out existing corrupt `insurance_fund` and `vault_balance` rows.

## Testing

- All 707 tests pass (50 suites)
- Verified corrupt markets via `/api/markets`: DsSVgDP9 has insurance_fund=1.008e18, FWqfo2mw has 1e14
- After fix: clean total /1e6 = ~$9.5M (correct range)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation thresholds for on-chain market statistics engine state values
  * Implemented enhanced data sanitization for insurance fund, insurance balance, and vault balance fields to maintain consistency
  * Deployed database migration to process and standardize historical market statistics records
  * Improved overall data quality across market-related financial fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->