### PR TITLE
fix(oracle-keeper): validate Pyth publish_time to prevent stale price bypass

### DIFF
--- a/bots/oracle-keeper/index.ts
+++ b/bots/oracle-keeper/index.ts
@@ -161,15 +161,22 @@ async function fetchPythPrices(symbols: string[]): Promise<void> {
       idToSymbol.set(id, sym);
     }
 
-    const now = Date.now();
     for (const entry of json.parsed) {
       const sym = idToSymbol.get(entry.id);
       if (!sym) continue;
       const rawPrice = parseInt(entry.price.price, 10);
       const expo = entry.price.expo;
       const price = rawPrice * Math.pow(10, expo);
-      if (price > 0) {
-        pythCache.set(sym, { price, ts: now });
+      // Use Pyth's publish_time as the cache timestamp (not fetch time).
+      // This ensures getPythPrice's 30s staleness check operates against the
+      // actual Pyth oracle clock, not the moment we fetched the HTTP response.
+      // Reject prices Pyth hasn't updated in 60s — they are stale at the source.
+      const publishMs = entry.price.publish_time * 1000;
+      const ageMs = Date.now() - publishMs;
+      if (price > 0 && ageMs < 60_000) {
+        pythCache.set(sym, { price, ts: publishMs });
+      } else if (price > 0) {
+        log(`⚠️ ${sym}: Pyth publish_time is ${Math.floor(ageMs / 1000)}s old — rejecting stale price`);
       }
     }
   } catch (e) {


### PR DESCRIPTION
## Problem

Security audit of PR #618 (Pyth Hermes oracle-keeper) found a **MEDIUM** severity issue:

`fetchPythPrices` was storing prices in `pythCache` with `ts: Date.now()` (the HTTP fetch time), not Pyth's actual `publish_time`. This caused `getPythPrice`'s 30-second staleness check to measure *time-since-fetch* rather than *time-since-Pyth-published*, meaning Pyth could serve a price it hadn't updated in minutes and our keeper would accept it.

## Fix

- Store `publishMs = entry.price.publish_time * 1000` as the cache timestamp instead of `now`  
- Reject prices where `ageMs = Date.now() - publishMs >= 60_000` (Pyth hasn't published in >60s)  
- Log a warning when a stale Pyth price is discarded  
- `getPythPrice` is unchanged — it continues checking `Date.now() - cached.ts > 30_000`, which now correctly operates against Pyth's oracle clock

## Testing

The fix is surgical — one function changed, no interface changes. Fallover to Jupiter/DexScreener remains intact when Pyth prices are stale.

Fixes: security finding from PR #618 review  
Reported by: @security agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced price caching validation for oracle data to ensure only fresh, valid prices are cached with a 60-second freshness threshold. Stale prices are now rejected and logged as warnings to maintain data reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->