### PR TITLE
fix: Create Market UX — Quick Launch, devnet mint, CA mismatch

### DIFF
--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FC, useState, useMemo, useCallback, useEffect } from "react";
+import { FC, useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { PublicKey } from "@solana/web3.js";
 import { useWalletCompat, useConnectionCompat } from "@/hooks/useWalletCompat";
 import { useCreateMarket, MIN_INIT_MARKET_SEED, type CreateMarketParams } from "@/hooks/useCreateMarket";
@@ -140,6 +140,37 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
   }, [wizard.slabTier]);
   const hasSufficientSol = solBalance !== null && solBalance >= requiredSol;
   const allValid = step1Valid && step2Valid && step3Valid && hasTokens && hasSufficientTokensForSeed && hasSufficientSol;
+
+  // Quick Launch auto-advance: step 1 → step 2 when token is resolved and params ready
+  const quickAutoAdvancedRef = useRef(false);
+  useEffect(() => {
+    if (wizard.mode !== "quick") { quickAutoAdvancedRef.current = false; return; }
+    if (quickAutoAdvancedRef.current) return;
+    if (wizard.step !== 1) return;
+    if (!step1Valid) return;
+    if (quickLaunch.loading) return;
+    if (!quickLaunch.config) return;
+
+    quickAutoAdvancedRef.current = true;
+    setCompletedSteps((prev) => new Set(prev).add(1));
+    setWizard((prev) => ({ ...prev, step: 2 as WizardStep }));
+  }, [wizard.mode, wizard.step, step1Valid, quickLaunch.loading, quickLaunch.config]);
+
+  // Quick Launch auto-advance: step 2 → step 4 when oracle is resolved
+  const quickOracleAutoAdvancedRef = useRef(false);
+  useEffect(() => {
+    if (wizard.mode !== "quick") { quickOracleAutoAdvancedRef.current = false; return; }
+    if (quickOracleAutoAdvancedRef.current) return;
+    if (wizard.step !== 2) return;
+    const oracleReady = wizard.oracleType === "admin" ||
+      (wizard.oracleType === "pyth" && isValidHex64(wizard.oracleFeed)) ||
+      (wizard.oracleType === "hyperp_ema" && isValidBase58Pubkey(wizard.oracleFeed));
+    if (!oracleReady) return;
+
+    quickOracleAutoAdvancedRef.current = true;
+    setCompletedSteps((prev) => { const s = new Set(prev); s.add(2); s.add(3); return s; });
+    setWizard((prev) => ({ ...prev, step: 4 as WizardStep }));
+  }, [wizard.mode, wizard.step, wizard.oracleType, wizard.oracleFeed]);
 
   // Navigation
   const goToStep = useCallback((step: WizardStep) => {
@@ -331,6 +362,10 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
         marketAddress={createState.slabAddress}
         txSigs={createState.txSigs}
         onDeployAnother={handleReset}
+        mainnetCA={wizard.mintAddress}
+        devnetMint={createState.devnetMint}
+        devnetAirdropAmount={createState.devnetAirdropAmount}
+        devnetAirdropSymbol={createState.devnetAirdropSymbol}
       />
     );
   }

