### PR TITLE
fix: MM bot collateral funding — resolve InitUser failure

### DIFF
--- a/scripts/diagnose-mm-bots.ts
+++ b/scripts/diagnose-mm-bots.ts
@@ -1,0 +1,188 @@
+#!/usr/bin/env npx tsx
+/**
+ * Diagnostic script: Investigate MM bot InitUser failures
+ *
+ * Checks:
+ * 1. What markets exist and their collateral mints
+ * 2. Bot wallet SOL + token balances
+ * 3. Whether bot ATAs exist for the collateral mints
+ * 4. Simulates InitUser to get the exact error
+ */
+
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  Transaction,
+  ComputeBudgetProgram,
+  LAMPORTS_PER_SOL,
+} from "@solana/web3.js";
+import {
+  getAssociatedTokenAddress,
+  getAccount,
+} from "@solana/spl-token";
+import {
+  discoverMarkets,
+  parseAllAccounts,
+  encodeInitUser,
+  ACCOUNTS_INIT_USER,
+  buildAccountMetas,
+  buildIx,
+  deriveVaultAuthority,
+} from "../packages/core/src/index.js";
+import * as fs from "fs";
+
+const HELIUS_KEY = process.env.HELIUS_API_KEY ?? "";
+const RPC_URL = process.env.RPC_URL ??
+  (HELIUS_KEY ? `https://devnet.helius-rpc.com/?api-key=${HELIUS_KEY}` : "https://api.devnet.solana.com");
+
+const PROGRAM_ID = new PublicKey("FwfBKZXbYr4vTK23bMFkbgKq3npJ3MSDxEaKmq9Aj4Qn");
+
+const FILLER_WALLET = new PublicKey("FPQa6EfDYwc35TDnfbMBojdTmcB9EPhzEQc27oEcRb2X");
+const MAKER_WALLET = new PublicKey("6cZPV3w2ySoiKgCUn5b3SbXrarPfaf72d9veTgRic7tL");
+const TEST_USDC_MINT = new PublicKey("DvH13uxzTzo1xVFwkbJ6YASkZWs6bm3vFDH4xu7kUYTs");
+
+async function main() {
+  const conn = new Connection(RPC_URL, "confirmed");
+  console.log("RPC:", RPC_URL.replace(/api-key=.*/, "api-key=***"));
+  console.log("");
+
+  // 1. Discover markets
+  console.log("═══ MARKET DISCOVERY ═══");
+  const markets = await discoverMarkets(conn, PROGRAM_ID);
+  console.log(`Found ${markets.length} markets`);
+
+  const mintSet = new Set<string>();
+  for (const m of markets) {
+    const feedId = m.config.indexFeedId;
+    const feedHex = Buffer.from(
+      feedId instanceof PublicKey ? feedId.toBytes() : (feedId as Uint8Array),
+    ).toString("hex");
+
+    const isHyperp = feedHex === "0".repeat(64);
+    let symbol = "UNKNOWN";
+    if (isHyperp) {
+      const markUsd = Number(m.config.authorityPriceE6 ?? 0n) / 1_000_000;
+      if (markUsd > 50_000) symbol = "BTC";
+      else if (markUsd > 2_000) symbol = "ETH";
+      else if (markUsd > 50) symbol = "SOL";
+    }
+
+    const mint = m.config.collateralMint.toBase58();
+    mintSet.add(mint);
+
+    // Parse accounts to see existing users/LPs
+    const slabInfo = await conn.getAccountInfo(m.slabAddress);
+    const slabData = slabInfo ? new Uint8Array(slabInfo.data) : null;
+    const accounts = slabData ? parseAllAccounts(slabData) : [];
+    const users = accounts.filter(a => a.account.kind === 0);
+    const lps = accounts.filter(a => a.account.kind === 1);
+
+    const fillerUser = users.find(u => u.account.owner.equals(FILLER_WALLET));
+    const makerUser = users.find(u => u.account.owner.equals(MAKER_WALLET));
+    const fillerLp = lps.find(u => u.account.owner.equals(FILLER_WALLET));
+    const makerLp = lps.find(u => u.account.owner.equals(MAKER_WALLET));
+
+    console.log(`\n  Market: ${symbol} | Slab: ${m.slabAddress.toBase58().slice(0,16)}...`);
+    console.log(`    Collateral mint: ${mint}`);
+    console.log(`    Paused: ${m.header.paused} | Resolved: ${m.header.resolved}`);
+    console.log(`    Oracle mode: ${isHyperp ? "authority" : "pyth"}`);
+    console.log(`    Price: $${(Number(m.config.authorityPriceE6 ?? 0n) / 1e6).toFixed(2)}`);
+    console.log(`    Total accounts: ${accounts.length} (${users.length} users, ${lps.length} LPs)`);
+    console.log(`    Filler user: ${fillerUser ? `idx=${fillerUser.idx}` : "NOT FOUND"}`);
+    console.log(`    Filler LP:   ${fillerLp ? `idx=${fillerLp.idx}` : "NOT FOUND"}`);
+    console.log(`    Maker user:  ${makerUser ? `idx=${makerUser.idx}` : "NOT FOUND"}`);
+    console.log(`    Maker LP:    ${makerLp ? `idx=${makerLp.idx}` : "NOT FOUND"}`);
+  }
+
+  // 2. Check wallet balances
+  console.log("\n═══ WALLET BALANCES ═══");
+  for (const [name, wallet] of [["Filler", FILLER_WALLET], ["Maker", MAKER_WALLET]] as const) {
+    const solBal = await conn.getBalance(wallet);
+    console.log(`\n  ${name}: ${wallet.toBase58()}`);
+    console.log(`    SOL: ${(solBal / LAMPORTS_PER_SOL).toFixed(4)}`);
+
+    // Check token balances for each unique mint
+    for (const mintStr of mintSet) {
+      const mint = new PublicKey(mintStr);
+      const ata = await getAssociatedTokenAddress(mint, wallet);
+      try {
+        const accInfo = await getAccount(conn, ata);
+        console.log(`    Token (${mintStr.slice(0,12)}...): ${Number(accInfo.amount) / 1e6} (ATA exists: ${ata.toBase58().slice(0,12)}...)`);
+      } catch {
+        console.log(`    Token (${mintStr.slice(0,12)}...): NO ATA (${ata.toBase58().slice(0,12)}...)`);
+      }
+    }
+
+    // Also check test USDC specifically
+    if (!mintSet.has(TEST_USDC_MINT.toBase58())) {
+      const ata = await getAssociatedTokenAddress(TEST_USDC_MINT, wallet);
+      try {
+        const accInfo = await getAccount(conn, ata);
+        console.log(`    Test USDC: ${Number(accInfo.amount) / 1e6} (ATA: ${ata.toBase58().slice(0,12)}...)`);
+      } catch {
+        console.log(`    Test USDC: NO ATA`);
+      }
+    }
+  }
+
+  // 3. Simulate InitUser for first active market with filler wallet
+  console.log("\n═══ SIMULATE InitUser ═══");
+  const activeMarkets = markets.filter(m => !m.header.paused && !m.header.resolved);
+  if (activeMarkets.length > 0) {
+    const m = activeMarkets[0];
+    const mint = m.config.collateralMint;
+    const slab = m.slabAddress;
+
+    console.log(`  Simulating on market: ${slab.toBase58().slice(0,16)}...`);
+
+    const fillerAta = await getAssociatedTokenAddress(mint, FILLER_WALLET);
+    const [vaultPda] = deriveVaultAuthority(PROGRAM_ID, slab);
+    const vaultAta = await getAssociatedTokenAddress(mint, vaultPda, true);
+
+    console.log(`  Filler ATA: ${fillerAta.toBase58()}`);
+    console.log(`  Vault PDA: ${vaultPda.toBase58()}`);
+    console.log(`  Vault ATA: ${vaultAta.toBase58()}`);
+
+    // Check if vault ATA exists
+    try {
+      const vaultAccInfo = await getAccount(conn, vaultAta);
+      console.log(`  Vault ATA balance: ${Number(vaultAccInfo.amount) / 1e6}`);
+    } catch {
+      console.log(`  Vault ATA: DOES NOT EXIST`);
+    }
+
+    // Build and simulate the InitUser tx
+    const initUserData = encodeInitUser({ feePayment: "1000000" });
+    const initUserKeys = buildAccountMetas(ACCOUNTS_INIT_USER, [
+      FILLER_WALLET, slab, fillerAta, vaultAta,
+      new PublicKey("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"),
+    ]);
+    const ix = buildIx({ programId: PROGRAM_ID, keys: initUserKeys, data: initUserData });
+
+    const tx = new Transaction();
+    tx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 200_000 }));
+    tx.add(ix);
+    tx.feePayer = FILLER_WALLET;
+
+    try {
+      const { blockhash } = await conn.getLatestBlockhash();
+      tx.recentBlockhash = blockhash;
+      const sim = await conn.simulateTransaction(tx);
+      console.log(`\n  Simulation result:`);
+      console.log(`    Error: ${JSON.stringify(sim.value.err)}`);
+      if (sim.value.logs) {
+        console.log(`    Logs:`);
+        for (const l of sim.value.logs) {
+          console.log(`      ${l}`);
+        }
+      }
+    } catch (e) {
+      console.log(`  Simulation error: ${e}`);
+    }
+  }
+
+  console.log("\n═══ DONE ═══");
+}
+
+main().catch(e => { console.error("Error:", e); process.exit(1); });

