### PR TITLE
fix: devnet mint detection — use getNetwork() + remove dead ORACLE_BRIDGE_URL

### DIFF
--- a/app/app/api/devnet-mint-token/route.ts
+++ b/app/app/api/devnet-mint-token/route.ts
@@ -37,7 +37,8 @@ export const dynamic = "force-dynamic";
 
 const NETWORK = process.env.NEXT_PUBLIC_SOLANA_NETWORK ?? "devnet";
 const AIRDROP_USD_VALUE = 500; // $500 worth of tokens
-const ORACLE_BRIDGE_URL = process.env.ORACLE_BRIDGE_URL ?? "http://127.0.0.1:18802";
+// ORACLE_BRIDGE_URL removed — unreachable from Vercel serverless.
+// Price fetching uses DexScreener API directly via fetchTokenInfo().
 
 interface DexScreenerToken {
   name: string;

--- a/app/components/create/LaunchSuccess.tsx
+++ b/app/components/create/LaunchSuccess.tsx
@@ -3,6 +3,7 @@
 import { FC, useState } from "react";
 import Link from "next/link";
 import { LogoUpload } from "./LogoUpload";
+import { getNetwork } from "@/lib/config";
 
 interface LaunchSuccessProps {
   tokenSymbol: string;
@@ -44,7 +45,7 @@ export const LaunchSuccess: FC<LaunchSuccessProps> = ({
 }) => {
   const [copied, setCopied] = useState(false);
   const [copiedDevnet, setCopiedDevnet] = useState(false);
-  const isDevnet = process.env.NEXT_PUBLIC_SOLANA_NETWORK === "devnet";
+  const isDevnet = getNetwork() === "devnet";
 
   const handleCopy = async () => {
     try {

--- a/app/components/create/StepReview.tsx
+++ b/app/components/create/StepReview.tsx
@@ -4,6 +4,7 @@ import { FC, useMemo } from "react";
 import { type SlabTierKey, SLAB_TIERS } from "@percolator/sdk";
 import { CostEstimate } from "./CostEstimate";
 import Link from "next/link";
+import { getNetwork } from "@/lib/config";
 
 interface StepReviewProps {
   // Token
@@ -167,7 +168,7 @@ export const StepReview: FC<StepReviewProps> = ({
       )}
 
       {/* Devnet: no tokens — guide to mint first */}
-      {walletConnected && !hasTokens && process.env.NEXT_PUBLIC_SOLANA_NETWORK === "devnet" && (
+      {walletConnected && !hasTokens && getNetwork() === "devnet" && (
         <div className="border border-[var(--short)]/20 bg-[var(--short)]/[0.04] px-4 py-3 space-y-2">
           <p className="text-[11px] text-[var(--text)]">
             <span className="text-[var(--short)] font-medium">No tokens found.</span>{" "}

--- a/app/hooks/useCreateMarket.ts
+++ b/app/hooks/useCreateMarket.ts
@@ -615,7 +615,7 @@ export function useCreateMarket() {
         // PERC-361: Post-creation hooks — register oracle bridge + mint devnet token
         const slabAddr = slabPk.toBase58();
         const mintAddr = params.mint.toBase58();
-        const isDevnet = process.env.NEXT_PUBLIC_SOLANA_NETWORK === "devnet";
+        const isDevnet = (process.env.NEXT_PUBLIC_SOLANA_NETWORK?.trim() || "devnet") === "devnet";
 
         if (isDevnet && slabAddr) {
           // Register with oracle bridge (fire-and-forget)


### PR DESCRIPTION
## Devnet Mint Not Showing — Two Fixes

### Bug 1: Devnet detection fails on Vercel
`LaunchSuccess.tsx`, `StepReview.tsx`, and `useCreateMarket.ts` used `process.env.NEXT_PUBLIC_SOLANA_NETWORK === 'devnet'` to detect devnet. If this env var isn't set in Vercel, the devnet token info block is completely hidden.

**Fix:** Use `getNetwork()` from `@/lib/config` which checks localStorage override → env var → defaults to `'devnet'`. Also default to `'devnet'` in `useCreateMarket` when env var is absent.

### Bug 2: Dead ORACLE_BRIDGE_URL constant
`devnet-mint-token/route.ts` had `ORACLE_BRIDGE_URL = 'http://127.0.0.1:18802'` — unreachable from Vercel serverless. The constant was declared but never used (price fetching already uses DexScreener via `fetchTokenInfo()`).

**Fix:** Removed the dead constant.

### Note for PM
`DEVNET_MINT_AUTHORITY_KEYPAIR` needs to be verified in Vercel env vars — if missing, the mint route returns 500. This is a config issue, not a code fix.