### PR TITLE
fix(security): add HSTS header, remove duplicate CSP from next.config

### DIFF
--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -119,6 +119,9 @@ function addSecurityHeaders(response: NextResponse, nonce?: string) {
   ].join("; ");
 
   response.headers.set("Content-Security-Policy", csp);
+  // HSTS: enforce HTTPS for 2 years, include subdomains, allow preload list submission.
+  // Vercel may add this at the edge, but explicit is defense-in-depth.
+  response.headers.set("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload");
   response.headers.set("X-Content-Type-Options", "nosniff");
   // SAMEORIGIN allows Privy's embedded wallet iframes to work.
   // frame-ancestors CSP directive provides more granular control.


### PR DESCRIPTION
## AUDIT-D Fixes (Issue #502)

### Finding 1: Missing Strict-Transport-Security ➜ FIXED
Added `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload` to:
- **middleware.ts** `addSecurityHeaders()` — applied to all matched routes
- **next.config.ts** `headers()` — defense-in-depth baseline for static assets

### Finding 2: Duplicate/Conflicting CSP ➜ FIXED
Removed the `Content-Security-Policy` header from `next.config.ts`.

**Problem:** Both `next.config.ts` and `middleware.ts` were setting CSP. When both apply, browsers use the **most restrictive intersection**, which could cause unexpected blocking (e.g. the permissive `connect-src 'self' https: wss:` in next.config would be intersected with middleware's scoped list).

**Solution:** CSP is now set exclusively in `middleware.ts`, which has:
- Per-request nonce generation for inline scripts
- Scoped `connect-src` with explicit allowlisted domains
- Proper `object-src 'none'` and `base-uri 'self'`

### Testing
- ✅ `pnpm build` passes
- ✅ All tests pass (1 pre-existing failure in Guide.test.tsx unrelated to this PR)

Closes #502