### PR TITLE
fix(privy): restore both chains in rpcs, pass explicit chain on sign (PERC-290)

### DIFF
--- a/app/hooks/useWalletCompat.ts
+++ b/app/hooks/useWalletCompat.ts
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { usePrivy } from "@privy-io/react-auth";
 import { useWallets, useSignTransaction } from "@privy-io/react-auth/solana";
 import { Connection, PublicKey, Transaction } from "@solana/web3.js";
-import { getConfig, getWsEndpoint } from "@/lib/config";
+import { getConfig, getNetwork, getWsEndpoint } from "@/lib/config";
 import { usePrivyAvailable } from "@/hooks/usePrivySafe";
 import { getBatchRpc } from "@/lib/batchRpc";
 
@@ -68,9 +68,15 @@ function useWalletCompatInner() {
         requireAllSignatures: false,
         verifySignatures: false,
       });
+      // Explicitly pass the chain so Privy uses the correct network's RPC.
+      // Without this, Privy defaults to solana:mainnet which causes 403s
+      // when the app is configured for devnet.
+      const network = getNetwork();
+      const chain = network === "mainnet" ? "solana:mainnet" : "solana:devnet";
       const result = await privySignTransaction({
         transaction: new Uint8Array(serialized),
         wallet: activeWallet,
+        chain: chain as any, // SolanaChain type from Privy
       });
       return Transaction.from(Buffer.from(result.signedTransaction));
     };


### PR DESCRIPTION
## Problem

PR #507 fixed the devnet 403 by scoping `config.solana.rpcs` to only the current network (devnet only on devnet, mainnet only on mainnet). This broke Privy initialization because **Privy always needs `solana:mainnet` RPC present** even in devnet mode.

**Error:**
```
No RPC configuration found for chain solana:mainnet
[WalletProvider] Privy initialization failed, running in read-only mode
```

## Root Cause

When only one chain was provided in `rpcs`, Privy couldn't find the mainnet RPC it requires for initialization. But when both chains were present (pre-#507), Privy defaulted to `solana:mainnet` for all transactions — causing 403s on devnet.

## Fix

**Two-part fix:**

1. **`PrivyProviderClient.tsx`**: Restore **both** `solana:mainnet` and `solana:devnet` in `config.solana.rpcs` so Privy initializes correctly regardless of app network. Removed unused `getNetwork` import.

2. **`useWalletCompat.ts`**: Pass explicit `chain` parameter (`'solana:devnet'` or `'solana:mainnet'`) to `useSignTransaction()` calls. This ensures Privy uses the correct network's RPC for signing, preventing the original 403 that occurred when Privy defaulted to mainnet.

## What's Kept from PR #507
- ✅ Helius API key URL building (`NEXT_PUBLIC_HELIUS_API_KEY`)
- ✅ `getNetwork()` export from config.ts
- ✅ Only the rpcs scoping is reverted

## Testing Checklist
- [ ] Privy initializes without error on devnet (no 'No RPC configuration found' error)
- [ ] Privy initializes without error on mainnet
- [ ] Transactions on devnet land on devnet (not mainnet)
- [ ] Transactions on mainnet land on mainnet
- [ ] Embedded wallet creation works
- [ ] External wallet (Phantom/Solflare) connection works

## Task
PERC-290 (P0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet transaction handling to better support both Solana mainnet and devnet networks.
  * Enhanced network-aware routing for wallet signing operations, ensuring correct network selection during transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->