--- a/app/components/create/LaunchSuccess.tsx
+++ b/app/components/create/LaunchSuccess.tsx
@@ -12,6 +12,14 @@ interface LaunchSuccessProps {
   marketAddress: string;
   txSigs: string[];
   onDeployAnother: () => void;
+  /** Original mainnet CA the user pasted */
+  mainnetCA?: string;
+  /** Devnet mint address (different from mainnet CA) */
+  devnetMint?: string | null;
+  /** Number of tokens airdropped */
+  devnetAirdropAmount?: number | null;
+  /** Token symbol for airdrop */
+  devnetAirdropSymbol?: string | null;
 }
 
 /**
@@ -26,8 +34,14 @@ export const LaunchSuccess: FC<LaunchSuccessProps> = ({
   marketAddress,
   txSigs,
   onDeployAnother,
+  mainnetCA,
+  devnetMint,
+  devnetAirdropAmount,
+  devnetAirdropSymbol,
 }) => {
   const [copied, setCopied] = useState(false);
+  const [copiedDevnet, setCopiedDevnet] = useState(false);
+  const isDevnet = process.env.NEXT_PUBLIC_SOLANA_NETWORK === "devnet";
 
   const handleCopy = async () => {
     try {
@@ -97,6 +111,80 @@ export const LaunchSuccess: FC<LaunchSuccessProps> = ({
           </div>
         </div>
       </div>
+
+      {/* Devnet Token Info — CA mismatch notice + airdrop confirmation */}
+      {isDevnet && (devnetMint || devnetAirdropAmount) && (
+        <div className="border border-[var(--accent)]/20 bg-[var(--accent)]/[0.03] p-4 mb-6 text-left w-full max-w-sm mx-auto space-y-3">
+          <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--accent)]">
+            DEVNET TOKEN INFO
+          </p>
+
+          {devnetAirdropAmount && devnetAirdropSymbol && (
+            <div className="flex items-center gap-2 text-[12px]">
+              <span className="text-[var(--long)]">✓</span>
+              <span className="text-[var(--text)]">
+                Airdropped <strong>{devnetAirdropAmount.toLocaleString(undefined, { maximumFractionDigits: 2 })} {devnetAirdropSymbol}</strong>{" "}
+                <span className="text-[var(--text-dim)]">(~$500 worth)</span>
+              </span>
+            </div>
+          )}
+
+          {devnetMint && (
+            <div className="space-y-1">
+              <p className="text-[10px] text-[var(--text-muted)]">
+                ⚠️ Devnet uses a <strong>different mint address</strong> than mainnet:
+              </p>
+              {mainnetCA && (
+                <div className="flex items-center gap-2 text-[10px]">
+                  <span className="text-[var(--text-dim)] w-16 flex-shrink-0">Mainnet:</span>
+                  <code className="font-mono text-[9px] text-[var(--text-dim)] truncate">{mainnetCA}</code>
+                </div>
+              )}
+              <div className="flex items-center gap-2 text-[10px]">
+                <span className="text-[var(--accent)] w-16 flex-shrink-0 font-medium">Devnet:</span>
+                <code className="font-mono text-[9px] text-[var(--accent)] truncate flex-1">{devnetMint}</code>
+                <button
+                  type="button"
+                  onClick={async () => {
+                    try {
+                      await navigator.clipboard.writeText(devnetMint);
+                      setCopiedDevnet(true);
+                      setTimeout(() => setCopiedDevnet(false), 2000);
+                    } catch {}
+                  }}
+                  className="border border-[var(--border)] px-1.5 py-0.5 text-[8px] font-medium text-[var(--text-muted)] hover:text-[var(--accent)] hover:border-[var(--accent)]/30 transition-colors flex-shrink-0"
+                >
+                  {copiedDevnet ? "✓" : "copy"}
+                </button>
+              </div>
+              <p className="text-[9px] text-[var(--text-dim)] mt-1">
+                Use the devnet mint address when adding tokens to your wallet or trading.
+              </p>
+            </div>
+          )}
+
+          {!devnetMint && !devnetAirdropAmount && (
+            <div className="flex items-center gap-2 text-[11px]">
+              <span className="text-[var(--text-dim)]">⏳</span>
+              <span className="text-[var(--text-dim)]">
+                Devnet token minting in progress...
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Devnet airdrop not available — show manual mint link */}
+      {isDevnet && !devnetMint && !devnetAirdropAmount && (
+        <div className="mb-6">
+          <Link
+            href={`/devnet-mint?ca=${mainnetCA ?? ""}&market=${marketAddress}`}
+            className="text-[11px] text-[var(--accent)] hover:underline"
+          >
+            Mint devnet tokens manually →
+          </Link>
+        </div>
+      )}
 
       {/* CTAs */}
       <div className="flex flex-col sm:flex-row items-center justify-center gap-3">

--- a/app/components/create/StepReview.tsx
+++ b/app/components/create/StepReview.tsx
@@ -3,6 +3,7 @@
 import { FC, useMemo } from "react";
 import { type SlabTierKey, SLAB_TIERS } from "@percolator/sdk";
 import { CostEstimate } from "./CostEstimate";
+import Link from "next/link";
 
 interface StepReviewProps {
   // Token
@@ -112,6 +113,9 @@ export const StepReview: FC<StepReviewProps> = ({
                 <p className="text-[10px] text-[var(--text-dim)]">
                   Oracle: {oracleTypeLabel} · {oracleLabel}
                 </p>
+                <p className="text-[9px] text-[var(--text-dim)] font-mono mt-0.5">
+                  Mint: {mintAddress.slice(0, 8)}...{mintAddress.slice(-6)}
+                </p>
               </div>
             </div>
             <div className="text-right">
@@ -159,6 +163,25 @@ export const StepReview: FC<StepReviewProps> = ({
               </span>
             </>
           )}
+        </div>
+      )}
+
+      {/* Devnet: no tokens — guide to mint first */}
+      {walletConnected && !hasTokens && process.env.NEXT_PUBLIC_SOLANA_NETWORK === "devnet" && (
+        <div className="border border-[var(--short)]/20 bg-[var(--short)]/[0.04] px-4 py-3 space-y-2">
+          <p className="text-[11px] text-[var(--text)]">
+            <span className="text-[var(--short)] font-medium">No tokens found.</span>{" "}
+            On devnet, you need to mint tokens first before creating a market.
+          </p>
+          <Link
+            href="/devnet-mint"
+            className="inline-block border border-[var(--accent)]/50 bg-[var(--accent)]/[0.08] px-4 py-2 text-[11px] font-bold uppercase tracking-[0.1em] text-[var(--accent)] transition-all hover:bg-[var(--accent)]/[0.15]"
+          >
+            MINT DEVNET TOKENS →
+          </Link>
+          <p className="text-[9px] text-[var(--text-dim)]">
+            After minting, come back here to launch your market. Your settings will be preserved.
+          </p>
         </div>
       )}
 

--- a/app/hooks/useCreateMarket.ts
+++ b/app/hooks/useCreateMarket.ts
@@ -93,6 +93,12 @@ export interface CreateMarketState {
   slabAddress: string | null;
   error: string | null;
   loading: boolean;
+  /** Devnet mint address (different from mainnet CA) */
+  devnetMint: string | null;
+  /** Number of tokens airdropped to creator */
+  devnetAirdropAmount: number | null;
+  /** Token symbol for devnet airdrop */
+  devnetAirdropSymbol: string | null;
 }
 
 const STEP_LABELS = [
@@ -113,6 +119,9 @@ export function useCreateMarket() {
     slabAddress: null,
     error: null,
     loading: false,
+    devnetMint: null,
+    devnetAirdropAmount: null,
+    devnetAirdropSymbol: null,
   });
 
   // Persist slab keypair across retries so we can resume from any step
@@ -601,7 +610,7 @@ export function useCreateMarket() {
         }
 
         // PERC-361: Post-creation hooks — register oracle bridge + mint devnet token
-        const slabAddr = state.slabAddress;
+        const slabAddr = slabPk.toBase58();
         const mintAddr = params.mint.toBase58();
         const isDevnet = process.env.NEXT_PUBLIC_SOLANA_NETWORK === "devnet";
 
@@ -622,7 +631,7 @@ export function useCreateMarket() {
 
           // Mint devnet token + airdrop $500 to creator
           try {
-            await fetch("/api/devnet-mint-token", {
+            const mintResp = await fetch("/api/devnet-mint-token", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({
@@ -630,7 +639,16 @@ export function useCreateMarket() {
                 marketAddress: slabAddr,
                 creatorWallet: wallet.publicKey.toBase58(),
               }),
-            }).catch(() => {});
+            });
+            if (mintResp.ok) {
+              const mintData = await mintResp.json();
+              setState((s) => ({
+                ...s,
+                devnetMint: mintData.devnetMint ?? null,
+                devnetAirdropAmount: mintData.airdropTokens ?? null,
+                devnetAirdropSymbol: mintData.symbol ?? null,
+              }));
+            }
           } catch {}
         }
 
@@ -660,6 +678,9 @@ export function useCreateMarket() {
       slabAddress: null,
       error: null,
       loading: false,
+      devnetMint: null,
+      devnetAirdropAmount: null,
+      devnetAirdropSymbol: null,
     });
   }, []);
 


