### PR TITLE
fix(hero): unify hero section with site-wide HUD design language (PERC-350)

### DIFF
--- a/app/components/marketing/HeroCtaGroup.tsx
+++ b/app/components/marketing/HeroCtaGroup.tsx
@@ -23,11 +23,7 @@ export function HeroCtaGroup() {
     <div ref={ref} className="flex flex-wrap items-center gap-3">
       <Link
         href="/create"
-        className={`hero-cta group relative inline-flex items-center gap-2 rounded-xl bg-purple-600 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-purple-500 ${prefersReduced ? '' : 'gsap-fade'}`}
-        style={{
-          boxShadow:
-            "0 0 20px rgba(124,58,237,0.4), 0 0 60px rgba(124,58,237,0.15)",
-        }}
+        className={`hero-cta group relative inline-flex items-center gap-2 border border-[var(--accent)]/50 bg-[var(--accent)]/[0.10] px-6 py-3 text-sm font-semibold text-[var(--accent)] transition-all duration-200 hud-btn-corners hover:border-[var(--accent)] hover:bg-[var(--accent)]/[0.18] press ${prefersReduced ? '' : 'gsap-fade'}`}
       >
         Launch a Market
         <svg
@@ -47,7 +43,7 @@ export function HeroCtaGroup() {
 
       <Link
         href="/markets"
-        className={`hero-cta group inline-flex items-center gap-2 rounded-xl border-[1.5px] border-green-400/30 bg-green-500/15 px-6 py-3 text-[15px] font-semibold text-green-400 transition-all hover:border-green-400/50 hover:bg-green-500/20 ${prefersReduced ? '' : 'gsap-fade'}`}
+        className={`hero-cta group inline-flex items-center gap-2 border border-[var(--long)]/40 bg-[var(--long)]/[0.06] px-6 py-3 text-sm font-semibold text-[var(--long)] transition-all duration-200 hover:border-[var(--long)]/60 hover:bg-[var(--long)]/[0.10] ${prefersReduced ? '' : 'gsap-fade'}`}
       >
         Trade Now
         <svg
@@ -67,7 +63,7 @@ export function HeroCtaGroup() {
 
       <Link
         href="#how-it-works"
-        className={`hero-cta inline-flex items-center gap-1 text-[14px] font-medium text-[#22d3ee] border-b border-[#22d3ee]/40 pb-px transition-colors hover:text-[#67e8f9] hover:border-[#67e8f9]/70 ${prefersReduced ? '' : 'gsap-fade'}`}
+        className={`hero-cta inline-flex items-center gap-1 text-[14px] font-medium text-[var(--cyan)] border-b border-[var(--cyan)]/40 pb-px transition-colors hover:text-[var(--cyan)] hover:border-[var(--cyan)]/70 ${prefersReduced ? '' : 'gsap-fade'}`}
       >
         Earn as Creator <span aria-hidden="true">→</span>
       </Link>

--- a/app/components/marketing/HeroDataChip.tsx
+++ b/app/components/marketing/HeroDataChip.tsx
@@ -36,7 +36,7 @@ export function HeroDataChip({
   return (
     <div
       ref={ref}
-      className={`hidden md:flex items-center gap-2 rounded-lg border border-white/10 bg-black/60 px-3 py-2 text-xs text-white/60 backdrop-blur-sm ${prefersReduced ? '' : 'gsap-fade'} ${className}`}
+      className={`hidden md:flex items-center gap-2 border border-[var(--border)] bg-[var(--panel-bg)]/90 px-3 py-2 text-xs text-[var(--text-secondary)] backdrop-blur-sm ${prefersReduced ? '' : 'gsap-fade'} ${className}`}
       style={{
         animation: prefersReduced
           ? undefined

--- a/app/components/marketing/HeroHeadline.tsx
+++ b/app/components/marketing/HeroHeadline.tsx
@@ -42,7 +42,7 @@ export function HeroHeadline() {
           Any Market.
         </span>
         <span
-          className={`hero-line block bg-gradient-to-r from-purple-400 via-violet-300 to-cyan-400 bg-clip-text text-transparent ${prefersReduced ? '' : 'gsap-fade'}`}
+          className={`hero-line block bg-gradient-to-r from-[var(--accent)] via-violet-400 to-[var(--cyan)] bg-clip-text text-transparent ${prefersReduced ? '' : 'gsap-fade'}`}
         >
           Permissionless.
         </span>

--- a/app/components/marketing/HeroSection.tsx
+++ b/app/components/marketing/HeroSection.tsx
@@ -124,17 +124,10 @@ export function HeroSection() {
         className="pointer-events-none absolute inset-0"
         style={{
           background:
-            "radial-gradient(ellipse 500px 600px at calc(100% + 100px) 200px, rgba(34,211,238,0.06), transparent)",
+            "radial-gradient(ellipse 500px 600px at calc(100% + 100px) 200px, rgba(34,211,238,0.09), transparent)",
         }}
       />
-      {/* Center horizon */}
-      <div
-        className="pointer-events-none absolute inset-0"
-        style={{
-          background:
-            "linear-gradient(90deg, transparent, rgba(124,58,237,0.03) 30%, rgba(34,211,238,0.03) 70%, transparent)",
-        }}
-      />
+      {/* Center horizon — removed (adds nothing visible) */}
 
       {/* ── Content ── */}
       <div className="relative z-10 mx-auto grid w-full max-w-[1280px] grid-cols-1 items-center gap-12 px-6 pt-12 pb-16 md:grid-cols-[55%_45%] lg:gap-16">
@@ -144,7 +137,7 @@ export function HeroSection() {
           <div
             className={`hero-fade ${prefersReduced ? '' : 'gsap-fade'}`}
           >
-            <div className="inline-flex items-center gap-2 rounded-full border border-purple-500/40 bg-purple-500/10 px-3 py-1">
+            <div className="inline-flex items-center gap-2 border border-[var(--accent)]/30 bg-[var(--accent)]/[0.05] px-3 py-1">
               <span className="relative flex h-2 w-2">
                 {sysStatus === "online" && (
                   <span
@@ -156,10 +149,10 @@ export function HeroSection() {
                 />
               </span>
               <span
-                className="text-[12px] font-medium uppercase tracking-widest text-purple-300"
+                className="text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--accent)]/80"
                 style={{ fontFamily: "var(--font-heading)" }}
               >
-                Live on Solana {network === "mainnet" ? "Mainnet" : "Devnet"}
+                // Live on Solana {network === "mainnet" ? "Mainnet" : "Devnet"}
               </span>
             </div>
           </div>
@@ -169,13 +162,13 @@ export function HeroSection() {
 
           {/* Subheadline */}
           <p
-            className={`hero-fade max-w-[520px] text-base leading-[1.6] text-[#d1d5db] sm:text-lg ${prefersReduced ? '' : 'gsap-fade'}`}
+            className={`hero-fade max-w-[520px] text-base leading-[1.6] text-[var(--text)] sm:text-lg ${prefersReduced ? '' : 'gsap-fade'}`}
           >
             Deploy a perpetual futures market for any Solana token.
             <br />
             No permission. No admin key. No gatekeepers.
             <br />
-            <span className="text-[#9ca3af]">
+            <span className="text-[var(--text-secondary)]">
               Earn 8% of all trading fees as the market creator.
             </span>
           </p>
@@ -193,22 +186,22 @@ export function HeroSection() {
 
           {/* Social proof bar */}
           <div
-            className={`hero-fade flex flex-wrap items-center gap-4 text-[12px] text-[#6b7280] ${prefersReduced ? '' : 'gsap-fade'}`}
+            className={`hero-fade flex flex-wrap items-center gap-4 text-[12px] text-[var(--text-muted)] ${prefersReduced ? '' : 'gsap-fade'}`}
           >
             <span className="flex items-center gap-1.5">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" className="text-[#6b7280]">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" className="text-[var(--text-muted)]">
                 <circle cx="12" cy="12" r="10" />
               </svg>
               Powered by Solana
             </span>
             <span className="flex items-center gap-1.5">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-[#6b7280]">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-[var(--text-muted)]">
                 <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
               </svg>
               Open Source
             </span>
             <span className="flex items-center gap-1.5">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" className="text-[#6b7280]">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" className="text-[var(--text-muted)]">
                 <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
               </svg>
               MIT License

--- a/app/components/marketing/HeroStats.tsx
+++ b/app/components/marketing/HeroStats.tsx
@@ -66,7 +66,7 @@ export function HeroStats({
           {i > 0 && (
             <span className="mr-2 hidden text-white/10 md:inline">|</span>
           )}
-          <span className="text-[#9ca3af]">{s.label}</span>
+          <span className="text-[var(--text-secondary)]">{s.label}</span>
           {s.value}
         </div>
       ))}

--- a/app/components/marketing/LiveMarketCard.tsx
+++ b/app/components/marketing/LiveMarketCard.tsx
@@ -18,31 +18,35 @@ export function LiveMarketCard({ className = "", animate = true }: { className?:
 
       {/* Floating card */}
       <div
-        className="w-full max-w-[380px] overflow-hidden rounded-2xl border border-white/10 bg-[#111118] shadow-[0_32px_80px_rgba(0,0,0,0.6)]"
+        className="w-full max-w-[380px] overflow-hidden border border-[var(--border)] bg-[var(--panel-bg)]"
         style={{
           animation: "market-card-float 4s ease-in-out infinite",
           willChange: "transform",
+          boxShadow: "0 0 40px rgba(153,69,255,0.08), 0 0 80px rgba(20,241,149,0.04)",
         }}
       >
         {/* Card header */}
-        <div className="flex items-center justify-between border-b border-white/5 px-5 py-3.5">
+        <div className="flex items-center justify-between border-b border-[var(--border-subtle)] px-5 py-3.5">
           <div className="flex items-center gap-3">
-            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gradient-to-br from-purple-500 to-violet-600 text-xs font-bold text-white">
+            <div
+              className="flex h-8 w-8 items-center justify-center bg-[var(--accent)]/[0.10] border border-[var(--accent)]/20 text-xs font-bold text-[var(--accent)]"
+              style={{ fontFamily: "var(--font-heading)" }}
+            >
               S
             </div>
             <div>
-              <div className="text-sm font-semibold text-white">SOL-PERP</div>
-              <div className="text-[10px] text-white/40">
+              <div className="text-sm font-semibold text-[var(--text)]" style={{ fontFamily: "var(--font-heading)" }}>SOL-PERP</div>
+              <div className="text-[10px] text-[var(--text-muted)]">
                 Perpetual · 20x max
               </div>
             </div>
           </div>
           <div className="text-right">
-            <div className="inline-flex items-center gap-1 rounded-full border border-green-400/30 bg-green-400/10 px-2 py-0.5 text-[10px] font-medium text-green-400">
-              <span className="h-1.5 w-1.5 rounded-full bg-green-400 animate-pulse" />
+            <div className="inline-flex items-center gap-1 border border-[var(--long)]/30 bg-[var(--long)]/10 px-2 py-0.5 text-[10px] font-medium text-[var(--long)]">
+              <span className="h-1.5 w-1.5 bg-[var(--long)] animate-pulse" />
               LIVE
             </div>
-            <div className="mt-0.5 text-[11px] font-medium text-green-400">
+            <div className="mt-0.5 text-[11px] font-medium text-[var(--long)]" style={{ fontFamily: "var(--font-heading)" }}>
               +3.24% ↑
             </div>
           </div>
@@ -62,20 +66,20 @@ export function LiveMarketCard({ className = "", animate = true }: { className?:
         <div className="grid grid-cols-2 gap-2 px-5 pb-3">
           <Link
             href="/markets"
-            className="flex h-10 items-center justify-center rounded-lg border border-green-500/40 bg-green-500/20 text-sm font-semibold text-green-400 transition-colors hover:bg-green-500/30"
+            className="flex h-10 items-center justify-center border border-[var(--long)]/40 bg-[var(--long)]/[0.12] text-sm font-bold text-[var(--long)] transition-colors hover:bg-[var(--long)]/[0.20]"
           >
             LONG
           </Link>
           <Link
             href="/markets"
-            className="flex h-10 items-center justify-center rounded-lg border border-red-500/40 bg-red-500/20 text-sm font-semibold text-red-400 transition-colors hover:bg-red-500/30"
+            className="flex h-10 items-center justify-center border border-[var(--short)]/40 bg-[var(--short)]/[0.12] text-sm font-bold text-[var(--short)] transition-colors hover:bg-[var(--short)]/[0.20]"
           >
             SHORT
           </Link>
         </div>
 
         {/* Card footer */}
-        <div className="border-t border-white/5 px-5 py-2.5 text-center text-[11px] text-white/40">
+        <div className="border-t border-[var(--border-subtle)] px-5 py-2.5 text-center text-[11px] text-[var(--text-muted)]">
           8% Creator Fee · $2,500 seed · Launch in 60s
         </div>
       </div>

--- a/app/components/marketing/MiniOrderBook.tsx
+++ b/app/components/marketing/MiniOrderBook.tsx
@@ -42,26 +42,26 @@ export function MiniOrderBook({ className = "" }: { className?: string }) {
       {[...sells].reverse().map((l, i) => (
         <div key={`s-${i}`} className="relative flex items-center justify-between py-0.5">
           <div
-            className="absolute inset-y-0 right-0 bg-red-500/15 transition-all duration-500"
+            className="absolute inset-y-0 right-0 bg-[var(--short)]/15 transition-all duration-500"
             style={{ width: `${l.width}%` }}
           />
-          <span className="relative z-10 text-white/40">SELL</span>
-          <span className="relative z-10 text-red-400/80">{l.price}</span>
+          <span className="relative z-10 text-[var(--text-muted)]">SELL</span>
+          <span className="relative z-10 text-[var(--short)]/80">{l.price}</span>
         </div>
       ))}
-      <div className="my-1 flex items-center gap-2 text-white/30">
-        <span className="h-px flex-1 bg-white/10" />
+      <div className="my-1 flex items-center gap-2 text-[var(--text-muted)]">
+        <span className="h-px flex-1 bg-[var(--border)]" />
         <span className="text-[10px]">{basePrice.toFixed(2)}</span>
-        <span className="h-px flex-1 bg-white/10" />
+        <span className="h-px flex-1 bg-[var(--border)]" />
       </div>
       {buys.map((l, i) => (
         <div key={`b-${i}`} className="relative flex items-center justify-between py-0.5">
           <div
-            className="absolute inset-y-0 right-0 bg-green-500/15 transition-all duration-500"
+            className="absolute inset-y-0 right-0 bg-[var(--long)]/15 transition-all duration-500"
             style={{ width: `${l.width}%` }}
           />
-          <span className="relative z-10 text-white/40">BUY</span>
-          <span className="relative z-10 text-green-400/80">{l.price}</span>
+          <span className="relative z-10 text-[var(--text-muted)]">BUY</span>
+          <span className="relative z-10 text-[var(--long)]/80">{l.price}</span>
         </div>
       ))}
     </div>

--- a/app/components/marketing/MiniSparkline.tsx
+++ b/app/components/marketing/MiniSparkline.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback, useId } from "react";
 
 /** Generate a seeded random-walk price series */
 function generatePriceSeries(length: number, seed: number, base: number): number[] {
@@ -65,16 +65,19 @@ export function MiniSparkline({
   const areaPoints = `0,${height} ${points} ${width},${height}`;
   const currentPrice = prices[prices.length - 1];
 
+  const gradientId = useId();
+  const fillId = `sparkFill-${gradientId}`;
+
   return (
     <div className={className}>
       <div className="mb-2 flex items-baseline gap-2">
         <span
-          className="text-[28px] font-semibold tracking-tight text-white"
+          className="text-[28px] font-semibold tracking-tight text-[var(--text)]"
           style={{ fontFamily: "var(--font-heading)" }}
         >
           ${currentPrice.toFixed(2)}
         </span>
-        <span className={`text-xs ${currentPrice >= basePrice ? "text-green-400" : "text-red-400"}`}>
+        <span className={`text-xs ${currentPrice >= basePrice ? "text-[var(--long)]" : "text-[var(--short)]"}`}>
           {currentPrice >= basePrice ? "+" : ""}{((currentPrice / basePrice - 1) * 100).toFixed(2)}%
         </span>
       </div>
@@ -86,16 +89,16 @@ export function MiniSparkline({
         preserveAspectRatio="none"
       >
         <defs>
-          <linearGradient id="sparkFill" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0%" stopColor="rgb(124,58,237)" stopOpacity="0.15" />
-            <stop offset="100%" stopColor="rgb(124,58,237)" stopOpacity="0" />
+          <linearGradient id={fillId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#14F195" stopOpacity="0.12" />
+            <stop offset="100%" stopColor="#14F195" stopOpacity="0" />
           </linearGradient>
         </defs>
-        <polygon points={areaPoints} fill="url(#sparkFill)" />
+        <polygon points={areaPoints} fill={`url(#${fillId})`} />
         <polyline
           points={points}
           fill="none"
-          stroke="rgb(124,58,237)"
+          stroke="var(--long)"
           strokeWidth="2"
           strokeLinejoin="round"
           strokeLinecap="round"


### PR DESCRIPTION
## Summary

Implements PERC-350 designer spec to align the hero section with the site-wide sharp/terminal HUD design language. The hero previously used rounded corners, SaaS-style pill badges, and hardcoded hex colors that clashed with the rest of the page.

## Changes (8 files, 52 insertions, 56 deletions)

### P1 — Visual consistency
- **HeroCtaGroup**: Remove `rounded-xl` from CTAs; primary uses `hud-btn-corners` + `var(--accent)` token; secondary uses `var(--long)` token
- **HeroSection eyebrow badge**: `rounded-full` → sharp border; `// section label` pattern with monospace font + `var(--accent)/80`
- **LiveMarketCard**: `rounded-2xl` → sharp; replace `border-white/10`, `bg-[#111118]`, drop shadow with `var(--border)`, `var(--panel-bg)`, subtle accent glow; all content colors via design tokens
- **MiniSparkline**: Purple line/fill → `var(--long)` green (`#14F195`); fix SVG gradient ID collision with `useId()`
- **LONG/SHORT buttons**: Remove `rounded-lg`; `green-500`/`red-500` → `var(--long)`/`var(--short)`

### P2 — Token alignment
- **HeroSection body**: `text-[#d1d5db]` → `var(--text)`; `text-[#9ca3af]` → `var(--text-secondary)`; `text-[#6b7280]` → `var(--text-muted)`
- **HeroDataChip**: `rounded-lg` → sharp; `border-white/10` → `var(--border)`; `bg-black/60` → `var(--panel-bg)/90`
- **HeroStats**: `text-[#9ca3af]` → `var(--text-secondary)`
- **MiniOrderBook**: `bg-red-500/15`/`bg-green-500/15` → `var(--short)`/`var(--long)`; `text-red-400`/`text-green-400` → tokens
- **HeroHeadline**: Gradient uses `var(--accent)` and `var(--cyan)` tokens

### P3 — Cleanup
- Remove invisible center horizon gradient from hero background
- Increase cyan right glow opacity slightly (0.06 → 0.09)

## Verification
- [x] TypeScript compiles clean (`tsc --noEmit` passes)
- [ ] Hero CTAs match footer CTA button style
- [ ] Sparkline is green, not purple
- [ ] No `rounded-xl`/`rounded-2xl`/`rounded-full` in hero components (except animate-ping dot)
- [ ] No hardcoded hex content colors remain in changed files

Implements designer spec from `perc-350-hero-live-market-redesign.md`.