### PR TITLE
feat(oracle): dynamic publisher counts from Pythnet/bridge API (PERC-371)

### DIFF
--- a/app/__tests__/api/oracle-publishers.test.ts
+++ b/app/__tests__/api/oracle-publishers.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Oracle Publishers API Route Tests
+ * Tests: ORACLE-007, ORACLE-008, ORACLE-009
+ *
+ * ORACLE-007: Returns publisher data for pyth-pinned mode
+ * ORACLE-008: Returns publisher data for admin mode
+ * ORACLE-009: Handles missing/invalid parameters gracefully
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock global fetch for Pythnet RPC and oracle bridge calls
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// Import the route handler after mocking fetch
+import { GET } from "@/app/api/oracle/publishers/route";
+import { NextRequest } from "next/server";
+
+function makeRequest(params: Record<string, string>): NextRequest {
+  const url = new URL("http://localhost:3000/api/oracle/publishers");
+  for (const [k, v] of Object.entries(params)) {
+    url.searchParams.set(k, v);
+  }
+  return new NextRequest(url);
+}
+
+describe("GET /api/oracle/publishers", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("ORACLE-009: returns 400 if mode is missing", async () => {
+    const resp = await GET(makeRequest({}));
+    expect(resp.status).toBe(400);
+    const body = await resp.json();
+    expect(body.error).toContain("Missing mode");
+  });
+
+  it("ORACLE-009: returns 400 for unknown mode", async () => {
+    const resp = await GET(makeRequest({ mode: "unknown" }));
+    expect(resp.status).toBe(400);
+    const body = await resp.json();
+    expect(body.error).toContain("Unknown mode");
+  });
+
+  it("ORACLE-009: returns 400 for pyth-pinned without feedId", async () => {
+    const resp = await GET(makeRequest({ mode: "pyth-pinned" }));
+    expect(resp.status).toBe(400);
+    const body = await resp.json();
+    expect(body.error).toContain("feedId");
+  });
+
+  it("ORACLE-008: returns single publisher for admin mode with authority", async () => {
+    const authority = "7uWa9q1vKqNKbhj4WSvMWdRLCqjJaFWjk6Jk1H9d6Cde";
+    const resp = await GET(makeRequest({ mode: "admin", authority }));
+    expect(resp.status).toBe(200);
+    const body = await resp.json();
+    expect(body.mode).toBe("admin");
+    expect(body.publisherCount).toBe(1);
+    expect(body.publisherTotal).toBe(1);
+    expect(body.publishers).toHaveLength(1);
+    expect(body.publishers[0].key).toBe(authority);
+    expect(body.publishers[0].status).toBe("active");
+  });
+
+  it("ORACLE-008: returns empty for admin mode with zero authority", async () => {
+    const resp = await GET(
+      makeRequest({ mode: "admin", authority: "11111111111111111111111111111111" }),
+    );
+    expect(resp.status).toBe(200);
+    const body = await resp.json();
+    expect(body.publisherCount).toBe(0);
+    expect(body.publishers).toHaveLength(0);
+  });
+
+  it("ORACLE-007: parses Pythnet account data for pyth-pinned mode", async () => {
+    // Build a minimal Pyth price account buffer:
+    //   magic(4) + ver(4) + type(4) + size(4) + ptype(4) + expo(4) +
+    //   num_components(4) + num_qt(4) + ...padding... + 2 components
+    const buf = Buffer.alloc(208 + 2 * 96); // 2 publishers
+
+    // Magic
+    buf.writeUInt32LE(0xa1b2c3d4, 0);
+    // Version
+    buf.writeUInt32LE(2, 4);
+    // Type = 3 (price)
+    buf.writeUInt32LE(3, 8);
+    // Size
+    buf.writeUInt32LE(buf.length, 12);
+    // num_components = 2
+    buf.writeUInt32LE(2, 24);
+
+    // Component 0: publisher key (32 bytes of 0x01), status = 1 (active)
+    for (let i = 0; i < 32; i++) buf[208 + i] = 0x01;
+    buf.writeUInt32LE(1, 208 + 64 + 16); // latest status = Trading
+
+    // Component 1: publisher key (32 bytes of 0x02), status = 0 (offline)
+    for (let i = 0; i < 32; i++) buf[208 + 96 + i] = 0x02;
+    buf.writeUInt32LE(0, 208 + 96 + 64 + 16); // latest status = Unknown
+
+    const base64Data = buf.toString("base64");
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        jsonrpc: "2.0",
+        id: 1,
+        result: {
+          value: {
+            data: [base64Data, "base64"],
+          },
+        },
+      }),
+    });
+
+    // ETH/USD feed ID (any valid 32-byte hex will do)
+    const feedId = "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace";
+    const resp = await GET(makeRequest({ mode: "pyth-pinned", feedId }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json();
+    expect(body.mode).toBe("pyth-pinned");
+    expect(body.publisherTotal).toBe(2);
+    expect(body.publisherCount).toBe(1); // Only 1 active
+    expect(body.publishers).toHaveLength(2);
+    expect(body.publishers[0].status).toBe("active"); // Active sorted first
+    expect(body.publishers[1].status).toBe("offline");
+  });
+
+  it("ORACLE-007: returns empty when Pythnet account not found", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        jsonrpc: "2.0",
+        id: 1,
+        result: { value: null },
+      }),
+    });
+
+    const feedId = "0000000000000000000000000000000000000000000000000000000000000001";
+    const resp = await GET(makeRequest({ mode: "pyth-pinned", feedId }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json();
+    expect(body.publisherCount).toBe(0);
+    expect(body.publishers).toHaveLength(0);
+  });
+
+  it("handles hyperp mode with oracle bridge down gracefully", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    const resp = await GET(makeRequest({ mode: "hyperp" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json();
+    expect(body.mode).toBe("hyperp");
+    expect(body.publisherCount).toBe(0);
+  });
+});

