### PR TITLE
fix: build SDK dist in oracle-keeper Docker image

### DIFF
--- a/Dockerfile.oracle-keeper
+++ b/Dockerfile.oracle-keeper
@@ -22,6 +22,9 @@ RUN pnpm install --frozen-lockfile --filter @percolator/oracle-keeper...
 COPY packages/core/ packages/core/
 COPY bots/oracle-keeper/ bots/oracle-keeper/
 
+# Build SDK so dist/index.js exists (exports field points there)
+RUN pnpm --filter @percolator/sdk run build
+
 # Set ownership and switch to non-root
 RUN chown -R keeper:keeper /app
 USER keeper


### PR DESCRIPTION
## Problem
Oracle-keeper container crashes on Railway with:
```
ERR_PACKAGE_PATH_NOT_EXPORTED: No "exports" main defined in @percolator/sdk/package.json
```

## Root Cause
Dockerfile.oracle-keeper copies `packages/core/` source but never runs the build step. The SDK's `exports` field points to `dist/index.js` which doesn't exist.

## Fix
Add `pnpm --filter @percolator/sdk run build` after copying source, before switching to non-root user.

## Testing
- Docker build + run locally: container starts without ERR_PACKAGE_PATH_NOT_EXPORTED
- Devops: please redeploy on Railway to verify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build process to ensure SDK builds correctly during deployment initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->