### PR TITLE
fix(PERC-342): D1/D2/D6 — stats formatting, overflow tooltips, SHORT button visual

### DIFF
--- a/app/__tests__/lib/format.test.ts
+++ b/app/__tests__/lib/format.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   formatTokenAmount,
+  formatCompactTokenAmount,
   formatPriceE6,
   formatBps,
   LIQ_PRICE_UNLIQUIDATABLE,
@@ -347,5 +348,38 @@ describe("formatFundingRate", () => {
     const expected = slotsPerYear / 100; // 788400
     const result = formatFundingRate(1n);
     expect(result).toBe(`+${expected.toFixed(2)}%`);
+  });
+});
+
+describe("formatCompactTokenAmount", () => {
+  it("returns '0' for null/undefined/zero", () => {
+    expect(formatCompactTokenAmount(null)).toBe("0");
+    expect(formatCompactTokenAmount(undefined)).toBe("0");
+    expect(formatCompactTokenAmount(0n)).toBe("0");
+  });
+
+  it("abbreviates millions (D2 fix: vault 2M)", () => {
+    // 2,000,000 tokens with 6 decimals = 2_000_000_000_000n raw
+    const raw = 2_000_000_000_000n;
+    expect(formatCompactTokenAmount(raw, 6)).toBe("2.0M");
+  });
+
+  it("abbreviates thousands", () => {
+    // 1,500 tokens with 6 decimals = 1_500_000_000n raw
+    const raw = 1_500_000_000n;
+    expect(formatCompactTokenAmount(raw, 6)).toBe("1.5K");
+  });
+
+  it("formats mid-range numbers with commas", () => {
+    // 500 tokens with 6 decimals = 500_000_000n raw
+    const raw = 500_000_000n;
+    const result = formatCompactTokenAmount(raw, 6);
+    expect(result).toBe("500");
+  });
+
+  it("falls back to full precision for sub-1 amounts", () => {
+    // 0.5 tokens with 6 decimals = 500_000n raw
+    const raw = 500_000n;
+    expect(formatCompactTokenAmount(raw, 6)).toBe("0.5");
   });
 });

--- a/app/components/trade/MarketStatsCard.tsx
+++ b/app/components/trade/MarketStatsCard.tsx
@@ -6,7 +6,7 @@ import { useMarketConfig } from "@/hooks/useMarketConfig";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { useUsdToggle } from "@/components/providers/UsdToggleProvider";
 import { useTokenMeta } from "@/hooks/useTokenMeta";
-import { formatTokenAmount, formatUsd, formatBps } from "@/lib/format";
+import { formatTokenAmount, formatCompactTokenAmount, formatUsd, formatBps } from "@/lib/format";
 import { sanitizeOnChainValue, sanitizeAccountCount } from "@/lib/health";
 import { useLivePrice } from "@/hooks/useLivePrice";
 import { resolveMarketPriceE6 } from "@/lib/oraclePrice";
