### PR TITLE
feat: Add wallet switching in Manage Wallets UI (PERC-292)

### DIFF
--- a/app/__tests__/hooks/usePreferredWallet.test.ts
+++ b/app/__tests__/hooks/usePreferredWallet.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { resolveActiveWallet } from "@/hooks/usePreferredWallet";
+
+// Minimal wallet mock
+function mockWallet(address: string, name?: string) {
+  return {
+    address,
+    standardWallet: name ? { name } : null,
+  };
+}
+
+describe("resolveActiveWallet", () => {
+  it("returns null for empty wallet list", () => {
+    expect(resolveActiveWallet([], null)).toBeNull();
+    expect(resolveActiveWallet([], "some-address")).toBeNull();
+  });
+
+  it("returns the preferred wallet when address matches", () => {
+    const wallets = [
+      mockWallet("aaa111", "Phantom"),
+      mockWallet("bbb222", "Backpack"),
+    ];
+    const result = resolveActiveWallet(wallets, "bbb222");
+    expect(result?.address).toBe("bbb222");
+  });
+
+  it("falls back to default heuristic when preferred address not found", () => {
+    const wallets = [
+      mockWallet("aaa111", "Phantom"),
+      mockWallet("bbb222", "Backpack"),
+    ];
+    // Preferred address doesn't match any wallet
+    const result = resolveActiveWallet(wallets, "zzz999");
+    // Should return first external wallet (Phantom)
+    expect(result?.address).toBe("aaa111");
+  });
+
+  it("falls back to default heuristic when preferred is null", () => {
+    const wallets = [
+      mockWallet("embedded1", "Privy"),
+      mockWallet("ext1", "Phantom"),
+    ];
+    const result = resolveActiveWallet(wallets, null);
+    // Should prefer external (Phantom) over embedded (Privy)
+    expect(result?.address).toBe("ext1");
+  });
+
+  it("default heuristic prefers external over privy embedded", () => {
+    const wallets = [
+      mockWallet("embedded1", "Privy"),
+      mockWallet("ext1", "Phantom"),
+    ];
+    const result = resolveActiveWallet(wallets, null);
+    expect(result?.address).toBe("ext1");
+  });
+
+  it("falls back to first wallet when all are embedded", () => {
+    const wallets = [
+      mockWallet("embedded1", "Privy"),
+      mockWallet("embedded2", "Privy 2"),
+    ];
+    const result = resolveActiveWallet(wallets, null);
+    expect(result?.address).toBe("embedded1");
+  });
+
+  it("returns single wallet when only one exists", () => {
+    const wallets = [mockWallet("only1", "Phantom")];
+    const result = resolveActiveWallet(wallets, null);
+    expect(result?.address).toBe("only1");
+  });
+
+  it("preferred wallet overrides default external preference", () => {
+    const wallets = [
+      mockWallet("ext1", "Phantom"),
+      mockWallet("embedded1", "Privy"),
+    ];
+    // User explicitly chose the embedded wallet
+    const result = resolveActiveWallet(wallets, "embedded1");
+    expect(result?.address).toBe("embedded1");
+  });
+});

--- a/app/components/providers/WalletProvider.tsx
+++ b/app/components/providers/WalletProvider.tsx
@@ -3,6 +3,10 @@
 import { Component, FC, ReactNode, useMemo, useState, useEffect } from "react";
 import dynamic from "next/dynamic";
 import { PrivyAvailableContext, PrivyLoginContext } from "@/hooks/usePrivySafe";
