### PR TITLE
fix: vault detail shows UNKNOWN-PERP for non-active markets (#547)

### DIFF
--- a/app/app/earn/[slab]/page.tsx
+++ b/app/app/earn/[slab]/page.tsx
@@ -10,6 +10,7 @@ import { useStakeDeposit } from '@/hooks/useStakeDeposit';
 import { useStakeWithdraw } from '@/hooks/useStakeWithdraw';
 import { useEngineState } from '@/hooks/useEngineState';
 import { useEarnStats, type MarketVaultInfo } from '@/hooks/useEarnStats';
+import { getSupabase } from '@/lib/supabase';
 import { OiCapMeter } from '@/components/earn/OiCapMeter';
 import { ScrollReveal } from '@/components/ui/ScrollReveal';
 import { AnimatedNumber } from '@/components/ui/AnimatedNumber';
@@ -70,6 +71,25 @@ function VaultDetailInner({ slabAddress }: { slabAddress: string }) {
     return earnStats.markets.find((m) => m.slabAddress === slabAddress) ?? null;
   }, [earnStats.markets, slabAddress]);
 
+  // Fallback: fetch symbol directly from Supabase if market not in earn stats
+  // (e.g., market status is not 'active' so it's filtered out of useEarnStats)
+  const [fallbackSymbol, setFallbackSymbol] = useState<string | null>(null);
+  useEffect(() => {
+    if (marketInfo || earnLoading) return;
+    let cancelled = false;
+    getSupabase()
+      .from('markets_with_stats')
+      .select('symbol, name')
+      .eq('slab_address', slabAddress)
+      .maybeSingle()
+      .then(({ data }) => {
+        if (!cancelled && data?.symbol) {
+          setFallbackSymbol(data.symbol);
+        }
+      });
+    return () => { cancelled = true; };
+  }, [marketInfo, earnLoading, slabAddress]);
+
   const loading = poolLoading || earnLoading;
 
   // Callbacks
@@ -89,7 +109,7 @@ function VaultDetailInner({ slabAddress }: { slabAddress: string }) {
     [stakeWithdraw, refreshState],
   );
 
-  const symbol = marketInfo?.symbol ?? 'UNKNOWN';
+  const symbol = marketInfo?.symbol ?? fallbackSymbol ?? 'UNKNOWN';
   const maxOI = marketInfo?.maxOI ?? 0;
   const currentOI = marketInfo?.totalOI ?? (totalOI ? Number(totalOI) / 1e6 : 0);
   const estimatedApy = marketInfo?.estimatedApyPct ?? 0;


### PR DESCRIPTION
## What
Vault detail page showed 'UNKNOWN-PERP' when the market wasn't in useEarnStats (which filters to status='active' only).

## Fix
Added a direct Supabase fallback query for the market symbol when not found in earn stats.

## Testing
- `pnpm build` ✅ | `pnpm test` — 745 passed ✅

Fixes #547

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced symbol retrieval on the earn page with fallback mechanisms to ensure consistent and reliable display when primary data sources are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->