### PR TITLE
PERC-372: Faucet 1K USDC, auto-deposit on wallet connect, tighter spread

### DIFF
--- a/app/app/api/airdrop/route.ts
+++ b/app/app/api/airdrop/route.ts
@@ -27,7 +27,7 @@ import * as Sentry from "@sentry/nextjs";
 export const dynamic = "force-dynamic";
 
 const NETWORK = process.env.NEXT_PUBLIC_SOLANA_NETWORK ?? "devnet";
-const AIRDROP_USD_VALUE = 500;
+const AIRDROP_USD_VALUE = 1000;
 const RATE_LIMIT_HOURS = 24;
 const ORACLE_BRIDGE_URL = process.env.ORACLE_BRIDGE_URL ?? "http://127.0.0.1:18802";
 

--- a/app/app/api/auto-fund/route.ts
+++ b/app/app/api/auto-fund/route.ts
@@ -28,7 +28,7 @@ export const dynamic = "force-dynamic";
 const NETWORK = process.env.NEXT_PUBLIC_SOLANA_NETWORK ?? "devnet";
 const MIN_SOL_BALANCE = 0.1 * LAMPORTS_PER_SOL; // 0.1 SOL threshold
 const AIRDROP_AMOUNT = 2 * LAMPORTS_PER_SOL; // 2 SOL
-const USDC_MINT_AMOUNT = 100_000_000; // 100 USDC (6 decimals)
+const USDC_MINT_AMOUNT = 1_000_000_000; // 1,000 USDC (6 decimals)
 const RATE_LIMIT_HOURS = 24;
 
 // Public devnet RPC for airdrop (Helius may not forward airdrop requests)

--- a/app/app/trade/[slab]/page.tsx
+++ b/app/app/trade/[slab]/page.tsx
@@ -32,6 +32,7 @@ import { useToast } from "@/hooks/useToast";
 import { isPlaceholderSymbol } from "@/lib/symbol-utils";
 import { OracleBadge } from "@/components/oracle/OracleBadge";
 import { useOracleFreshness } from "@/hooks/useOracleFreshness";
+import { useAutoDeposit } from "@/hooks/useAutoDeposit";
 
 /* ── Reusable tiny components ─────────────────────────────── */
 
