### PR TITLE
fix(#479): responsive mobile card layout for /markets page

### DIFF
--- a/app/__tests__/components/MarketCard.test.tsx
+++ b/app/__tests__/components/MarketCard.test.tsx
@@ -150,7 +150,7 @@ describe("MarketBrowser Component Tests", () => {
       render(<MarketBrowser />);
 
       // Should display market
-      expect(screen.getByText(/SOL\/USD PERP/i)).toBeInTheDocument();
+      expect(screen.getAllByText(/SOL\/USD PERP/i).length).toBeGreaterThanOrEqual(1);
     });
 
     // Placeholder for future search debouncing test
@@ -176,7 +176,7 @@ describe("MarketBrowser Component Tests", () => {
 
       render(<MarketBrowser />);
 
-      expect(screen.getByText(/SOL\/USD PERP/i)).toBeInTheDocument();
+      expect(screen.getAllByText(/SOL\/USD PERP/i).length).toBeGreaterThanOrEqual(1);
     });
 
     // Placeholder for future URL persistence test
@@ -303,7 +303,7 @@ describe("MarketBrowser Component Tests", () => {
       render(<MarketBrowser />);
 
       // Should show shortened address when symbol is not available
-      expect(screen.getByText(/1111\.\.\.1111\/USD PERP/i)).toBeInTheDocument();
+      expect(screen.getAllByText(/1111\.\.\.1111\/USD PERP/i).length).toBeGreaterThanOrEqual(1);
     });
   });
 
@@ -323,7 +323,7 @@ describe("MarketBrowser Component Tests", () => {
 
       render(<MarketBrowser />);
 
-      expect(screen.getByText(/SOL\/USD PERP/i)).toBeInTheDocument();
+      expect(screen.getAllByText(/SOL\/USD PERP/i).length).toBeGreaterThanOrEqual(1);
     });
 
     // Placeholder for future clear search test
@@ -401,11 +401,11 @@ describe("MarketBrowser Component Tests", () => {
       render(<MarketBrowser />);
 
       // Check Open Interest
-      expect(screen.getByText(/5 SOL/i)).toBeInTheDocument();
+      expect(screen.getAllByText(/5 SOL/i).length).toBeGreaterThanOrEqual(1);
       // Check Insurance Fund
-      expect(screen.getByText(/1 SOL/i)).toBeInTheDocument();
+      expect(screen.getAllByText(/1 SOL/i).length).toBeGreaterThanOrEqual(1);
       // Check Account Count
-      expect(screen.getByText("42")).toBeInTheDocument();
+      expect(screen.getAllByText("42").length).toBeGreaterThanOrEqual(1);
     });
 
     it("should render trade link with correct href", () => {
@@ -428,7 +428,8 @@ describe("MarketBrowser Component Tests", () => {
 
       render(<MarketBrowser />);
 
-      const tradeLink = screen.getByRole("link", { name: /Trade/i });
+      const tradeLinks = screen.getAllByRole("link", { name: /Trade/i });
+      const tradeLink = tradeLinks[0];
       expect(tradeLink).toHaveAttribute("href", `/trade/${slabKey.toBase58()}`);
     });
   });
@@ -452,7 +453,7 @@ describe("MarketBrowser Component Tests", () => {
 
       render(<MarketBrowser />);
 
-      expect(screen.getByText("Admin")).toBeInTheDocument();
+      expect(screen.getAllByText("Admin").length).toBeGreaterThanOrEqual(1);
     });
 
     it("should show Pyth badge for non-zero oracle feed ID", () => {
@@ -473,7 +474,7 @@ describe("MarketBrowser Component Tests", () => {
 
       render(<MarketBrowser />);
 
-      expect(screen.getByText("Pyth")).toBeInTheDocument();
+      expect(screen.getAllByText("Pyth").length).toBeGreaterThanOrEqual(1);
     });
   });
 });

--- a/app/components/market/MarketBrowser.tsx
+++ b/app/components/market/MarketBrowser.tsx
@@ -53,9 +53,22 @@ export const MarketBrowser: FC = () => {
     );
   }
 
