### PR TITLE
feat: Chart empty state with designer SVG asset

### DIFF
--- a/app/components/trade/ChartEmptyState.tsx
+++ b/app/components/trade/ChartEmptyState.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { FC } from "react";
+import Image from "next/image";
+
+interface ChartEmptyStateProps {
+  /** Optional current price to display alongside the empty state */
+  currentPrice?: number;
+  /** Height class for the container (default: h-[300px]) */
+  heightClass?: string;
+}
+
+/**
+ * Empty state for chart components when no OHLCV / price data is available.
+ * Uses the designer-provided SVG with ghost candlestick bars.
+ */
+export const ChartEmptyState: FC<ChartEmptyStateProps> = ({
+  currentPrice,
+  heightClass = "h-[300px]",
+}) => {
+  return (
+    <div
+      className={`relative flex ${heightClass} flex-col items-center justify-center rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 overflow-hidden`}
+    >
+      {/* Background SVG illustration */}
+      <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+        <Image
+          src="/chart-empty-state.svg"
+          alt=""
+          width={600}
+          height={320}
+          className="w-full h-full object-contain opacity-80"
+          priority={false}
+          aria-hidden="true"
+        />
+      </div>
+
+      {/* Overlay content — sits above the SVG */}
+      <div className="relative z-10 flex flex-col items-center text-center px-4">
+        {currentPrice != null && currentPrice > 0 ? (
+          <>
+            <div
+              className="text-2xl font-bold text-[var(--text)] drop-shadow-sm"
+              style={{ fontFamily: "var(--font-mono)" }}
+            >
+              ${currentPrice < 0.01 ? currentPrice.toFixed(6) : currentPrice.toFixed(2)}
+            </div>
+            <div className="mt-1 text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">
+              Price chart building…
+            </div>
+          </>
+        ) : (
+          <>
+            <div
+              className="text-[15px] font-semibold text-[#94a3b8]"
+              style={{ fontFamily: "'Space Grotesk', system-ui, sans-serif" }}
+            >
+              No chart data yet
+            </div>
+            <div
+              className="mt-1 text-xs text-[#475569]"
+              style={{ fontFamily: "'Space Grotesk', system-ui, sans-serif" }}
+            >
+              Price history will appear once trading begins
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/app/components/trade/PriceChart.tsx
+++ b/app/components/trade/PriceChart.tsx
@@ -6,6 +6,7 @@ import gsap from "gsap";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
 import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab, getMockPriceHistory } from "@/lib/mock-trade-data";
+import { ChartEmptyState } from "./ChartEmptyState";
 
 interface PricePoint {
   price_e6: number;
@@ -282,19 +283,10 @@ export const PriceChart: FC<{ slabAddress: string }> = ({ slabAddress }) => {
 
   if (prices.length < 2) {
     return (
-      <div className="flex h-[200px] flex-col items-center justify-center rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 relative">
-        {currentPrice > 0 ? (
-          <>
-            <div className="text-2xl font-bold text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>${currentPrice < 0.01 ? currentPrice.toFixed(6) : currentPrice.toFixed(2)}</div>
-            <div className="mt-1 text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Price chart building...</div>
-          </>
-        ) : (
-          <>
-            <div className="text-[11px] text-[var(--text-muted)]">No price data yet</div>
-            <div className="mt-1 text-[10px] text-[var(--text-dim)]">Prices will appear after the first trade.</div>
-          </>
-        )}
-      </div>
+      <ChartEmptyState
+        currentPrice={currentPrice > 0 ? currentPrice : undefined}
+        heightClass="h-[300px]"
+      />
     );
   }
 

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -3,6 +3,7 @@
 import { FC, useState, useMemo, useCallback, useRef, useEffect } from "react";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { useLivePrice } from "@/hooks/useLivePrice";
+import { ChartEmptyState } from "./ChartEmptyState";
 
 type ChartType = "line" | "candle";
 type Timeframe = "1h" | "4h" | "1d" | "7d" | "30d";
@@ -212,12 +213,10 @@ export const TradingChart: FC<{ slabAddress: string }> = ({ slabAddress }) => {
 
   if (filteredPrices.length === 0) {
     return (
-      <div className="flex h-[200px] sm:h-[400px] items-center justify-center rounded-none border border-[var(--border)] bg-[var(--bg)]">
-        <div className="text-center">
-          <div className="text-sm text-[var(--text-secondary)]">No price data yet</div>
-          <div className="mt-1 text-xs text-[var(--text-dim)]">Prices will appear after trades</div>
-        </div>
-      </div>
+      <ChartEmptyState
+        currentPrice={priceUsd ?? undefined}
+        heightClass="h-[200px] sm:h-[400px]"
+      />
     );
   }
 

--- a/app/public/chart-empty-state.svg
+++ b/app/public/chart-empty-state.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 320" width="600" height="320" role="img" aria-label="No chart data available">
+  <!-- Background: transparent — inherits dark surface from parent -->
+
+  <!-- Subtle grid lines -->
+  <line x1="0" y1="80" x2="600" y2="80" stroke="#1e2530" stroke-width="1"/>
+  <line x1="0" y1="160" x2="600" y2="160" stroke="#1e2530" stroke-width="1"/>
+  <line x1="0" y1="240" x2="600" y2="240" stroke="#1e2530" stroke-width="1"/>
+  <line x1="150" y1="0" x2="150" y2="320" stroke="#1e2530" stroke-width="1"/>
+  <line x1="300" y1="0" x2="300" y2="320" stroke="#1e2530" stroke-width="1"/>
+  <line x1="450" y1="0" x2="450" y2="320" stroke="#1e2530" stroke-width="1"/>
+
+  <!-- Ghost candlestick bars — muted, dashed outline only -->
+  <!-- Bar 1 -->
+  <rect x="60" y="180" width="28" height="70" rx="2" fill="none" stroke="#22d3ee" stroke-width="1.5" stroke-dasharray="4 3" opacity="0.2"/>
+  <line x1="74" y1="160" x2="74" y2="180" stroke="#22d3ee" stroke-width="1.5" stroke-dasharray="4 3" opacity="0.2"/>
+  <line x1="74" y1="250" x2="74" y2="268" stroke="#22d3ee" stroke-width="1.5" stroke-dasharray="4 3" opacity="0.2"/>
+  <!-- Bar 2 -->
+  <rect x="110" y="140" width="28" height="90" rx="2" fill="none" stroke="#22d3ee" stroke-width="1.5" stroke-dasharray="4 3" opacity="0.2"/>
+  <line x1="124" y1="120" x2="124" y2="140" stroke="#22d3ee" stroke-width="1.5" stroke-dasharray="4 3" opacity="0.2"/>
+  <line x1="124" y1="230" x2="124" y2="252" stroke="#22d3ee" stroke-width="1.5" stroke-dasharray="4 3" opacity="0.2"/>
+  <!-- Bar 3 -->
+  <rect x="160" y="160" width="28" height="60" rx="2" fill="none" stroke="#f87171" stroke-width="1.5" stroke-dasharray="4 3" opacity="0.2"/>
+  <line x1="174" y1="148" x2="174" y2="160" stroke="#f87171" stroke-width="1.5" stroke-dasharray="4 3" opacity="0.2"/>
+  <line x1="174" y1="220" x2="174" y2="238" stroke="#f87171" stroke-width="1.5" stroke-dasharray="4 3" opacity="0.2"/>
+  <!-- Bar 4 -->
+  <rect x="210" y="190" width="28" height="50" rx="2" fill="none" stroke="#22d3ee" stroke-width="1.5" stroke-dasharray="4 3" opacity="0.2"/>
+  <line x1="224" y1="174" x2="224" y2="190" stroke="#22d3ee" stroke-width="1.5" stroke-dasharray="4 3" opacity="0.2"/>
+  <line x1="224" y1="240" x2="224" y2="256" stroke="#22d3ee" stroke-width="1.5" stroke-dasharray="4 3" opacity="0.2"/>
+  <!-- Bar 5 -->
+  <rect x="380" y="150" width="28" height="80" rx="2" fill="none" stroke="#f87171" stroke-width="1.5" stroke-dasharray="4 3" opacity="0.2"/>
+  <line x1="394" y1="132" x2="394" y2="150" stroke="#f87171" stroke-width="1.5" stroke-dasharray="4 3" opacity="0.2"/>
+  <line x1="394" y1="230" x2="394" y2="248" stroke="#f87171" stroke-width="1.5" stroke-dasharray="4 3" opacity="0.2"/>
+  <!-- Bar 6 -->
+  <rect x="430" y="170" width="28" height="65" rx="2" fill="none" stroke="#22d3ee" stroke-width="1.5" stroke-dasharray="4 3" opacity="0.2"/>
+  <line x1="444" y1="154" x2="444" y2="170" stroke="#22d3ee" stroke-width="1.5" stroke-dasharray="4 3" opacity="0.2"/>
+  <line x1="444" y1="235" x2="444" y2="252" stroke="#22d3ee" stroke-width="1.5" stroke-dasharray="4 3" opacity="0.2"/>
+  <!-- Bar 7 -->
+  <rect x="480" y="185" width="28" height="55" rx="2" fill="none" stroke="#22d3ee" stroke-width="1.5" stroke-dasharray="4 3" opacity="0.2"/>
+  <line x1="494" y1="166" x2="494" y2="185" stroke="#22d3ee" stroke-width="1.5" stroke-dasharray="4 3" opacity="0.2"/>
+  <line x1="494" y1="240" x2="494" y2="258" stroke="#22d3ee" stroke-width="1.5" stroke-dasharray="4 3" opacity="0.2"/>
+
+  <!-- Central icon: chart-up with question mark overlay -->
+  <g transform="translate(270, 110)">
+    <!-- Outer ring -->
+    <circle cx="30" cy="30" r="30" fill="#0f1622" stroke="#22d3ee" stroke-width="1.5" opacity="0.5"/>
+    <!-- Mini bar chart icon -->
+    <rect x="12" y="34" width="7" height="12" rx="1" fill="#22d3ee" opacity="0.35"/>
+    <rect x="22" y="26" width="7" height="20" rx="1" fill="#22d3ee" opacity="0.35"/>
+    <rect x="32" y="20" width="7" height="26" rx="1" fill="#22d3ee" opacity="0.35"/>
+    <rect x="42" y="28" width="7" height="18" rx="1" fill="#22d3ee" opacity="0.35"/>
+    <!-- Slash / no-data overlay -->
+    <line x1="14" y1="46" x2="46" y2="14" stroke="#64748b" stroke-width="1.5" stroke-linecap="round" opacity="0.6"/>
+  </g>
+
+  <!-- Primary label -->
+  <text x="300" y="186" text-anchor="middle" font-family="'Space Grotesk', system-ui, sans-serif" font-size="15" font-weight="600" fill="#94a3b8" letter-spacing="0.02em">No chart data yet</text>
+
+  <!-- Sub-label -->
+  <text x="300" y="208" text-anchor="middle" font-family="'Space Grotesk', system-ui, sans-serif" font-size="12" fill="#475569">Price history will appear once trading begins</text>
+</svg>


### PR DESCRIPTION
## Summary
Replaces the plain-text chart empty states in **PriceChart** and **TradingChart** with a polished designer-provided SVG illustration.

## What changed
- **New component**: `ChartEmptyState` — reusable empty state for chart containers
- **SVG asset**: `public/chart-empty-state.svg` — ghost dashed candlestick bars (cyan/red), center icon with no-data slash, grid lines matching the live chart
- **PriceChart.tsx**: Uses `ChartEmptyState` when `prices.length < 2`, shows current price overlay when available
- **TradingChart.tsx**: Uses `ChartEmptyState` when `filteredPrices.length === 0`

## Design spec (from designer)
- 600×320px viewBox, transparent background (inherits dark surface)
- Ghost dashed candlestick bars (#22d3ee cyan + #f87171 red, 20% opacity)
- Centre icon: bar chart + diagonal no-data slash, 60px circle
- Primary label: "No chart data yet" — Space Grotesk 15px semibold
- Sub-label: "Price history will appear once trading begins"
- Grid lines (#1e2530) match the live chart grid

## Testing
- TypeScript compiles cleanly (`tsc --noEmit` passes)
- Show when: market has 0 OHLCV records OR chart lib returns empty dataset
- Height matches chart container (300–320px)