### PR TITLE
fix(PERC-380): oracle-keeper entrypoint + SDK exports resolution

### DIFF
--- a/Dockerfile.oracle-keeper
+++ b/Dockerfile.oracle-keeper
@@ -44,4 +44,4 @@ ENV HEALTH_HOST=0.0.0.0
 ENV MAX_PRICE_MOVE_PCT=10
 ENV STALE_THRESHOLD_S=30
 
-CMD ["npx", "tsx", "index.ts"]
+CMD ["pnpm", "run", "start"]

--- a/bots/oracle-keeper/package.json
+++ b/bots/oracle-keeper/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "description": "PERC-374/380: Oracle keeper — mirrors Binance spot prices to Percolator devnet markets",
   "scripts": {
-    "start": "tsx src/index.ts",
-    "dev": "tsx watch src/index.ts"
+    "start": "tsx index.ts",
+    "dev": "tsx watch index.ts"
   },
   "dependencies": {
     "@percolator/sdk": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }
   },


### PR DESCRIPTION
## Problem
Oracle-keeper crashes on Railway with `ERR_PACKAGE_PATH_NOT_EXPORTED` — deployments d464d78c and 518a5335 both failed.

## Root Cause
Three compounding issues:

1. **Wrong start script path**: `package.json` had `tsx src/index.ts` but the file is at `bots/oracle-keeper/index.ts` (no `src/` directory)
2. **CMD bypasses workspace resolution**: `npx tsx index.ts` doesn't go through pnpm's workspace symlink resolution, causing Node.js to fail resolving `@percolator/sdk` exports
3. **SDK exports missing fallback conditions**: Only `import` was declared — no `require`/`default` fallback for non-ESM resolution contexts

## Fix
- `bots/oracle-keeper/package.json`: `src/index.ts` → `index.ts`
- `Dockerfile.oracle-keeper` CMD: `npx tsx index.ts` → `pnpm run start`
- `packages/core/package.json`: Add `require` + `default` export conditions

## Verification
Confirmed `pnpm run start` resolves `@percolator/sdk` correctly via workspace symlink locally (no ERR_PACKAGE_PATH_NOT_EXPORTED).

## Affected
- `Dockerfile.oracle-keeper`
- `bots/oracle-keeper/package.json`
- `packages/core/package.json`

Fixes PERC-380. P0 — ready for immediate deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined oracle-keeper Docker startup command and npm script configurations for improved deployment
  * Updated oracle-keeper service entry point references
  * Expanded core package export support to include CommonJS and default imports alongside existing ES module patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->