### PR TITLE
fix(oracle-keeper): remove dead HEALTH_HOST/HEALTH_SECRET vars, fix docstring (#617)

### DIFF
--- a/bots/oracle-keeper/index.ts
+++ b/bots/oracle-keeper/index.ts
@@ -22,8 +22,8 @@
  *   ADMIN_KEYPAIR_PATH — Oracle authority keypair
  *   PUSH_INTERVAL_MS  — Push interval (default: 3000)
  *   HEALTH_PORT       — HTTP health check port (default: 18810)
- *   HEALTH_HOST       — Bind address for health server (default: 127.0.0.1)
- *   HEALTH_SECRET     — Bearer token for health endpoint auth (optional but recommended)
+ *   HEALTH_BIND       — Bind address for health server (default: 127.0.0.1)
+ *   HEALTH_AUTH_TOKEN — Bearer token for health endpoint auth (optional but recommended)
  *   MAX_PRICE_MOVE_PCT — Circuit breaker % (default: 10)
  *   STALE_THRESHOLD_S  — Staleness alert threshold (default: 30)
  */
@@ -49,10 +49,6 @@ const STALE_THRESHOLD_S = Number(process.env.STALE_THRESHOLD_S ?? "30");
 const ADMIN_KP_PATH = process.env.ADMIN_KEYPAIR_PATH ??
   `${process.env.HOME}/.config/solana/percolator-upgrade-authority.json`;
 const RPC_URL = process.env.RPC_URL ?? "https://api.devnet.solana.com";
-// #613: bind health server to localhost by default; set HEALTH_HOST=0.0.0.0 for external access
-const HEALTH_HOST = process.env.HEALTH_HOST ?? "127.0.0.1";
-// #613: optional bearer token for health endpoint auth
-const HEALTH_SECRET = process.env.HEALTH_SECRET ?? "";
 
 const conn = new Connection(RPC_URL, "confirmed");
 // Support inline keypair via ADMIN_KEYPAIR env var (JSON array) for Railway/Docker deployments


### PR DESCRIPTION
## Summary

Fixes #617.

Dead variables `HEALTH_HOST` and `HEALTH_SECRET` were declared from env vars but never read anywhere in the code. The actual health server implementation uses `HEALTH_BIND` (bind address) and `HEALTH_AUTH_TOKEN` (bearer token), introduced in the #616 security hardening pass.

This caused a silent operator misconfiguration risk: the module docstring instructed operators to set `HEALTH_HOST=0.0.0.0` to expose the health endpoint externally, but this had **no effect** — the server binds to `HEALTH_BIND`, not `HEALTH_HOST`.

## Changes
- Remove dead `HEALTH_HOST` constant declaration (was read from env, never used)
- Remove dead `HEALTH_SECRET` constant declaration (was read from env, never used)
- Update module docstring to reference `HEALTH_BIND` + `HEALTH_AUTH_TOKEN` instead of the dead names

## No runtime behaviour change
Only dead code removed and operator documentation corrected. Security defaults remain: `HEALTH_BIND` defaults to `127.0.0.1`, auth is gated by `HEALTH_AUTH_TOKEN`.

## Notes on related issues
- #614 (RPC URL redaction) — already fixed in commit `1703f44b` (uses URL hostname-only logging)
- #615 (Jupiter mint addresses) — already fixed in commit `1703f44b` (JUPITER_MINTS map + `ids=${mint}`)
- Both issues were resolved by the earlier oracle-keeper security hardening PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed health endpoint configuration environment variables: HEALTH_HOST → HEALTH_BIND and HEALTH_SECRET → HEALTH_AUTH_TOKEN. Update your environment configuration accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->