### PR TITLE
feat(PERC-352): P0 UI fixes — skeleton loaders, tabular-nums, SOL-PERP default, mobile bottom nav

### DIFF
--- a/app/app/globals.css
+++ b/app/app/globals.css
@@ -59,6 +59,21 @@ body {
   color: var(--text);
   font-family: var(--font-sans);
   font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum";
+}
+
+/* ─── Tabular Numbers — enforce on all numeric displays ─── */
+[style*="font-family: var(--font-jetbrains-mono)"],
+[style*="font-family:var(--font-jetbrains-mono)"],
+[data-numeric],
+.tabular-nums {
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum";
+}
+
+/* ─── Safe Area — mobile bottom nav ─── */
+.safe-area-bottom {
+  padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
 /* ─── Noise Texture Overlay ─── */

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -7,6 +7,7 @@ import "./globals.css";
 import { Providers } from "./providers";
 import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
+import { MobileBottomNav } from "@/components/layout/MobileBottomNav";
 import { TickerBanner } from "@/components/layout/TickerBanner";
 import { CursorGlow } from "@/components/ui/CursorGlow";
 import { MusicPlayer } from "@/components/ui/MusicPlayer";
@@ -53,8 +54,9 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           <div className="relative z-[1] flex min-h-screen flex-col">
             <TickerBanner />
             <Header />
-            <main className="flex-1">{children}</main>
+            <main className="flex-1 pb-[60px] md:pb-0">{children}</main>
             <Footer />
+            <MobileBottomNav />
           </div>
           <MusicPlayer />
         </Providers>

--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -692,18 +692,18 @@ function MarketsPageInner() {
                         </div>
                       </div>
                       <div className="text-right truncate">
-                        <span className="text-sm text-white" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
+                        <span className="text-sm text-white tabular-nums" style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>
                           {lastPrice != null
                             ? `$${lastPrice < 0.01 ? lastPrice.toFixed(6) : lastPrice < 1 ? lastPrice.toFixed(4) : lastPrice.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
                             : "\u2014"}
                         </span>
                       </div>
-                      <div className="text-right text-sm text-[var(--text-secondary)] truncate" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>{oiDisplay}</div>
-                      <div className="text-right text-sm text-[var(--text-secondary)] truncate" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
+                      <div className="text-right text-sm text-[var(--text-secondary)] truncate tabular-nums" style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>{oiDisplay}</div>
+                      <div className="text-right text-sm text-[var(--text-secondary)] truncate tabular-nums" style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>
                         {volumeDisplay ?? "\u2014"}
                       </div>
-                      <div className="text-right text-sm text-[var(--text)] truncate" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>{insuranceDisplay}</div>
-                      <div className="text-right text-sm text-[var(--text-secondary)]">{m.maxLeverage}x</div>
+                      <div className="text-right text-sm text-[var(--text)] truncate tabular-nums" style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>{insuranceDisplay}</div>
+                      <div className="text-right text-sm text-[var(--text-secondary)] tabular-nums" style={{ fontVariantNumeric: "tabular-nums" }}>{m.maxLeverage}x</div>
                       <div className="text-right"><HealthBadge level={health.level} /></div>
                     </Link>
                   );
@@ -742,9 +742,24 @@ function MarketsPageInner() {
 export default function MarketsPage() {
   return (
     <Suspense fallback={
-      <div className="min-h-[calc(100vh-48px)] flex flex-col items-center justify-center gap-3">
-        <div className="h-8 w-8 animate-spin rounded-full border-2 border-[var(--accent)] border-t-transparent" />
-        <span className="text-xs text-[var(--text-muted)]">Loading markets…</span>
+      <div className="min-h-[calc(100vh-48px)] relative">
+        <div className="absolute inset-x-0 top-0 h-32 bg-grid pointer-events-none" />
+        <div className="relative mx-auto max-w-4xl px-4 pt-4 pb-10">
+          <div className="mb-8">
+            <ShimmerSkeleton className="h-3 w-20 mb-2" />
+            <ShimmerSkeleton className="h-8 w-48 mb-2" />
+            <ShimmerSkeleton className="h-4 w-72" />
+          </div>
+          <div className="mb-6 flex gap-3">
+            <ShimmerSkeleton className="flex-1 h-11" />
+            <ShimmerSkeleton className="h-11 w-48" />
+          </div>
+          <div className="space-y-2">
+            {[1, 2, 3, 4, 5, 6].map((i) => (
+              <ShimmerSkeleton key={i} className="h-[52px]" />
+            ))}
+          </div>
+        </div>
       </div>
     }>
       <MarketsPageInner />

--- a/app/app/portfolio/page.tsx
+++ b/app/app/portfolio/page.tsx
@@ -8,6 +8,7 @@ import { formatTokenAmount, formatPriceE6 } from "@/lib/format";
 import dynamic from "next/dynamic";
 import { ScrollReveal } from "@/components/ui/ScrollReveal";
 import { GlowButton } from "@/components/ui/GlowButton";
+import { ShimmerSkeleton } from "@/components/ui/ShimmerSkeleton";
 import { useMultiTokenMeta } from "@/hooks/useMultiTokenMeta";
 import { PublicKey } from "@solana/web3.js";
 import { isMockMode } from "@/lib/mock-mode";
@@ -150,7 +151,7 @@ export default function PortfolioPage() {
             ].map((stat) => (
               <div key={stat.label} className="bg-[var(--panel-bg)] p-5 transition-colors duration-200 hover:bg-[var(--bg-elevated)]">
                 <p className="mb-2 text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-dim)]">{stat.label}</p>
-                <p className={`text-xl font-bold ${stat.color}`} style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
+                <p className={`text-xl font-bold tabular-nums ${stat.color}`} style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>
                   {stat.value}
                 </p>
                 {stat.sub && (
@@ -166,9 +167,29 @@ export default function PortfolioPage() {
         {/* Positions */}
         <ScrollReveal delay={0.2}>
           {loading || tokenMetasLoading ? (
-            <div className="space-y-px">
+            <div className="space-y-3">
               {[1, 2, 3].map((i) => (
-                <div key={i} className="h-14 animate-pulse bg-[var(--panel-bg)] border border-[var(--border)]" />
+                <div key={i} className="border border-[var(--border)] bg-[var(--panel-bg)] p-4">
+                  <div className="flex items-center justify-between mb-3">
+                    <div className="flex items-center gap-3">
+                      <ShimmerSkeleton className="h-5 w-28" />
+                      <ShimmerSkeleton className="h-5 w-14 rounded" />
+                      <ShimmerSkeleton className="h-5 w-10 rounded" />
+                    </div>
+                    <div className="text-right flex items-center gap-2">
+                      <ShimmerSkeleton className="h-5 w-20" />
+                      <ShimmerSkeleton className="h-4 w-14" />
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-2 gap-x-6 gap-y-1.5 sm:grid-cols-5">
+                    {[1, 2, 3, 4, 5].map((j) => (
+                      <div key={j}>
+                        <ShimmerSkeleton className="h-3 w-12 mb-1.5" />
+                        <ShimmerSkeleton className="h-4 w-16" />
+                      </div>
+                    ))}
+                  </div>
+                </div>
               ))}
             </div>
           ) : positions.length === 0 ? (
@@ -231,7 +252,7 @@ export default function PortfolioPage() {
                       {/* Row 1: Market name, side, PnL */}
                       <div className="flex items-center justify-between gap-4">
                         <div className="flex items-center gap-3">
-                          <span className="text-sm font-semibold text-white" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
+                          <span className="text-sm font-semibold text-white" style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>
                             {tokenMetaMap.get(pos.market.config.collateralMint.toBase58())?.symbol ?? pos.slabAddress.slice(0, 8) + "\u2026"}/USD
                           </span>
                           <span className={`rounded px-2 py-0.5 text-[10px] font-bold ${
@@ -252,7 +273,7 @@ export default function PortfolioPage() {
                         <div className="text-right">
                           <span
                             className={`text-sm font-bold ${pnlPositive ? "text-[var(--long)]" : "text-[var(--short)]"}`}
-                            style={{ fontFamily: "var(--font-jetbrains-mono)" }}
+                            style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}
                           >
                             {formatPnl(unrealizedPnl)}
                           </span>
@@ -268,25 +289,25 @@ export default function PortfolioPage() {
                       <div className="mt-3 grid grid-cols-2 gap-x-6 gap-y-1.5 sm:grid-cols-5">
                         <div>
                           <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">Size</p>
-                          <p className="text-[12px] text-white" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
+                          <p className="text-[12px] text-white" style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>
                             {formatTokenAmount(sizeAbs)}
                           </p>
                         </div>
                         <div>
                           <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">Entry</p>
-                          <p className="text-[12px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
+                          <p className="text-[12px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>
                             {formatPriceE6(posEntry)}
                           </p>
                         </div>
                         <div>
                           <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">Mark Price</p>
-                          <p className="text-[12px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
+                          <p className="text-[12px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>
                             {oraclePriceE6 > 0n ? formatPriceE6(oraclePriceE6) : "—"}
                           </p>
                         </div>
                         <div>
                           <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">Capital</p>
-                          <p className="text-[12px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
+                          <p className="text-[12px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>
                             {formatTokenAmount(posCapital)}
                           </p>
                         </div>
@@ -313,7 +334,7 @@ export default function PortfolioPage() {
                                   ? "text-[var(--warning)]"
                                   : "text-[var(--text-secondary)]"
                               }`}
-                              style={{ fontFamily: "var(--font-jetbrains-mono)" }}
+                              style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}
                             >
                               {hasPosition && liquidationPriceE6 > 0n
                                 ? formatPriceE6(liquidationPriceE6)

--- a/app/app/trade/page.tsx
+++ b/app/app/trade/page.tsx
@@ -3,15 +3,17 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import { ShimmerSkeleton } from "@/components/ui/ShimmerSkeleton";
 
 /**
  * /trade (no slab parameter)
  *
- * Redirects to the highest-volume active market.
- * Falls back to the markets browser if no markets are available.
+ * Redirects to SOL-PERP (by symbol match) or the highest-volume
+ * active market. Falls back to the markets browser if no markets
+ * are available.
  *
- * Fixes: GitHub issue #480 — /trade was returning 404 because
- * the only trade route was /trade/[slab] (dynamic segment required).
+ * PERC-352: Default to SOL-PERP instead of a blank state.
+ * Shows skeleton UI during redirect for perceived performance.
  */
 
 interface MarketRow {
@@ -55,8 +57,27 @@ export default function TradeRedirectPage() {
           (m) => m.last_price != null && m.last_price > 0 && m.last_price < 1e18
         );
 
-        // Pick by highest 24h volume, falling back to first active, then first overall
-        const sorted = [...(active.length > 0 ? active : markets)].sort(
+        const pool = active.length > 0 ? active : markets;
+
+        // PERC-352: Prefer SOL-PERP or SOL/USD by symbol match
+        const solPerp = pool.find((m) => {
+          const sym = (m.symbol ?? "").toUpperCase();
+          return (
+            sym === "SOL-PERP" ||
+            sym === "SOL/USD" ||
+            sym === "SOL" ||
+            sym.startsWith("SOL-") ||
+            sym.startsWith("SOL/")
+          );
+        });
+
+        if (solPerp?.slab_address) {
+          router.replace(`/trade/${solPerp.slab_address}`);
+          return;
+        }
+
+        // Fallback: highest 24h volume
+        const sorted = [...pool].sort(
           (a, b) => (b.volume_24h ?? 0) - (a.volume_24h ?? 0)
         );
 
@@ -121,6 +142,12 @@ export default function TradeRedirectPage() {
           </p>
           <div className="mt-4 flex items-center justify-center gap-3">
             <Link
+              href="/create"
+              className="border border-[var(--accent)]/40 bg-[var(--accent)]/10 px-4 py-1.5 text-[11px] text-[var(--accent)] hover:bg-[var(--accent)]/20 transition-colors"
+            >
+              Create Market
+            </Link>
+            <Link
               href="/markets"
               className="border border-[var(--border)] px-4 py-1.5 text-[11px] text-[var(--text-secondary)] hover:border-[var(--accent)]/40 hover:text-[var(--text)] transition-colors"
             >
@@ -132,13 +159,60 @@ export default function TradeRedirectPage() {
     );
   }
 
-  // Loading / redirecting
+  // PERC-352: Skeleton loading state (replaces spinner)
+  // Matches the trade page layout to reduce perceived loading time
   return (
-    <div className="min-h-[calc(100vh-48px)] flex flex-col items-center justify-center gap-3">
-      <div className="h-8 w-8 animate-spin rounded-full border-2 border-[var(--accent)] border-t-transparent" />
-      <p className="text-[11px] text-[var(--text-muted)] uppercase tracking-[0.15em]">
-        Finding best market…
-      </p>
+    <div className="min-h-[calc(100vh-48px)]">
+      {/* Mobile header skeleton */}
+      <div className="sticky top-0 z-30 border-b border-[var(--border)]/50 bg-[var(--bg)]/95 px-3 py-2 backdrop-blur-sm lg:hidden">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <ShimmerSkeleton className="h-8 w-8 rounded-full" />
+            <ShimmerSkeleton className="h-5 w-32" />
+          </div>
+          <ShimmerSkeleton className="h-6 w-20" />
+        </div>
+      </div>
+
+      {/* Desktop header skeleton */}
+      <div className="hidden lg:flex items-start justify-between px-4 py-2 gap-3 border-b border-[var(--border)]/30">
+        <div className="min-w-0">
+          <ShimmerSkeleton className="h-3 w-16 mb-2" />
+          <div className="flex items-center gap-2.5">
+            <ShimmerSkeleton className="h-12 w-12 rounded-full" />
+            <ShimmerSkeleton className="h-7 w-40" />
+          </div>
+        </div>
+        <ShimmerSkeleton className="h-8 w-24" />
+      </div>
+
+      {/* Mobile layout skeleton */}
+      <div className="flex flex-col gap-1.5 px-2 pt-2 pb-4 lg:hidden">
+        <ShimmerSkeleton className="h-[300px] w-full" />
+        <ShimmerSkeleton className="h-[240px] w-full" />
+      </div>
+
+      {/* Desktop layout skeleton */}
+      <div className="hidden lg:grid grid-cols-[1fr_340px] gap-1.5 px-3 pb-3 pt-1.5">
+        <div className="min-w-0 space-y-1.5">
+          <ShimmerSkeleton className="h-[500px] w-full" />
+          <ShimmerSkeleton className="h-[200px] w-full" />
+        </div>
+        <div className="min-w-0 space-y-1.5">
+          <ShimmerSkeleton className="h-[350px] w-full" />
+          <ShimmerSkeleton className="h-[300px] w-full" />
+        </div>
+      </div>
+
+      {/* Subtle loading indicator */}
+      <div className="fixed bottom-20 md:bottom-4 left-1/2 -translate-x-1/2 z-50">
+        <div className="flex items-center gap-2 rounded-sm border border-[var(--border)] bg-[var(--bg)]/95 px-3 py-1.5 backdrop-blur-sm">
+          <div className="h-3 w-3 animate-spin rounded-full border border-[var(--accent)] border-t-transparent" />
+          <span className="text-[10px] text-[var(--text-muted)] uppercase tracking-[0.15em]">
+            Loading SOL-PERP…
+          </span>
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/components/layout/MobileBottomNav.tsx
+++ b/app/components/layout/MobileBottomNav.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { FC } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+interface NavTab {
+  href: string;
+  label: string;
+  /** Match prefix for active state (e.g. "/trade" matches "/trade/xxx") */
+  matchPrefix?: string;
+  icon: React.ReactNode;
+}
+
+const tabs: NavTab[] = [
+  {
+    href: "/",
+    label: "Home",
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 12l8.954-8.955a1.126 1.126 0 011.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
+      </svg>
+    ),
+  },
+  {
+    href: "/markets",
+    label: "Markets",
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5m.75-9l3-3 2.148 2.148A12.061 12.061 0 0116.5 7.605" />
+      </svg>
+    ),
+  },
+  {
+    href: "/trade",
+    label: "Trade",
+    matchPrefix: "/trade",
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3 7.5L7.5 3m0 0L12 7.5M7.5 3v13.5m13.5 0L16.5 21m0 0L12 16.5m4.5 4.5V7.5" />
+      </svg>
+    ),
+  },
+  {
+    href: "/portfolio",
+    label: "Portfolio",
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M21 12a2.25 2.25 0 00-2.25-2.25H15a3 3 0 11-6 0H5.25A2.25 2.25 0 003 12m18 0v6a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 18v-6m18 0V9M3 12V9m18 0a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 9m18 0V6a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6v3" />
+      </svg>
+    ),
+  },
+  {
+    href: "/earn",
+    label: "Earn",
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v12m-3-2.818l.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    ),
+  },
+];
+
+export const MobileBottomNav: FC = () => {
+  const pathname = usePathname();
+
+  const isActive = (tab: NavTab): boolean => {
+    if (tab.matchPrefix) {
+      return pathname.startsWith(tab.matchPrefix);
+    }
+    return pathname === tab.href;
+  };
+
+  return (
+    <nav
+      className="fixed bottom-0 inset-x-0 z-50 border-t border-[var(--border)] bg-[var(--bg)]/95 backdrop-blur-md md:hidden safe-area-bottom"
+      aria-label="Mobile navigation"
+    >
+      <div className="flex items-stretch justify-around">
+        {tabs.map((tab) => {
+          const active = isActive(tab);
+          return (
+            <Link
+              key={tab.href}
+              href={tab.href}
+              className={[
+                "flex flex-1 flex-col items-center justify-center gap-0.5 py-2 min-h-[56px] transition-colors duration-150 relative",
+                active
+                  ? "text-[var(--accent)]"
+                  : "text-[var(--text-muted)] active:text-[var(--text-secondary)]",
+              ].join(" ")}
+              aria-current={active ? "page" : undefined}
+            >
+              {/* Active indicator line */}
+              {active && (
+                <span className="absolute top-0 inset-x-3 h-[2px] bg-[var(--accent)] rounded-b-full" />
+              )}
+              <span className={active ? "text-[var(--accent)]" : "text-[var(--text-muted)]"}>
+                {tab.icon}
+              </span>
+              <span className="text-[10px] font-medium tracking-wide">
+                {tab.label}
+              </span>
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+};

--- a/app/components/marketing/MiniOrderBook.tsx
+++ b/app/components/marketing/MiniOrderBook.tsx
@@ -37,7 +37,7 @@ export function MiniOrderBook({ className = "" }: { className?: string }) {
   return (
     <div
       className={`font-mono text-[11px] leading-relaxed ${className}`}
-      style={{ fontFamily: "var(--font-mono, 'JetBrains Mono', monospace)" }}
+      style={{ fontFamily: "var(--font-mono, 'JetBrains Mono', monospace)", fontVariantNumeric: "tabular-nums" }}
     >
       {[...sells].reverse().map((l, i) => (
         <div key={`s-${i}`} className="relative flex items-center justify-between py-0.5">

--- a/app/components/trade/AccountsCard.tsx
+++ b/app/components/trade/AccountsCard.tsx
@@ -130,7 +130,7 @@ export const AccountsCard: FC = () => {
             {t.label} ({t.count})
           </button>
         ))}
-        <span className="ml-auto text-[9px] text-[var(--text-dim)]" style={{ fontFamily: "var(--font-mono)" }}>{accounts.length} total</span>
+        <span className="ml-auto text-[9px] text-[var(--text-dim)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>{accounts.length} total</span>
       </div>
 
       {sortedRows.length === 0 ? (
@@ -158,8 +158,8 @@ export const AccountsCard: FC = () => {
                 const absPos = row.positionSize < 0n ? -row.positionSize : row.positionSize;
                 return (
                   <tr key={row.idx} className="border-b border-[var(--border)]/20 transition-colors hover:bg-[var(--accent)]/[0.03]">
-                    <td className="whitespace-nowrap px-2 py-1.5 text-left text-[var(--text-dim)]" style={{ fontFamily: "var(--font-mono)" }}>{i + 1}</td>
-                    <td className="whitespace-nowrap px-2 py-1.5 text-left text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-mono)" }}>{shortenAddress(row.owner)}</td>
+                    <td className="whitespace-nowrap px-2 py-1.5 text-left text-[var(--text-dim)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>{i + 1}</td>
+                    <td className="whitespace-nowrap px-2 py-1.5 text-left text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>{shortenAddress(row.owner)}</td>
                     {isOpenLike && (
                       <td className="whitespace-nowrap px-2 py-1.5 text-left">
                         {row.direction === "IDLE" ? <span className="text-[var(--text-dim)]">-</span> : (
@@ -170,16 +170,16 @@ export const AccountsCard: FC = () => {
                       </td>
                     )}
                     {isOpenLike && (
-                      <td className={`whitespace-nowrap px-2 py-1.5 text-right ${row.positionSize > 0n ? "text-[var(--long)]" : row.positionSize < 0n ? "text-[var(--short)]" : "text-[var(--text-dim)]"}`} style={{ fontFamily: "var(--font-mono)" }}>
+                      <td className={`whitespace-nowrap px-2 py-1.5 text-right ${row.positionSize > 0n ? "text-[var(--long)]" : row.positionSize < 0n ? "text-[var(--short)]" : "text-[var(--text-dim)]"}`} style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
                         {row.positionSize !== 0n ? formatTokenAmount(absPos) : "-"}
                       </td>
                     )}
-                    {isOpenLike && <td className="whitespace-nowrap px-2 py-1.5 text-right text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>{row.entryPrice > 0n ? formatUsd(row.entryPrice) : "-"}</td>}
+                    {isOpenLike && <td className="whitespace-nowrap px-2 py-1.5 text-right text-[var(--text)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>{row.entryPrice > 0n ? formatUsd(row.entryPrice) : "-"}</td>}
                     {isOpenLike && (
                       <td className="whitespace-nowrap px-2 py-1.5 text-right">
                         {row.positionSize !== 0n ? (
                           <div className="flex items-center justify-end gap-1">
-                            <span className="text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>{formatLiqPrice(row.liqPrice)}</span>
+                            <span className="text-[var(--text)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>{formatLiqPrice(row.liqPrice)}</span>
                             <div className="h-1 w-8 shrink-0 bg-[var(--border)]/50">
                               <div className={`h-1 ${liqBarColor(row.liqHealthPct)}`} style={{ width: `${Math.max(8, row.liqHealthPct)}%` }} />
                             </div>
@@ -187,12 +187,12 @@ export const AccountsCard: FC = () => {
                         ) : "-"}
                       </td>
                     )}
-                    <td className={`whitespace-nowrap px-2 py-1.5 text-right ${row.pnl > 0n ? "text-[var(--long)]" : row.pnl < 0n ? "text-[var(--short)]" : "text-[var(--text-dim)]"}`} style={{ fontFamily: "var(--font-mono)" }}>
+                    <td className={`whitespace-nowrap px-2 py-1.5 text-right ${row.pnl > 0n ? "text-[var(--long)]" : row.pnl < 0n ? "text-[var(--short)]" : "text-[var(--text-dim)]"}`} style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
                       {formatPnl(row.pnl)}
                     </td>
-                    <td className="whitespace-nowrap px-2 py-1.5 text-right text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>{formatTokenAmount(row.capital)}</td>
+                    <td className="whitespace-nowrap px-2 py-1.5 text-right text-[var(--text)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>{formatTokenAmount(row.capital)}</td>
                     {isOpenLike && (
-                      <td className={`whitespace-nowrap px-2 py-1.5 text-right ${row.marginPct > 50 ? "text-[var(--long)]" : row.marginPct > 20 ? "text-[var(--warning)]" : "text-[var(--short)]"}`} style={{ fontFamily: "var(--font-mono)" }}>
+                      <td className={`whitespace-nowrap px-2 py-1.5 text-right ${row.marginPct > 50 ? "text-[var(--long)]" : row.marginPct > 20 ? "text-[var(--warning)]" : "text-[var(--short)]"}`} style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
                         {row.positionSize !== 0n ? `${row.marginPct.toFixed(1)}%` : "-"}
                       </td>
                     )}

--- a/app/components/trade/DepositTrigger.tsx
+++ b/app/components/trade/DepositTrigger.tsx
@@ -87,7 +87,7 @@ export const DepositTrigger: FC<{ slabAddress: string }> = ({ slabAddress }) => 
       >
         <div className="flex items-center gap-2">
           <span className="text-[9px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Account</span>
-          <span className="text-[11px] font-medium text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>
+          <span className="text-[11px] font-medium text-[var(--text)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
             {formatTokenAmount(capital)} {symbol}
           </span>
         </div>

--- a/app/components/trade/FundingRateCard.tsx
+++ b/app/components/trade/FundingRateCard.tsx
@@ -212,7 +212,7 @@ export const FundingRateCard: FC<{ slabAddress: string }> = ({ slabAddress }) =>
           <div className="flex items-baseline gap-1.5">
             <span
               className={`text-sm font-bold ${hourlyRatePercent >= 0 ? "text-[var(--short)]" : "text-[var(--long)]"}`}
-              style={{ fontFamily: "var(--font-mono)" }}
+              style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}
             >
               {rateDisplay}
             </span>
@@ -228,7 +228,7 @@ export const FundingRateCard: FC<{ slabAddress: string }> = ({ slabAddress }) =>
               <span className="ml-1.5 text-[9px] text-[var(--text-dim)]">· next {formatCountdown(countdown)}</span>
             )}
           </div>
-          <span className="text-[10px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-mono)" }}>
+          <span className="text-[10px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
             {(fundingData.aprPercent ?? 0) >= 0 ? "+" : ""}{(fundingData.aprPercent ?? 0).toFixed(1)}% APR
           </span>
         </div>
@@ -240,7 +240,7 @@ export const FundingRateCard: FC<{ slabAddress: string }> = ({ slabAddress }) =>
               <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">
                 Est. 24h ({positionDirection})
               </span>
-              <span className={`text-[11px] font-bold ${fundingColor}`} style={{ fontFamily: "var(--font-mono)" }}>
+              <span className={`text-[11px] font-bold ${fundingColor}`} style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
                 {fundingSign}{estimatedFunding24h.toFixed(4)} tokens
               </span>
             </div>

--- a/app/components/trade/MarketStatsCard.tsx
+++ b/app/components/trade/MarketStatsCard.tsx
@@ -75,7 +75,7 @@ export const MarketStatsCard: FC = () => {
           {stats.map((s) => (
             <div key={s.label} className="px-1.5 py-1 overflow-hidden border-b border-r border-[var(--border)]/20 last:border-r-0 [&:nth-child(3n)]:border-r-0 [&:nth-last-child(-n+3)]:border-b-0">
               <p className="text-[8px] uppercase tracking-[0.1em] text-[var(--text-muted)] truncate">{s.label}</p>
-              <p className="text-[11px] font-medium text-[var(--text)] truncate" title={s.tooltip || s.value} style={{ fontFamily: "var(--font-mono)" }}>{s.value}</p>
+              <p className="text-[11px] font-medium text-[var(--text)] truncate" title={s.tooltip || s.value} style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>{s.value}</p>
             </div>
           ))}
         </div>

--- a/app/components/trade/PositionsTable.tsx
+++ b/app/components/trade/PositionsTable.tsx
@@ -183,28 +183,28 @@ export const PositionsTable: FC<{ slabAddress: string }> = ({ slabAddress }) => 
               </td>
 
               {/* Size */}
-              <td className="whitespace-nowrap px-3 py-2.5 text-right" style={{ fontFamily: "var(--font-mono)" }}>
+              <td className="whitespace-nowrap px-3 py-2.5 text-right" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
                 <span className="text-[var(--text)]">{formatTokenAmount(absPosition, decimals)}</span>
                 <span className="ml-1 text-[var(--text-dim)]">{symbol}</span>
               </td>
 
               {/* Entry */}
-              <td className="whitespace-nowrap px-3 py-2.5 text-right text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>
+              <td className="whitespace-nowrap px-3 py-2.5 text-right text-[var(--text)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
                 {formatUsd(entryPriceE6)}
               </td>
 
               {/* Mark */}
-              <td className="whitespace-nowrap px-3 py-2.5 text-right text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>
+              <td className="whitespace-nowrap px-3 py-2.5 text-right text-[var(--text)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
                 {hasValidMark ? formatUsd(currentPriceE6) : <span className="text-[var(--text-dim)]">--</span>}
               </td>
 
               {/* Liq. Price */}
-              <td className="whitespace-nowrap px-3 py-2.5 text-right text-[var(--warning)]" style={{ fontFamily: "var(--font-mono)" }}>
+              <td className="whitespace-nowrap px-3 py-2.5 text-right text-[var(--warning)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
                 {formatLiqPrice(liqPriceE6)}
               </td>
 
               {/* PnL */}
-              <td className={`whitespace-nowrap px-3 py-2.5 text-right ${hasValidMark ? pnlColor : "text-[var(--text-dim)]"}`} style={{ fontFamily: "var(--font-mono)" }}>
+              <td className={`whitespace-nowrap px-3 py-2.5 text-right ${hasValidMark ? pnlColor : "text-[var(--text-dim)]"}`} style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
                 {hasValidMark ? (
                   <>
                     <div>{formatPnl(pnlTokens, decimals)} {symbol}</div>
@@ -220,7 +220,7 @@ export const PositionsTable: FC<{ slabAddress: string }> = ({ slabAddress }) => 
               </td>
 
               {/* ROE% */}
-              <td className={`whitespace-nowrap px-3 py-2.5 text-right font-medium ${hasValidMark ? roeColor : "text-[var(--text-dim)]"}`} style={{ fontFamily: "var(--font-mono)" }}>
+              <td className={`whitespace-nowrap px-3 py-2.5 text-right font-medium ${hasValidMark ? roeColor : "text-[var(--text-dim)]"}`} style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
                 {hasValidMark ? formatPercent(roe) : "--"}
               </td>
 

--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -304,7 +304,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
       <div className="mb-2">
         <div className="mb-1 flex items-center justify-between">
           <label className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Margin ({symbol})<InfoIcon tooltip="The amount of collateral you're putting up for this trade. If your position loses more than your margin, you get liquidated." /></label>
-          <span className="text-[10px] text-[var(--text-dim)]" style={{ fontFamily: "var(--font-mono)" }}>
+          <span className="text-[10px] text-[var(--text-dim)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
             Bal: {formatPerc(capital, decimals)}
           </span>
         </div>
@@ -314,7 +314,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
             value={marginInput}
             onChange={(e) => setMarginInput(e.target.value.replace(/[^0-9.]/g, ""))}
             placeholder="0.00"
-            style={{ fontFamily: "var(--font-mono)" }}
+            style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}
             className={`w-full rounded-none border px-3 py-2 pr-14 text-sm text-[var(--text)] placeholder-[var(--text-muted)] focus:outline-none focus:ring-1 ${
               exceedsMargin
                 ? "border-[var(--short)]/50 bg-[var(--short)]/5 focus:border-[var(--short)] focus:ring-[var(--short)]/30"
@@ -331,7 +331,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
           </button>
         </div>
         {exceedsMargin && (
-          <p className="mt-1 text-[10px] text-[var(--short)]" style={{ fontFamily: "var(--font-mono)" }}>
+          <p className="mt-1 text-[10px] text-[var(--short)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
             Exceeds balance ({formatPerc(capital, decimals)} {symbol})
           </p>
         )}
@@ -354,7 +354,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
       <div className="mb-5">
         <div className="mb-1 flex items-center justify-between">
           <label className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Leverage<InfoIcon tooltip="Multiplies your position size. 5x leverage means 5x the profit but also 5x the loss. Higher leverage = higher risk of liquidation." /></label>
-          <span className="text-[11px] font-medium text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>{leverage}x</span>
+          <span className="text-[11px] font-medium text-[var(--text)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>{leverage}x</span>
         </div>
         <input
           type="range"
@@ -459,7 +459,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
       )}
 
       {lastSig && (
-        <p className="mt-2 text-[10px] text-[var(--text-dim)]" style={{ fontFamily: "var(--font-mono)" }}>
+        <p className="mt-2 text-[10px] text-[var(--text-dim)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
           Tx:{" "}
           <a
             href={`${explorerTxUrl(lastSig)}`}

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -225,7 +225,7 @@ export const TradingChart: FC<{ slabAddress: string }> = ({ slabAddress }) => {
       {/* Header */}
       <div className="mb-3 flex items-center justify-between">
         <div>
-          <div className="text-2xl font-bold" style={{ fontFamily: "var(--font-mono)", color: isUp ? "var(--long)" : "var(--short)" }}>
+          <div className="text-2xl font-bold" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums", color: isUp ? "var(--long)" : "var(--short)" }}>
             ${currentPrice.toFixed(currentPrice < 1 ? 4 : 2)}
           </div>
           <div className="text-xs" style={{ color: isUp ? "var(--long)" : "var(--short)" }}>


### PR DESCRIPTION
## PERC-352: P0 UI Fixes from Design Brief

Implements all 4 P0 items from the designer's UI/UX audit (PERC-351):

### 1. ✅ Skeleton Loaders Everywhere
- **`/trade` redirect page**: Full-page skeleton matching trade layout (replaces bare spinner)
- **`/markets` Suspense fallback**: Skeleton matching page structure (replaces spinner)
- **`/portfolio` positions loading**: ShimmerSkeleton cards matching actual position card layout (replaces `animate-pulse` divs)

### 2. ✅ Tabular Number Formatting
- Added `font-feature-settings: 'tnum'` to `body` alongside `font-variant-numeric: tabular-nums`
- Explicit `fontVariantNumeric: 'tabular-nums'` on all price/PnL elements across:
  - PositionsTable, TradeForm, TradingChart, MarketStatsCard
  - FundingRateCard, AccountsCard, DepositTrigger, MiniOrderBook
  - Markets table columns (price, OI, volume, insurance, leverage)
  - Portfolio summary stats
- Added `.tabular-nums` utility class in `globals.css`
- **Prevents number jitter** when digits change in real-time displays

### 3. ✅ Default `/trade` to SOL-PERP
- `/trade` now prefers SOL-PERP (or SOL/USD, SOL) by symbol match
- Falls back to highest-volume market if no SOL market found
- Loading indicator says "Loading SOL-PERP…" for clear user expectation

### 4. ✅ Mobile Bottom Tab Navigation
- New `MobileBottomNav` component: **Home | Markets | Trade | Portfolio | Earn**
- Fixed bottom with iOS safe-area padding
- Active tab indicator with accent color
- 56px min-height touch targets (thumb-zone optimized)
- Hidden on desktop (`md:` breakpoint), visible on mobile only
- `pb-[60px]` on main content to prevent bottom-nav overlap

### Files Changed (14)
- `app/globals.css` — tabular-nums + safe-area CSS
- `app/layout.tsx` — MobileBottomNav + mobile padding
- `app/trade/page.tsx` — SOL-PERP default + skeleton loading
- `app/markets/page.tsx` — skeleton Suspense fallback + tabular-nums
- `app/portfolio/page.tsx` — skeleton positions loading + tabular-nums
- `components/layout/MobileBottomNav.tsx` — NEW
- `components/trade/*` — tabular-nums across 7 trade components
- `components/marketing/MiniOrderBook.tsx` — tabular-nums

Closes PERC-352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile bottom navigation for quick access to Home, Markets, Trade, Portfolio, and Earn sections
  * Introduced skeleton-based loading screens across Markets, Portfolio, and Trade pages for improved visual feedback
  * Enhanced Trade page with improved redirect logic and better no-markets state UI

* **Style**
  * Improved numeric alignment across all numeric displays for better readability
  * Added mobile safe-area support for devices with notches

<!-- end of auto-generated comment: release notes by coderabbit.ai -->