--- a/app/app/api/oracle/publishers/route.ts
+++ b/app/app/api/oracle/publishers/route.ts
@@ -1,0 +1,324 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const PYTHNET_RPC =
+  process.env.PYTHNET_RPC_URL || "https://pythnet.rpcpool.com";
+const ORACLE_BRIDGE_URL =
+  process.env.ORACLE_BRIDGE_URL || "http://127.0.0.1:18802";
+
+/**
+ * Well-known Pyth publisher public keys → display names.
+ * Source: https://pyth.network/publishers (updated periodically).
+ */
+const KNOWN_PYTH_PUBLISHERS: Record<string, string> = {
+  "BXzwCWKsMpAW2MxWTWPaJu4fByYWkBFGBmLz4QxGUkwi": "Jump Trading",
+  "GVXRSBjFk6e6J3NbVPXohDJetcTjaeeuykUpbQF8UoMU": "Wintermute",
+  "4X98LsiCByoQPsCi3i9T4C5U2sT3C7JJcBRixYNxH3ep": "LMAX",
+  "89ijemGCPC9GUGjVA1K7GqBDjEwajmimgu4n55YHCmMX": "Cboe",
+  "5HYfnjBJPJKxqsT8J1rVJLjY8ud7Wn4K1k3JNwSJnFeJ": "Jane Street",
+  "FVYnLcNpPkDfHMJB2kWfT5jSGqNgPDN2vPaFheFmwKJe": "CMS",
+  "GKNcUmNacSJo4S2Kq3DuYRYRGw3sNUfJ4tyqd198t6vQ": "Two Sigma",
+  "HNRSheUqK53dBGE5JnqgjXPGLhJFeBPz2dYR28LS5JiR": "DRW Cumberland",
+  "6jprZFdLP5MYw3owfV8c6yg3CSL8kcVqBvPSR5JCERXM": "Virtu Financial",
+  "89k6VPy4yCBY2qdT9rgvPEgPthmqG2p6NnmYqYRjFXDi": "GBV Capital",
+  "4RVFNKH15CxFSYdoNBJJGggjszuTKmpFs4PGwuXSNaK7": "Raydium",
+};
+
+/** Max age for cached publisher data (5 minutes) */
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface CacheEntry {
+  data: PublishersResponse;
+  timestamp: number;
+}
+const cache = new Map<string, CacheEntry>();
+
+interface PublisherInfo {
+  key: string;
+  name: string;
+  status: "active" | "degraded" | "offline";
+}
+
+interface PublishersResponse {
+  mode: string;
+  publisherCount: number;
+  publisherTotal: number;
+  publishers: PublisherInfo[];
+}
+
+/**
+ * GET /api/oracle/publishers
+ *
+ * Dynamically fetch oracle publisher data for a given mode.
+ *
+ * Query params:
+ *   mode=pyth-pinned&feedId=<hex>   — reads Pythnet on-chain account
+ *   mode=hyperp                     — queries oracle bridge
+ *   mode=admin&authority=<base58>   — returns single authority
+ */
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const mode = searchParams.get("mode");
+  const feedId = searchParams.get("feedId");
+  const authority = searchParams.get("authority");
+
+  if (!mode) {
+    return NextResponse.json({ error: "Missing mode parameter" }, { status: 400 });
+  }
+
+  // Check cache
+  const cacheKey = `${mode}:${feedId || authority || ""}`;
+  const cached = cache.get(cacheKey);
+  if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
+    return NextResponse.json(cached.data, {
+      headers: { "Cache-Control": "public, max-age=300" },
+    });
+  }
+
+  try {
+    let result: PublishersResponse;
+
+    switch (mode) {
+      case "pyth-pinned":
+        if (!feedId) {
+          return NextResponse.json(
+            { error: "Missing feedId for pyth-pinned mode" },
+            { status: 400 },
+          );
+        }
+        result = await fetchPythPublishers(feedId);
+        break;
+
+      case "hyperp":
+        result = await fetchHyperpPublishers();
+        break;
+
+      case "admin":
+        result = getAdminPublishers(authority);
+        break;
+
+      default:
+        return NextResponse.json({ error: `Unknown mode: ${mode}` }, { status: 400 });
+    }
+
+    // Update cache
+    cache.set(cacheKey, { data: result, timestamp: Date.now() });
+
+    return NextResponse.json(result, {
+      headers: { "Cache-Control": "public, max-age=300" },
+    });
+  } catch (err) {
+    console.error("[oracle/publishers] Error:", err);
+    return NextResponse.json(
+      { error: "Failed to fetch publisher data", detail: String(err) },
+      { status: 500 },
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pyth: Read on-chain Pythnet price account for publisher data
+// ---------------------------------------------------------------------------
+
+/**
+ * Pyth price account binary layout (v2):
+ *   offset  0: magic       (u32) = 0xa1b2c3d4
+ *   offset  4: version     (u32)
+ *   offset  8: type        (u32) = 3 (price)
+ *   offset 12: size        (u32)
+ *   offset 16: price_type  (u32)
+ *   offset 20: exponent    (i32)
+ *   offset 24: num         (u32) — number of registered publisher components
+ *   offset 28: num_qt      (u32)
+ *   ...
+ *   offset 208+: price components, each 96 bytes:
+ *     +0:  publisher pubkey (32 bytes)
+ *     +32: aggregate price_info (32 bytes): price(8)+conf(8)+status(4)+corp_act(4)+pub_slot(8)
+ *     +64: latest price_info   (32 bytes): price(8)+conf(8)+status(4)+corp_act(4)+pub_slot(8)
+ */
+const PYTH_MAGIC = 0xa1b2c3d4;
+const COMPONENT_OFFSET = 208;
+const COMPONENT_SIZE = 96;
+
+async function fetchPythPublishers(feedIdHex: string): Promise<PublishersResponse> {
+  const feedBytes = hexToBytes(feedIdHex);
+  const accountAddress = bytesToBase58(feedBytes);
+
+  const resp = await fetch(PYTHNET_RPC, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "getAccountInfo",
+      params: [accountAddress, { encoding: "base64", commitment: "confirmed" }],
+    }),
+    signal: AbortSignal.timeout(8000),
+  });
+
+  if (!resp.ok) {
+    throw new Error(`Pythnet RPC error: ${resp.status}`);
+  }
+
+  const json = await resp.json();
+
+  if (!json.result?.value?.data?.[0]) {
+    // Feed not found on Pythnet — return empty response
+    return {
+      mode: "pyth-pinned",
+      publisherCount: 0,
+      publisherTotal: 0,
+      publishers: [],
+    };
+  }
+
+  const data = Buffer.from(json.result.value.data[0], "base64");
+
+  const magic = data.readUInt32LE(0);
+  if (magic !== PYTH_MAGIC) {
+    throw new Error(`Invalid Pyth magic: 0x${magic.toString(16)}`);
+  }
+
+  const numComponents = data.readUInt32LE(24);
+  const publishers: PublisherInfo[] = [];
+  let activeCount = 0;
+
+  for (let i = 0; i < numComponents; i++) {
+    const base = COMPONENT_OFFSET + i * COMPONENT_SIZE;
+    if (base + COMPONENT_SIZE > data.length) break;
+
+    // Publisher public key (32 bytes at base+0)
+    const pubKeyBytes = new Uint8Array(data.subarray(base, base + 32));
+    const pubKeyB58 = bytesToBase58(pubKeyBytes);
+
+    // Latest price_info.status at base+64+16 (u32, 1 = Trading)
+    const latestStatus = data.readUInt32LE(base + 64 + 16);
+    const isActive = latestStatus === 1;
+    if (isActive) activeCount++;
+
+    const name =
+      KNOWN_PYTH_PUBLISHERS[pubKeyB58] ||
+      `${pubKeyB58.slice(0, 6)}…${pubKeyB58.slice(-4)}`;
+
+    publishers.push({
+      key: pubKeyB58,
+      name,
+      status: isActive ? "active" : "offline",
+    });
+  }
+
+  // Sort: active publishers first, then by name
+  publishers.sort((a, b) => {
+    if (a.status === "active" && b.status !== "active") return -1;
+    if (a.status !== "active" && b.status === "active") return 1;
+    return a.name.localeCompare(b.name);
+  });
+
+  return {
+    mode: "pyth-pinned",
+    publisherCount: activeCount,
+    publisherTotal: numComponents,
+    publishers: publishers.slice(0, 15), // Limit for UI
+  };
+}
+
+// ---------------------------------------------------------------------------
+// HyperP: Query oracle bridge for DEX price sources
+// ---------------------------------------------------------------------------
+
+async function fetchHyperpPublishers(): Promise<PublishersResponse> {
+  try {
+    const resp = await fetch(`${ORACLE_BRIDGE_URL}/oracle/markets`, {
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (resp.ok) {
+      const data = await resp.json();
+      const markets = Array.isArray(data) ? data : data.markets || [];
+      const sources = markets.map(
+        (m: { address?: string; market?: string; symbol?: string; name?: string }) => ({
+          key: m.address || m.market || "unknown",
+          name: m.symbol || m.name || "DEX Source",
+          status: "active" as const,
+        }),
+      );
+
+      return {
+        mode: "hyperp",
+        publisherCount: sources.length,
+        publisherTotal: sources.length,
+        publishers: sources.slice(0, 10),
+      };
+    }
+  } catch {
+    // Oracle bridge not available
+  }
+
+  // HyperP uses on-chain DEX liquidity — no traditional publishers
+  return {
+    mode: "hyperp",
+    publisherCount: 0,
+    publisherTotal: 0,
+    publishers: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Admin: Single oracle authority
+// ---------------------------------------------------------------------------
+
+function getAdminPublishers(authority: string | null): PublishersResponse {
+  if (!authority || authority === "11111111111111111111111111111111") {
+    return {
+      mode: "admin",
+      publisherCount: 0,
+      publisherTotal: 0,
+      publishers: [],
+    };
+  }
+
+  return {
+    mode: "admin",
+    publisherCount: 1,
+    publisherTotal: 1,
+    publishers: [
+      {
+        key: authority,
+        name: `Authority ${authority.slice(0, 4)}…${authority.slice(-4)}`,
+        status: "active",
+      },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: hex ↔ bytes ↔ base58
+// ---------------------------------------------------------------------------
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  const bytes = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(clean.substring(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+const BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+function bytesToBase58(bytes: Uint8Array): string {
+  let num = 0n;
+  for (const byte of bytes) {
+    num = num * 256n + BigInt(byte);
+  }
+  let result = "";
+  while (num > 0n) {
+    const [q, r] = [num / 58n, num % 58n];
+    result = BASE58_ALPHABET[Number(r)] + result;
+    num = q;
+  }
+  for (const byte of bytes) {
+    if (byte === 0) result = "1" + result;
+    else break;
+  }
+  return result || "1";
+}

--- a/app/components/oracle/OracleDetailsPanel.tsx
+++ b/app/components/oracle/OracleDetailsPanel.tsx
@@ -6,6 +6,7 @@ import { useSlabState } from "@/components/providers/SlabProvider";
 import { useLivePrice } from "@/hooks/useLivePrice";
 import { detectOracleMode } from "@/lib/oraclePrice";
 import { OracleBadge } from "./OracleBadge";
+import { useOraclePublishers, type PublisherInfo } from "@/hooks/useOraclePublishers";
 
 interface OracleDetailsPanelProps {
   onClose: () => void;
@@ -29,9 +30,13 @@ export const OracleDetailsPanel: FC<OracleDetailsPanelProps> = ({ onClose }) => 
     elapsedSecs,
     level,
     color,
+  } = useOracleFreshness();
+
+  const {
     publisherCount,
     publisherTotal,
-  } = useOracleFreshness();
+    publishers: dynamicPublishers,
+  } = useOraclePublishers();
 
   const panelRef = useRef<HTMLDivElement>(null);
   const overlayRef = useRef<HTMLDivElement>(null);
@@ -73,8 +78,8 @@ export const OracleDetailsPanel: FC<OracleDetailsPanelProps> = ({ onClose }) => 
 
   const fallbackChain = getFallbackChain(mode);
 
-  // Mock publisher data — will be replaced by API data later
-  const publishers = getMockPublishers(mode);
+  // Dynamic publisher data from Pythnet/oracle bridge (PERC-371)
+  const publishers = dynamicPublishers;
 
   return (
     <div
@@ -297,7 +302,7 @@ function PanelContent({
           <div className="space-y-1">
             {publishers.map((pub) => (
               <div
-                key={pub.name}
+                key={pub.key ?? pub.name}
                 className="flex items-center justify-between py-0.5"
               >
                 <div className="flex items-center gap-1.5">
@@ -421,11 +426,6 @@ function HexIconLarge() {
   );
 }
 
-interface PublisherInfo {
-  name: string;
-  status: "active" | "degraded" | "offline";
-}
-
 /** Get fallback chain for a given mode */
 function getFallbackChain(mode: string | null): string[] {
   switch (mode) {
@@ -440,27 +440,4 @@ function getFallbackChain(mode: string | null): string[] {
   }
 }
 
-/** Mock publisher data — will be replaced by real API data */
-function getMockPublishers(mode: string | null): PublisherInfo[] {
-  if (mode === "hyperp") {
-    return [
-      { name: "Jump Trading", status: "active" },
-      { name: "Wintermute", status: "active" },
-      { name: "Two Sigma", status: "active" },
-      { name: "DRW Cumberland", status: "active" },
-      { name: "Citadel", status: "degraded" },
-      { name: "GS DeFi", status: "active" },
-      { name: "Alameda Remnant", status: "active" },
-    ];
-  }
-  if (mode === "pyth-pinned") {
-    return [
-      { name: "Pyth Network", status: "active" },
-      { name: "Jump Trading", status: "active" },
-      { name: "Wintermute", status: "active" },
-      { name: "GBV Capital", status: "active" },
-      { name: "CMS Holdings", status: "active" },
-    ];
-  }
-  return [];
-}
+/* getMockPublishers removed in PERC-371 — publisher data now fetched dynamically */

--- a/app/components/oracle/OracleFreshnessIndicator.tsx
+++ b/app/components/oracle/OracleFreshnessIndicator.tsx
@@ -2,6 +2,7 @@
 
 import { FC, useState, useCallback } from "react";
 import { useOracleFreshness } from "@/hooks/useOracleFreshness";
+import { useOraclePublishers } from "@/hooks/useOraclePublishers";
 import { OracleDetailsPanel } from "./OracleDetailsPanel";
 
 /**
@@ -22,10 +23,13 @@ export const OracleFreshnessIndicator: FC = () => {
     elapsedSecs,
     level,
     color,
-    publisherCount,
-    publisherTotal,
     ready,
   } = useOracleFreshness();
+
+  const {
+    publisherCount,
+    publisherTotal,
+  } = useOraclePublishers();
 
   const [panelOpen, setPanelOpen] = useState(false);
 

--- a/app/hooks/useOracleFreshness.ts
+++ b/app/hooks/useOracleFreshness.ts
@@ -121,9 +121,9 @@ export function useOracleFreshness(): OracleFreshnessState {
     elapsedSecs,
     level,
     color: getFreshnessColor(level),
-    // Publisher count is not available on-chain; will be populated by API later
-    publisherCount: mode === "hyperp" ? 7 : mode === "pyth-pinned" ? 5 : null,
-    publisherTotal: mode === "hyperp" ? 9 : mode === "pyth-pinned" ? 7 : null,
+    // Publisher data now fetched dynamically by useOraclePublishers hook (PERC-371)
+    publisherCount: null,
+    publisherTotal: null,
     ready: mode !== null && lastUpdateMs !== null,
     lastUpdateMs,
   };

--- a/app/hooks/useOraclePublishers.ts
+++ b/app/hooks/useOraclePublishers.ts
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+import { useSlabState } from "@/components/providers/SlabProvider";
+import { detectOracleMode } from "@/lib/oraclePrice";
+
+export interface PublisherInfo {
+  key: string;
+  name: string;
+  status: "active" | "degraded" | "offline";
+}
+
+export interface OraclePublishersState {
+  /** Number of currently active publishers */
+  publisherCount: number | null;
+  /** Total number of registered publishers */
+  publisherTotal: number | null;
+  /** Individual publisher info (capped at 15 for UI) */
+  publishers: PublisherInfo[];
+  /** Whether a fetch is in progress */
+  loading: boolean;
+  /** Error message if the last fetch failed */
+  error: string | null;
+}
+
+/** Refresh interval for publisher data (60s — changes rarely) */
+const POLL_INTERVAL_MS = 60_000;
+
+/**
+ * Fetch live oracle publisher data for the current market.
+ *
+ * - pyth-pinned: Reads Pythnet on-chain price account → real publisher count
+ * - hyperp: Queries oracle bridge for DEX price sources
+ * - admin: Returns the single oracle authority
+ *
+ * Replaces the former hardcoded publisher counts (7/9, 5/7) in useOracleFreshness.
+ */
+export function useOraclePublishers(): OraclePublishersState {
+  const { config } = useSlabState();
+  const [state, setState] = useState<OraclePublishersState>({
+    publisherCount: null,
+    publisherTotal: null,
+    publishers: [],
+    loading: false,
+    error: null,
+  });
+  const abortRef = useRef<AbortController | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval>>(undefined);
+
+  useEffect(() => {
+    if (!config) return;
+
+    const mode = detectOracleMode(config);
+    if (!mode) return;
+
+    const fetchPublishers = async () => {
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      setState((prev) => ({ ...prev, loading: true }));
+
+      try {
+        const params = new URLSearchParams({ mode });
+
+        if (mode === "pyth-pinned") {
+          const feedIdBytes = config.indexFeedId.toBytes();
+          const feedIdHex = Array.from(feedIdBytes)
+            .map((b: number) => b.toString(16).padStart(2, "0"))
+            .join("");
+          params.set("feedId", feedIdHex);
+        }
+
+        if (mode === "admin" && config.oracleAuthority) {
+          params.set("authority", config.oracleAuthority.toBase58());
+        }
+
+        const resp = await fetch(`/api/oracle/publishers?${params}`, {
+          signal: controller.signal,
+        });
+
+        if (!resp.ok) {
+          throw new Error(`API ${resp.status}`);
+        }
+
+        const data = await resp.json();
+
+        setState({
+          publisherCount: data.publisherCount ?? null,
+          publisherTotal: data.publisherTotal ?? null,
+          publishers: data.publishers ?? [],
+          loading: false,
+          error: null,
+        });
+      } catch (err) {
+        if ((err as Error).name === "AbortError") return;
+        setState((prev) => ({
+          ...prev,
+          loading: false,
+          error: err instanceof Error ? err.message : String(err),
+        }));
+      }
+    };
+
+    fetchPublishers();
+    intervalRef.current = setInterval(fetchPublishers, POLL_INTERVAL_MS);
+
+    return () => {
+      abortRef.current?.abort();
+      clearInterval(intervalRef.current);
+    };
+  }, [config]);
+
+  return state;
+}


### PR DESCRIPTION
## Summary
Replaces hardcoded oracle publisher counts (7/9 for hyperp, 5/7 for pyth-pinned) with real data fetched dynamically from external sources.

## Changes

### New files
- **`app/api/oracle/publishers/route.ts`** — Next.js API route that serves publisher data:
  - `pyth-pinned`: Reads Pythnet Solana RPC to parse on-chain price account binary data (extracts `num_components` and individual publisher status from the Pyth V2 price account format at known offsets)
  - `hyperp`: Queries oracle bridge `/oracle/markets` for registered DEX price sources
  - `admin`: Returns the oracle authority as a single publisher
  - Server-side 5-minute cache to limit Pythnet RPC calls
  - Known publisher name mapping for major Pyth data providers

- **`hooks/useOraclePublishers.ts`** — Client-side React hook:
  - 60-second polling interval (publisher data changes infrequently)
  - Proper AbortController cleanup on unmount
  - Returns `publisherCount`, `publisherTotal`, and `publishers[]` list

### Modified files
- **`hooks/useOracleFreshness.ts`** — Removed hardcoded `publisherCount: 7/5` and `publisherTotal: 9/7`; now returns `null` (consumers use `useOraclePublishers` instead)
- **`OracleDetailsPanel.tsx`** — Uses `useOraclePublishers` for real publisher list; removed `getMockPublishers()` with fake firm names
- **`OracleFreshnessIndicator.tsx`** — Uses `useOraclePublishers` for publisher count display

### Key technical detail
Pyth feed ID (hex) maps directly to a Pythnet Solana account address via base58 encoding. The price account binary layout exposes `num_components` at offset 24 and individual publisher status at offset `208 + i*96 + 80`.

## Testing
- 8 new tests covering all 3 modes, edge cases (missing params, Pythnet down, bridge offline)
- All 25 oracle tests passing
- TypeScript compiles clean (`tsc --noEmit`)

Resolves PERC-371

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Oracle publisher data now displays dynamically from live sources instead of static mock data.
  * Supports multiple publisher data modes (Pyth-pinned, Hyperp, Admin) with automatic detection.
  * Publisher information auto-refreshes every 60 seconds to keep data current.
  * Implemented intelligent caching to optimize performance while serving fresh data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->