### PR TITLE
security: scrub ADMIN_KEYPAIR from env after parse

### DIFF
--- a/bots/oracle-keeper/index.ts
+++ b/bots/oracle-keeper/index.ts
@@ -49,10 +49,19 @@ const RPC_URL = process.env.RPC_URL ?? "https://api.devnet.solana.com";
 
 const conn = new Connection(RPC_URL, "confirmed");
 // Support inline keypair via ADMIN_KEYPAIR env var (JSON array) for Railway/Docker deployments
-const adminSecretKey = process.env.ADMIN_KEYPAIR
-  ? Uint8Array.from(JSON.parse(process.env.ADMIN_KEYPAIR))
-  : Uint8Array.from(JSON.parse(fs.readFileSync(ADMIN_KP_PATH, "utf8")));
+let adminSecretKey: Uint8Array;
+try {
+  adminSecretKey = process.env.ADMIN_KEYPAIR
+    ? Uint8Array.from(JSON.parse(process.env.ADMIN_KEYPAIR))
+    : Uint8Array.from(JSON.parse(fs.readFileSync(ADMIN_KP_PATH, "utf8")));
+} catch (err) {
+  console.error("❌ Failed to parse admin keypair:", (err as Error).message);
+  console.error("Set ADMIN_KEYPAIR (JSON array) or ADMIN_KEYPAIR_PATH to a valid keypair file.");
+  process.exit(1);
+}
 const admin = Keypair.fromSecretKey(adminSecretKey);
+// Scrub private key from process environment so it's not accessible via /proc or debug dumps
+delete process.env.ADMIN_KEYPAIR;
 
 // ── Types ───────────────────────────────────────────────────
 interface MarketInfo {


### PR DESCRIPTION
## Security Fix (LOW)
Per security review: the ADMIN_KEYPAIR env var containing the private key was retained in process.env after parsing, making it accessible via /proc/$PID/environ or debug dumps.

## Changes
- Wrap `JSON.parse(ADMIN_KEYPAIR)` in try/catch with clean error message and exit
- `delete process.env.ADMIN_KEYPAIR` after parsing so the secret key is not retained in memory via environment

## Testing
- Bot still boots correctly with valid keypair
- Invalid keypair now gives a clean error instead of unhandled exception