### PR TITLE
fix: align fill-time display consistency (#605)

### DIFF
--- a/app/components/marketing/HeroSection.tsx
+++ b/app/components/marketing/HeroSection.tsx
@@ -221,7 +221,7 @@ export function HeroSection() {
           />
           <HeroDataChip
             icon="⚡"
-            text="412ms fill time"
+            text="< 400ms fills"
             delay={1.2}
             floatPhase={0}
             className="absolute -bottom-4 -right-4 z-20 lg:right-0 lg:-bottom-8"


### PR DESCRIPTION
## Problem
HeroDataChip showed '412ms fill time' while the marquee HeroStats claimed '< 400ms'. This creates a credibility inconsistency on the homepage.

## Fix
Align the chip text to '< 400ms fills' to match the marquee claim.

## Testing
Visual check on homepage — both elements now show consistent messaging.

Fixes #605