### PR TITLE
fix: correct MM bot default keypair paths

### DIFF
--- a/bots/devnet-mm/src/config.ts
+++ b/bots/devnet-mm/src/config.ts
@@ -97,11 +97,11 @@ export function loadConfig(): BotConfig {
     fillerKeypairPath:
       process.env.FILLER_KEYPAIR ??
       process.env.BOOTSTRAP_KEYPAIR ??
-      "/tmp/percolator-keepers/filler.json",
+      "/tmp/percolator-bots/filler.json",
     makerKeypairPath:
       process.env.MAKER_KEYPAIR ??
       process.env.BOOTSTRAP_KEYPAIR ??
-      "/tmp/percolator-keepers/maker.json",
+      "/tmp/percolator-bots/maker.json",
 
     crankIntervalMs: parseNum(process.env.CRANK_INTERVAL_MS, 5000),
     maxCrankStalenessSlots: parseNum(process.env.MAX_CRANK_STALENESS, 200),


### PR DESCRIPTION
Replaces #603 (which had merge conflicts).

keygen.ts outputs wallets to `/tmp/percolator-bots/` but config.ts defaulted to `/tmp/percolator-keepers/`. 2-line fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default file paths for bot keypair configuration. Filler and maker keypair files now reference new directory locations to align with the updated deployment structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->