### PR TITLE
fix(oracle-keeper): robust authority check + expose TX logs for BTC-PERP-3 diagnosis

### DIFF
--- a/bots/oracle-keeper/index.ts
+++ b/bots/oracle-keeper/index.ts
@@ -75,6 +75,8 @@ const HEALTH_AUTH_TOKEN = process.env.HEALTH_AUTH_TOKEN ?? "";
 
 // Track markets where we're not the oracle authority (skip future attempts)
 const skippedMarkets = new Set<string>();
+// Track markets where oracle authority has been successfully verified
+const authorityVerified = new Set<string>();
 
 // ── Types ───────────────────────────────────────────────────
 interface MarketInfo {
@@ -278,20 +280,24 @@ async function pushAndCrank(market: MarketInfo, programId: PublicKey): Promise<v
   // Skip markets where we've already confirmed we're not the oracle authority
   if (skippedMarkets.has(market.slab)) return;
 
-  // On first push attempt, validate on-chain oracle authority matches our admin key
-  if (s.totalPushes === 0 && s.totalErrors === 0) {
+  // Validate oracle authority on-chain: run on first attempt, or every 50 errors
+  // (catches cases where fetchSlab failed transiently on the first check)
+  const needsAuthorityCheck = !authorityVerified.has(market.slab) &&
+    (s.totalErrors === 0 || s.totalErrors % 50 === 0);
+  if (needsAuthorityCheck) {
     try {
       const slabData = await fetchSlab(conn, new PublicKey(market.slab));
       const cfg = parseConfig(slabData);
       if (!cfg.oracleAuthority.equals(admin.publicKey)) {
-        log(`⚠️ ${market.label}: oracle authority mismatch — expected ${admin.publicKey.toBase58().slice(0, 12)}..., got ${cfg.oracleAuthority.toBase58().slice(0, 12)}... Skipping.`);
+        log(`🚨 ${market.label}: ORACLE AUTHORITY MISMATCH — slab has ${cfg.oracleAuthority.toBase58()}, keeper is signing as ${admin.publicKey.toBase58()}. Needs reinit. Skipping.`);
         skippedMarkets.add(market.slab);
         return;
       }
-      log(`✓ ${market.label}: oracle authority verified`);
+      authorityVerified.add(market.slab);
+      log(`✓ ${market.label}: oracle authority verified (${admin.publicKey.toBase58().slice(0, 12)}...)`);
     } catch (e) {
-      log(`⚠️ ${market.label}: failed to verify oracle authority: ${(e as Error).message?.slice(0, 60)}`);
-      // Continue anyway — the tx will fail with a clear error if authority is wrong
+      log(`⚠️ ${market.label}: failed to verify oracle authority (attempt ${s.totalErrors + 1}): ${(e as Error).message?.slice(0, 80)}`);
+      // Continue anyway — the tx will fail with a clear program error if authority is wrong
     }
   }
 
@@ -434,6 +440,29 @@ async function main() {
   log(`Program: ${programId.toBase58().slice(0, 12)}...`);
   log(`Markets: ${markets.map(m => m.label).join(", ")}`);
 
+  // ── Startup oracle authority check ──────────────────────────
+  // Verify all slabs before entering the main loop so mismatches are obvious in boot logs.
+  log(`Verifying oracle authority for ${markets.length} market(s)...`);
+  for (const m of markets) {
+    try {
+      const slabData = await fetchSlab(conn, new PublicKey(m.slab));
+      const cfg = parseConfig(slabData);
+      if (!cfg.oracleAuthority.equals(admin.publicKey)) {
+        log(`🚨 STARTUP: ${m.label} (${m.slab.slice(0, 12)}...) — authority MISMATCH. Slab: ${cfg.oracleAuthority.toBase58()} | Keeper: ${admin.publicKey.toBase58()} → SLAB NEEDS REINIT`);
+        skippedMarkets.add(m.slab);
+      } else {
+        authorityVerified.add(m.slab);
+        log(`✅ STARTUP: ${m.label} — authority OK (${admin.publicKey.toBase58().slice(0, 12)}...)`);
+      }
+    } catch (e) {
+      log(`⚠️ STARTUP: ${m.label} — authority check failed: ${(e as Error).message?.slice(0, 80)}. Will retry during push loop.`);
+    }
+  }
+  if (skippedMarkets.size > 0) {
+    log(`⛔ ${skippedMarkets.size} market(s) skipped due to authority mismatch: ${markets.filter(m => skippedMarkets.has(m.slab)).map(m => m.label).join(", ")}`);
+    log(`   Action required: reinitialise slab(s) with current keeper authority, or update ADMIN_KEYPAIR to match.`);
+  }
+
   // Initialize stats
   for (const m of markets) getOrCreateStats(m);
 
@@ -461,7 +490,18 @@ async function main() {
         const s = getOrCreateStats(market);
         s.totalErrors++;
         s.consecutiveErrors++;
-        log(`❌ ${market.label}: ${(e as Error).message?.slice(0, 80)}`);
+        // Safely extract error info — SendTransactionError.message may be undefined
+        // on some @solana/web3.js versions; .logs contains the on-chain program output
+        const err = e as any;
+        const msg: string = (typeof err?.message === "string" && err.message.length > 0)
+          ? err.message.slice(0, 120)
+          : (typeof err === "string" ? err.slice(0, 120) : `[${Object.prototype.toString.call(err)}]`);
+        const txLogs = Array.isArray(err?.logs) ? (err.logs as string[]) : [];
+        log(`❌ ${market.label}: ${msg}`);
+        if (txLogs.length > 0) {
+          // Print last 5 program log lines — this reveals the actual on-chain error
+          log(`   TX logs: ${txLogs.slice(-5).join(" | ").slice(0, 400)}`);
+        }
       })
     );
     await Promise.allSettled(promises);


### PR DESCRIPTION
## Problem

BTC-PERP-3 (slab `CBrKY6WNZhVFUmRWbVxGEd2SUm54Jza4dRssQHunhNfx`) has been failing with `undefined` error on every tx cycle (1155+ consecutive). Three root issues found in the current code:

### Issue 1: Authority check dead after first error
The existing check used condition `totalPushes === 0 && totalErrors === 0`. After the first failed cycle `totalErrors` becomes non-zero, so the authority check **never runs again** for the life of the process. If `fetchSlab` also failed transiently on cycle 1, the mismatch was never detected.

**Fix:** Authority check now runs at **startup** (pre-loop, eagerly for all markets) and retries **every 50 errors** until verified. A new `authorityVerified Set` tracks confirmed-OK slabs separately from the failure counter.

### Issue 2: `undefined` error messages hide real on-chain failures
`(e as Error).message?.slice(0, 80)` logs the string `"undefined"` when `SendTransactionError.message` is not set (observed with certain `@solana/web3.js` versions + `skipPreflight: true`). The **real error** is in `e.logs` — the on-chain program logs — which was never printed.

**Fix:** Error handler now falls back through `typeof` checks and **prints the last 5 program log lines** from `SendTransactionError.logs`. After this deploys, a single failed cycle for BTC-PERP-3 will show the actual Solana program error.

### Issue 3: No startup visibility into authority state
**Fix:** On boot, before the push loop starts, the keeper now logs **all markets** as either `✅ authority OK` or `🚨 MISMATCH` with full pubkeys. Devops can see the authority state immediately from Railway boot logs without waiting for the first push cycle.

## What this will tell us

After deploying, Railway boot logs will show one of:
- `🚨 STARTUP: BTC-PERP-3 — authority MISMATCH. Slab: <old-key> | Keeper: <current-key> → SLAB NEEDS REINIT` → devops runs `scripts/reinit-slab.ts` to reinit CBrKY6... with current keeper keypair
- `✅ STARTUP: BTC-PERP-3 — authority OK` → the tx logs from the first failure will reveal the real program error

## Testing
- TypeScript compiles clean (`tsc --noEmit` passes)
- Logic change: authority check runs eagerly at boot + every 50 errors until verified
- Error handler: safe string extraction + `SendTransactionError.logs` printed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced oracle authority validation with periodic verification checks for improved error detection
  * Expanded error handling to capture and log safer error messages along with relevant on-chain program logs
  * Added startup verification for market authorities to identify mismatches early with clear guidance for remediation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->