### PR TITLE
feat(PERC-366): Multi-profile MM fleet — 3 makers per market

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "format:check": "prettier --check packages/*/src/**/*.ts",
     "start": "pnpm --filter @percolator/app start",
     "maker": "tsx scripts/floating-maker.ts",
-    "maker:dry": "DRY_RUN=true tsx scripts/floating-maker.ts"
+    "maker:dry": "DRY_RUN=true tsx scripts/floating-maker.ts",
+    "fleet": "tsx scripts/mm-fleet.ts",
+    "fleet:dry": "DRY_RUN=true tsx scripts/mm-fleet.ts"
   },
   "engines": {
     "node": ">=20"

--- a/scripts/README-mm-fleet.md
+++ b/scripts/README-mm-fleet.md
@@ -1,0 +1,213 @@
+# PERC-366: Market Maker Fleet
+
+Multi-profile oracle-anchored market making for Percolator devnet. Runs **3 independent market maker instances per market** to create realistic-looking orderbook depth.
+
+## Why a Fleet?
+
+A single market maker creates one bid and one ask. Real orderbooks have depth — multiple price levels with varying sizes. The fleet runs 3 profiles per market:
+
+| Profile | Spread | Size | Re-quote | Role |
+|---------|--------|------|----------|------|
+| **WIDE** | 60 bps | $2,000/side | 8s | "Bedrock" liquidity — wide spread, large size, backstop |
+| **TIGHT_A** | 15 bps | $300/side | 3s | Top-of-book action — tight spread, fast updates |
+| **TIGHT_B** | 20 bps | $250/side | 4s | Second aggressive layer — slight oracle offset for staggering |
+
+This creates 6 distinct price levels per market (3 bids + 3 asks) with $2,550 depth per side.
+
+## Quick Start
+
+```bash
+# Generate a fleet wallet
+solana-keygen new -o /tmp/fleet-wallet.json --no-bip39-passphrase
+
+# Fund it (needs more SOL than single-instance — 3x the tx volume)
+solana airdrop 5 $(solana-keygen pubkey /tmp/fleet-wallet.json) --url devnet
+
+# Run the fleet
+BOOTSTRAP_KEYPAIR=/tmp/fleet-wallet.json \
+HELIUS_API_KEY=your-key \
+npx tsx scripts/mm-fleet.ts
+
+# Or use the npm script
+pnpm fleet
+
+# Dry run (no transactions)
+pnpm fleet:dry
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   MM Fleet Orchestrator                  │
+│  ┌──────────────────────────────────────────────────┐   │
+│  │            Shared Price Cache (2s TTL)            │   │
+│  │            Binance → CoinGecko fallback           │   │
+│  └──────────────────────────────────────────────────┘   │
+│  ┌──────────────────────────────────────────────────┐   │
+│  │            TX Queue (rate-limited, 200ms gap)     │   │
+│  └──────────────────────────────────────────────────┘   │
+│                                                         │
+│  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐       │
+│  │ SOL / WIDE  │ │ SOL / TIGHT │ │ SOL / TIGHT │       │
+│  │  60bps      │ │ _A  15bps   │ │ _B  20bps   │       │
+│  │  $2k/side   │ │ $300/side   │ │ $250/side   │       │
+│  │  8s cycle   │ │ 3s cycle    │ │ 4s cycle    │       │
+│  │  own subacct│ │ own subacct │ │ own subacct │       │
+│  └─────────────┘ └─────────────┘ └─────────────┘       │
+│                                                         │
+│  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐       │
+│  │ BTC / WIDE  │ │ BTC / TIGHT │ │ BTC / TIGHT │       │
+│  │  ...        │ │ _A  ...     │ │ _B  ...     │       │
+│  └─────────────┘ └─────────────┘ └─────────────┘       │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Key Design Decisions
+
+1. **Single process** — all instances run in one Node.js process. Simpler ops, shared price cache, rate-limited TX queue avoids 429s.
+
+2. **Subaccount isolation** — each profile gets its own LP + User account on each market. Positions don't bleed across profiles.
+
+3. **Staggered timing** — each instance has random jitter on its quote interval so they don't all fire simultaneously.
+
+4. **Shared oracle pushes** — for Hyperp-mode markets, oracle price is only pushed once per market per cycle (not 3x).
+
+5. **Price cache** — 2-second TTL shared across all instances. One Binance call serves all 3 profiles.
+
+## Environment Variables
+
+### Core
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BOOTSTRAP_KEYPAIR` | `/tmp/bootstrap-wallet.json` | Path to fleet wallet keypair |
+| `RPC_URL` | Helius devnet | Solana RPC endpoint |
+| `HELIUS_API_KEY` | — | Helius API key |
+| `DRY_RUN` | `false` | Simulate without transactions |
+| `MARKETS_FILTER` | all | Comma-separated market symbols |
+| `FLEET_PROFILES` | all 3 | Comma-separated profiles to run |
+| `PROMETHEUS_PORT` | off | Enable Prometheus `/metrics` endpoint |
+
+### Profile Overrides
+Override any profile parameter via environment variables with the pattern `MM_<PROFILE>_<PARAM>`:
+
+```bash
+# Make WIDE even wider
+MM_WIDE_SPREAD_BPS=80
+
+# Give TIGHT_A more firepower
+MM_TIGHT_A_MAX_QUOTE_SIZE_USDC=500
+MM_TIGHT_A_MAX_POSITION_PCT=12
+
+# Speed up TIGHT_B
+MM_TIGHT_B_QUOTE_INTERVAL_MS=2000
+```
+
+## Monitoring
+
+### Dashboard (stdout)
+Every 60 seconds, the fleet prints a combined dashboard:
+
+```
+════════════════════════════════════════════════════════════════════════
+  MM Fleet Dashboard | Uptime: 5m30s | Trades: 180/200 ok | 6 instances
+────────────────────────────────────────────────────────────────────────
+  Market    Profile   Oracle      Bid         Ask         Pos       Skew
+────────────────────────────────────────────────────────────────────────
+  SOL       WIDE      $  150.25   $  149.35   $  151.15   $   250    2.5%
+  SOL       TIGHT_A   $  150.25   $  150.03   $  150.48   $   -50   -0.5%
+  SOL       TIGHT_B   $  150.25   $  149.95   $  150.55   $   120    1.2%
+  BTC       WIDE      $97345.00   $96761.93   $97928.07   $     0    0.0%
+  BTC       TIGHT_A   $97345.00   $97199.48   $97490.52   $  -200   -2.0%
+  BTC       TIGHT_B   $97345.00   $97150.31   $97541.64   $   100    1.0%
+════════════════════════════════════════════════════════════════════════
+```
+
+### Prometheus Metrics
+When `PROMETHEUS_PORT` is set, exposes:
+
+- `mm_fleet_quote_cycles` — total cycles per instance
+- `mm_fleet_trades_total{result}` — trades succeeded/failed
+- `mm_fleet_position_usd` — current position per instance
+- `mm_fleet_last_cycle_ms` — cycle latency
+- `mm_fleet_skew_pct` — current skew
+
+### Health Check
+```bash
+curl http://localhost:9464/metrics
+```
+
+## Comparison: Single Maker vs Fleet
+
+| Feature | PERC-364 (Single) | PERC-366 (Fleet) |
+|---------|-------------------|------------------|
+| Instances | 1 per market | 3 per market |
+| Price levels | 2 (1 bid + 1 ask) | 6 (3 bids + 3 asks) |
+| Depth per side | $500 | $2,550 |
+| Spread range | 30bps | 15–60bps |
+| Quote timing | Synchronized | Staggered with jitter |
+| Position isolation | None | Per-profile subaccounts |
+| TX rate limiting | None | Queue with 200ms gap |
+| Price caching | None | 2s shared cache |
+| Prometheus | None | Optional `/metrics` |
+| Size variation | Fixed | Random jitter ±30% |
+| Spread variation | Fixed | Random noise ±5bps |
+| Re-discovery | Every 50s | Every 5min |
+
+## Operational Guide
+
+### Running in Production (systemd)
+
+```ini
+[Unit]
+Description=Percolator MM Fleet
+After=network.target
+
+[Service]
+Type=simple
+User=percolator
+WorkingDirectory=/opt/percolator-launch
+ExecStart=/usr/bin/npx tsx scripts/mm-fleet.ts
+Environment=BOOTSTRAP_KEYPAIR=/etc/percolator/fleet-wallet.json
+Environment=HELIUS_API_KEY=xxx
+Environment=PROMETHEUS_PORT=9464
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Running with Docker
+
+```bash
+docker run -d \
+  -e BOOTSTRAP_KEYPAIR=/keys/fleet.json \
+  -e HELIUS_API_KEY=xxx \
+  -v /path/to/fleet.json:/keys/fleet.json \
+  percolator-launch:latest \
+  npx tsx scripts/mm-fleet.ts
+```
+
+### Running Only Specific Profiles
+
+```bash
+# Only run the WIDE profile (for minimal devnet activity)
+FLEET_PROFILES=WIDE BOOTSTRAP_KEYPAIR=/tmp/fleet.json npx tsx scripts/mm-fleet.ts
+
+# Only tight profiles (for top-of-book action)
+FLEET_PROFILES=TIGHT_A,TIGHT_B npx tsx scripts/mm-fleet.ts
+```
+
+## Development
+
+```bash
+# Run tests
+pnpm test tests/mm-fleet.test.ts
+
+# Dry run
+pnpm fleet:dry
+
+# Specific market
+MARKETS_FILTER=SOL pnpm fleet:dry
+```

--- a/scripts/mm-fleet.ts
+++ b/scripts/mm-fleet.ts
@@ -1,0 +1,1000 @@
+/**
+ * PERC-366: Market Maker Fleet Orchestrator
+ *
+ * Runs 3 market maker profiles (1 WIDE + 2 TIGHT) per market in a single
+ * process. Each profile gets its own subaccount for position isolation.
+ *
+ * Usage:
+ *   BOOTSTRAP_KEYPAIR=/path/to/keypair.json npx tsx scripts/mm-fleet.ts
+ *
+ * Environment variables (all optional, sane defaults):
+ *   BOOTSTRAP_KEYPAIR     — Path to fleet controller keypair JSON (required)
+ *   RPC_URL               — Solana RPC URL (default: devnet via Helius)
+ *   HELIUS_API_KEY        — Helius API key for devnet RPC
+ *   DRY_RUN               — "true" for simulation only
+ *   MARKETS_FILTER        — Comma-separated market symbols (default: all)
+ *   FLEET_PROFILES        — Comma-separated profiles to run (default: WIDE,TIGHT_A,TIGHT_B)
+ *   MM_WIDE_SPREAD_BPS    — Override WIDE spread (see mm-profiles.ts)
+ *   MM_TIGHT_A_SPREAD_BPS — Override TIGHT_A spread
+ *   PROMETHEUS_PORT        — Expose /metrics on this port (default: off)
+ */
+
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  Transaction,
+  ComputeBudgetProgram,
+  sendAndConfirmTransaction,
+  SYSVAR_CLOCK_PUBKEY,
+} from "@solana/web3.js";
+import {
+  encodeInitUser,
+  encodeInitLP,
+  encodeDepositCollateral,
+  encodeTradeCpi,
+  encodeKeeperCrank,
+  encodePushOraclePrice,
+  ACCOUNTS_INIT_USER,
+  ACCOUNTS_INIT_LP,
+  ACCOUNTS_DEPOSIT_COLLATERAL,
+  ACCOUNTS_TRADE_CPI,
+  ACCOUNTS_KEEPER_CRANK,
+  ACCOUNTS_PUSH_ORACLE_PRICE,
+  buildAccountMetas,
+  buildIx,
+  getAta,
+  deriveVaultAuthority,
+  deriveLpPda,
+  WELL_KNOWN,
+  parseAllAccounts,
+  discoverMarkets,
+  type DiscoveredMarket,
+} from "../packages/core/src/index.js";
+import { getProgramId } from "../packages/core/src/config/program-ids.js";
+import {
+  DEFAULT_PROFILES,
+  applyEnvOverrides,
+  calculateProfileQuotes,
+  type MakerProfile,
+} from "./mm-profiles.js";
+import * as fs from "fs";
+import * as http from "http";
+
+// ═══════════════════════════════════════════════════════════════
+// Configuration
+// ═══════════════════════════════════════════════════════════════
+
+const RPC_URL =
+  process.env.RPC_URL ??
+  `https://devnet.helius-rpc.com/?api-key=${process.env.HELIUS_API_KEY ?? ""}`;
+const PROGRAM_ID = getProgramId("devnet");
+const MATCHER_ID = new PublicKey(
+  process.env.MATCHER_ID ?? "GTRgyTDfrMvBubALAqtHuQwT8tbGyXid7svXZKtWfC9k",
+);
+const DRY_RUN = process.env.DRY_RUN === "true";
+const MARKETS_FILTER = process.env.MARKETS_FILTER
+  ? process.env.MARKETS_FILTER.split(",").map((s) => s.trim().toUpperCase())
+  : null;
+const PROMETHEUS_PORT = process.env.PROMETHEUS_PORT
+  ? Number(process.env.PROMETHEUS_PORT)
+  : null;
+
+// Select profiles
+const PROFILE_FILTER = process.env.FLEET_PROFILES
+  ? process.env.FLEET_PROFILES.split(",").map((s) => s.trim().toUpperCase())
+  : null;
+
+const allProfiles = applyEnvOverrides(DEFAULT_PROFILES);
+const activeProfiles = PROFILE_FILTER
+  ? allProfiles.filter((p) => PROFILE_FILTER.includes(p.name))
+  : allProfiles;
+
+// ═══════════════════════════════════════════════════════════════
+// Types
+// ═══════════════════════════════════════════════════════════════
+
+interface FleetInstance {
+  /** Profile configuration */
+  profile: MakerProfile;
+  /** On-chain market slab address */
+  slabAddress: PublicKey;
+  /** Collateral mint */
+  mint: PublicKey;
+  /** Market symbol (e.g., SOL, BTC) */
+  symbol: string;
+  /** Account index — LP subaccount for this profile */
+  lpIdx: number;
+  /** Account index — User (taker) subaccount for this profile */
+  userIdx: number;
+  /** LP owner pubkey */
+  lpOwner: PublicKey;
+  /** Matcher program */
+  matcherProgram: PublicKey;
+  /** Matcher context */
+  matcherContext: PublicKey;
+  /** Oracle mode */
+  oracleMode: "authority" | "pyth";
+  /** Current position (signed, 6 decimals) */
+  positionSize: bigint;
+  /** Collateral deposited (6 decimals) */
+  collateral: bigint;
+  /** Last oracle price pushed (e6) */
+  lastOraclePrice: bigint;
+  /** Stats */
+  stats: InstanceStats;
+  /** Timer handle for this instance's quote loop */
+  timerHandle: ReturnType<typeof setTimeout> | null;
+  /** Is this instance's loop currently running? */
+  busy: boolean;
+}
+
+interface InstanceStats {
+  quoteCycles: number;
+  tradesAttempted: number;
+  tradesSucceeded: number;
+  tradesFailed: number;
+  lastCycleMs: number;
+  lastOraclePrice: number;
+  lastBidPrice: number;
+  lastAskPrice: number;
+  lastSkewPct: number;
+  startedAt: number;
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Logging
+// ═══════════════════════════════════════════════════════════════
+
+function log(component: string, msg: string) {
+  const ts = new Date().toISOString().slice(11, 19);
+  console.log(`[${ts}] [${component}] ${msg}`);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Wallet & Connection
+// ═══════════════════════════════════════════════════════════════
+
+function loadKeypair(path: string): Keypair {
+  const raw = JSON.parse(fs.readFileSync(path, "utf8"));
+  return Keypair.fromSecretKey(Uint8Array.from(raw));
+}
+
+const connection = new Connection(RPC_URL, "confirmed");
+let fleetWallet: Keypair;
+
+/**
+ * Send a transaction with retry logic.
+ * Rate-limits to avoid 429s on devnet RPC.
+ */
+const txQueue: Array<{
+  ixs: any[];
+  signers: Keypair[];
+  cu: number;
+  resolve: (sig: string) => void;
+  reject: (e: Error) => void;
+}> = [];
+let txProcessing = false;
+
+async function processTxQueue() {
+  if (txProcessing) return;
+  txProcessing = true;
+
+  while (txQueue.length > 0) {
+    const item = txQueue.shift()!;
+    try {
+      const tx = new Transaction();
+      tx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: item.cu }));
+      for (const ix of item.ixs) tx.add(ix);
+      const sig = await sendAndConfirmTransaction(
+        connection,
+        tx,
+        item.signers,
+        { commitment: "confirmed", skipPreflight: true },
+      );
+      item.resolve(sig);
+    } catch (e: any) {
+      item.reject(e);
+    }
+    // Rate-limit: 200ms between txs to avoid devnet rate limiting
+    await new Promise((r) => setTimeout(r, 200));
+  }
+
+  txProcessing = false;
+}
+
+function sendTx(
+  ixs: any[],
+  signers: Keypair[],
+  computeUnits = 400_000,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    txQueue.push({ ixs, signers, cu: computeUnits, resolve, reject });
+    processTxQueue();
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Price Feeds (shared across all instances)
+// ═══════════════════════════════════════════════════════════════
+
+const BINANCE_MAP: Record<string, string> = {
+  SOL: "SOLUSDT",
+  BTC: "BTCUSDT",
+  ETH: "ETHUSDT",
+  BONK: "BONKUSDT",
+  WIF: "WIFUSDT",
+  JUP: "JUPUSDT",
+  PYTH: "PYTHUSDT",
+  RAY: "RAYUSDT",
+  JTO: "JTOUSDT",
+};
+
+const COINGECKO_MAP: Record<string, string> = {
+  SOL: "solana",
+  BTC: "bitcoin",
+  ETH: "ethereum",
+  BONK: "bonk",
+  JUP: "jupiter-exchange-solana",
+  WIF: "dogwifcoin",
+  PYTH: "pyth-network",
+  RAY: "raydium",
+  JTO: "jito-governance-token",
+};
+
+/** Shared price cache to avoid hammering APIs from 3 instances */
+const priceCache = new Map<
+  string,
+  { price: number; source: string; ts: number }
+>();
+const PRICE_CACHE_TTL_MS = 2_000; // 2s cache — all instances within same cycle share
+
+async function fetchPrice(
+  symbol: string,
+): Promise<{ price: number; source: string } | null> {
+  const cached = priceCache.get(symbol);
+  if (cached && Date.now() - cached.ts < PRICE_CACHE_TTL_MS) {
+    return { price: cached.price, source: cached.source };
+  }
+
+  // Binance
+  const pair = BINANCE_MAP[symbol.toUpperCase()];
+  if (pair) {
+    try {
+      const resp = await fetch(
+        `https://api.binance.com/api/v3/ticker/price?symbol=${pair}`,
+        { signal: AbortSignal.timeout(4000) },
+      );
+      const json = (await resp.json()) as { price?: string };
+      if (json.price) {
+        const price = parseFloat(json.price);
+        priceCache.set(symbol, { price, source: "binance", ts: Date.now() });
+        return { price, source: "binance" };
+      }
+    } catch {
+      /* fallthrough */
+    }
+  }
+
+  // CoinGecko fallback
+  const cgId = COINGECKO_MAP[symbol.toUpperCase()];
+  if (cgId) {
+    try {
+      const resp = await fetch(
+        `https://api.coingecko.com/api/v3/simple/price?ids=${cgId}&vs_currencies=usd`,
+        { signal: AbortSignal.timeout(5000) },
+      );
+      const json = (await resp.json()) as Record<string, { usd?: number }>;
+      if (json[cgId]?.usd) {
+        const price = json[cgId].usd;
+        priceCache.set(symbol, { price, source: "coingecko", ts: Date.now() });
+        return { price, source: "coingecko" };
+      }
+    } catch {
+      /* fallthrough */
+    }
+  }
+
+  return null;
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Market Discovery
+// ═══════════════════════════════════════════════════════════════
+
+/** Infer symbol from market data (same as PERC-364). */
+function inferSymbol(market: DiscoveredMarket): string {
+  const feedHex = Buffer.from(market.config.indexFeedId).toString("hex");
+  const KNOWN_FEEDS: Record<string, string> = {
+    ef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d: "SOL",
+    e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43: "BTC",
+    ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace: "ETH",
+  };
+  if (KNOWN_FEEDS[feedHex]) return KNOWN_FEEDS[feedHex];
+
+  const isHyperp = feedHex === "0".repeat(64);
+  if (isHyperp) {
+    const markE6 = market.engine.lastOraclePrice ?? 0n;
+    const markUsd = Number(markE6) / 1_000_000;
+    if (markUsd > 50_000) return "BTC";
+    if (markUsd > 2_000) return "ETH";
+    if (markUsd > 50) return "SOL";
+    return "UNKNOWN";
+  }
+  return "UNKNOWN";
+}
+
+/**
+ * For each discovered market, create one FleetInstance per active profile.
+ * Each profile gets its own subaccount (LP + User).
+ */
+async function discoverAndSetup(): Promise<FleetInstance[]> {
+  log("discovery", `Scanning for markets on ${PROGRAM_ID.toBase58().slice(0, 8)}...`);
+  const discovered = await discoverMarkets(connection, PROGRAM_ID);
+  log("discovery", `Found ${discovered.length} market(s) on-chain`);
+
+  const instances: FleetInstance[] = [];
+
+  for (const market of discovered) {
+    const symbol = inferSymbol(market);
+    if (MARKETS_FILTER && !MARKETS_FILTER.includes(symbol)) continue;
+    if (market.header.resolved || market.header.paused) {
+      log("discovery", `Skipping ${symbol} — resolved/paused`);
+      continue;
+    }
+
+    const feedHex = Buffer.from(market.config.indexFeedId).toString("hex");
+    const isHyperp = feedHex === "0".repeat(64);
+
+    for (const profile of activeProfiles) {
+      try {
+        const inst = await setupInstance(market, symbol, profile, isHyperp);
+        if (inst) {
+          instances.push(inst);
+          log(
+            "discovery",
+            `✅ ${symbol}/${profile.name} — LP idx ${inst.lpIdx}, User idx ${inst.userIdx}`,
+          );
+        }
+      } catch (e: any) {
+        log(
+          "discovery",
+          `❌ ${symbol}/${profile.name}: ${e.message?.slice(0, 100)}`,
+        );
+      }
+    }
+  }
+
+  return instances;
+}
+
+async function setupInstance(
+  market: DiscoveredMarket,
+  symbol: string,
+  profile: MakerProfile,
+  isHyperp: boolean,
+): Promise<FleetInstance | null> {
+  const slabAddress = market.slabAddress;
+  const mint = market.config.collateralMint;
+
+  const slabInfo = await connection.getAccountInfo(slabAddress);
+  if (!slabInfo) throw new Error("Slab account not found");
+
+  const data = new Uint8Array(slabInfo.data);
+  const accounts = parseAllAccounts(data);
+
+  // Each profile needs its own accounts. We tag them by looking for
+  // accounts owned by our wallet. Since we may create multiple,
+  // we track them by index.
+  const myAccounts = accounts.filter((a) =>
+    a.account.owner.equals(fleetWallet.publicKey),
+  );
+  const myLPs = myAccounts.filter((a) => a.account.kind === 1);
+  const myUsers = myAccounts.filter((a) => a.account.kind === 0);
+
+  // Profile index determines which subaccount to use
+  const profileIdx = activeProfiles.indexOf(profile);
+
+  let lpAccount = myLPs[profileIdx] ?? null;
+  let userAccount = myUsers[profileIdx] ?? null;
+
+  const walletAta = await getAta(fleetWallet.publicKey, mint);
+  const [vaultPda] = deriveVaultAuthority(PROGRAM_ID, slabAddress);
+  const vaultAta = await getAta(vaultPda, mint, true);
+
+  // Create missing LP account
+  if (!lpAccount) {
+    if (DRY_RUN) {
+      log("setup", `[DRY] ${symbol}/${profile.name}: would create LP`);
+    } else {
+      log("setup", `${symbol}/${profile.name}: creating LP account...`);
+      const initData = encodeInitLP({
+        matcherProgram: MATCHER_ID,
+        matcherContext: PublicKey.default,
+        feePayment: "1000000",
+      });
+      const initKeys = buildAccountMetas(ACCOUNTS_INIT_LP, [
+        fleetWallet.publicKey,
+        slabAddress,
+        walletAta,
+        vaultAta,
+        WELL_KNOWN.tokenProgram,
+      ]);
+      const initIx = buildIx({ programId: PROGRAM_ID, keys: initKeys, data: initData });
+
+      const depositData = encodeDepositCollateral({
+        userIdx: 0,
+        amount: profile.initialCollateralUsdc.toString(),
+      });
+      const depositKeys = buildAccountMetas(ACCOUNTS_DEPOSIT_COLLATERAL, [
+        fleetWallet.publicKey,
+        slabAddress,
+        walletAta,
+        vaultAta,
+        WELL_KNOWN.tokenProgram,
+        SYSVAR_CLOCK_PUBKEY,
+      ]);
+      const depositIx = buildIx({ programId: PROGRAM_ID, keys: depositKeys, data: depositData });
+
+      await sendTx([initIx, depositIx], [fleetWallet]);
+    }
+
+    // Refetch
+    const newInfo = await connection.getAccountInfo(slabAddress);
+    if (newInfo) {
+      const newAccs = parseAllAccounts(newInfo.data);
+      const newLPs = newAccs
+        .filter((a) => a.account.kind === 1 && a.account.owner.equals(fleetWallet.publicKey));
+      lpAccount = newLPs[profileIdx] ?? newLPs[newLPs.length - 1] ?? null;
+    }
+  }
+
+  // Create missing user account
+  if (!userAccount) {
+    if (DRY_RUN) {
+      log("setup", `[DRY] ${symbol}/${profile.name}: would create User`);
+    } else {
+      log("setup", `${symbol}/${profile.name}: creating User account...`);
+      const initData = encodeInitUser({ feePayment: "1000000" });
+      const initKeys = buildAccountMetas(ACCOUNTS_INIT_USER, [
+        fleetWallet.publicKey,
+        slabAddress,
+        walletAta,
+        vaultAta,
+        WELL_KNOWN.tokenProgram,
+      ]);
+      const initIx = buildIx({ programId: PROGRAM_ID, keys: initKeys, data: initData });
+
+      const depositData = encodeDepositCollateral({
+        userIdx: 1,
+        amount: profile.initialCollateralUsdc.toString(),
+      });
+      const depositKeys = buildAccountMetas(ACCOUNTS_DEPOSIT_COLLATERAL, [
+        fleetWallet.publicKey,
+        slabAddress,
+        walletAta,
+        vaultAta,
+        WELL_KNOWN.tokenProgram,
+        SYSVAR_CLOCK_PUBKEY,
+      ]);
+      const depositIx = buildIx({ programId: PROGRAM_ID, keys: depositKeys, data: depositData });
+
+      await sendTx([initIx, depositIx], [fleetWallet]);
+    }
+
+    // Refetch
+    const newInfo = await connection.getAccountInfo(slabAddress);
+    if (newInfo) {
+      const newAccs = parseAllAccounts(newInfo.data);
+      const newUsers = newAccs
+        .filter((a) => a.account.kind === 0 && a.account.owner.equals(fleetWallet.publicKey));
+      userAccount = newUsers[profileIdx] ?? newUsers[newUsers.length - 1] ?? null;
+    }
+  }
+
+  if (DRY_RUN && (!lpAccount || !userAccount)) {
+    log("setup", `[DRY] ${symbol}/${profile.name} — would be ready on live run`);
+    return null;
+  }
+
+  if (!lpAccount || !userAccount) {
+    log("setup", `❌ ${symbol}/${profile.name}: missing accounts`);
+    return null;
+  }
+
+  return {
+    profile,
+    slabAddress,
+    mint,
+    symbol,
+    lpIdx: lpAccount.idx,
+    userIdx: userAccount.idx,
+    lpOwner: lpAccount.account.owner,
+    matcherProgram: lpAccount.account.matcherProgram ?? MATCHER_ID,
+    matcherContext: lpAccount.account.matcherContext ?? PublicKey.default,
+    oracleMode: isHyperp ? "authority" : "pyth",
+    positionSize: userAccount.account.position ?? 0n,
+    collateral: userAccount.account.collateral ?? profile.initialCollateralUsdc,
+    lastOraclePrice: 0n,
+    stats: {
+      quoteCycles: 0,
+      tradesAttempted: 0,
+      tradesSucceeded: 0,
+      tradesFailed: 0,
+      lastCycleMs: 0,
+      lastOraclePrice: 0,
+      lastBidPrice: 0,
+      lastAskPrice: 0,
+      lastSkewPct: 0,
+      startedAt: Date.now(),
+    },
+    timerHandle: null,
+    busy: false,
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Oracle Price Push (shared — only push once per market per cycle)
+// ═══════════════════════════════════════════════════════════════
+
+const lastPushed = new Map<string, bigint>();
+
+async function pushOracleIfNeeded(
+  inst: FleetInstance,
+  priceUsd: number,
+): Promise<boolean> {
+  if (inst.oracleMode !== "authority") return true;
+
+  const priceE6 = BigInt(Math.round(priceUsd * 1_000_000));
+  const slabKey = inst.slabAddress.toBase58();
+  const prev = lastPushed.get(slabKey) ?? 0n;
+
+  // Skip if price hasn't changed
+  if (priceE6 === prev) {
+    inst.lastOraclePrice = priceE6;
+    return true;
+  }
+
+  if (DRY_RUN) {
+    lastPushed.set(slabKey, priceE6);
+    inst.lastOraclePrice = priceE6;
+    return true;
+  }
+
+  try {
+    const timestamp = BigInt(Math.floor(Date.now() / 1000));
+    const pushData = encodePushOraclePrice({ priceE6, timestamp });
+    const pushKeys = buildAccountMetas(ACCOUNTS_PUSH_ORACLE_PRICE, [
+      fleetWallet.publicKey,
+      inst.slabAddress,
+    ]);
+    const pushIx = buildIx({ programId: PROGRAM_ID, keys: pushKeys, data: pushData });
+
+    await sendTx([pushIx], [fleetWallet], 200_000);
+    lastPushed.set(slabKey, priceE6);
+    inst.lastOraclePrice = priceE6;
+    return true;
+  } catch (e: any) {
+    log(`${inst.symbol}/${inst.profile.name}`, `⚠ Oracle push failed: ${e.message?.slice(0, 60)}`);
+    return false;
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Trade Execution
+// ═══════════════════════════════════════════════════════════════
+
+async function executeTrade(
+  inst: FleetInstance,
+  size: bigint,
+  label: string,
+): Promise<boolean> {
+  inst.stats.tradesAttempted++;
+
+  if (DRY_RUN) {
+    const sizeUsd = Number(size) / 1_000_000;
+    log(`${inst.symbol}/${inst.profile.name}`, `[DRY] ${label}: $${sizeUsd.toFixed(2)}`);
+    inst.stats.tradesSucceeded++;
+    return true;
+  }
+
+  try {
+    const [lpPda] = deriveLpPda(PROGRAM_ID, inst.slabAddress, inst.lpIdx);
+
+    const crankData = encodeKeeperCrank({ callerIdx: 65535, allowPanic: false });
+    const crankKeys = buildAccountMetas(ACCOUNTS_KEEPER_CRANK, [
+      fleetWallet.publicKey,
+      inst.slabAddress,
+      SYSVAR_CLOCK_PUBKEY,
+      inst.slabAddress,
+    ]);
+    const crankIx = buildIx({ programId: PROGRAM_ID, keys: crankKeys, data: crankData });
+
+    const tradeData = encodeTradeCpi({
+      lpIdx: inst.lpIdx,
+      userIdx: inst.userIdx,
+      size: size.toString(),
+    });
+    const tradeKeys = buildAccountMetas(ACCOUNTS_TRADE_CPI, [
+      fleetWallet.publicKey,
+      inst.lpOwner,
+      inst.slabAddress,
+      inst.slabAddress,
+      inst.matcherProgram,
+      inst.matcherContext,
+      lpPda,
+    ]);
+    const tradeIx = buildIx({ programId: PROGRAM_ID, keys: tradeKeys, data: tradeData });
+
+    const sig = await sendTx([crankIx, tradeIx], [fleetWallet], 600_000);
+    inst.positionSize += size;
+    inst.stats.tradesSucceeded++;
+
+    const sizeUsd = Number(size) / 1_000_000;
+    log(
+      `${inst.symbol}/${inst.profile.name}`,
+      `✅ ${label}: $${sizeUsd.toFixed(2)} — ${sig.slice(0, 12)}...`,
+    );
+    return true;
+  } catch (e: any) {
+    inst.stats.tradesFailed++;
+    log(
+      `${inst.symbol}/${inst.profile.name}`,
+      `❌ ${label}: ${e.message?.slice(0, 80)}`,
+    );
+    return false;
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Quote Cycle (per instance)
+// ═══════════════════════════════════════════════════════════════
+
+async function runQuoteCycle(inst: FleetInstance): Promise<void> {
+  if (inst.busy) return;
+  inst.busy = true;
+  const cycleStart = Date.now();
+
+  try {
+    inst.stats.quoteCycles++;
+
+    // Fetch price (cached across instances)
+    const priceData = await fetchPrice(inst.symbol);
+    if (!priceData) {
+      log(`${inst.symbol}/${inst.profile.name}`, "⚠ No price, skipping");
+      return;
+    }
+
+    // Push oracle if authority mode (deduped per market)
+    await pushOracleIfNeeded(inst, priceData.price);
+
+    // Refresh position from chain (every 5th cycle to save RPC calls)
+    if (inst.stats.quoteCycles % 5 === 1) {
+      try {
+        const slabInfo = await connection.getAccountInfo(inst.slabAddress);
+        if (slabInfo) {
+          const accounts = parseAllAccounts(slabInfo.data);
+          const userAcc = accounts.find(
+            (a) =>
+              a.idx === inst.userIdx &&
+              a.account.kind === 0 &&
+              a.account.owner.equals(fleetWallet.publicKey),
+          );
+          if (userAcc) {
+            inst.positionSize = userAcc.account.position ?? inst.positionSize;
+            inst.collateral = userAcc.account.collateral ?? inst.collateral;
+          }
+        }
+      } catch {
+        /* non-fatal */
+      }
+    }
+
+    // Calculate quotes using profile parameters
+    const { bidPrice, askPrice, bidSize, askSize, skewFactor, effectiveSpreadBps } =
+      calculateProfileQuotes(
+        inst.profile,
+        priceData.price,
+        inst.positionSize,
+        inst.collateral,
+      );
+
+    // Update stats
+    inst.stats.lastOraclePrice = priceData.price;
+    inst.stats.lastBidPrice = bidPrice;
+    inst.stats.lastAskPrice = askPrice;
+    inst.stats.lastSkewPct = skewFactor * 100;
+
+    const posUsd = Number(inst.positionSize) / 1_000_000;
+    log(
+      `${inst.symbol}/${inst.profile.name}`,
+      `$${priceData.price.toFixed(2)} | bid=$${bidPrice.toFixed(4)} ask=$${askPrice.toFixed(4)} | spread=${effectiveSpreadBps.toFixed(1)}bps | pos=$${posUsd.toFixed(0)} | skew=${(skewFactor * 100).toFixed(1)}%`,
+    );
+
+    // Execute bid
+    if (bidSize > 0n) {
+      await executeTrade(inst, bidSize, `BID@${bidPrice.toFixed(2)}`);
+    }
+
+    // Small stagger between bid and ask
+    await new Promise((r) => setTimeout(r, 300 + Math.random() * 200));
+
+    // Execute ask
+    if (askSize > 0n) {
+      await executeTrade(inst, -askSize, `ASK@${askPrice.toFixed(2)}`);
+    }
+  } catch (e: any) {
+    log(
+      `${inst.symbol}/${inst.profile.name}`,
+      `❌ Cycle error: ${e.message?.slice(0, 100)}`,
+    );
+  } finally {
+    inst.stats.lastCycleMs = Date.now() - cycleStart;
+    inst.busy = false;
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Scheduling — each instance runs independently
+// ═══════════════════════════════════════════════════════════════
+
+function startInstance(inst: FleetInstance): void {
+  const jitter = Math.floor(Math.random() * inst.profile.jitterMs);
+
+  const scheduleNext = () => {
+    if (!running) return;
+    const interval =
+      inst.profile.quoteIntervalMs +
+      Math.floor(Math.random() * inst.profile.jitterMs);
+    inst.timerHandle = setTimeout(async () => {
+      await runQuoteCycle(inst);
+      scheduleNext();
+    }, interval);
+  };
+
+  // Stagger initial start so instances don't all fire at once
+  setTimeout(() => {
+    runQuoteCycle(inst).then(scheduleNext);
+  }, jitter);
+}
+
+function stopInstance(inst: FleetInstance): void {
+  if (inst.timerHandle) {
+    clearTimeout(inst.timerHandle);
+    inst.timerHandle = null;
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Prometheus Metrics (optional)
+// ═══════════════════════════════════════════════════════════════
+
+function startMetricsServer(port: number, instances: FleetInstance[]) {
+  const server = http.createServer((req, res) => {
+    if (req.url !== "/metrics") {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+
+    const lines: string[] = [
+      "# HELP mm_fleet_quote_cycles Total quote cycles per instance",
+      "# TYPE mm_fleet_quote_cycles counter",
+    ];
+
+    for (const inst of instances) {
+      const labels = `symbol="${inst.symbol}",profile="${inst.profile.name}"`;
+      lines.push(`mm_fleet_quote_cycles{${labels}} ${inst.stats.quoteCycles}`);
+    }
+
+    lines.push("# HELP mm_fleet_trades_total Total trades attempted");
+    lines.push("# TYPE mm_fleet_trades_total counter");
+    for (const inst of instances) {
+      const labels = `symbol="${inst.symbol}",profile="${inst.profile.name}"`;
+      lines.push(`mm_fleet_trades_total{${labels},result="success"} ${inst.stats.tradesSucceeded}`);
+      lines.push(`mm_fleet_trades_total{${labels},result="failed"} ${inst.stats.tradesFailed}`);
+    }
+
+    lines.push("# HELP mm_fleet_position_usd Current position in USD");
+    lines.push("# TYPE mm_fleet_position_usd gauge");
+    for (const inst of instances) {
+      const labels = `symbol="${inst.symbol}",profile="${inst.profile.name}"`;
+      const posUsd = Number(inst.positionSize) / 1_000_000;
+      lines.push(`mm_fleet_position_usd{${labels}} ${posUsd.toFixed(2)}`);
+    }
+
+    lines.push("# HELP mm_fleet_last_cycle_ms Last cycle duration in ms");
+    lines.push("# TYPE mm_fleet_last_cycle_ms gauge");
+    for (const inst of instances) {
+      const labels = `symbol="${inst.symbol}",profile="${inst.profile.name}"`;
+      lines.push(`mm_fleet_last_cycle_ms{${labels}} ${inst.stats.lastCycleMs}`);
+    }
+
+    lines.push("# HELP mm_fleet_skew_pct Current skew percentage");
+    lines.push("# TYPE mm_fleet_skew_pct gauge");
+    for (const inst of instances) {
+      const labels = `symbol="${inst.symbol}",profile="${inst.profile.name}"`;
+      lines.push(`mm_fleet_skew_pct{${labels}} ${inst.stats.lastSkewPct.toFixed(2)}`);
+    }
+
+    res.writeHead(200, { "Content-Type": "text/plain; version=0.0.4" });
+    res.end(lines.join("\n") + "\n");
+  });
+
+  server.listen(port, () => {
+    log("metrics", `Prometheus metrics at http://localhost:${port}/metrics`);
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Dashboard Printer
+// ═══════════════════════════════════════════════════════════════
+
+function printDashboard(instances: FleetInstance[]) {
+  const elapsed = Math.floor((Date.now() - globalStartedAt) / 1000);
+  const min = Math.floor(elapsed / 60);
+  const sec = elapsed % 60;
+
+  const totalTrades = instances.reduce(
+    (sum, i) => sum + i.stats.tradesSucceeded,
+    0,
+  );
+  const totalFailed = instances.reduce(
+    (sum, i) => sum + i.stats.tradesFailed,
+    0,
+  );
+
+  console.log("\n" + "═".repeat(72));
+  console.log(
+    `  MM Fleet Dashboard | Uptime: ${min}m${sec}s | Trades: ${totalTrades}/${totalTrades + totalFailed} ok | ${instances.length} instances`,
+  );
+  console.log("─".repeat(72));
+  console.log(
+    "  Market    Profile   Oracle      Bid         Ask         Pos       Skew",
+  );
+  console.log("─".repeat(72));
+
+  for (const inst of instances) {
+    const posUsd = Number(inst.positionSize) / 1_000_000;
+    console.log(
+      `  ${inst.symbol.padEnd(8)}  ${inst.profile.name.padEnd(8)}  ` +
+        `$${inst.stats.lastOraclePrice.toFixed(2).padStart(9)}  ` +
+        `$${inst.stats.lastBidPrice.toFixed(2).padStart(9)}  ` +
+        `$${inst.stats.lastAskPrice.toFixed(2).padStart(9)}  ` +
+        `$${posUsd.toFixed(0).padStart(7)}  ` +
+        `${inst.stats.lastSkewPct.toFixed(1).padStart(5)}%`,
+    );
+  }
+  console.log("═".repeat(72) + "\n");
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Main
+// ═══════════════════════════════════════════════════════════════
+
+let running = true;
+let globalStartedAt = Date.now();
+
+process.on("SIGINT", () => {
+  log("main", "Shutting down...");
+  running = false;
+});
+process.on("SIGTERM", () => {
+  log("main", "Shutting down...");
+  running = false;
+});
+
+async function main() {
+  console.log(`
+╔══════════════════════════════════════════════════════════════╗
+║  PERC-366: Market Maker Fleet                                ║
+║  Multi-profile oracle-anchored market making                 ║
+║  Profiles: ${activeProfiles.map((p) => p.name).join(", ").padEnd(48)}║
+╚══════════════════════════════════════════════════════════════╝
+`);
+
+  globalStartedAt = Date.now();
+
+  // Load wallet
+  const KP_PATH =
+    process.env.BOOTSTRAP_KEYPAIR ?? "/tmp/bootstrap-wallet.json";
+  try {
+    fleetWallet = loadKeypair(KP_PATH);
+    log("main", `Wallet: ${fleetWallet.publicKey.toBase58()}`);
+  } catch (e: any) {
+    console.error(`❌ Failed to load keypair from ${KP_PATH}: ${e.message}`);
+    process.exit(1);
+  }
+
+  // Check balance
+  const balance = await connection.getBalance(fleetWallet.publicKey);
+  const balSol = balance / 1e9;
+  log("main", `SOL: ${balSol.toFixed(4)}`);
+  if (balSol < 0.05) {
+    log("main", "⚠ Low SOL — fleet needs more for multi-instance txs");
+  }
+
+  log("main", `Profiles: ${activeProfiles.map((p) => `${p.name}(${p.spreadBps}bps)`).join(", ")}`);
+  if (DRY_RUN) log("main", "🔸 DRY RUN MODE");
+  if (MARKETS_FILTER) log("main", `🔸 Markets: ${MARKETS_FILTER.join(", ")}`);
+
+  // Discover markets and create instances
+  let instances = await discoverAndSetup();
+  if (instances.length === 0) {
+    log("main", "No instances created. Retrying in 30s...");
+    await new Promise((r) => setTimeout(r, 30_000));
+    instances = await discoverAndSetup();
+    if (instances.length === 0) {
+      log("main", "Still nothing. Exiting.");
+      process.exit(1);
+    }
+  }
+
+  const marketCount = new Set(instances.map((i) => i.slabAddress.toBase58())).size;
+  log(
+    "main",
+    `🚀 Starting fleet: ${instances.length} instances across ${marketCount} market(s)`,
+  );
+
+  // Start all instances
+  for (const inst of instances) {
+    startInstance(inst);
+  }
+
+  // Prometheus metrics
+  if (PROMETHEUS_PORT) {
+    startMetricsServer(PROMETHEUS_PORT, instances);
+  }
+
+  // Dashboard printer every 60s
+  const dashInterval = setInterval(() => {
+    if (running) printDashboard(instances);
+  }, 60_000);
+
+  // Re-discovery every 5 minutes
+  const rediscoverInterval = setInterval(async () => {
+    if (!running) return;
+    try {
+      const newInstances = await discoverAndSetup();
+      for (const ni of newInstances) {
+        const exists = instances.find(
+          (i) =>
+            i.slabAddress.equals(ni.slabAddress) &&
+            i.profile.name === ni.profile.name,
+        );
+        if (!exists) {
+          instances.push(ni);
+          startInstance(ni);
+          log("main", `📊 New: ${ni.symbol}/${ni.profile.name}`);
+        }
+      }
+    } catch (e: any) {
+      log("main", `⚠ Re-discovery error: ${e.message?.slice(0, 60)}`);
+    }
+  }, 5 * 60_000);
+
+  // Keep process alive
+  await new Promise<void>((resolve) => {
+    const check = setInterval(() => {
+      if (!running) {
+        clearInterval(check);
+        resolve();
+      }
+    }, 1000);
+  });
+
+  // Cleanup
+  clearInterval(dashInterval);
+  clearInterval(rediscoverInterval);
+  for (const inst of instances) {
+    stopInstance(inst);
+  }
+
+  printDashboard(instances);
+  log("main", "Fleet stopped.");
+}
+
+main().catch((e) => {
+  console.error("Fatal:", e);
+  process.exit(1);
+});

--- a/scripts/mm-profiles.ts
+++ b/scripts/mm-profiles.ts
@@ -1,0 +1,233 @@
+/**
+ * PERC-366: Market Maker Profile Definitions
+ *
+ * Three profiles per market create realistic-looking orderbook depth:
+ *   - WIDE:    Conservative MM — wide spread, large size, slow re-quote
+ *   - TIGHT_A: Aggressive MM A — tight spread, small size, fast re-quote
+ *   - TIGHT_B: Aggressive MM B — tight spread, small size, fast re-quote (offset)
+ *
+ * Each profile runs as an independent quote loop with its own subaccount,
+ * so positions are isolated and risk limits apply per-profile.
+ */
+
+export interface MakerProfile {
+  /** Human-readable profile name */
+  name: string;
+  /** Half-spread in basis points */
+  spreadBps: number;
+  /** Max quote size per side in USDC (6 decimal units) */
+  maxQuoteSizeUsdc: bigint;
+  /** Max position as % of collateral before one-siding */
+  maxPositionPct: number;
+  /** Re-quote interval in ms */
+  quoteIntervalMs: number;
+  /** Spread multiplier at max exposure (skew aggressiveness) */
+  skewMaxMultiplier: number;
+  /** Collateral to deposit per market (6 decimals) */
+  initialCollateralUsdc: bigint;
+  /** Random jitter range added to quote interval (ms) — prevents lockstep */
+  jitterMs: number;
+  /** Offset from oracle in bps — TIGHT_B uses this to stagger with TIGHT_A */
+  oracleOffsetBps: number;
+  /** Whether to add small random walk noise to spread (makes orderbook look organic) */
+  spreadNoise: boolean;
+  /** Max random spread noise in bps (applied ± each cycle) */
+  spreadNoiseBps: number;
+  /** Size randomization factor (0–1). 0 = fixed size, 0.3 = ±30% variation */
+  sizeJitter: number;
+}
+
+/**
+ * WIDE profile — the "bedrock" liquidity layer.
+ * Wide spread captures large moves, big size makes the book look deep.
+ */
+export const PROFILE_WIDE: MakerProfile = {
+  name: "WIDE",
+  spreadBps: 60, // 0.60% half-spread
+  maxQuoteSizeUsdc: 2_000_000_000n, // $2,000 per side
+  maxPositionPct: 15,
+  quoteIntervalMs: 8_000,
+  skewMaxMultiplier: 2.5,
+  initialCollateralUsdc: 25_000_000_000n, // $25,000
+  jitterMs: 2_000,
+  oracleOffsetBps: 0,
+  spreadNoise: true,
+  spreadNoiseBps: 5,
+  sizeJitter: 0.2,
+};
+
+/**
+ * TIGHT_A — aggressive MM #1.
+ * Tight spread, small size, fast re-quote. Creates top-of-book action.
+ */
+export const PROFILE_TIGHT_A: MakerProfile = {
+  name: "TIGHT_A",
+  spreadBps: 15, // 0.15% half-spread
+  maxQuoteSizeUsdc: 300_000_000n, // $300 per side
+  maxPositionPct: 8,
+  quoteIntervalMs: 3_000,
+  skewMaxMultiplier: 4.0,
+  initialCollateralUsdc: 10_000_000_000n, // $10,000
+  jitterMs: 1_000,
+  oracleOffsetBps: 0,
+  spreadNoise: true,
+  spreadNoiseBps: 3,
+  sizeJitter: 0.3,
+};
+
+/**
+ * TIGHT_B — aggressive MM #2.
+ * Similar to TIGHT_A but with a small oracle offset so they don't stack
+ * on the exact same price. Slight timing offset via different jitter seed.
+ */
+export const PROFILE_TIGHT_B: MakerProfile = {
+  name: "TIGHT_B",
+  spreadBps: 20, // 0.20% half-spread
+  maxQuoteSizeUsdc: 250_000_000n, // $250 per side
+  maxPositionPct: 8,
+  quoteIntervalMs: 4_000,
+  skewMaxMultiplier: 3.5,
+  initialCollateralUsdc: 10_000_000_000n, // $10,000
+  jitterMs: 1_500,
+  oracleOffsetBps: 2, // +0.02% oracle offset — slightly different reference price
+  spreadNoise: true,
+  spreadNoiseBps: 4,
+  sizeJitter: 0.25,
+};
+
+/** All default profiles for the fleet */
+export const DEFAULT_PROFILES: MakerProfile[] = [
+  PROFILE_WIDE,
+  PROFILE_TIGHT_A,
+  PROFILE_TIGHT_B,
+];
+
+/**
+ * Calculate bid/ask quotes for a given profile.
+ *
+ * @param profile - The maker profile parameters
+ * @param oraclePrice - Current oracle price in USD
+ * @param positionSize - Current position in 6-decimal units (signed)
+ * @param collateral - Collateral deposited in 6-decimal units
+ * @returns Quote prices and sizes with skew info
+ */
+export function calculateProfileQuotes(
+  profile: MakerProfile,
+  oraclePrice: number,
+  positionSize: bigint,
+  collateral: bigint,
+): {
+  bidPrice: number;
+  askPrice: number;
+  bidSize: bigint;
+  askSize: bigint;
+  skewFactor: number;
+  effectiveSpreadBps: number;
+} {
+  // Apply oracle offset
+  const offsetFrac = profile.oracleOffsetBps / 10_000;
+  const refPrice = oraclePrice * (1 + offsetFrac);
+
+  // Base spread
+  let spreadBps = profile.spreadBps;
+
+  // Apply spread noise if enabled
+  if (profile.spreadNoise) {
+    const noise =
+      (Math.random() * 2 - 1) * profile.spreadNoiseBps;
+    spreadBps = Math.max(1, spreadBps + noise);
+  }
+
+  const spreadFrac = spreadBps / 10_000;
+  const collateralUsd = Number(collateral) / 1_000_000;
+  const positionUsd = Number(positionSize) / 1_000_000;
+
+  // Exposure: position / (collateral × maxPositionPct%)
+  const maxPosUsd = collateralUsd * (profile.maxPositionPct / 100);
+  const exposure =
+    maxPosUsd > 0
+      ? Math.max(-1, Math.min(1, positionUsd / maxPosUsd))
+      : 0;
+
+  const skewFactor = exposure;
+
+  // Skew spread multipliers
+  const bidSpreadMul =
+    1 + Math.max(0, skewFactor) * (profile.skewMaxMultiplier - 1);
+  const askSpreadMul =
+    1 + Math.max(0, -skewFactor) * (profile.skewMaxMultiplier - 1);
+
+  const bidPrice = refPrice * (1 - spreadFrac * bidSpreadMul);
+  const askPrice = refPrice * (1 + spreadFrac * askSpreadMul);
+
+  // Size scaling
+  const absExposure = Math.abs(exposure);
+  const sizeFactor = Math.max(0.1, 1 - absExposure * 0.8);
+
+  let bidSize = profile.maxQuoteSizeUsdc;
+  let askSize = profile.maxQuoteSizeUsdc;
+
+  if (absExposure >= 0.95) {
+    // At max exposure, only quote on the reducing side
+    if (exposure > 0) {
+      bidSize = 0n;
+    } else {
+      askSize = 0n;
+    }
+  } else {
+    const baseSize = BigInt(
+      Math.floor(Number(profile.maxQuoteSizeUsdc) * sizeFactor),
+    );
+
+    // Apply size jitter
+    if (profile.sizeJitter > 0) {
+      const jitterFactor =
+        1 + (Math.random() * 2 - 1) * profile.sizeJitter;
+      const jitteredSize = BigInt(
+        Math.floor(Number(baseSize) * Math.max(0.1, jitterFactor)),
+      );
+      bidSize = jitteredSize;
+      askSize = jitteredSize;
+    } else {
+      bidSize = baseSize;
+      askSize = baseSize;
+    }
+  }
+
+  return {
+    bidPrice,
+    askPrice,
+    bidSize,
+    askSize,
+    skewFactor,
+    effectiveSpreadBps: spreadBps,
+  };
+}
+
+/**
+ * Parse profile overrides from environment variables.
+ * Format: MM_WIDE_SPREAD_BPS=80, MM_TIGHT_A_MAX_QUOTE_SIZE_USDC=200, etc.
+ */
+export function applyEnvOverrides(profiles: MakerProfile[]): MakerProfile[] {
+  return profiles.map((p) => {
+    const prefix = `MM_${p.name}_`;
+    const clone = { ...p };
+
+    const envSpread = process.env[`${prefix}SPREAD_BPS`];
+    if (envSpread) clone.spreadBps = Number(envSpread);
+
+    const envSize = process.env[`${prefix}MAX_QUOTE_SIZE_USDC`];
+    if (envSize) clone.maxQuoteSizeUsdc = BigInt(envSize) * 1_000_000n;
+
+    const envPos = process.env[`${prefix}MAX_POSITION_PCT`];
+    if (envPos) clone.maxPositionPct = Number(envPos);
+
+    const envInterval = process.env[`${prefix}QUOTE_INTERVAL_MS`];
+    if (envInterval) clone.quoteIntervalMs = Number(envInterval);
+
+    const envCollateral = process.env[`${prefix}INITIAL_COLLATERAL`];
+    if (envCollateral) clone.initialCollateralUsdc = BigInt(envCollateral);
+
+    return clone;
+  });
+}

--- a/tests/mm-fleet.test.ts
+++ b/tests/mm-fleet.test.ts
@@ -1,0 +1,586 @@
+/**
+ * PERC-366: Market Maker Fleet — Unit Tests
+ *
+ * Tests profile configurations, quote calculations with profile-specific
+ * parameters, and fleet orchestration logic.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  PROFILE_WIDE,
+  PROFILE_TIGHT_A,
+  PROFILE_TIGHT_B,
+  DEFAULT_PROFILES,
+  calculateProfileQuotes,
+  type MakerProfile,
+} from "../scripts/mm-profiles.js";
+
+// ═══════════════════════════════════════════════════════════════
+// Profile Configuration Tests
+// ═══════════════════════════════════════════════════════════════
+
+describe("MM Profiles — Configuration Validation", () => {
+  it("has exactly 3 default profiles", () => {
+    expect(DEFAULT_PROFILES).toHaveLength(3);
+  });
+
+  it("profiles have unique names", () => {
+    const names = DEFAULT_PROFILES.map((p) => p.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("WIDE has widest spread", () => {
+    expect(PROFILE_WIDE.spreadBps).toBeGreaterThan(PROFILE_TIGHT_A.spreadBps);
+    expect(PROFILE_WIDE.spreadBps).toBeGreaterThan(PROFILE_TIGHT_B.spreadBps);
+  });
+
+  it("WIDE has largest quote size", () => {
+    expect(PROFILE_WIDE.maxQuoteSizeUsdc).toBeGreaterThan(
+      PROFILE_TIGHT_A.maxQuoteSizeUsdc,
+    );
+    expect(PROFILE_WIDE.maxQuoteSizeUsdc).toBeGreaterThan(
+      PROFILE_TIGHT_B.maxQuoteSizeUsdc,
+    );
+  });
+
+  it("WIDE has slowest re-quote interval", () => {
+    expect(PROFILE_WIDE.quoteIntervalMs).toBeGreaterThan(
+      PROFILE_TIGHT_A.quoteIntervalMs,
+    );
+    expect(PROFILE_WIDE.quoteIntervalMs).toBeGreaterThan(
+      PROFILE_TIGHT_B.quoteIntervalMs,
+    );
+  });
+
+  it("WIDE has most collateral", () => {
+    expect(PROFILE_WIDE.initialCollateralUsdc).toBeGreaterThan(
+      PROFILE_TIGHT_A.initialCollateralUsdc,
+    );
+  });
+
+  it("TIGHT_B has non-zero oracle offset (staggers with TIGHT_A)", () => {
+    expect(PROFILE_TIGHT_B.oracleOffsetBps).toBeGreaterThan(0);
+    expect(PROFILE_TIGHT_A.oracleOffsetBps).toBe(0);
+  });
+
+  it("all profiles have positive spread", () => {
+    for (const p of DEFAULT_PROFILES) {
+      expect(p.spreadBps).toBeGreaterThan(0);
+    }
+  });
+
+  it("all profiles have reasonable maxPositionPct (1-50)", () => {
+    for (const p of DEFAULT_PROFILES) {
+      expect(p.maxPositionPct).toBeGreaterThanOrEqual(1);
+      expect(p.maxPositionPct).toBeLessThanOrEqual(50);
+    }
+  });
+
+  it("all profiles have positive skewMaxMultiplier", () => {
+    for (const p of DEFAULT_PROFILES) {
+      expect(p.skewMaxMultiplier).toBeGreaterThan(1);
+    }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// Quote Calculation Tests — Per Profile
+// ═══════════════════════════════════════════════════════════════
+
+describe("MM Profiles — Quote Calculation", () => {
+  const COLLATERAL = 10_000_000_000n; // $10,000
+
+  // Disable noise/jitter for deterministic tests
+  const deterministicProfile = (base: MakerProfile): MakerProfile => ({
+    ...base,
+    spreadNoise: false,
+    sizeJitter: 0,
+    oracleOffsetBps: 0,
+  });
+
+  describe("WIDE profile — flat position", () => {
+    const profile = deterministicProfile(PROFILE_WIDE);
+
+    it("quotes symmetrically around oracle", () => {
+      const { bidPrice, askPrice, skewFactor } = calculateProfileQuotes(
+        profile,
+        100.0,
+        0n,
+        COLLATERAL,
+      );
+
+      expect(skewFactor).toBe(0);
+      // WIDE spread = 60bps = 0.60%
+      expect(bidPrice).toBeCloseTo(99.4, 1);
+      expect(askPrice).toBeCloseTo(100.6, 1);
+    });
+
+    it("has full size when flat", () => {
+      const { bidSize, askSize } = calculateProfileQuotes(
+        profile,
+        100.0,
+        0n,
+        COLLATERAL,
+      );
+
+      expect(bidSize).toBe(profile.maxQuoteSizeUsdc);
+      expect(askSize).toBe(profile.maxQuoteSizeUsdc);
+    });
+  });
+
+  describe("TIGHT_A profile — flat position", () => {
+    const profile = deterministicProfile(PROFILE_TIGHT_A);
+
+    it("quotes much tighter than WIDE", () => {
+      const tight = calculateProfileQuotes(profile, 100.0, 0n, COLLATERAL);
+      const wide = calculateProfileQuotes(
+        deterministicProfile(PROFILE_WIDE),
+        100.0,
+        0n,
+        COLLATERAL,
+      );
+
+      const tightSpread = tight.askPrice - tight.bidPrice;
+      const wideSpread = wide.askPrice - wide.bidPrice;
+      expect(tightSpread).toBeLessThan(wideSpread);
+    });
+
+    it("has smaller quote size than WIDE", () => {
+      const tight = calculateProfileQuotes(profile, 100.0, 0n, COLLATERAL);
+      const wide = calculateProfileQuotes(
+        deterministicProfile(PROFILE_WIDE),
+        100.0,
+        0n,
+        COLLATERAL,
+      );
+
+      expect(tight.bidSize).toBeLessThan(wide.bidSize);
+    });
+  });
+
+  describe("TIGHT_B profile — oracle offset", () => {
+    it("shifts reference price by oracleOffsetBps", () => {
+      const withOffset: MakerProfile = {
+        ...deterministicProfile(PROFILE_TIGHT_B),
+        oracleOffsetBps: 10, // 0.10% offset
+      };
+      const noOffset: MakerProfile = {
+        ...deterministicProfile(PROFILE_TIGHT_B),
+        oracleOffsetBps: 0,
+      };
+
+      const qWith = calculateProfileQuotes(withOffset, 100.0, 0n, COLLATERAL);
+      const qWithout = calculateProfileQuotes(noOffset, 100.0, 0n, COLLATERAL);
+
+      // Both bid and ask should be slightly higher with positive offset
+      expect(qWith.bidPrice).toBeGreaterThan(qWithout.bidPrice);
+      expect(qWith.askPrice).toBeGreaterThan(qWithout.askPrice);
+    });
+  });
+
+  describe("position skewing — all profiles", () => {
+    for (const baseProfile of DEFAULT_PROFILES) {
+      const profile = deterministicProfile(baseProfile);
+
+      describe(`${profile.name}`, () => {
+        it("widens bid when long", () => {
+          // 50% of max position
+          const maxPosUsdc =
+            (Number(COLLATERAL) / 1_000_000) *
+            (profile.maxPositionPct / 100) *
+            0.5;
+          const pos = BigInt(Math.floor(maxPosUsdc * 1_000_000));
+
+          const { bidPrice, askPrice } = calculateProfileQuotes(
+            profile,
+            100.0,
+            pos,
+            COLLATERAL,
+          );
+
+          const bidSpread = 100.0 - bidPrice;
+          const askSpread = askPrice - 100.0;
+          expect(bidSpread).toBeGreaterThan(askSpread);
+        });
+
+        it("widens ask when short", () => {
+          const maxPosUsdc =
+            (Number(COLLATERAL) / 1_000_000) *
+            (profile.maxPositionPct / 100) *
+            0.5;
+          const pos = BigInt(Math.floor(-maxPosUsdc * 1_000_000));
+
+          const { bidPrice, askPrice } = calculateProfileQuotes(
+            profile,
+            100.0,
+            pos,
+            COLLATERAL,
+          );
+
+          const bidSpread = 100.0 - bidPrice;
+          const askSpread = askPrice - 100.0;
+          expect(askSpread).toBeGreaterThan(bidSpread);
+        });
+
+        it("stops bidding at max long", () => {
+          const maxPosUsdc =
+            (Number(COLLATERAL) / 1_000_000) *
+            (profile.maxPositionPct / 100);
+          const pos = BigInt(Math.floor(maxPosUsdc * 1_000_000));
+
+          const { bidSize, askSize } = calculateProfileQuotes(
+            profile,
+            100.0,
+            pos,
+            COLLATERAL,
+          );
+
+          expect(bidSize).toBe(0n);
+          expect(askSize).toBeGreaterThan(0n);
+        });
+
+        it("stops asking at max short", () => {
+          const maxPosUsdc =
+            (Number(COLLATERAL) / 1_000_000) *
+            (profile.maxPositionPct / 100);
+          const pos = BigInt(Math.floor(-maxPosUsdc * 1_000_000));
+
+          const { bidSize, askSize } = calculateProfileQuotes(
+            profile,
+            100.0,
+            pos,
+            COLLATERAL,
+          );
+
+          expect(askSize).toBe(0n);
+          expect(bidSize).toBeGreaterThan(0n);
+        });
+      });
+    }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// Invariant Tests
+// ═══════════════════════════════════════════════════════════════
+
+describe("MM Profiles — Invariants", () => {
+  const COLLATERAL = 10_000_000_000n;
+  const PRICES = [0.00002, 1.5, 150, 3500, 98000]; // BONK, low-cap, SOL, ETH, BTC
+  const POSITIONS = [0n, 500_000_000n, -500_000_000n, 1_500_000_000n, -1_500_000_000n];
+
+  for (const baseProfile of DEFAULT_PROFILES) {
+    const profile: MakerProfile = {
+      ...baseProfile,
+      spreadNoise: false,
+      sizeJitter: 0,
+    };
+
+    describe(`${profile.name} invariants`, () => {
+      for (const price of PRICES) {
+        for (const pos of POSITIONS) {
+          const label = `price=$${price} pos=${Number(pos) / 1e6}`;
+
+          it(`bid < ask: ${label}`, () => {
+            const { bidPrice, askPrice } = calculateProfileQuotes(
+              profile,
+              price,
+              pos,
+              COLLATERAL,
+            );
+            expect(bidPrice).toBeLessThan(askPrice);
+          });
+
+          it(`bid < oracle ref: ${label}`, () => {
+            const { bidPrice } = calculateProfileQuotes(
+              profile,
+              price,
+              pos,
+              COLLATERAL,
+            );
+            const refPrice = price * (1 + profile.oracleOffsetBps / 10_000);
+            expect(bidPrice).toBeLessThan(refPrice);
+          });
+
+          it(`ask > oracle ref: ${label}`, () => {
+            const { askPrice } = calculateProfileQuotes(
+              profile,
+              price,
+              pos,
+              COLLATERAL,
+            );
+            const refPrice = price * (1 + profile.oracleOffsetBps / 10_000);
+            expect(askPrice).toBeGreaterThan(refPrice);
+          });
+
+          it(`sizes non-negative: ${label}`, () => {
+            const { bidSize, askSize } = calculateProfileQuotes(
+              profile,
+              price,
+              pos,
+              COLLATERAL,
+            );
+            expect(bidSize).toBeGreaterThanOrEqual(0n);
+            expect(askSize).toBeGreaterThanOrEqual(0n);
+          });
+        }
+      }
+    });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════
+// Spread Noise & Jitter Tests
+// ═══════════════════════════════════════════════════════════════
+
+describe("MM Profiles — Spread Noise", () => {
+  const COLLATERAL = 10_000_000_000n;
+
+  it("spread noise creates variation across runs", () => {
+    const profile: MakerProfile = {
+      ...PROFILE_TIGHT_A,
+      spreadNoise: true,
+      spreadNoiseBps: 5,
+      sizeJitter: 0,
+      oracleOffsetBps: 0,
+    };
+
+    const spreads = new Set<string>();
+    for (let i = 0; i < 20; i++) {
+      const { effectiveSpreadBps } = calculateProfileQuotes(
+        profile,
+        100.0,
+        0n,
+        COLLATERAL,
+      );
+      spreads.add(effectiveSpreadBps.toFixed(4));
+    }
+
+    // Should have at least a few different spread values
+    expect(spreads.size).toBeGreaterThan(1);
+  });
+
+  it("spread noise stays within bounds", () => {
+    const profile: MakerProfile = {
+      ...PROFILE_TIGHT_A,
+      spreadNoise: true,
+      spreadNoiseBps: 5,
+      sizeJitter: 0,
+      oracleOffsetBps: 0,
+    };
+
+    for (let i = 0; i < 100; i++) {
+      const { effectiveSpreadBps } = calculateProfileQuotes(
+        profile,
+        100.0,
+        0n,
+        COLLATERAL,
+      );
+      // Base = 15bps, noise = ±5bps → range [10, 20]
+      expect(effectiveSpreadBps).toBeGreaterThanOrEqual(1); // floor from max(1, ...)
+      expect(effectiveSpreadBps).toBeLessThanOrEqual(
+        profile.spreadBps + profile.spreadNoiseBps + 0.01,
+      );
+    }
+  });
+
+  it("size jitter creates variation", () => {
+    const profile: MakerProfile = {
+      ...PROFILE_TIGHT_A,
+      spreadNoise: false,
+      sizeJitter: 0.3,
+      oracleOffsetBps: 0,
+    };
+
+    const sizes = new Set<bigint>();
+    for (let i = 0; i < 20; i++) {
+      const { bidSize } = calculateProfileQuotes(
+        profile,
+        100.0,
+        0n,
+        COLLATERAL,
+      );
+      sizes.add(bidSize);
+    }
+
+    expect(sizes.size).toBeGreaterThan(1);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// Edge Cases
+// ═══════════════════════════════════════════════════════════════
+
+describe("MM Profiles — Edge Cases", () => {
+  it("handles zero collateral gracefully", () => {
+    const profile: MakerProfile = {
+      ...PROFILE_WIDE,
+      spreadNoise: false,
+      sizeJitter: 0,
+    };
+
+    const { bidPrice, askPrice, skewFactor } = calculateProfileQuotes(
+      profile,
+      100.0,
+      500_000_000n,
+      0n,
+    );
+
+    expect(skewFactor).toBe(0);
+    expect(bidPrice).toBeLessThan(100.0);
+    expect(askPrice).toBeGreaterThan(100.0);
+  });
+
+  it("handles very small oracle price (micro-cap tokens)", () => {
+    const profile: MakerProfile = {
+      ...PROFILE_TIGHT_A,
+      spreadNoise: false,
+      sizeJitter: 0,
+      oracleOffsetBps: 0,
+    };
+
+    const { bidPrice, askPrice } = calculateProfileQuotes(
+      profile,
+      0.000001,
+      0n,
+      10_000_000_000n,
+    );
+
+    expect(bidPrice).toBeGreaterThan(0);
+    expect(askPrice).toBeGreaterThan(bidPrice);
+  });
+
+  it("handles very large oracle price", () => {
+    const profile: MakerProfile = {
+      ...PROFILE_WIDE,
+      spreadNoise: false,
+      sizeJitter: 0,
+    };
+
+    const { bidPrice, askPrice } = calculateProfileQuotes(
+      profile,
+      200_000.0,
+      0n,
+      10_000_000_000n,
+    );
+
+    expect(bidPrice).toBeCloseTo(198_800, -1); // 200k * (1 - 0.006)
+    expect(askPrice).toBeCloseTo(201_200, -1); // 200k * (1 + 0.006)
+  });
+
+  it("different profiles produce different spreads at same oracle price", () => {
+    const col = 10_000_000_000n;
+    const price = 150.0;
+
+    const wideQ = calculateProfileQuotes(
+      { ...PROFILE_WIDE, spreadNoise: false, sizeJitter: 0 },
+      price,
+      0n,
+      col,
+    );
+    const tightQ = calculateProfileQuotes(
+      { ...PROFILE_TIGHT_A, spreadNoise: false, sizeJitter: 0, oracleOffsetBps: 0 },
+      price,
+      0n,
+      col,
+    );
+
+    const wideSpread = wideQ.askPrice - wideQ.bidPrice;
+    const tightSpread = tightQ.askPrice - tightQ.bidPrice;
+
+    // WIDE should be at least 2x wider than TIGHT_A
+    expect(wideSpread / tightSpread).toBeGreaterThan(2);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// Profile Combination Tests (simulating fleet behavior)
+// ═══════════════════════════════════════════════════════════════
+
+describe("MM Fleet — Combined Orderbook Depth", () => {
+  it("3 profiles create 6 price levels (3 bids + 3 asks) when flat", () => {
+    const col = 10_000_000_000n;
+    const price = 150.0;
+    const levels: { side: string; price: number; size: bigint; profile: string }[] =
+      [];
+
+    for (const base of DEFAULT_PROFILES) {
+      const profile = { ...base, spreadNoise: false, sizeJitter: 0 };
+      const { bidPrice, askPrice, bidSize, askSize } = calculateProfileQuotes(
+        profile,
+        price,
+        0n,
+        col,
+      );
+
+      if (bidSize > 0n) levels.push({ side: "bid", price: bidPrice, size: bidSize, profile: profile.name });
+      if (askSize > 0n) levels.push({ side: "ask", price: askPrice, size: askSize, profile: profile.name });
+    }
+
+    const bids = levels.filter((l) => l.side === "bid");
+    const asks = levels.filter((l) => l.side === "ask");
+
+    expect(bids).toHaveLength(3);
+    expect(asks).toHaveLength(3);
+
+    // All bids below oracle
+    for (const b of bids) expect(b.price).toBeLessThan(price);
+    // All asks above oracle
+    for (const a of asks) expect(a.price).toBeGreaterThan(price);
+  });
+
+  it("total depth (all profiles) is substantial", () => {
+    const col = 10_000_000_000n;
+    const price = 150.0;
+
+    let totalBidSize = 0n;
+    let totalAskSize = 0n;
+
+    for (const base of DEFAULT_PROFILES) {
+      const profile = { ...base, spreadNoise: false, sizeJitter: 0 };
+      const { bidSize, askSize } = calculateProfileQuotes(
+        profile,
+        price,
+        0n,
+        col,
+      );
+      totalBidSize += bidSize;
+      totalAskSize += askSize;
+    }
+
+    // Total should be > $2000 on each side (WIDE=$2000 + TIGHT_A=$300 + TIGHT_B=$250)
+    expect(Number(totalBidSize) / 1_000_000).toBeGreaterThan(2_000);
+    expect(Number(totalAskSize) / 1_000_000).toBeGreaterThan(2_000);
+  });
+
+  it("bid/ask spread layers create realistic-looking depth", () => {
+    const col = 10_000_000_000n;
+    const price = 150.0;
+    const bids: number[] = [];
+    const asks: number[] = [];
+
+    for (const base of DEFAULT_PROFILES) {
+      const profile = { ...base, spreadNoise: false, sizeJitter: 0 };
+      const { bidPrice, askPrice } = calculateProfileQuotes(
+        profile,
+        price,
+        0n,
+        col,
+      );
+      bids.push(bidPrice);
+      asks.push(askPrice);
+    }
+
+    // Bids should be at distinct price levels
+    bids.sort((a, b) => b - a); // highest first
+    for (let i = 0; i < bids.length - 1; i++) {
+      expect(bids[i]).toBeGreaterThan(bids[i + 1]);
+    }
+
+    // Asks should be at distinct price levels
+    asks.sort((a, b) => a - b); // lowest first
+    for (let i = 0; i < asks.length - 1; i++) {
+      expect(asks[i]).toBeLessThan(asks[i + 1]);
+    }
+  });
+});


### PR DESCRIPTION
## PERC-366: Multi-Profile Market Maker Fleet

### What
Multi-profile oracle-anchored market making that runs **3 independent MM instances per market** to create realistic orderbook depth. Builds on PERC-364's single floating maker.

### Why
Per researcher memo (PERC-354): *"Run 3 bot instances per market — one conservative MM (wider spread, large size) + two aggressive MMs (tight spread, smaller size). Creates realistic-looking orderbook."*

### New Files
- **`scripts/mm-profiles.ts`** — Profile definitions (WIDE/TIGHT_A/TIGHT_B) + `calculateProfileQuotes()` with spread noise & size jitter
- **`scripts/mm-fleet.ts`** — Fleet orchestrator: single process, staggered timing, shared price cache, TX rate limiting, per-profile subaccount isolation, optional Prometheus metrics
- **`scripts/README-mm-fleet.md`** — Full documentation
- **`tests/mm-fleet.test.ts`** — 337 unit tests

### Profiles

| Profile | Spread | Size/side | Re-quote | Role |
|---------|--------|-----------|----------|------|
| WIDE | 60 bps | $2,000 | 8s | Bedrock liquidity — backstop |
| TIGHT_A | 15 bps | $300 | 3s | Top-of-book action |
| TIGHT_B | 20 bps | $250 | 4s | Second layer — oracle-offset staggering |

### Key Design
- **Single process** — all instances share price cache (2s TTL) and TX queue (200ms rate limit)
- **Subaccount isolation** — each profile gets own LP + User account per market
- **Staggered timing** — random jitter prevents lockstep quoting
- **Spread noise + size jitter** — quotes vary organically, not mechanical
- **Profile overrides** — `MM_WIDE_SPREAD_BPS=80` etc. via env
- **Prometheus** — optional `PROMETHEUS_PORT` for ops monitoring
- **Auto re-discovery** — new markets added every 5 minutes

### Tests
```
337 tests | all pass
- Profile configuration validation
- Quote calculation per profile (flat + long + short)
- Invariants across all profiles × 5 prices × 5 positions
- Spread noise & size jitter distribution
- Edge cases (zero collateral, micro-cap, BTC-scale)
- Combined orderbook depth (6 price levels, >/side)
```

### Usage
```bash
pnpm fleet           # Run all 3 profiles
pnpm fleet:dry       # Dry run
FLEET_PROFILES=WIDE pnpm fleet  # Single profile
```

Ref: PERC-354 researcher memo, PERC-364 single maker