### PR TITLE
chore: clarify depositDone intent in useDevnetFaucet

### DIFF
--- a/app/hooks/useDevnetFaucet.ts
+++ b/app/hooks/useDevnetFaucet.ts
@@ -75,6 +75,9 @@ export function useDevnetFaucet(): DevnetFaucetState {
   const [usdcBalance, setUsdcBalance] = useState<number | null>(null);
   const [solDone, setSolDone] = useState(false);
   const [usdcDone, setUsdcDone] = useState(false);
+  // depositDone is intentionally never set to true here — the actual deposit
+  // completion is tracked by AutoDepositProvider. This flag exists in the
+  // return type for UI consumers that need a unified status interface.
   const [depositDone, setDepositDone] = useState(false);
   const [rateLimited, setRateLimited] = useState(false);
   const [nextClaimAt, setNextClaimAt] = useState<string | null>(null);


### PR DESCRIPTION
Adds a clarifying comment to `useDevnetFaucet` explaining that `depositDone` is intentionally never set to true in this hook — deposit completion is tracked by `AutoDepositProvider`. Flagged by QA during PERC-376 review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal documentation with clarifying comments on state management behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->