+import {
+  PreferredWalletContext,
+  usePreferredWalletState,
+} from "@/hooks/usePreferredWallet";
 
 /**
  * Error boundary that catches PrivyProvider crashes and renders children
@@ -49,10 +53,13 @@ const PrivyProviderClient = dynamic(
 
 export const WalletProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const appId = process.env.NEXT_PUBLIC_PRIVY_APP_ID;
+  const preferredWallet = usePreferredWalletState();
 
   const readOnlyFallback = (
     <PrivyAvailableContext.Provider value={false}>
-      {children}
+      <PreferredWalletContext.Provider value={preferredWallet}>
+        {children}
+      </PreferredWalletContext.Provider>
     </PrivyAvailableContext.Provider>
   );
 
@@ -65,9 +72,11 @@ export const WalletProvider: FC<{ children: ReactNode }> = ({ children }) => {
   return (
     <PrivyErrorBoundary fallback={readOnlyFallback}>
       <PrivyAvailableContext.Provider value={true}>
-        <PrivyProviderClient appId={appId}>
-          {children}
-        </PrivyProviderClient>
+        <PreferredWalletContext.Provider value={preferredWallet}>
+          <PrivyProviderClient appId={appId}>
+            {children}
+          </PrivyProviderClient>
+        </PreferredWalletContext.Provider>
       </PrivyAvailableContext.Provider>
     </PrivyErrorBoundary>
   );

--- a/app/components/wallet/ConnectButton.tsx
+++ b/app/components/wallet/ConnectButton.tsx
@@ -7,6 +7,7 @@ import { usePrivy, type LinkedAccountWithMetadata } from "@privy-io/react-auth";
 import { useFundWallet, useWallets } from "@privy-io/react-auth/solana";
 import { getConfig } from "@/lib/config";
 import { usePrivyAvailable } from "@/hooks/usePrivySafe";
+import { usePreferredWallet, resolveActiveWallet } from "@/hooks/usePreferredWallet";
 import { buildSolflareBrowseUrl } from "@/lib/solflare";
 
 /**
@@ -39,15 +40,14 @@ const ConnectButtonInner: FC = () => {
   const { ready, authenticated, login, logout, exportWallet, user } = usePrivy();
   const { wallets } = useWallets();
   const { fundWallet } = useFundWallet();
+  const { preferredAddress } = usePreferredWallet();
   const searchParams = useSearchParams();
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
   const activeWallet = useMemo(() => {
-    if (!wallets.length) return null;
-    // Prefer external wallets over Privy embedded
-    return wallets.find((w) => !w.standardWallet?.name?.toLowerCase().includes("privy")) || wallets[0];
-  }, [wallets]);
+    return resolveActiveWallet(wallets, preferredAddress);
+  }, [wallets, preferredAddress]);
 
   const displayAddress = useMemo(() => {
     if (!activeWallet) return "";

--- a/app/hooks/usePreferredWallet.ts
+++ b/app/hooks/usePreferredWallet.ts
@@ -1,0 +1,84 @@
+"use client";
+
+import { createContext, useContext, useState, useCallback, useEffect } from "react";
+
+const STORAGE_KEY = "percolator:preferred-wallet";
+
+interface PreferredWalletContextValue {
+  /** The user's manually selected wallet address, or null if using default */
+  preferredAddress: string | null;
+  /** Set the preferred wallet address. Pass null to clear and revert to default. */
+  setPreferredAddress: (address: string | null) => void;
+}
+
+export const PreferredWalletContext = createContext<PreferredWalletContextValue>({
+  preferredAddress: null,
+  setPreferredAddress: () => {},
+});
+
+/**
+ * Hook to access and set the user's preferred active wallet.
+ * The preferred address is persisted in localStorage so it survives page reloads.
+ */
+export function usePreferredWallet(): PreferredWalletContextValue {
+  return useContext(PreferredWalletContext);
+}
+
+/**
+ * Hook to create the context value for PreferredWalletContext.Provider.
+ * Call this once in a provider component.
+ */
+export function usePreferredWalletState(): PreferredWalletContextValue {
+  const [preferredAddress, setPreferredAddressState] = useState<string | null>(null);
+
+  // Hydrate from localStorage on mount
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        setPreferredAddressState(stored);
+      }
+    } catch {
+      // localStorage may be unavailable (SSR, privacy mode)
+    }
+  }, []);
+
+  const setPreferredAddress = useCallback((address: string | null) => {
+    setPreferredAddressState(address);
+    try {
+      if (address) {
+        localStorage.setItem(STORAGE_KEY, address);
+      } else {
+        localStorage.removeItem(STORAGE_KEY);
+      }
+    } catch {
+      // localStorage may be unavailable
+    }
+  }, []);
+
+  return { preferredAddress, setPreferredAddress };
+}
+
+/**
+ * Resolve the active wallet from a list using the user's preference.
+ * Falls back to the default heuristic (prefer external over embedded)
+ * if the preferred wallet is not found in the list.
+ */
+export function resolveActiveWallet<
+  T extends { address: string; standardWallet?: { name?: string } | null },
+>(wallets: T[], preferredAddress: string | null): T | null {
+  if (!wallets.length) return null;
+
+  // If user has explicitly selected a wallet, use it
+  if (preferredAddress) {
+    const preferred = wallets.find((w) => w.address === preferredAddress);
+    if (preferred) return preferred;
+  }
+
+  // Default heuristic: prefer external wallet over Privy embedded
+  return (
+    wallets.find(
+      (w) => !w.standardWallet?.name?.toLowerCase().includes("privy"),
+    ) || wallets[0]
+  );
+}

