### PR TITLE
feat(PERC-363): airdrop button + API for user-created markets

### DIFF
--- a/app/app/api/airdrop/route.ts
+++ b/app/app/api/airdrop/route.ts
@@ -1,0 +1,199 @@
+/**
+ * PERC-363: Token airdrop endpoint
+ *
+ * POST /api/airdrop { marketAddress: string, walletAddress: string }
+ *
+ * Airdrops $500 USD worth of the market's devnet token to the wallet.
+ * Rate limited: 1 claim per wallet per market per 24h.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  Transaction,
+  sendAndConfirmTransaction,
+} from "@solana/web3.js";
+import {
+  getAssociatedTokenAddress,
+  createAssociatedTokenAccountInstruction,
+  createMintToInstruction,
+} from "@solana/spl-token";
+import { getConfig } from "@/lib/config";
+import { getServiceClient } from "@/lib/supabase";
+import * as Sentry from "@sentry/nextjs";
+
+export const dynamic = "force-dynamic";
+
+const NETWORK = process.env.NEXT_PUBLIC_SOLANA_NETWORK ?? "devnet";
+const AIRDROP_USD_VALUE = 500;
+const RATE_LIMIT_HOURS = 24;
+const ORACLE_BRIDGE_URL = process.env.ORACLE_BRIDGE_URL ?? "http://127.0.0.1:18802";
+
+export async function POST(req: NextRequest) {
+  try {
+    if (NETWORK !== "devnet") {
+      return NextResponse.json({ error: "Only available on devnet" }, { status: 403 });
+    }
+
+    const body = await req.json();
+    const { marketAddress, walletAddress } = body;
+
+    if (!marketAddress || !walletAddress) {
+      return NextResponse.json({ error: "Missing marketAddress or walletAddress" }, { status: 400 });
+    }
+
+    let walletPk: PublicKey;
+    try { walletPk = new PublicKey(walletAddress); } catch {
+      return NextResponse.json({ error: "Invalid walletAddress" }, { status: 400 });
+    }
+
+    const supabase = getServiceClient();
+
+    // Rate limit check
+    const cutoff = new Date(Date.now() - RATE_LIMIT_HOURS * 60 * 60 * 1000).toISOString();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: recent } = await (supabase as any)
+      .from("airdrop_claims")
+      .select("id")
+      .eq("wallet", walletAddress)
+      .eq("market_address", marketAddress)
+      .gte("claimed_at", cutoff)
+      .limit(1);
+
+    if (recent && recent.length > 0) {
+      // Calculate time remaining
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data: lastClaim } = await (supabase as any)
+        .from("airdrop_claims")
+        .select("claimed_at")
+        .eq("wallet", walletAddress)
+        .eq("market_address", marketAddress)
+        .order("claimed_at", { ascending: false })
+        .limit(1)
+        .single();
+
+      const nextClaimAt = lastClaim
+        ? new Date(new Date(lastClaim.claimed_at).getTime() + RATE_LIMIT_HOURS * 60 * 60 * 1000).toISOString()
+        : null;
+
+      return NextResponse.json(
+        { error: "Already claimed in the last 24 hours", nextClaimAt },
+        { status: 429 },
+      );
+    }
+
+    // Look up the devnet mint for this market
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: marketData } = await (supabase as any)
+      .from("markets")
+      .select("mint_address, symbol")
+      .eq("slab_address", marketAddress)
+      .maybeSingle();
+
+    if (!marketData?.mint_address) {
+      return NextResponse.json({ error: "Market not found" }, { status: 404 });
+    }
+
+    const mintPk = new PublicKey(marketData.mint_address);
+    const symbol = marketData.symbol ?? "TOKEN";
+
+    // Get current price from oracle bridge
+    let priceUsd = 1.0; // fallback
+    try {
+      // Try to get price from the market's oracle or bridge
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data: stats } = await (supabase as any)
+        .from("markets_with_stats")
+        .select("last_price")
+        .eq("slab_address", marketAddress)
+        .maybeSingle();
+
+      if (stats?.last_price && stats.last_price > 0) {
+        priceUsd = stats.last_price;
+      }
+    } catch {}
+
+    // Load mint authority
+    const mintAuthKeyJson = process.env.DEVNET_MINT_AUTHORITY_KEYPAIR;
+    if (!mintAuthKeyJson) {
+      return NextResponse.json(
+        { error: "Server not configured for minting" },
+        { status: 500 },
+      );
+    }
+    const mintAuthority = Keypair.fromSecretKey(
+      Uint8Array.from(JSON.parse(mintAuthKeyJson)),
+    );
+
+    const cfg = getConfig();
+    const connection = new Connection(cfg.rpcUrl, "confirmed");
+
+    // Calculate airdrop amount
+    const decimals = 6; // Standard for devnet mirrors
+    const tokensFloat = AIRDROP_USD_VALUE / priceUsd;
+    const airdropAmount = BigInt(Math.floor(tokensFloat * 10 ** decimals));
+
+    const tx = new Transaction();
+
+    // Create ATA if needed
+    const ata = await getAssociatedTokenAddress(mintPk, walletPk);
+    try {
+      await connection.getTokenAccountBalance(ata);
+    } catch {
+      tx.add(
+        createAssociatedTokenAccountInstruction(
+          mintAuthority.publicKey,
+          ata,
+          walletPk,
+          mintPk,
+        ),
+      );
+    }
+
+    // Mint tokens
+    tx.add(
+      createMintToInstruction(
+        mintPk,
+        ata,
+        mintAuthority.publicKey,
+        airdropAmount,
+      ),
+    );
+
+    const sig = await sendAndConfirmTransaction(
+      connection,
+      tx,
+      [mintAuthority],
+      { commitment: "confirmed" },
+    );
+
+    // Record claim
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (supabase as any).from("airdrop_claims").insert({
+      wallet: walletAddress,
+      market_address: marketAddress,
+      amount_tokens: tokensFloat,
+      amount_usd: AIRDROP_USD_VALUE,
+      signature: sig,
+    });
+
+    return NextResponse.json({
+      status: "airdropped",
+      symbol,
+      tokens: tokensFloat,
+      usdValue: AIRDROP_USD_VALUE,
+      signature: sig,
+      nextClaimAt: new Date(Date.now() + RATE_LIMIT_HOURS * 60 * 60 * 1000).toISOString(),
+    });
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: { endpoint: "/api/airdrop", method: "POST" },
+    });
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/components/trade/AirdropButton.tsx
+++ b/app/components/trade/AirdropButton.tsx
@@ -1,0 +1,132 @@
+/**
+ * PERC-363: Airdrop button for user-created markets
+ *
+ * Shows a "Get [TOKEN]" button that airdrops $500 USD worth of devnet tokens.
+ * Rate limited: 1 claim per wallet per market per 24h with countdown timer.
+ */
+
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import { useWalletCompat } from "@/hooks/useWalletCompat";
+
+interface AirdropButtonProps {
+  marketAddress: string;
+  symbol: string;
+  /** Only show on user-created markets (not SOL-PERP, etc.) */
+  isUserCreated?: boolean;
+}
+
+export function AirdropButton({ marketAddress, symbol, isUserCreated = true }: AirdropButtonProps) {
+  const { publicKey, connected } = useWalletCompat();
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<{ tokens: number; nextClaimAt: string } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [countdown, setCountdown] = useState<string | null>(null);
+  const [nextClaimAt, setNextClaimAt] = useState<string | null>(null);
+
+  const isDevnet = process.env.NEXT_PUBLIC_SOLANA_NETWORK === "devnet";
+
+  // Countdown timer
+  useEffect(() => {
+    const target = nextClaimAt ?? result?.nextClaimAt;
+    if (!target) { setCountdown(null); return; }
+
+    const update = () => {
+      const remaining = new Date(target).getTime() - Date.now();
+      if (remaining <= 0) {
+        setCountdown(null);
+        setNextClaimAt(null);
+        setResult(null);
+        return;
+      }
+      const h = Math.floor(remaining / 3600000);
+      const m = Math.floor((remaining % 3600000) / 60000);
+      setCountdown(`${h}h ${m}m`);
+    };
+
+    update();
+    const interval = setInterval(update, 60000);
+    return () => clearInterval(interval);
+  }, [nextClaimAt, result?.nextClaimAt]);
+
+  const claim = useCallback(async () => {
+    if (!publicKey || loading) return;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const resp = await fetch("/api/airdrop", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          marketAddress,
+          walletAddress: publicKey.toBase58(),
+        }),
+      });
+
+      const data = await resp.json();
+
+      if (resp.status === 429) {
+        setNextClaimAt(data.nextClaimAt);
+        setError("Already claimed — try again later");
+      } else if (!resp.ok) {
+        setError(data.error ?? "Airdrop failed");
+      } else {
+        setResult({ tokens: data.tokens, nextClaimAt: data.nextClaimAt });
+      }
+    } catch (e: any) {
+      setError(e.message ?? "Network error");
+    } finally {
+      setLoading(false);
+    }
+  }, [publicKey, marketAddress, loading]);
+
+  // Don't render on mainnet or for non-user-created markets
+  if (!isDevnet || !isUserCreated) return null;
+
+  // Not connected
+  if (!connected) return null;
+
+  // Already claimed with countdown
+  if (countdown) {
+    return (
+      <div className="flex items-center gap-2 px-3 py-1.5 rounded bg-[var(--panel-bg)] border border-[var(--border)] text-[11px]">
+        <span className="text-[var(--text-secondary)]">Next claim in</span>
+        <span className="text-[var(--accent)] font-mono tabular-nums">{countdown}</span>
+      </div>
+    );
+  }
+
+  // Success state
+  if (result) {
+    return (
+      <div className="flex items-center gap-2 px-3 py-1.5 rounded bg-[var(--long)]/10 border border-[var(--long)]/20 text-[11px]">
+        <span className="text-[var(--long)]">
+          ✅ Got {result.tokens.toLocaleString(undefined, { maximumFractionDigits: 2 })} {symbol}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      onClick={claim}
+      disabled={loading}
+      className="px-4 py-2 rounded bg-[var(--accent)] text-black text-[12px] font-medium
+                 hover:brightness-110 active:brightness-95 transition-all
+                 disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      {loading ? (
+        <span className="flex items-center gap-2">
+          <span className="animate-spin">⟳</span> Claiming...
+        </span>
+      ) : (
+        <>Get {symbol} 💰</>
+      )}
+      {error && (
+        <span className="block text-[10px] text-red-400 mt-0.5">{error}</span>
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
## What
'Get [TOKEN] 💰' button on market pages that airdrops $500 worth of devnet tokens.

## Backend
`POST /api/airdrop { marketAddress, walletAddress }`
- Mints $500 USD / current price = tokens to wallet
- Rate limited: 1 claim per wallet per market per 24h

## Frontend
`AirdropButton` component with:
- Countdown timer after claim
- Success state showing tokens received
- Only renders on devnet + user-created markets

## Testing
- `pnpm build` ✅ | `pnpm test` — 745 passed ✅