### PR TITLE
fix(oracle-keeper): remove dead HEALTH_HOST/HEALTH_SECRET vars + startup symbol validation (#617)

### DIFF
--- a/bots/oracle-keeper/index.ts
+++ b/bots/oracle-keeper/index.ts
@@ -22,8 +22,8 @@
  *   ADMIN_KEYPAIR_PATH — Oracle authority keypair
  *   PUSH_INTERVAL_MS  — Push interval (default: 3000)
  *   HEALTH_PORT       — HTTP health check port (default: 18810)
- *   HEALTH_HOST       — Bind address for health server (default: 127.0.0.1)
- *   HEALTH_SECRET     — Bearer token for health endpoint auth (optional but recommended)
+ *   HEALTH_BIND       — Bind address for health server (default: 127.0.0.1)
+ *   HEALTH_AUTH_TOKEN — Bearer token for health endpoint auth (optional but recommended)
  *   MAX_PRICE_MOVE_PCT — Circuit breaker % (default: 10)
  *   STALE_THRESHOLD_S  — Staleness alert threshold (default: 30)
  */
@@ -49,10 +49,6 @@ const STALE_THRESHOLD_S = Number(process.env.STALE_THRESHOLD_S ?? "30");
 const ADMIN_KP_PATH = process.env.ADMIN_KEYPAIR_PATH ??
   `${process.env.HOME}/.config/solana/percolator-upgrade-authority.json`;
 const RPC_URL = process.env.RPC_URL ?? "https://api.devnet.solana.com";
-// #613: bind health server to localhost by default; set HEALTH_HOST=0.0.0.0 for external access
-const HEALTH_HOST = process.env.HEALTH_HOST ?? "127.0.0.1";
-// #613: optional bearer token for health endpoint auth
-const HEALTH_SECRET = process.env.HEALTH_SECRET ?? "";
 
 const conn = new Connection(RPC_URL, "confirmed");
 // Support inline keypair via ADMIN_KEYPAIR env var (JSON array) for Railway/Docker deployments
@@ -400,7 +396,21 @@ async function main() {
   const markets = deploy.markets as MarketInfo[];
 
   log(`Program: ${programId.toBase58().slice(0, 12)}...`);
-  log(`Markets: ${markets.map(m => m.label).join(", ")}`);
+  log(`Markets: ${markets.map(m => `${m.label}(${m.symbol})`).join(", ")}`);
+
+  // Validate market symbols at startup — catch mismatched symbol/label configs early
+  const KNOWN_SYMBOLS = new Set([
+    ...Object.keys(BINANCE_MAP),
+    ...Object.keys(COINGECKO_IDS),
+    ...Object.keys(JUPITER_MINTS),
+  ]);
+  for (const m of markets) {
+    if (!m.symbol) {
+      log(`⚠️ STARTUP WARNING: ${m.label} has no symbol field in deployment JSON — will always fail price fetch`);
+    } else if (!KNOWN_SYMBOLS.has(m.symbol)) {
+      log(`⚠️ STARTUP WARNING: ${m.label} has unrecognized symbol "${m.symbol}" — not in any price source (Binance/CoinGecko/Jupiter). This market will log "no price from any source" forever. Fix: set symbol to one of: ${[...KNOWN_SYMBOLS].join(", ")}`);
+    }
+  }
 
   // Initialize stats
   for (const m of markets) getOrCreateStats(m);


### PR DESCRIPTION
## Summary

Fixes #617

### Changes
1. **Remove dead variables** — `HEALTH_HOST` and `HEALTH_SECRET` were declared (lines 52-55) but never used anywhere in the file. The actual runtime vars controlling health server bind/auth are `HEALTH_BIND` and `HEALTH_AUTH_TOKEN`. Operators setting `HEALTH_HOST=0.0.0.0` on Railway would be silently ignored.
2. **Fix docstring** — Module comment previously documented `HEALTH_HOST`/`HEALTH_SECRET`; updated to reference `HEALTH_BIND`/`HEALTH_AUTH_TOKEN`.
3. **Startup symbol validation** — On startup, the keeper now logs each market as `label(symbol)` and emits a clear `⚠️ STARTUP WARNING` if any market's `symbol` is missing or not found in Binance/CoinGecko/Jupiter maps. This diagnoses the **BTC-PERP-3 issue**: 430+ consecutive 'no price from any source' failures are caused by an unrecognized `symbol` in the DEPLOYMENT_JSON env var — the startup log will now expose this immediately on next restart.

### Root Cause for BTC-PERP-3
On-chain investigation confirms:
- All 3 markets are initialized and parseable ✅
- All 3 have oracle authority = Railway's admin key ✅  
- Market 3 (CBrKY6...) has a different admin/collateral_mint than markets 1+2 (created separately)
- PERP-3's 'no price from any source' errors = `getPrice(market.symbol)` returning null → **wrong symbol in DEPLOYMENT_JSON**

**Action needed by devops**: Check `DEPLOYMENT_JSON` env var on Railway oracle-keeper service. The third market entry's `symbol` field must be a valid ticker (e.g. `"BTC"`, `"ETH"`) — not the label (`"BTC-PERP-3"`).

### Testing
- `bots/oracle-keeper`: TypeScript compiles clean, no dead-var references