--- a/app/hooks/useWalletCompat.ts
+++ b/app/hooks/useWalletCompat.ts
@@ -6,6 +6,7 @@ import { useWallets, useSignTransaction } from "@privy-io/react-auth/solana";
 import { Connection, PublicKey, Transaction } from "@solana/web3.js";
 import { getConfig, getNetwork, getWsEndpoint } from "@/lib/config";
 import { usePrivyAvailable } from "@/hooks/usePrivySafe";
+import { usePreferredWallet, resolveActiveWallet } from "@/hooks/usePreferredWallet";
 import { getBatchRpc } from "@/lib/batchRpc";
 
 /**
@@ -39,15 +40,11 @@ function useWalletCompatInner() {
   const { ready, authenticated, user, logout } = usePrivy();
   const { wallets } = useWallets();
   const { signTransaction: privySignTransaction } = useSignTransaction();
+  const { preferredAddress } = usePreferredWallet();
 
   const activeWallet = useMemo(() => {
-    if (!wallets.length) return null;
-    // Prefer external wallet, fall back to embedded
-    return (
-      wallets.find((w) => !w.standardWallet?.name?.toLowerCase().includes("privy")) ||
-      wallets[0]
-    );
-  }, [wallets]);
+    return resolveActiveWallet(wallets, preferredAddress);
+  }, [wallets, preferredAddress]);
 
   const publicKey = useMemo(() => {
     if (!activeWallet) return null;


### PR DESCRIPTION
## Summary

Fixes the bug where users with multiple wallets connected (e.g. Phantom + Privy embedded, or Phantom + Backpack) had no way to switch which wallet is used for transactions.

## Changes

### New: `usePreferredWallet` hook (`app/hooks/usePreferredWallet.ts`)
- `PreferredWalletContext` — React context for the user's preferred wallet address
- `usePreferredWalletState()` — provider-side hook with localStorage persistence
- `usePreferredWallet()` — consumer hook for reading/writing the preference
- `resolveActiveWallet()` — shared utility replacing 3 duplicated selection heuristics

### Updated: `WalletProvider.tsx`
- Wraps children in `PreferredWalletContext.Provider` so the preference is available app-wide

### Updated: `useWalletCompat.ts`
- Uses `resolveActiveWallet()` with the user's preferred address instead of hard-coded heuristic
- All downstream transaction hooks automatically use the selected wallet

### Updated: `ConnectButton.tsx`
- Uses shared `resolveActiveWallet()` instead of duplicated logic

### Updated: `wallet/page.tsx` (Manage Wallets)
- Each wallet in the Linked Wallets section is now a clickable button
- Active wallet shows a highlighted border + `ACTIVE` badge
- Embedded wallets still show their `EMBEDDED` badge
- Hint text appears when multiple wallets are connected
- Clicking a wallet sets it as the active signing wallet immediately

### Tests
- 8 unit tests for `resolveActiveWallet` covering: preference match, fallback when preferred not found, null preference, external preference over embedded, single wallet, explicit embedded selection

## QA Checklist
- [ ] Connect 2+ wallets (e.g. Phantom + Privy embedded)
- [ ] Verify Manage Wallets page shows all wallets with clickable cards
- [ ] Click a non-active wallet → verify it becomes active (border highlight + ACTIVE badge)
- [ ] Navigate away and back → verify selection persists (localStorage)
- [ ] Perform a transaction → verify it uses the selected wallet
- [ ] Disconnect the active wallet → verify fallback to remaining wallet
- [ ] Refresh the page → verify preferred wallet is restored

Closes PERC-292

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now select and persist a preferred wallet across sessions
  * Active wallet is visually highlighted in the wallet management interface
  * Added helper messaging when multiple wallets are linked

* **Tests**
  * Added comprehensive test suite validating wallet selection behavior under various scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->