### PR TITLE
fix: Portfolio test skeleton selector — match ShimmerSkeleton class

### DIFF
--- a/app/__tests__/components/Portfolio.test.tsx
+++ b/app/__tests__/components/Portfolio.test.tsx
@@ -363,9 +363,12 @@ describe("Portfolio Component Tests", () => {
 
       render(<PortfolioPage />);
 
-      // Should show loading skeletons
+      // Should show loading skeletons (ShimmerSkeleton uses shimmer-sweep animation,
+      // rendered as a bg-[var(--border)] div with an inner shimmer overlay)
       const skeletons = screen.getAllByRole("generic").filter(
-        (el) => el.className.includes("animate-pulse")
+        (el) =>
+          el.className.includes("animate-pulse") ||
+          el.className.includes("bg-[var(--border)]")
       );
       expect(skeletons.length).toBeGreaterThan(0);
     });


### PR DESCRIPTION
## What

PORT-004 test (`should show skeleton while token metadata is loading`) was failing because it checked for `animate-pulse` CSS class, but `PortfolioPage` uses `ShimmerSkeleton` which renders with `bg-[var(--border)]` and a custom `shimmer-sweep` animation instead.

## Fix

Updated the selector to match both class patterns so the skeleton-loading assertion works correctly.

## Tests

All 757 app tests pass (was 756 before — this test was the 1 failure).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations for loading indicators to improve test coverage accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->