@@ -144,6 +145,7 @@ function TradePageInner({ slab }: { slab: string }) {
   const health = engine ? computeMarketHealth(engine) : null;
   const { mode: oracleMode, level: oracleLevel } = useOracleFreshness();
   const oracleBadgeStatus = oracleLevel === "stale" ? "stale" : "healthy";
+  const { status: autoDepositStatus } = useAutoDeposit(slab);
   const pageRef = useRef<HTMLDivElement>(null);
   const shortAddress = `${slab.slice(0, 4)}…${slab.slice(-4)}`;
 
@@ -258,6 +260,16 @@ function TradePageInner({ slab }: { slab: string }) {
 
   return (
     <div ref={pageRef} className="mx-auto max-w-[1920px] overflow-x-hidden gsap-fade">
+
+      {/* ── Auto-deposit banner (devnet only) ── */}
+      {autoDepositStatus !== "idle" && autoDepositStatus !== "done" && (
+        <div className="border-b border-[var(--accent)]/20 bg-[var(--accent)]/5 px-4 py-2 text-center text-[11px] text-[var(--accent)]">
+          {autoDepositStatus === "funding" && "⏳ Setting up your devnet wallet…"}
+          {autoDepositStatus === "creating" && "⏳ Creating your trading account…"}
+          {autoDepositStatus === "depositing" && "⏳ Depositing test collateral…"}
+          {autoDepositStatus === "error" && "⚠️ Auto-setup failed — you can deposit manually below"}
+        </div>
+      )}
 
       {/* ── MOBILE: Sticky header ── */}
       <div className="sticky top-0 z-30 border-b border-[var(--border)]/50 bg-[var(--bg)]/95 px-3 py-2 backdrop-blur-sm lg:hidden">

--- a/app/hooks/useAutoDeposit.ts
+++ b/app/hooks/useAutoDeposit.ts
@@ -1,0 +1,209 @@
+/**
+ * PERC-372: Auto-deposit hook
+ *
+ * Full zero-to-trading flow on wallet connect (devnet only):
+ *   1. Detect zero token balance → call /api/auto-fund (SOL airdrop + USDC mint)
+ *   2. Detect no protocol user account → init user account on-chain
+ *   3. Detect zero collateral → deposit tokens into the user account
+ *
+ * Fires once per session per wallet+market. Non-blocking — runs in background.
+ * Surfaces progress via status state so UI can show a toast/banner.
+ */
+
+"use client";
+
+import { useEffect, useRef, useCallback, useState } from "react";
+import { PublicKey } from "@solana/web3.js";
+import {
+  getAssociatedTokenAddress,
+  getAccount,
+  createAssociatedTokenAccountInstruction,
+} from "@solana/spl-token";
+import { useWalletCompat, useConnectionCompat } from "@/hooks/useWalletCompat";
+import { useSlabState } from "@/components/providers/SlabProvider";
+import { useUserAccount } from "@/hooks/useUserAccount";
+import {
+  encodeInitUser,
+  encodeDepositCollateral,
+  ACCOUNTS_INIT_USER,
+  ACCOUNTS_DEPOSIT_COLLATERAL,
+  buildAccountMetas,
+  WELL_KNOWN,
+  buildIx,
+  getAta,
+  AccountKind,
+} from "@percolator/sdk";
+import { sendTx } from "@/lib/tx";
+
+export type AutoDepositStatus =
+  | "idle"
+  | "funding"       // Requesting SOL + USDC from faucet
+  | "creating"      // Creating user account on-chain
+  | "depositing"    // Depositing collateral
+  | "done"          // All steps complete
+  | "error";
+
+/** Default deposit amount: 100 USDC (6 decimals) */
+const DEFAULT_DEPOSIT_AMOUNT = 100_000_000n;
+
+/** Minimum token balance to skip auto-deposit (1 USDC) */
+const MIN_TOKEN_BALANCE = 1_000_000n;
+
+export function useAutoDeposit(slabAddress: string) {
+  const { connection } = useConnectionCompat();
+  const wallet = useWalletCompat();
+  const { config: mktConfig, programId: slabProgramId, accounts } = useSlabState();
+  const userAccount = useUserAccount();
+
+  const [status, setStatus] = useState<AutoDepositStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const attemptedRef = useRef<Set<string>>(new Set());
+
+  const run = useCallback(async () => {
+    if (!wallet.publicKey || !wallet.connected || !mktConfig || !slabProgramId) return;
+
+    const isDevnet = process.env.NEXT_PUBLIC_SOLANA_NETWORK === "devnet";
+    if (!isDevnet) return;
+
+    const key = `${wallet.publicKey.toBase58()}:${slabAddress}`;
+    if (attemptedRef.current.has(key)) return;
+    attemptedRef.current.add(key);
+
+    const programId = slabProgramId;
+    const slabPk = new PublicKey(slabAddress);
+
+    try {
+      // Step 1: Check token balance, fund if zero
+      const userAta = await getAta(wallet.publicKey, mktConfig.collateralMint);
+      let tokenBalance = 0n;
+      try {
+        const acct = await getAccount(connection, userAta);
+        tokenBalance = acct.amount;
+      } catch {
+        // ATA doesn't exist — balance is zero
+      }
+
+      if (tokenBalance < MIN_TOKEN_BALANCE) {
+        setStatus("funding");
+        try {
+          const resp = await fetch("/api/auto-fund", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ wallet: wallet.publicKey.toBase58() }),
+          });
+          if (!resp.ok && resp.status !== 429) {
+            const data = await resp.json().catch(() => ({}));
+            console.warn("[auto-deposit] Fund failed:", data.error);
+          }
+          // Wait for confirmation to propagate
+          await new Promise((r) => setTimeout(r, 2000));
+
+          // Re-check balance
+          try {
+            const acct = await getAccount(connection, userAta);
+            tokenBalance = acct.amount;
+          } catch {
+            // Still no ATA — funding may have failed, continue anyway
+          }
+        } catch (e) {
+          console.warn("[auto-deposit] Fund request error:", e);
+        }
+      }
+
+      // Step 2: Check if user account exists, create if not
+      if (!userAccount) {
+        setStatus("creating");
+
+        const instructions = [];
+
+        // Ensure ATA exists
+        try {
+          await getAccount(connection, userAta);
+        } catch {
+          instructions.push(
+            createAssociatedTokenAccountInstruction(
+              wallet.publicKey,
+              userAta,
+              wallet.publicKey,
+              mktConfig.collateralMint,
+            ),
+          );
+        }
+
+        // Init user account
+        const initIx = buildIx({
+          programId,
+          keys: buildAccountMetas(ACCOUNTS_INIT_USER, [
+            wallet.publicKey,
+            slabPk,
+            userAta,
+            mktConfig.vaultPubkey,
+            WELL_KNOWN.tokenProgram,
+          ]),
+          data: encodeInitUser({ feePayment: "0" }),
+        });
+        instructions.push(initIx);
+
+        await sendTx({ connection, wallet, instructions });
+
+        // Small delay for state to propagate
+        await new Promise((r) => setTimeout(r, 2000));
+      }
+
+      // Step 3: Deposit collateral if user has tokens but zero collateral
+      // Re-read user account after potential creation
+      const freshAccounts = accounts;
+      const pkStr = wallet.publicKey.toBase58();
+      const currentUser = freshAccounts.find(
+        ({ account }) =>
+          account.kind === AccountKind.User && account.owner.toBase58() === pkStr,
+      );
+
+      if (currentUser && tokenBalance >= MIN_TOKEN_BALANCE) {
+        const collateral = currentUser.account.capital ?? 0n;
+        if (collateral === 0n) {
+          setStatus("depositing");
+
+          // Deposit up to DEFAULT_DEPOSIT_AMOUNT or whatever they have
+          const depositAmt =
+            tokenBalance < DEFAULT_DEPOSIT_AMOUNT ? tokenBalance : DEFAULT_DEPOSIT_AMOUNT;
+
+          const depositIx = buildIx({
+            programId,
+            keys: buildAccountMetas(ACCOUNTS_DEPOSIT_COLLATERAL, [
+              wallet.publicKey,
+              slabPk,
+              await getAta(wallet.publicKey, mktConfig.collateralMint),
+              mktConfig.vaultPubkey,
+              WELL_KNOWN.tokenProgram,
+              WELL_KNOWN.clock,
+            ]),
+            data: encodeDepositCollateral({
+              userIdx: currentUser.idx,
+              amount: depositAmt.toString(),
+            }),
+          });
+
+          await sendTx({ connection, wallet, instructions: [depositIx] });
+
+          // State will refresh on next poll cycle
+        }
+      }
+
+      setStatus("done");
+    } catch (e: any) {
+      console.error("[auto-deposit] Error:", e);
+      setError(e.message ?? "Auto-deposit failed");
+      setStatus("error");
+    }
+  }, [wallet, connection, mktConfig, slabProgramId, slabAddress, userAccount, accounts]);
+
+  // Trigger on wallet connect
+  useEffect(() => {
+    if (wallet.connected && wallet.publicKey && mktConfig) {
+      run();
+    }
+  }, [wallet.connected, wallet.publicKey, mktConfig, run]);
+
+  return { status, error };
+}

