### PR TITLE
fix(oracle): admin freshness indicator uses authorityPriceE6 fallback [PERC-369]

### DIFF
--- a/app/__tests__/components/oracle/OracleFreshness.test.tsx
+++ b/app/__tests__/components/oracle/OracleFreshness.test.tsx
@@ -1,36 +1,46 @@
 /**
  * useOracleFreshness Hook Tests
- * Tests: ORACLE-004, ORACLE-005, ORACLE-006
+ * Tests: ORACLE-004, ORACLE-005, ORACLE-006, ORACLE-007
  *
  * ORACLE-004: Returns correct freshness levels based on elapsed time
  * ORACLE-005: Detects oracle mode from config
  * ORACLE-006: Returns mode label correctly
+ * ORACLE-007: Admin mode with zero timestamp uses authorityPriceE6 fallback
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { PublicKey } from "@solana/web3.js";
 
-// Mock SlabProvider
-const mockConfig = {
-  oracleAuthority: PublicKey.default,
-  indexFeedId: PublicKey.default,
-  authorityPriceE6: 42000_000000n,
-  authorityTimestamp: 0n,
-  lastEffectivePriceE6: 42000_000000n,
-  collateralMint: new PublicKey("So11111111111111111111111111111111111111112"),
-};
+// Dynamic mock config — reassign before each test as needed
+let currentConfig: Record<string, unknown> | null = null;
 
 vi.mock("@/components/providers/SlabProvider", () => ({
   useSlabState: () => ({
-    config: mockConfig,
+    config: currentConfig,
     slabAddress: "test-slab",
   }),
 }));
 
 import { useOracleFreshness } from "@/hooks/useOracleFreshness";
 
+// Non-zero authority key for admin mode
+const ADMIN_AUTHORITY = new PublicKey("Sysvar1111111111111111111111111111111111112");
+const NON_ZERO_FEED = new PublicKey("Sysvar1111111111111111111111111111111111113");
+
 describe("useOracleFreshness", () => {
+  beforeEach(() => {
+    // Default: hyperp mode config
+    currentConfig = {
+      oracleAuthority: PublicKey.default,
+      indexFeedId: PublicKey.default,
+      authorityPriceE6: 42000_000000n,
+      authorityTimestamp: 0n,
+      lastEffectivePriceE6: 42000_000000n,
+      collateralMint: new PublicKey("So11111111111111111111111111111111111111112"),
+    };
+  });
+
   it("ORACLE-005: detects hyperp mode when indexFeedId is zero", () => {
     // indexFeedId = PublicKey.default (all zeros) → hyperp mode
     const { result } = renderHook(() => useOracleFreshness());
@@ -49,5 +59,42 @@ describe("useOracleFreshness", () => {
   it("ORACLE-006: returns ready=true when config is available", () => {
     const { result } = renderHook(() => useOracleFreshness());
     expect(result.current.ready).toBe(true);
+  });
+
+  it("ORACLE-007: admin mode with zero timestamp and zero lastEffectivePriceE6 uses authorityPriceE6", () => {
+    // Simulate the exact bug: admin market where authorityTimestamp=0, lastEffectivePriceE6=0,
+    // but authorityPriceE6 is set (the actual displayed price)
+    currentConfig = {
+      oracleAuthority: ADMIN_AUTHORITY,
+      indexFeedId: NON_ZERO_FEED,
+      authorityPriceE6: 21_100_011_000000n,
+      authorityTimestamp: 0n,
+      lastEffectivePriceE6: 0n,
+      collateralMint: new PublicKey("So11111111111111111111111111111111111111112"),
+    };
+
+    const { result } = renderHook(() => useOracleFreshness());
+    expect(result.current.mode).toBe("admin");
+    expect(result.current.modeLabel).toBe("ADMIN");
+    // The key assertion: ready should be true because authorityPriceE6 > 0
+    expect(result.current.ready).toBe(true);
+    expect(result.current.lastUpdateMs).not.toBeNull();
+  });
+
+  it("ORACLE-007b: admin mode with valid authorityTimestamp uses it directly", () => {
+    const nowSecs = BigInt(Math.floor(Date.now() / 1000));
+    currentConfig = {
+      oracleAuthority: ADMIN_AUTHORITY,
+      indexFeedId: NON_ZERO_FEED,
+      authorityPriceE6: 50_000_000000n,
+      authorityTimestamp: nowSecs,
+      lastEffectivePriceE6: 0n,
+      collateralMint: new PublicKey("So11111111111111111111111111111111111111112"),
+    };
+
+    const { result } = renderHook(() => useOracleFreshness());
+    expect(result.current.mode).toBe("admin");
+    expect(result.current.ready).toBe(true);
+    expect(result.current.lastUpdateMs).toBe(Number(nowSecs) * 1000);
   });
 });

--- a/app/hooks/useOracleFreshness.ts
+++ b/app/hooks/useOracleFreshness.ts
@@ -86,17 +86,23 @@ export function useOracleFreshness(): OracleFreshnessState {
       const ts = config.authorityTimestamp;
       if (ts > 0n) {
         setLastUpdateMs(Number(ts) * 1000);
-      } else if (config.lastEffectivePriceE6 > 0n) {
+      } else {
         // Fallback: admin price is set but timestamp is zero (legacy/static markets).
-        // Reset freshness on each observed price change so the elapsed timer restarts.
-        const currentPrice = config.lastEffectivePriceE6;
-        if (prevPriceRef.current !== null && currentPrice !== prevPriceRef.current) {
-          setLastUpdateMs(Date.now());
-        } else if (prevPriceRef.current === null) {
-          // First load — assume relatively fresh
-          setLastUpdateMs(Date.now());
+        // Use authorityPriceE6 (the canonical admin price, matching resolveMarketPriceE6)
+        // and fall back to lastEffectivePriceE6 only if authority price is zero.
+        const adminPrice = config.authorityPriceE6 > 0n
+          ? config.authorityPriceE6
+          : config.lastEffectivePriceE6;
+        if (adminPrice > 0n) {
+          // Reset freshness on each observed price change so the elapsed timer restarts.
+          if (prevPriceRef.current !== null && adminPrice !== prevPriceRef.current) {
+            setLastUpdateMs(Date.now());
+          } else if (prevPriceRef.current === null) {
+            // First load — assume relatively fresh
+            setLastUpdateMs(Date.now());
+          }
+          prevPriceRef.current = adminPrice;
         }
-        prevPriceRef.current = currentPrice;
       }
     } else {
       // Hyperp / Pyth: track when the price value changes


### PR DESCRIPTION
## Problem

`OracleFreshnessIndicator` was not rendering on admin-mode markets (e.g. Er8evJo5/USD PERP) where:
- `authorityTimestamp = 0n` (legacy/static market, no real timestamp)
- `lastEffectivePriceE6 = 0n` (not populated for this admin market)
- `authorityPriceE6 > 0n` (the actual pushed price, displayed in header)

The `useOracleFreshness` hook's admin fallback branch only checked `lastEffectivePriceE6`, so `lastUpdateMs` was never set and `ready` stayed `false`.

## Fix

Aligned the admin fallback logic with `resolveMarketPriceE6`: check `authorityPriceE6` first, then fall back to `lastEffectivePriceE6`. This ensures admin markets with a valid authority price correctly show the freshness indicator.

## Changes
- **`app/hooks/useOracleFreshness.ts`**: Admin zero-timestamp fallback now uses `authorityPriceE6 > 0n ? authorityPriceE6 : lastEffectivePriceE6` (2 files, +73/-20)
- **`app/__tests__/components/oracle/OracleFreshness.test.tsx`**: Added ORACLE-007 + ORACLE-007b tests for admin mode fallback. Made mock config dynamic per-test.

## Testing
- `pnpm vitest run __tests__/components/oracle/OracleFreshness.test.tsx` → 5/5 pass ✅
- Manually verified: designer confirmed keyframes present, component code deployed, root cause isolated to this hook logic

Closes PERC-369 (freshness indicator portion)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved oracle freshness logic in admin mode to properly prioritize canonical admin prices and handle fallback scenarios when timestamps are unavailable, ensuring more accurate freshness tracking.

* **Tests**
  * Expanded test coverage for oracle freshness with additional admin mode scenarios and dynamic configuration handling for improved test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->