### PR TITLE
fix(#550,#551): add Health tab to mobile trade page, fix Insurance Fund inconsistency

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -126,7 +126,7 @@ export default function Home() {
       }
 
       try {
-        const { data, error: dbError } = await getSupabase().from("markets_with_stats").select("slab_address, symbol, volume_24h, insurance_balance, last_price, total_open_interest, open_interest_long, open_interest_short, decimals") as { data: { slab_address: string; symbol: string | null; volume_24h: number | null; insurance_balance: number | null; last_price: number | null; total_open_interest: number | null; open_interest_long: number | null; open_interest_short: number | null; decimals: number | null }[] | null; error: { message: string } | null };
+        const { data, error: dbError } = await getSupabase().from("markets_with_stats").select("slab_address, symbol, volume_24h, insurance_balance, insurance_fund, last_price, total_open_interest, open_interest_long, open_interest_short, decimals") as { data: { slab_address: string; symbol: string | null; volume_24h: number | null; insurance_balance: number | null; insurance_fund: number | null; last_price: number | null; total_open_interest: number | null; open_interest_long: number | null; open_interest_short: number | null; decimals: number | null }[] | null; error: { message: string } | null };
         if (dbError) {
           console.error("Failed to query markets_with_stats:", dbError.message);
           throw new Error(dbError.message);
@@ -152,7 +152,13 @@ export default function Home() {
           setStats({
             markets: activeData.length,
             volume: activeData.reduce((s, m) => s + toUsd(Number(m.volume_24h || 0), m.decimals, m.last_price), 0),
-            insurance: activeData.reduce((s, m) => s + toUsd(Number(m.insurance_balance || 0), m.decimals, m.last_price), 0),
+            insurance: activeData.reduce((s, m) => {
+              // Use insurance_fund (raw on-chain value in token micro-units) consistent with earn page.
+              // Fall back to insurance_balance if insurance_fund is missing.
+              const raw = Number(m.insurance_fund ?? m.insurance_balance ?? 0);
+              if (!isSaneMarketValue(raw)) return s;
+              return s + toUsd(raw, m.decimals, m.last_price);
+            }, 0),
           });
           setStatsLoaded(true);
           // Convert to USD first, then sort by converted volume

--- a/app/app/trade/[slab]/page.tsx
+++ b/app/app/trade/[slab]/page.tsx
@@ -404,9 +404,13 @@ function TradePageInner({ slab }: { slab: string }) {
         </ErrorBoundary>
 
         {/* Bottom tabs: Stats | Trades | Book */}
-        <Tabs tabs={["Stats", "Trades", "Risk", "Book"]}>
+        <Tabs tabs={["Stats", "Trades", "Health", "Risk", "Book"]}>
           <ErrorBoundary label="MarketStatsCard"><MarketStatsCard /></ErrorBoundary>
           <ErrorBoundary label="TradeHistory"><TradeHistory slabAddress={slab} /></ErrorBoundary>
+          <ErrorBoundary label="EngineHealthCard">
+            <EngineHealthCard />
+            <div className="mt-2"><CrankHealthCard /></div>
+          </ErrorBoundary>
           <ErrorBoundary label="RiskAnalytics">
             <OpenInterestCard slabAddress={slab} />
             <div className="mt-2"><InsuranceDashboard slabAddress={slab} /></div>


### PR DESCRIPTION
## Summary
Fixes two QA-reported bugs:

### #550 — Health tab missing on mobile trade page
Mobile layout had `[Stats, Trades, Risk, Book]` while desktop had `[Stats, Trades, Health, Risk, Book]`. Added Health tab with EngineHealthCard + CrankHealthCard to mobile layout.

### #551 — Insurance Fund shows $2K on homepage vs $2.4M on earn page
Homepage used `insurance_balance` column while earn page used `insurance_fund` column from `markets_with_stats` view. These contain different values. Aligned homepage to use `insurance_fund` (with `insurance_balance` fallback) and same `toUsd()` conversion.

## Testing
- Build passes ✅
- Verify on mobile: /trade/[slab] should show 5 tabs (Stats|Trades|Health|Risk|Book)
- Verify homepage Insurance Fund value matches /earn page

Fixes #550, #551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Health" tab with health monitoring cards for tracking system status.
  * Improved insurance calculation with enhanced fallback logic and per-market limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->