### PR TITLE
fix: Quick Launch flow — stop at Pool Size, fix devnet auto-mint

### DIFF
--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -156,7 +156,8 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
     setWizard((prev) => ({ ...prev, step: 2 as WizardStep }));
   }, [wizard.mode, wizard.step, step1Valid, quickLaunch.loading, quickLaunch.config]);
 
-  // Quick Launch auto-advance: step 2 → step 4 when oracle is resolved
+  // Quick Launch auto-advance: step 2 → step 3 (Pool Size) when oracle is resolved
+  // Pool size selection is NOT skipped — user must choose Small/Medium/Large
   const quickOracleAutoAdvancedRef = useRef(false);
   useEffect(() => {
     if (wizard.mode !== "quick") { quickOracleAutoAdvancedRef.current = false; return; }
@@ -168,8 +169,8 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
     if (!oracleReady) return;
 
     quickOracleAutoAdvancedRef.current = true;
-    setCompletedSteps((prev) => { const s = new Set(prev); s.add(2); s.add(3); return s; });
-    setWizard((prev) => ({ ...prev, step: 4 as WizardStep }));
+    setCompletedSteps((prev) => new Set(prev).add(2));
+    setWizard((prev) => ({ ...prev, step: 3 as WizardStep }));
   }, [wizard.mode, wizard.step, wizard.oracleType, wizard.oracleFeed]);
 
   // Navigation
@@ -366,6 +367,7 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
         devnetMint={createState.devnetMint}
         devnetAirdropAmount={createState.devnetAirdropAmount}
         devnetAirdropSymbol={createState.devnetAirdropSymbol}
+        devnetMintError={createState.devnetMintError}
       />
     );
   }

--- a/app/components/create/LaunchSuccess.tsx
+++ b/app/components/create/LaunchSuccess.tsx
@@ -20,6 +20,8 @@ interface LaunchSuccessProps {
   devnetAirdropAmount?: number | null;
   /** Token symbol for airdrop */
   devnetAirdropSymbol?: string | null;
+  /** Error from devnet mint attempt */
+  devnetMintError?: string | null;
 }
 
 /**
@@ -38,6 +40,7 @@ export const LaunchSuccess: FC<LaunchSuccessProps> = ({
   devnetMint,
   devnetAirdropAmount,
   devnetAirdropSymbol,
+  devnetMintError,
 }) => {
   const [copied, setCopied] = useState(false);
   const [copiedDevnet, setCopiedDevnet] = useState(false);
@@ -163,7 +166,16 @@ export const LaunchSuccess: FC<LaunchSuccessProps> = ({
             </div>
           )}
 
-          {!devnetMint && !devnetAirdropAmount && (
+          {devnetMintError && (
+            <div className="flex items-center gap-2 text-[11px]">
+              <span className="text-[var(--short)]">✗</span>
+              <span className="text-[var(--short)]">
+                Token mint failed: {devnetMintError}
+              </span>
+            </div>
+          )}
+
+          {!devnetMint && !devnetAirdropAmount && !devnetMintError && (
             <div className="flex items-center gap-2 text-[11px]">
               <span className="text-[var(--text-dim)]">⏳</span>
               <span className="text-[var(--text-dim)]">
@@ -174,8 +186,8 @@ export const LaunchSuccess: FC<LaunchSuccessProps> = ({
         </div>
       )}
 
-      {/* Devnet airdrop not available — show manual mint link */}
-      {isDevnet && !devnetMint && !devnetAirdropAmount && (
+      {/* Devnet airdrop failed or not available — show manual mint link */}
+      {isDevnet && !devnetMint && (devnetMintError || !devnetAirdropAmount) && (
         <div className="mb-6">
           <Link
             href={`/devnet-mint?ca=${mainnetCA ?? ""}&market=${marketAddress}`}

--- a/app/hooks/useCreateMarket.ts
+++ b/app/hooks/useCreateMarket.ts
@@ -99,6 +99,8 @@ export interface CreateMarketState {
   devnetAirdropAmount: number | null;
   /** Token symbol for devnet airdrop */
   devnetAirdropSymbol: string | null;
+  /** Error from devnet mint attempt */
+  devnetMintError: string | null;
 }
 
 const STEP_LABELS = [
@@ -122,6 +124,7 @@ export function useCreateMarket() {
     devnetMint: null,
     devnetAirdropAmount: null,
     devnetAirdropSymbol: null,
+    devnetMintError: null,
   });
 
   // Persist slab keypair across retries so we can resume from any step
@@ -630,6 +633,7 @@ export function useCreateMarket() {
           } catch {}
 
           // Mint devnet token + airdrop $500 to creator
+          setState((s) => ({ ...s, stepLabel: "Minting devnet tokens..." }));
           try {
             const mintResp = await fetch("/api/devnet-mint-token", {
               method: "POST",
@@ -640,16 +644,29 @@ export function useCreateMarket() {
                 creatorWallet: wallet.publicKey.toBase58(),
               }),
             });
+            const mintData = await mintResp.json();
             if (mintResp.ok) {
-              const mintData = await mintResp.json();
               setState((s) => ({
                 ...s,
                 devnetMint: mintData.devnetMint ?? null,
                 devnetAirdropAmount: mintData.airdropTokens ?? null,
                 devnetAirdropSymbol: mintData.symbol ?? null,
               }));
+            } else {
+              console.warn("Devnet mint failed:", mintData.error ?? mintResp.status);
+              // Non-fatal — market is live, just no tokens minted
+              setState((s) => ({
+                ...s,
+                devnetMintError: mintData.error ?? `HTTP ${mintResp.status}`,
+              }));
             }
-          } catch {}
+          } catch (mintErr) {
+            console.warn("Devnet mint error:", mintErr);
+            setState((s) => ({
+              ...s,
+              devnetMintError: mintErr instanceof Error ? mintErr.message : "Mint request failed",
+            }));
+          }
         }
 
         // Done! Clear persisted keypair from localStorage
@@ -681,6 +698,7 @@ export function useCreateMarket() {
       devnetMint: null,
       devnetAirdropAmount: null,
       devnetAirdropSymbol: null,
+    devnetMintError: null,
     });
   }, []);
 


### PR DESCRIPTION
## Urgent fix for PR #619 regression

PR #619 broke Quick Launch by skipping TOO MUCH — went straight to Review without pool size selection.

### Changes

**Quick Launch flow corrected:**
- Before: Token → (skip Oracle, skip Pool Size) → Review ❌
- After: Token → (auto-skip Oracle) → **Pool Size** → Review ✅
- User MUST select Small/Medium/Large tier — this step is never skipped

**Devnet auto-mint improvements:**
- Shows "Minting devnet tokens..." status label during the mint API call
- Captures and displays mint errors in state (`devnetMintError`)
- LaunchSuccess shows error message + "Mint manually →" link when auto-mint fails
- Better error handling: parse response JSON for error messages

### BTC-PERP-3 note
PM asked to remove BTC-PERP-3 from deployment.json — this is a runtime file at `/tmp/percolator-devnet-deployment.json`, not in the repo. PR #616 already skips it at runtime via authority mismatch check. DevOps should regenerate the deployment.json without it on next deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added error messaging for failed devnet token minting attempts, displayed on the success screen.

* **Bug Fixes**
  * Corrected Quick Launch auto-advance flow: Pool Size selection is now required and no longer skipped when oracle is ready.
  * Enhanced success screen to show mint error status when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->