### PR TITLE
fix(oracle-ui): PERC-369 designer review fixes + CodeRabbit improvements

### DIFF
--- a/app/app/trade/[slab]/page.tsx
+++ b/app/app/trade/[slab]/page.tsx
@@ -143,6 +143,7 @@ function TradePageInner({ slab }: { slab: string }) {
   const { priceUsd } = useLivePrice();
   const health = engine ? computeMarketHealth(engine) : null;
   const { mode: oracleMode, level: oracleLevel } = useOracleFreshness();
+  const oracleBadgeStatus = oracleLevel === "stale" ? "stale" : "healthy";
   const pageRef = useRef<HTMLDivElement>(null);
   const shortAddress = `${slab.slice(0, 4)}…${slab.slice(-4)}`;
 
@@ -272,7 +273,7 @@ function TradePageInner({ slab }: { slab: string }) {
           <div className="flex items-center gap-1.5 min-w-0 overflow-hidden">
             <UsdToggleButton />
             {health && <HealthBadge level={health.level} />}
-            {oracleMode && <OracleBadge mode={oracleMode} status={oracleLevel === "stale" ? "stale" : "healthy"} />}
+            {oracleMode && <OracleBadge mode={oracleMode} status={oracleBadgeStatus} />}
             {priceDisplay && (
               <span className="shrink-0 text-sm font-bold text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>{priceDisplay}</span>
             )}
@@ -339,7 +340,7 @@ function TradePageInner({ slab }: { slab: string }) {
             <span className="h-3.5 w-px bg-[var(--border)]/40" />
             <OracleBadge
               mode={oracleMode}
-              status={oracleLevel === "stale" ? "stale" : "healthy"}
+              status={oracleBadgeStatus}
             />
           </>
         )}

--- a/app/hooks/useOracleFreshness.ts
+++ b/app/hooks/useOracleFreshness.ts
@@ -88,8 +88,15 @@ export function useOracleFreshness(): OracleFreshnessState {
         setLastUpdateMs(Number(ts) * 1000);
       } else if (config.lastEffectivePriceE6 > 0n) {
         // Fallback: admin price is set but timestamp is zero (legacy/static markets).
-        // Show a degraded freshness state rather than hiding entirely.
-        setLastUpdateMs((prev) => prev ?? Date.now());
+        // Reset freshness on each observed price change so the elapsed timer restarts.
+        const currentPrice = config.lastEffectivePriceE6;
+        if (prevPriceRef.current !== null && currentPrice !== prevPriceRef.current) {
+          setLastUpdateMs(Date.now());
+        } else if (prevPriceRef.current === null) {
+          // First load — assume relatively fresh
+          setLastUpdateMs(Date.now());
+        }
+        prevPriceRef.current = currentPrice;
       }
     } else {
       // Hyperp / Pyth: track when the price value changes


### PR DESCRIPTION
## Summary

Addresses designer review feedback and CodeRabbit suggestions for the PERC-369 oracle UI feature.

### Changes
- **Track admin price changes**: Oracle freshness hook now detects admin-set price updates, not just Pyth oracle updates
- **DRY badge status logic**: Extracted shared status computation to avoid duplication across oracle components
- **Trade page integration**: Minor fixes to oracle integration on the trade page

### Notes
- All 5 CSS keyframe animations (freshness-ping, oracle-pulse, slide-in-right, slide-out-right, fade-out) were already included in the original PERC-369 commit on main
- Designer flagged these as missing but they are present in globals.css lines 876-911

### Related
- Task: PERC-369
- Original PR: oracle UI feature merged to main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected Oracle Badge status display for aging oracle levels—now properly indicates healthy status instead of stale
* Enhanced oracle freshness tracking in admin mode with improved fallback logic to better handle edge cases when price data is present

<!-- end of auto-generated comment: release notes by coderabbit.ai -->