### PR DESCRIPTION
## P0: Create Market UX Fixes

Three bugs reported by Khubair on the Create Market flow.

### Bug 1: Quick Launch broken
**Problem:** Auto oracle detect wasn't advancing — user forced to go Manual > HyperpEMA > select market type manually.

**Fix:** Added auto-advance effects in `CreateMarketWizard`:
- Step 1 → Step 2: auto-advances once token is resolved and quick launch params are ready
- Step 2 → Step 4: auto-advances once oracle is resolved (Pyth/HyperpEMA/Admin)
- Steps 2 & 3 are skipped entirely in Quick mode — user goes from Token → Review

### Bug 2: No devnet token minting at Step 4
**Problem:** No way to mint devnet tokens. Post-creation `/api/devnet-mint-token` call used stale `state.slabAddress` (captured before setState updates), so it was called with `null`.

**Fix:**
- Changed to use `slabPk.toBase58()` directly (not the stale state closure)
- API response (devnetMint, airdropAmount, symbol) now stored in `CreateMarketState`
- `LaunchSuccess` shows airdrop confirmation (✓ Airdropped X tokens)
- StepReview shows "Mint Devnet Tokens →" link when user has no tokens on devnet

### Bug 3: CA mismatch UX
**Problem:** Devnet mint CA differs from mainnet CA user pasted. No indication of this.

**Fix:** `LaunchSuccess` now shows:
- ⚠️ "Devnet uses a different mint address" notice
- Mainnet CA and Devnet CA side-by-side
- Copy button for devnet mint address
- Explanation of what to use when trading

### Files Changed
- `app/components/create/CreateMarketWizard.tsx` — auto-advance effects, pass new props
- `app/components/create/LaunchSuccess.tsx` — devnet mint info, CA comparison, airdrop confirmation
- `app/components/create/StepReview.tsx` — mint address display, devnet token guide link
- `app/hooks/useCreateMarket.ts` — new state fields, fixed stale closure bug