### PR TITLE
fix: homepage insurance fund shows $2K instead of $2.4M (#551)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ render-pdf.mjs
 .worktrees/
 program/target/
 percolator/target/
+tests/devnet-e2e-large*.ts

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -145,6 +145,15 @@ export default function Home() {
             const usd = (raw / 10 ** d) * p;
             return usd > MAX_PER_MARKET_USD ? 0 : usd; // discard absurd values
           };
+          // For insurance/TVL: when price is missing, fall back to raw token amount
+          // (correct for stablecoins like USDC where 1 token ≈ $1)
+          const toUsdWithFallback = (raw: number, decimals: number | null, price: number | null): number => {
+            if (!isSaneMarketValue(raw)) return 0;
+            const d = Math.min(Math.max(decimals ?? 6, 0), 18);
+            const p = price ?? 0;
+            const usd = p > 0 ? (raw / 10 ** d) * p : raw / 10 ** d;
+            return usd > MAX_PER_MARKET_USD ? 0 : usd;
+          };
 
           // Filter out empty/abandoned markets using shared active-market filter
           // (consistent with /api/stats and markets page)
@@ -157,7 +166,8 @@ export default function Home() {
               // Fall back to insurance_balance if insurance_fund is missing.
               const raw = Number(m.insurance_fund ?? m.insurance_balance ?? 0);
               if (!isSaneMarketValue(raw)) return s;
-              return s + toUsd(raw, m.decimals, m.last_price);
+              // Use fallback converter — insurance should show even when price oracle is unavailable
+              return s + toUsdWithFallback(raw, m.decimals, m.last_price);
             }, 0),
           });
           setStatsLoaded(true);


### PR DESCRIPTION
## What
Homepage Insurance Fund metric showed $2.0K while /earn showed $2,464,907 — a 1,200x discrepancy.

## Root Cause
`toUsd()` returns 0 when `last_price` is null/0. Most devnet markets lack price data, so their insurance was dropped from the homepage total.

## Fix
Add `toUsdWithFallback()` that falls back to `raw / 10^decimals` when price is unavailable (correct for stablecoins like USDC). Applied only to insurance fund aggregation.

## Testing
- `pnpm build` ✅ | `pnpm test` — 745 passed ✅

Fixes #551