@@ -46,18 +46,25 @@ export const MarketStatsCard: FC = () => {
   const vault = sanitizeOnChainValue(engine.vault ?? 0n);
   const oiDisplay = showUsd && priceUsd != null
     ? formatNum((Number(totalOI) / tokenDivisor) * priceUsd)
-    : formatTokenAmount(totalOI, decimals);
+    : formatCompactTokenAmount(totalOI, decimals);
   const vaultDisplay = showUsd && priceUsd != null
+    ? formatNum((Number(vault) / tokenDivisor) * priceUsd)
+    : formatCompactTokenAmount(vault, decimals);
+  // Full-precision tooltips for truncated stat cells (D1/D2)
+  const oiFullDisplay = showUsd && priceUsd != null
+    ? formatNum((Number(totalOI) / tokenDivisor) * priceUsd)
+    : formatTokenAmount(totalOI, decimals);
+  const vaultFullDisplay = showUsd && priceUsd != null
     ? formatNum((Number(vault) / tokenDivisor) * priceUsd)
     : formatTokenAmount(vault, decimals);
 
   const stats = [
-    { label: `${symbol} Price`, value: formatUsd(livePriceE6 ?? (mktConfig ? resolveMarketPriceE6(mktConfig) : 0n)) },
-    { label: "Open Interest", value: oiDisplay },
-    { label: "Vault", value: vaultDisplay },
-    { label: "Trading Fee", value: formatBps(params.tradingFeeBps) },
-    { label: "Init. Margin", value: formatBps(params.initialMarginBps) },
-    { label: "Accounts", value: sanitizeAccountCount(engine.numUsedAccounts ?? 0, params ? Number(params.maxAccounts) : undefined).toString() },
+    { label: `${symbol} Price`, value: formatUsd(livePriceE6 ?? (mktConfig ? resolveMarketPriceE6(mktConfig) : 0n)), tooltip: "" },
+    { label: "Open Interest", value: oiDisplay, tooltip: oiFullDisplay },
+    { label: "Vault", value: vaultDisplay, tooltip: vaultFullDisplay },
+    { label: "Trading Fee", value: formatBps(params.tradingFeeBps), tooltip: "" },
+    { label: "Init. Margin", value: formatBps(params.initialMarginBps), tooltip: "" },
+    { label: "Accounts", value: sanitizeAccountCount(engine.numUsedAccounts ?? 0, params ? Number(params.maxAccounts) : undefined).toString(), tooltip: "" },
   ];
 
   return (
@@ -66,9 +73,9 @@ export const MarketStatsCard: FC = () => {
       <div className="relative rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 p-2">
         <div className="grid grid-cols-3 gap-px">
           {stats.map((s) => (
-            <div key={s.label} className="px-1.5 py-1 border-b border-r border-[var(--border)]/20 last:border-r-0 [&:nth-child(3n)]:border-r-0 [&:nth-last-child(-n+3)]:border-b-0">
+            <div key={s.label} className="px-1.5 py-1 overflow-hidden border-b border-r border-[var(--border)]/20 last:border-r-0 [&:nth-child(3n)]:border-r-0 [&:nth-last-child(-n+3)]:border-b-0">
               <p className="text-[8px] uppercase tracking-[0.1em] text-[var(--text-muted)] truncate">{s.label}</p>
-              <p className="text-[11px] font-medium text-[var(--text)] truncate" style={{ fontFamily: "var(--font-mono)" }}>{s.value}</p>
+              <p className="text-[11px] font-medium text-[var(--text)] truncate" title={s.tooltip || s.value} style={{ fontFamily: "var(--font-mono)" }}>{s.value}</p>
             </div>
           ))}
         </div>

--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -293,7 +293,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
           className={`flex-1 rounded-none py-2 text-[11px] font-medium uppercase tracking-[0.1em] transition-all duration-150 ${
             direction === "short"
               ? "border border-[var(--short)]/60 text-[var(--short)] bg-[var(--short)]/8 shadow-[0_0_12px_rgba(255,59,92,0.1)]"
-              : "border border-[var(--border)]/30 text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:border-[var(--border)]"
+              : "border border-[var(--short)]/30 text-[var(--short)]/60 hover:text-[var(--short)] hover:border-[var(--short)]/50 hover:bg-[var(--short)]/5"
           }`}
         >
           Short

--- a/app/lib/format.ts
+++ b/app/lib/format.ts
@@ -62,6 +62,25 @@ export function shortenAddress(address: string, chars: number = 4): string {
   return `${address.slice(0, chars)}...${address.slice(-chars)}`;
 }
 
+/**
+ * Format a token amount compactly for dashboard/stats display.
+ * ≥ 1 000 000 → "2.0M", ≥ 1 000 → "1.5K", otherwise comma-separated.
+ * Falls back to formatTokenAmount for sub-1 values.
+ */
+export function formatCompactTokenAmount(
+  raw: bigint | null | undefined,
+  decimals: number = 6,
+): string {
+  if (raw == null || raw <= 0n) return "0";
+  const divisor = 10n ** BigInt(decimals);
+  const num = Number(raw) / Number(divisor);
+  if (num >= 1_000_000) return `${(num / 1_000_000).toFixed(1)}M`;
+  if (num >= 1_000) return `${(num / 1_000).toFixed(1)}K`;
+  if (num >= 1) return num.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 2 });
+  // Sub-1 amounts: use full precision
+  return formatTokenAmount(raw, decimals);
+}
+
 export function formatSlotAge(currentSlot: bigint | null | undefined, targetSlot: bigint | null | undefined): string {
   if (currentSlot == null || targetSlot == null) return "—";
   const diff = currentSlot - targetSlot;


### PR DESCRIPTION
## Design Audit PERC-342 — P1/P2 Fixes

Addresses D1, D2, and D6 from the design audit at `perc342-design-audit.md`.

### D2: Vault/OI raw integer display (P1)
- Added `formatCompactTokenAmount()` to `lib/format.ts` — abbreviates large token amounts (≥1M → "2.0M", ≥1K → "1.5K", otherwise comma-formatted)
- Applied to Vault and Open Interest stats in `MarketStatsCard`
- Previously showed raw "2000000" for a 2M-token vault

### D1: Trading fee stat cell overflow (P1)
- Added `title` attribute with full-precision value on all stat cells for hover tooltip
- Added `overflow-hidden` on cell containers as an extra guard beyond `truncate`
- Values that truncate (e.g. "1844674307370…") now show full value on hover

### D6: SHORT button visual affordance (P2)
- Inactive SHORT button now uses `border-[var(--short)]/30` + `text-[var(--short)]/60` instead of generic muted styling
- Hover: `text-[var(--short)]` + `border-[var(--short)]/50` + subtle red background
- Matches common perp DEX patterns (dYdX, Drift) — red always means short

### Tests
- 5 new unit tests for `formatCompactTokenAmount` covering null, millions, thousands, mid-range, and sub-1 amounts
- All 76 format tests pass, all 30 component tests pass, full build succeeds

### Not in this PR (needs designer coordination)
- **D3**: Chart empty state placeholder SVG — waiting on designer spec
- **D4**: /markets mobile regression check — separate PR
- **D5**: Quick Start stepper visual states — separate PR