### PR TITLE
fix(PERC-350): align hero section with site-wide HUD design system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ render-pdf.mjs
 .worktrees/
 program/target/
 percolator/target/
+tests/devnet-e2e-large*.ts

--- a/app/components/marketing/LiveMarketCard.tsx
+++ b/app/components/marketing/LiveMarketCard.tsx
@@ -29,7 +29,7 @@ export function LiveMarketCard({ className = "", animate = true }: { className?:
         <div className="flex items-center justify-between border-b border-[var(--border-subtle)] px-5 py-3.5">
           <div className="flex items-center gap-3">
             <div
-              className="flex h-8 w-8 items-center justify-center bg-[var(--accent)]/[0.10] border border-[var(--accent)]/20 text-xs font-bold text-[var(--accent)]"
+              className="flex h-8 w-8 items-center justify-center border border-[var(--accent)]/20 bg-[var(--accent)]/[0.10] text-xs font-bold text-[var(--accent)]"
               style={{ fontFamily: "var(--font-heading)" }}
             >
               S

--- a/app/components/marketing/MiniSparkline.tsx
+++ b/app/components/marketing/MiniSparkline.tsx
@@ -64,7 +64,6 @@ export function MiniSparkline({
 
   const areaPoints = `0,${height} ${points} ${width},${height}`;
   const currentPrice = prices[prices.length - 1];
-
   const gradientId = useId();
   const fillId = `sparkFill-${gradientId}`;
 


### PR DESCRIPTION
## PERC-350: Hero Section Design Token Alignment

Implements designer spec to resolve the jarring style break between the hero section (rounded SaaS aesthetic) and the rest of the site (sharp terminal/HUD design).

### Changes (8 files)
- **HeroCtaGroup**: rounded-xl → sharp with hud-btn-corners, --accent/--long tokens
- **HeroSection**: eyebrow badge sharp with // prefix, body text → design tokens, social proof → --text-muted, remove center horizon glow
- **LiveMarketCard**: rounded-2xl → sharp, all hardcoded white/green/red → design tokens, subtle accent glow
- **MiniSparkline**: purple line → var(--long) green, unique gradient IDs via useId()
- **HeroDataChip**: rounded-lg → sharp, --border/--panel-bg tokens
- **HeroStats**: hardcoded hex → var(--text-secondary)
- **HeroHeadline**: gradient → design token vars
- **MiniOrderBook**: green-*/red-* → var(--long)/var(--short)

### Testing
- pnpm build ✅ | pnpm test — 741 passed ✅
- No hardcoded hex colors remain in changed files
- All border radii removed (except animate-ping dot)