### PR TITLE
fix: guard against uninitialized oracle prices displaying as $13T

### DIFF
--- a/app/components/trade/MarketStatsCard.tsx
+++ b/app/components/trade/MarketStatsCard.tsx
@@ -51,7 +51,15 @@ export const MarketStatsCard: FC = () => {
     : formatTokenAmount(vault, decimals);
 
   const stats = [
-    { label: `${symbol} Price`, value: formatUsd(livePriceE6 ?? config.lastEffectivePriceE6) },
+    { label: `${symbol} Price`, value: (() => {
+      const raw = livePriceE6 ?? config.lastEffectivePriceE6;
+      if (raw == null || raw === 0n) return "—";
+      // Guard against uninitialized on-chain values (e.g. hyperp markets with no trades)
+      // A price > $1M per token is almost certainly a raw integer / scaling bug
+      const usd = Number(raw) / 1_000_000;
+      if (usd > 1_000_000 || usd < 0) return "—";
+      return formatUsd(raw);
+    })() },
     { label: "Open Interest", value: oiDisplay },
     { label: "Vault", value: vaultDisplay },
     { label: "Trading Fee", value: formatBps(params.tradingFeeBps) },

--- a/app/lib/format.ts
+++ b/app/lib/format.ts
@@ -39,6 +39,8 @@ export const LIQ_PRICE_UNLIQUIDATABLE = 18446744073709551615n; // max u64
 export function formatUsd(priceE6: bigint | null | undefined): string {
   if (priceE6 == null) return "$0.00";
   const val = Number(priceE6) / 1_000_000;
+  // Guard against uninitialized on-chain values that produce absurd USD prices
+  if (val > 1_000_000_000 || val < -1_000_000_000) return "—";
   return `$${val.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 6 })}`;
 }
 

--- a/app/lib/oraclePrice.ts
+++ b/app/lib/oraclePrice.ts
@@ -55,11 +55,16 @@ export function resolveMarketPriceE6(cfg: {
       // authorityPriceE6 may be stale/garbage — never use it
       return cfg.lastEffectivePriceE6;
 
-    case "hyperp":
+    case "hyperp": {
       // Hyperp (DEX oracle): lastEffectivePriceE6 is the index price from on-chain crank
       // authorityPriceE6 is the mark price — use index price for display
       // Note: authorityTimestamp stores funding rate, NOT a real timestamp
+      // Guard: uninitialized hyperp markets may have garbage values in price fields
+      // A valid e6 price should be < 1e15 (~$1B); anything above is bogus data
+      const MAX_SANE_E6 = 1_000_000_000_000_000n; // $1B in e6
+      if (cfg.lastEffectivePriceE6 > MAX_SANE_E6) return 0n;
       return cfg.lastEffectivePriceE6;
+    }
 
     case "admin":
       // Admin oracle: authorityPriceE6 is the latest pushed price


### PR DESCRIPTION
## What
Fixes #516 — TEST/USD PERP trade page showed $13,065,687,626,137.56 as the token price.

## Root Cause
Hyperp-mode markets with no trades have uninitialized/garbage data in `lastEffectivePriceE6`. The `useLivePrice` hook correctly guards against this (line 74: `if (usd > 1_000_000) return`), but when it returns null, `MarketStatsCard` fell through to `config.lastEffectivePriceE6` — the raw garbage value.

## Changes
1. **`MarketStatsCard.tsx`**: Added sanity check — rejects prices > $1M per token, displays "—"
2. **`format.ts` (`formatUsd`)**: Defense-in-depth cap at $1B — returns "—" for absurd values
3. **`oraclePrice.ts` (`resolveMarketPriceE6`)**: Returns `0n` for hyperp markets with uninitialized price data (> $1B e6)

## Testing
- 694 tests pass (1 pre-existing failure in Guide.test.tsx, unrelated)
- Verified on-chain: market `6Zyt…Xa9D` has `lastEffectivePriceE6 = 13065687626137562091` (garbage)
- With fix: displays "—" instead of $13T

## Also from PERC-296 audit
All other displayed values match on-chain data:
| Field | UI | On-chain | Status |
|-------|-----|----------|--------|
| Vault | 7.10K | 7100.01 TEST | ✅ |
| Total Capital | 6.98K | 6979.01 TEST | ✅ |
| Insurance | 112.00 | 112.00 TEST | ✅ |
| Open Interest | 0.00 | 0 | ✅ |
| Active Accounts | 2 | 2 | ✅ |
| Liq Fee | 1.00% | 100 bps | ✅ |
| Buffer | 0.50% | 50 bps | ✅ |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved price display reliability by adding safeguards against invalid, uninitialized, or unrealistically extreme price values. The app now displays "—" for problematic prices instead of corrupted data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->