### PR TITLE
fix: use getAllByText for tier names in Guide test (#533)

### DIFF
--- a/app/__tests__/components/Guide.test.tsx
+++ b/app/__tests__/components/Guide.test.tsx
@@ -120,10 +120,10 @@ describe('Guide Page', () => {
   it('should render Market Tiers table with cost information', () => {
     render(<GuidePage />);
 
-    // Check for tier information
-    expect(screen.getByText(/Small/i)).toBeInTheDocument();
-    expect(screen.getByText(/Medium/i)).toBeInTheDocument();
-    expect(screen.getByText(/Large/i)).toBeInTheDocument();
+    // Check for tier information (multiple elements may match)
+    expect(screen.getAllByText(/Small/i).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/Medium/i).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/Large/i).length).toBeGreaterThanOrEqual(1);
 
     // Check for slot counts
     expect(screen.getByText('256')).toBeInTheDocument();


### PR DESCRIPTION
## What
Fix Guide.test.tsx failing with 'Found multiple elements with text matching /Small/i'.

## Why
Small/Medium/Large appear in multiple places on the Guide page, causing getByText to throw.

## How
Switch to getAllByText with length assertion for tier name checks.

Closes #533