### PR TITLE
fix: markets page shows 0 markets due to aggressive filter (#544, #545)

### DIFF
--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -218,8 +218,9 @@ function MarketsPageInner() {
         : (isSaneNum(m.supabase?.total_open_interest ?? 0) ||
            isSaneNum((m.supabase?.open_interest_long ?? 0) + (m.supabase?.open_interest_short ?? 0)));
 
-      // Keep market if it has at least a price (on-chain or Supabase)
-      return hasOnChainPrice || hasSupabasePrice || hasVolume || hasOI;
+      // Keep market if it has data OR if it's marked active in Supabase
+      const isActive = m.supabase ? isActiveMarket(m.supabase) : false;
+      return isActive || hasOnChainPrice || hasSupabasePrice || hasVolume || hasOI;
     });
   }, [effectiveMarkets]);
 


### PR DESCRIPTION
## What
/markets showed 0 markets while /earn showed 157. 

## Root Cause
The markets page's `activeMarkets` filter required at least price, volume, or OI data. Most devnet markets have none of these yet, so they were all filtered out. The /earn page only checks `status='active'` from Supabase.

## Fix
Include markets that are marked 'active' in Supabase, regardless of trading data.

## Testing
- `pnpm build` ✅ | `pnpm test` — 745 passed ✅

Fixes #544, #545