+  const sortedMarkets = useMemo(
+    () =>
+      [...markets].sort((a, b) => {
+        const order: Record<string, number> = { healthy: 0, caution: 1, warning: 2, empty: 3 };
+        return (
+          (order[computeMarketHealth(a.engine).level] ?? 4) -
+          (order[computeMarketHealth(b.engine).level] ?? 4)
+        );
+      }),
+    [markets],
+  );
+
   return (
     <div className="rounded-sm border border-[var(--border)] bg-[var(--panel-bg)] shadow-sm">
-      <div className="overflow-x-auto">
+      {/* Desktop table — hidden on mobile */}
+      <div className="hidden sm:block overflow-x-auto">
         <table className="w-full text-left text-sm">
           <thead>
             <tr className="border-b border-[var(--border)] text-xs uppercase text-[var(--text-secondary)]">
@@ -70,11 +83,7 @@ export const MarketBrowser: FC = () => {
             </tr>
           </thead>
           <tbody className="divide-y divide-[var(--border-subtle)]">
-            {[...markets].sort((a, b) => {
-              const order: Record<string, number> = { healthy: 0, caution: 1, warning: 2, empty: 3 };
-              return (order[computeMarketHealth(a.engine).level] ?? 4) -
-                     (order[computeMarketHealth(b.engine).level] ?? 4);
-            }).map((m) => {
+            {sortedMarkets.map((m) => {
               const slab = m.slabAddress.toBase58();
               const mintBase58 = m.config.collateralMint.toBase58();
               const meta = tokenMetaMap.get(mintBase58);
@@ -133,6 +142,72 @@ export const MarketBrowser: FC = () => {
             })}
           </tbody>
         </table>
+      </div>
+
+      {/* Mobile card layout — visible only on small screens */}
+      <div className="sm:hidden divide-y divide-[var(--border-subtle)]">
+        {sortedMarkets.map((m) => {
+          const slab = m.slabAddress.toBase58();
+          const mintBase58 = m.config.collateralMint.toBase58();
+          const meta = tokenMetaMap.get(mintBase58);
+          const symbol = meta?.symbol ?? shortenAddress(mintBase58, 4);
+          const decimals = meta?.decimals ?? 6;
+          const health = computeMarketHealth(m.engine);
+
+          return (
+            <div key={slab} className="p-4">
+              {/* Row 1: Market name + Health + Trade */}
+              <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center gap-2 min-w-0">
+                  <div>
+                    <div className="font-medium text-sm text-[var(--text)]">{symbol}/USD PERP</div>
+                    <div className="font-mono text-[10px] text-[var(--text-muted)]">{shortenAddress(slab, 4)}</div>
+                  </div>
+                  <span
+                    className={`inline-block rounded-full px-1.5 py-0.5 text-[10px] font-medium ${
+                      isAdminOracle(m)
+                        ? "bg-[var(--warning)]/20 text-[var(--warning)]"
+                        : "bg-[var(--long)]/[0.08] text-[var(--long)]"
+                    }`}
+                  >
+                    {isAdminOracle(m) ? "Admin" : "Pyth"}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <HealthBadge level={health.level} />
+                  <Link
+                    href={`/trade/${slab}`}
+                    className="rounded-sm border border-[var(--accent)]/40 text-[var(--accent)] bg-transparent px-2.5 py-1 text-xs font-medium transition-colors hover:bg-[var(--accent)]/[0.08]"
+                  >
+                    Trade
+                  </Link>
+                </div>
+              </div>
+
+              {/* Row 2: Key metrics grid */}
+              <div className="grid grid-cols-3 gap-2 text-[11px]">
+                <div>
+                  <div className="text-[var(--text-secondary)] uppercase tracking-wider text-[9px] mb-0.5">OI</div>
+                  <div className="text-[var(--text)] font-mono tabular-nums truncate">
+                    {formatTokenAmount(m.engine.totalOpenInterest, decimals)}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-[var(--text-secondary)] uppercase tracking-wider text-[9px] mb-0.5">Insurance</div>
+                  <div className="text-[var(--text)] font-mono tabular-nums truncate">
+                    {formatTokenAmount(m.engine.insuranceFund.balance, decimals)}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-[var(--text-secondary)] uppercase tracking-wider text-[9px] mb-0.5">Accounts</div>
+                  <div className="text-[var(--text)] font-mono tabular-nums">
+                    {sanitizeAccountCount(m.engine.numUsedAccounts)}
+                  </div>
+                </div>
+              </div>
+            </div>
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Fixes #479 — Markets table overflows at 375px mobile viewport.

## Changes

- **Desktop (≥640px)**: Table layout unchanged
- **Mobile (<640px)**: New card layout per market showing:
  - Market name, oracle type badge, health badge, trade button
  - 3-column metrics grid: OI, Insurance, Accounts
- Tests updated to handle dual rendering (table + cards) using `getAllByText`

## Testing

- All 707 tests pass (50 suites)
- Card layout uses `sm:hidden` / `hidden sm:block` for clean breakpoint switching
- All data rendered in both views — no information loss on mobile