### PR TITLE
fix(#482): show dash instead of $0 for zero 24h volume on homepage

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -205,7 +205,7 @@ export default function Home() {
               <div className="grid grid-cols-2 gap-px overflow-hidden border border-[var(--border)] bg-[var(--border)] md:grid-cols-4">
                 {[
                   { label: "Markets Live", value: statsLoaded ? String(stats.markets) : "—", color: "text-[var(--accent)]" },
-                  { label: "24h Volume", value: statsLoaded ? formatCompact(stats.volume) : "—", color: "text-[var(--long)]" },
+                  { label: "24h Volume", value: statsLoaded ? (stats.volume > 0 ? formatCompact(stats.volume) : "—") : "—", color: stats.volume > 0 ? "text-[var(--long)]" : "text-[var(--text-secondary)]" },
                   { label: "Insurance Fund", value: statsLoaded ? formatCompact(stats.insurance) : "—", color: "text-[var(--accent)]" },
                   { label: "Access", value: "Open", color: "text-[var(--long)]" },
                 ].map((stat) => (


### PR DESCRIPTION
## Summary

Fixes #482 — Homepage 24h Volume shows $0 alongside healthy market/insurance stats, looking broken.

## Change

When `stats.volume` is 0 (common on devnet where no real trades occur), display **—** instead of **$0** and dim the text to secondary color. This matches the loading state style and avoids implying a data error.

## Testing
- All 707 tests pass (50 suites)
- When volume > 0: shows formatted value in green as before
- When volume == 0: shows — in muted color