--- a/scripts/fund-mm-bots.ts
+++ b/scripts/fund-mm-bots.ts
@@ -1,0 +1,245 @@
+#!/usr/bin/env npx tsx
+/**
+ * Fund MM bot wallets with collateral tokens.
+ *
+ * Creates ATAs and mints devnet collateral tokens to the filler and maker
+ * bot wallets so they can InitUser + deposit on Percolator markets.
+ *
+ * Uses the program upgrade authority as the mint authority (it created
+ * the collateral mints during deploy-devnet-mm.ts).
+ *
+ * Usage:
+ *   npx tsx scripts/fund-mm-bots.ts
+ *
+ * Env:
+ *   ADMIN_KEYPAIR_PATH — path to upgrade authority (default: ~/.config/solana/percolator-upgrade-authority.json)
+ *   RPC_URL or HELIUS_API_KEY — Solana RPC
+ *   MINT_AMOUNT — amount to mint per wallet (default: 50000000000 = 50,000 tokens)
+ */
+
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  Transaction,
+  sendAndConfirmTransaction,
+  ComputeBudgetProgram,
+  LAMPORTS_PER_SOL,
+} from "@solana/web3.js";
+import {
+  getAssociatedTokenAddress,
+  createAssociatedTokenAccountInstruction,
+  createMintToInstruction,
+  getAccount,
+  TOKEN_PROGRAM_ID,
+} from "@solana/spl-token";
+import {
+  discoverMarkets,
+  deriveVaultAuthority,
+} from "../packages/core/src/index.js";
+import * as fs from "fs";
+
+// ═══════════════════════════════════════════════════════════════
+// Configuration
+// ═══════════════════════════════════════════════════════════════
+
+const HELIUS_KEY = process.env.HELIUS_API_KEY ?? "";
+const RPC_URL = process.env.RPC_URL ??
+  (HELIUS_KEY ? `https://devnet.helius-rpc.com/?api-key=${HELIUS_KEY}` : "https://api.devnet.solana.com");
+
+const ADMIN_KP_PATH = process.env.ADMIN_KEYPAIR_PATH ??
+  `${process.env.HOME}/.config/solana/percolator-upgrade-authority.json`;
+
+const PROGRAM_ID = new PublicKey("FwfBKZXbYr4vTK23bMFkbgKq3npJ3MSDxEaKmq9Aj4Qn");
+
+const FILLER_WALLET = new PublicKey("FPQa6EfDYwc35TDnfbMBojdTmcB9EPhzEQc27oEcRb2X");
+const MAKER_WALLET = new PublicKey("6cZPV3w2ySoiKgCUn5b3SbXrarPfaf72d9veTgRic7tL");
+
+// 50,000 tokens (6 decimals) per wallet — enough for InitUser fee + collateral deposits
+const MINT_AMOUNT = BigInt(process.env.MINT_AMOUNT ?? "50000000000");
+
+function loadKeypair(path: string): Keypair {
+  const raw = JSON.parse(fs.readFileSync(path, "utf8"));
+  return Keypair.fromSecretKey(Uint8Array.from(raw));
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Main
+// ═══════════════════════════════════════════════════════════════
+
+async function main() {
+  console.log("═══ Fund MM Bot Wallets ═══");
+  console.log(`RPC: ${RPC_URL.replace(/api-key=.*/, "api-key=***")}`);
+
+  const conn = new Connection(RPC_URL, "confirmed");
+
+  // Load admin/mint authority
+  if (!fs.existsSync(ADMIN_KP_PATH)) {
+    console.error(`❌ Admin keypair not found: ${ADMIN_KP_PATH}`);
+    process.exit(1);
+  }
+  const admin = loadKeypair(ADMIN_KP_PATH);
+  console.log(`Admin/Mint authority: ${admin.publicKey.toBase58()}`);
+
+  const adminBal = await conn.getBalance(admin.publicKey);
+  console.log(`Admin SOL balance: ${(adminBal / LAMPORTS_PER_SOL).toFixed(4)}`);
+  if (adminBal < 0.01 * LAMPORTS_PER_SOL) {
+    console.error("❌ Admin has insufficient SOL for transaction fees");
+    process.exit(1);
+  }
+
+  // Discover markets to find collateral mints
+  console.log("\nDiscovering markets...");
+  const markets = await discoverMarkets(conn, PROGRAM_ID);
+  const activeMarkets = markets.filter(m => !m.header.paused && !m.header.resolved);
+  console.log(`Found ${markets.length} markets, ${activeMarkets.length} active`);
+
+  // Collect unique collateral mints we can fund (where admin is mint authority)
+  const mintsToFund = new Map<string, PublicKey>();
+
+  for (const m of activeMarkets) {
+    const mint = m.config.collateralMint;
+    const mintStr = mint.toBase58();
+    if (!mintsToFund.has(mintStr)) {
+      mintsToFund.set(mintStr, mint);
+    }
+  }
+
+  console.log(`\nUnique collateral mints: ${mintsToFund.size}`);
+
+  const wallets = [
+    { name: "Filler", pubkey: FILLER_WALLET },
+    { name: "Maker", pubkey: MAKER_WALLET },
+  ];
+
+  let totalFunded = 0;
+
+  for (const [mintStr, mint] of mintsToFund) {
+    console.log(`\n═══ Mint: ${mintStr.slice(0, 16)}... ═══`);
+
+    // Check if admin is the mint authority
+    const { getMint } = await import("@solana/spl-token");
+    let mintInfo;
+    try {
+      mintInfo = await getMint(conn, mint);
+    } catch (e) {
+      console.log(`  ⚠️ Could not fetch mint info — skipping`);
+      continue;
+    }
+
+    if (!mintInfo.mintAuthority?.equals(admin.publicKey)) {
+      console.log(`  ⚠️ Admin is NOT mint authority (authority: ${mintInfo.mintAuthority?.toBase58() ?? "NONE"}) — skipping`);
+      continue;
+    }
+
+    console.log(`  ✅ Admin is mint authority`);
+    console.log(`  Decimals: ${mintInfo.decimals}`);
+
+    for (const wallet of wallets) {
+      const ata = await getAssociatedTokenAddress(mint, wallet.pubkey);
+      console.log(`\n  ${wallet.name} (${wallet.pubkey.toBase58().slice(0, 16)}...)`);
+      console.log(`    ATA: ${ata.toBase58()}`);
+
+      // Check if ATA exists
+      let ataExists = false;
+      let currentBalance = 0n;
+      try {
+        const accInfo = await getAccount(conn, ata);
+        ataExists = true;
+        currentBalance = accInfo.amount;
+        console.log(`    Existing balance: ${Number(currentBalance) / 1e6} tokens`);
+      } catch {
+        console.log(`    ATA does not exist — will create`);
+      }
+
+      // Skip if already has enough
+      if (currentBalance >= MINT_AMOUNT) {
+        console.log(`    Already has sufficient balance — skipping`);
+        continue;
+      }
+
+      const mintAmount = MINT_AMOUNT - currentBalance;
+
+      // Build transaction
+      const tx = new Transaction();
+      tx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 100_000 }));
+      tx.add(ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 50_000 }));
+
+      if (!ataExists) {
+        tx.add(
+          createAssociatedTokenAccountInstruction(
+            admin.publicKey,  // payer
+            ata,              // ATA address
+            wallet.pubkey,    // owner
+            mint,             // mint
+          )
+        );
+        console.log(`    + CreateATA instruction`);
+      }
+
+      tx.add(
+        createMintToInstruction(
+          mint,             // mint
+          ata,              // destination
+          admin.publicKey,  // authority
+          mintAmount,       // amount
+        )
+      );
+      console.log(`    + MintTo ${Number(mintAmount) / 1e6} tokens`);
+
+      try {
+        const sig = await sendAndConfirmTransaction(conn, tx, [admin], {
+          commitment: "confirmed",
+          skipPreflight: false,
+        });
+        console.log(`    ✅ Success: ${sig.slice(0, 24)}...`);
+        totalFunded++;
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        console.error(`    ❌ Failed: ${msg.slice(0, 200)}`);
+      }
+
+      // Small delay between transactions
+      await sleep(500);
+    }
+  }
+
+  // Also ensure vault ATAs exist for each active market
+  console.log("\n═══ Verify Vault ATAs ═══");
+  for (const m of activeMarkets) {
+    const [vaultPda] = deriveVaultAuthority(PROGRAM_ID, m.slabAddress);
+    const vaultAta = await getAssociatedTokenAddress(m.config.collateralMint, vaultPda, true);
+    try {
+      await getAccount(conn, vaultAta);
+      console.log(`  ${m.slabAddress.toBase58().slice(0, 16)}... vault ATA: ✅ exists`);
+    } catch {
+      console.log(`  ${m.slabAddress.toBase58().slice(0, 16)}... vault ATA: ❌ MISSING`);
+    }
+  }
+
+  // Final verification
+  console.log("\n═══ VERIFICATION ═══");
+  for (const wallet of wallets) {
+    console.log(`\n  ${wallet.name}:`);
+    for (const [mintStr, mint] of mintsToFund) {
+      const ata = await getAssociatedTokenAddress(mint, wallet.pubkey);
+      try {
+        const accInfo = await getAccount(conn, ata);
+        console.log(`    ${mintStr.slice(0, 12)}...: ${Number(accInfo.amount) / 1e6} tokens ✅`);
+      } catch {
+        console.log(`    ${mintStr.slice(0, 12)}...: NO ATA ❌`);
+      }
+    }
+  }
+
+  console.log(`\n═══ Done — funded ${totalFunded} wallet/mint pairs ═══`);
+}
+
+main().catch(e => {
+  console.error("Fatal:", e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Problem
MM bots (Filler + Maker) were failing InitUser on BTC markets with `Custom(24) = InvalidTokenAccount`.

## Root Cause
Bot wallets had ~2 SOL each but **no associated token accounts (ATAs)** for the market collateral mint (`CJUyV594JzJpK2BUakNpm6NbmCkhQoPJWkKjfKTvxJ3C`). The program's InitUser instruction requires a valid user ATA to transfer the fee payment from.

## Fix
- **`scripts/fund-mm-bots.ts`** — Creates ATAs and mints 50,000 collateral tokens to both bot wallets using the upgrade authority (which is the mint authority for the deploy-time collateral mint). Idempotent — safe to re-run.
- **`scripts/diagnose-mm-bots.ts`** — Diagnostic tool that checks market state, wallet balances, ATA existence, vault ATAs, and simulates InitUser to pinpoint errors.

## Verification
- InitUser simulation now passes (Error: null)
- Filler: 50,000 tokens ✅ 
- Maker: 50,000 tokens ✅

## Note
3rd market uses a different mint authority (`GRMMNsNPM1GbgxFh...`) — not fundable with current keys. Oracle prices also look stale/wrong (~$3.8T for BTC) — flagged to devops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added diagnostic script enabling inspection of market maker bot market states, wallet balances, and initialization transaction simulation for troubleshooting deployment issues.
  * Added automation script to provision market maker bot wallets with devnet collateral tokens, manage token account creation, and verify vault setup across markets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->