### PR TITLE
fix: sanitize on-chain sentinel values in market params and earn stats

### DIFF
--- a/app/__tests__/health.test.ts
+++ b/app/__tests__/health.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeMarketHealth } from "../lib/health";
+import { computeMarketHealth, sanitizeBps } from "../lib/health";
 import type { EngineState } from "@percolator/sdk";
 
 function makeEngine(overrides: Partial<EngineState> = {}): EngineState {
@@ -65,5 +65,30 @@ describe("computeMarketHealth", () => {
       insuranceFund: { balance: 100000n, feeRevenue: 0n },
     }));
     expect(h.level).toBe("warning");
+  });
+});
+
+describe("sanitizeBps", () => {
+  it("returns valid bps values", () => {
+    expect(sanitizeBps(10)).toBe(10);
+    expect(sanitizeBps(500)).toBe(500);
+    expect(sanitizeBps(10_000)).toBe(10_000);
+    expect(sanitizeBps(0)).toBe(0);
+  });
+
+  it("returns null for garbage / sentinel values", () => {
+    expect(sanitizeBps(444301198)).toBeNull();
+    expect(sanitizeBps(18446744073709551615n)).toBeNull();
+    expect(sanitizeBps(-1)).toBeNull();
+  });
+
+  it("respects custom maxBps", () => {
+    expect(sanitizeBps(3000, 5_000)).toBe(3000);
+    expect(sanitizeBps(6000, 5_000)).toBeNull();
+  });
+
+  it("handles null/undefined", () => {
+    expect(sanitizeBps(null)).toBeNull();
+    expect(sanitizeBps(undefined)).toBeNull();
   });
 });

--- a/app/components/trade/MarketStatsCard.tsx
+++ b/app/components/trade/MarketStatsCard.tsx
@@ -7,7 +7,7 @@ import { useSlabState } from "@/components/providers/SlabProvider";
 import { useUsdToggle } from "@/components/providers/UsdToggleProvider";
 import { useTokenMeta } from "@/hooks/useTokenMeta";
 import { formatTokenAmount, formatCompactTokenAmount, formatUsd, formatBps } from "@/lib/format";
-import { sanitizeOnChainValue, sanitizeAccountCount } from "@/lib/health";
+import { sanitizeOnChainValue, sanitizeAccountCount, sanitizeBps } from "@/lib/health";
 import { useLivePrice } from "@/hooks/useLivePrice";
 import { resolveMarketPriceE6 } from "@/lib/oraclePrice";
 import { FundingRateCard } from "./FundingRateCard";
@@ -62,8 +62,8 @@ export const MarketStatsCard: FC = () => {
     { label: `${symbol} Price`, value: formatUsd(livePriceE6 ?? (mktConfig ? resolveMarketPriceE6(mktConfig) : 0n)), tooltip: "" },
     { label: "Open Interest", value: oiDisplay, tooltip: oiFullDisplay },
     { label: "Vault", value: vaultDisplay, tooltip: vaultFullDisplay },
-    { label: "Trading Fee", value: formatBps(params.tradingFeeBps), tooltip: "" },
-    { label: "Init. Margin", value: formatBps(params.initialMarginBps), tooltip: "" },
+    { label: "Trading Fee", value: sanitizeBps(params.tradingFeeBps, 5_000) != null ? formatBps(sanitizeBps(params.tradingFeeBps, 5_000)!) : "—", tooltip: "" },
+    { label: "Init. Margin", value: sanitizeBps(params.initialMarginBps) != null ? formatBps(sanitizeBps(params.initialMarginBps)!) : "—", tooltip: "" },
     { label: "Accounts", value: sanitizeAccountCount(engine.numUsedAccounts ?? 0, params ? Number(params.maxAccounts) : undefined).toString(), tooltip: "" },
   ];
 

--- a/app/hooks/useEarnStats.ts
+++ b/app/hooks/useEarnStats.ts
@@ -202,12 +202,18 @@ export function useEarnStats() {
           const oiLongRaw = m.open_interest_long ?? 0;
           const oiShortRaw = m.open_interest_short ?? 0;
           const totalOIRaw = m.total_open_interest ?? oiLongRaw + oiShortRaw;
+          // Sentinel filter: u64::MAX (≈1.84e19) leaks from uninitialized on-chain fields.
+          // Any value above 1e18 is garbage — treat as 0.
+          const isSentinel = (v: number) => v > 1e18;
           // OI values are stored in USDC micro-units (6 decimals) — convert to USD
-          const totalOI = totalOIRaw / 1e6;
+          const totalOI = isSentinel(totalOIRaw) ? 0 : totalOIRaw / 1e6;
           const maxLeverage = m.max_leverage ?? 10;
-          const vaultBalance = m.lp_collateral ?? 0;
-          const tradingFeeBps = m.trading_fee_bps ?? 10;
-          const volume24h = m.volume_24h ?? 0;
+          const vaultBalanceRaw = m.lp_collateral ?? 0;
+          const vaultBalance = isSentinel(vaultBalanceRaw) ? 0 : vaultBalanceRaw;
+          const tradingFeeBpsRaw = m.trading_fee_bps ?? 10;
+          const tradingFeeBps = tradingFeeBpsRaw > 5_000 ? 0 : tradingFeeBpsRaw;
+          const volume24hRaw = m.volume_24h ?? 0;
+          const volume24h = isSentinel(volume24hRaw) ? 0 : volume24hRaw;
           const insuranceRaw = m.insurance_fund ?? 0;
           // Sanity cap: insurance_fund values > 10 billion USDC micro-units ($10M)
           // are corrupt data from bad slab tier detection — clamp to 0

--- a/app/lib/health.ts
+++ b/app/lib/health.ts
@@ -32,6 +32,21 @@ export function sanitizeOnChainValue(v: bigint): bigint {
 }
 
 /**
+ * Sanitize a basis-point parameter from on-chain risk params.
+ * Valid BPS values are in [0, maxBps]. Anything above is treated as garbage
+ * (uninitialized on-chain data) and returns null so the UI can show "—".
+ */
+export function sanitizeBps(
+  bps: bigint | number | null | undefined,
+  maxBps: number = 10_000, // 100%
+): number | null {
+  if (bps == null) return null;
+  const n = typeof bps === "bigint" ? Number(bps) : bps;
+  if (n < 0 || n > maxBps || !Number.isFinite(n)) return null;
+  return n;
+}
+
+/**
  * Maximum possible account slots across all slab tiers (large slab = 4096).
  * Any numUsedAccounts value above this is garbage data from an uninitialized slab.
  */


### PR DESCRIPTION
## What
Fixes display of garbage on-chain values (u64::MAX sentinels from uninitialized slabs) that leak through to the UI as absurd numbers.

## Fixes
- **#543**: Trading Fee displays 4443011.98%
- **#548**: OI Capacity scientific notation overflow

## Changes
- `app/lib/health.ts`: New `sanitizeBps()` — filters BPS values outside valid range
- `app/components/trade/MarketStatsCard.tsx`: Trading Fee and Init. Margin sanitized
- `app/hooks/useEarnStats.ts`: Sentinel filtering for totalOI, vaultBalance, volume24h, tradingFeeBps
- `app/__tests__/health.test.ts`: Tests for sanitizeBps()

## Testing
- pnpm build ✅ | pnpm test — 741 passed ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved data validation for market statistics. Invalid or uninitialized on-chain values now display as "—" instead of erroneous numbers.
  * Enhanced handling of numeric blockchain data to filter out garbage values and prevent invalid display.

* **Tests**
  * Added comprehensive test coverage for data validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->