### PR TITLE
fix: /markets page shows 0 markets (#544, #545)

### DIFF
--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -218,8 +218,9 @@ function MarketsPageInner() {
         : (isSaneNum(m.supabase?.total_open_interest ?? 0) ||
            isSaneNum((m.supabase?.open_interest_long ?? 0) + (m.supabase?.open_interest_short ?? 0)));
 
-      // Keep market if it has at least a price (on-chain or Supabase)
-      return hasOnChainPrice || hasSupabasePrice || hasVolume || hasOI;
+      // Keep market if it has data OR if it's marked active in Supabase
+      const isActive = m.supabase ? isActiveMarket(m.supabase) : false;
+      return isActive || hasOnChainPrice || hasSupabasePrice || hasVolume || hasOI;
     });
   }, [effectiveMarkets]);
 


### PR DESCRIPTION
## What
/markets showed 0 markets while /earn showed 157 — critical broken navigation.

## Root Cause
`activeMarkets` filter required price, volume, or OI to show a market. Devnet markets with `status='active'` but no oracle price/volume data were all filtered out.

## Fix
Include markets marked active in Supabase (`isActiveMarket()`) regardless of on-chain data, consistent with /earn page.

## Testing
- `pnpm build` ✅ | `pnpm test` — 745 passed ✅

Fixes #544, Fixes #545