### PR TITLE
fix: Pyth clock skew guard (security follow-up)

### DIFF
--- a/bots/oracle-keeper/index.ts
+++ b/bots/oracle-keeper/index.ts
@@ -169,7 +169,7 @@ async function fetchPythPrices(symbols: string[]): Promise<void> {
       // Reject prices Pyth hasn't updated in 60s — they are stale at the source.
       const publishMs = entry.price.publish_time * 1000;
       const ageMs = Date.now() - publishMs;
-      if (price > 0 && ageMs < 60_000) {
+      if (price > 0 && ageMs >= 0 && ageMs < 60_000) {
         pythCache.set(sym, { price, ts: publishMs });
       } else if (price > 0) {
         log(`⚠️ ${sym}: Pyth publish_time is ${Math.floor(ageMs / 1000)}s old — rejecting stale price`);


### PR DESCRIPTION
Follow-up from security review on PR #625.\n\nAdds `ageMs >= 0` guard to Pyth publish_time staleness check. Without this, a future publish_time (clock skew) would produce negative ageMs, passing the `< 60_000` check and creating a cache entry that never expires.\n\nOne-line change, LOW priority.