--- a/scripts/floating-maker.ts
+++ b/scripts/floating-maker.ts
@@ -73,7 +73,7 @@ const MATCHER_ID = new PublicKey(
 );
 
 // Market maker config
-const SPREAD_BPS = Number(process.env.SPREAD_BPS ?? "30"); // 0.30% half-spread
+const SPREAD_BPS = Number(process.env.SPREAD_BPS ?? "25"); // 0.25% half-spread (bid+ask < 1% total, per PERC-372)
 const MAX_QUOTE_SIZE = BigInt(
   process.env.MAX_QUOTE_SIZE_USDC ?? "500",
 ) * 1_000_000n; // Convert to 6-decimal USDC

--- a/supabase/migrations/029_auto_fund_log.sql
+++ b/supabase/migrations/029_auto_fund_log.sql
@@ -1,0 +1,31 @@
+-- PERC-372: Auto-fund log + airdrop_claims tables for devnet faucet
+
+CREATE TABLE IF NOT EXISTS auto_fund_log (
+  id BIGSERIAL PRIMARY KEY,
+  wallet TEXT NOT NULL,
+  sol_airdropped BOOLEAN NOT NULL DEFAULT FALSE,
+  usdc_minted BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_auto_fund_wallet_time ON auto_fund_log (wallet, created_at DESC);
+
+-- Enable RLS but allow service role full access
+ALTER TABLE auto_fund_log ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "service_role_auto_fund" ON auto_fund_log FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- Airdrop claims (if not exists — may already be from PERC-363)
+CREATE TABLE IF NOT EXISTS airdrop_claims (
+  id BIGSERIAL PRIMARY KEY,
+  wallet TEXT NOT NULL,
+  market_address TEXT NOT NULL,
+  amount_tokens DOUBLE PRECISION,
+  amount_usd DOUBLE PRECISION,
+  signature TEXT,
+  claimed_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_airdrop_claims_wallet ON airdrop_claims (wallet, market_address, claimed_at DESC);
+
+ALTER TABLE airdrop_claims ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "service_role_airdrop_claims" ON airdrop_claims FOR ALL TO service_role USING (true) WITH CHECK (true);


### PR DESCRIPTION
## Changes

### Faucet Upgrade
- Bumped per-market airdrop from $500 → $1,000 USDC/24h
- Bumped auto-fund USDC mint from 100 → 1,000 USDC on wallet connect
- No wallet gating — any devnet wallet can claim

### Auto-Deposit Flow (new `useAutoDeposit` hook)
Zero-to-trading on wallet connect (devnet only):
1. Detect zero token balance → call `/api/auto-fund` (SOL airdrop + USDC mint)
2. Detect no protocol user account → init user account on-chain
3. Detect zero collateral → deposit 100 USDC into the user account

Non-blocking, fires once per session per wallet+market. Shows progress banner in trade UI.

### Orderbook Spread
- Tightened floating maker half-spread from 30bps → 25bps (total spread < 1% of oracle)

### Migration
- `029_auto_fund_log.sql`: Creates `auto_fund_log` and `airdrop_claims` tables with RLS

## Testing
- Connect wallet on devnet trade page → should auto-fund, init user, and deposit
- Verify airdrop endpoint returns 1000 USDC
- Verify floating maker places orders within 0.5% of oracle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streamlined trading setup: Auto-deposit flow now automatically funds your account and deposits collateral upon wallet connection, enabling immediate trading.

* **Improvements**
  * Increased airdrop from $500 to $1,000.
  * Increased auto-fund amount from 100 to 1,000 USDC.
  * Tightened market maker spreads for improved pricing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->