### PR TITLE
fix: Create Market — all 6 Quick Launch bugs resolved

### DIFF
--- a/app/app/api/devnet-mint-token/route.ts
+++ b/app/app/api/devnet-mint-token/route.ts
@@ -102,6 +102,24 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    // Reject URLs and non-base58 inputs — prevents DexScreener being called with a URL
+    const isUrl = typeof mainnetCA === "string" &&
+      (mainnetCA.startsWith("http://") || mainnetCA.startsWith("https://") || mainnetCA.includes("://"));
+    if (isUrl) {
+      return NextResponse.json(
+        { error: "Paste a valid Solana token address, not a URL" },
+        { status: 400 },
+      );
+    }
+    try {
+      new PublicKey(mainnetCA);
+    } catch {
+      return NextResponse.json(
+        { error: "Invalid token address: must be a valid Solana base58 public key" },
+        { status: 400 },
+      );
+    }
+
     let creatorPk: PublicKey;
     try {
       creatorPk = new PublicKey(creatorWallet);

--- a/app/app/api/oracle/resolve/[ca]/route.ts
+++ b/app/app/api/oracle/resolve/[ca]/route.ts
@@ -1,0 +1,251 @@
+import { NextRequest, NextResponse } from "next/server";
+import { PublicKey } from "@solana/web3.js";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/oracle/resolve/[ca]
+ *
+ * Given a Solana token mint (base58), resolves oracle config using a
+ * Pyth Hermes → Jupiter → DexScreener fallback chain.
+ *
+ * Returns: { feedId, symbol, price, source }
+ *   feedId — Pyth feed ID (hex64) if found, else null
+ *   symbol — token ticker
+ *   price  — USD price (number)
+ *   source — "pyth" | "jupiter" | "dexscreener"
+ *
+ * Bug: PERC-oracle-resolve — route was missing, causing 404 on Create Market flow.
+ */
+
+// ---------------------------------------------------------------------------
+// Static Pyth feed map: mint → { feedId, symbol }
+// ---------------------------------------------------------------------------
+
+const MINT_TO_PYTH: Record<string, { feedId: string; symbol: string }> = {
+  // SOL
+  So11111111111111111111111111111111111111112: {
+    feedId: "ef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d",
+    symbol: "SOL",
+  },
+  // BTC
+  "9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E": {
+    feedId: "e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
+    symbol: "BTC",
+  },
+  // ETH
+  "7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs": {
+    feedId: "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
+    symbol: "ETH",
+  },
+  // USDC
+  EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v: {
+    feedId: "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
+    symbol: "USDC",
+  },
+  // USDT
+  Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB: {
+    feedId: "2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b",
+    symbol: "USDT",
+  },
+  // BONK
+  DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263: {
+    feedId: "72b021217ca3fe68922a19aaf990109cb9d84e9ad004b4d2025ad6f529314419",
+    symbol: "BONK",
+  },
+  // JTO
+  jtojtomepa8beP8AuQc6eXt5FriJwfFMwQx2v2f9mCL: {
+    feedId: "b43660a5f790c69354b0729a5ef9d50d68f1df92107540210b9cccba1f947cc2",
+    symbol: "JTO",
+  },
+  // JUP
+  JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN: {
+    feedId: "0a0408d619e9380abad35060f9192039ed5042fa6f82301d0e48bb52be830996",
+    symbol: "JUP",
+  },
+  // WIF
+  EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYxdM65zcjm: {
+    feedId: "4ca4beeca86f0d164160323817a4e42b10010a724c2217c6ee41b54e6c5c4b03",
+    symbol: "WIF",
+  },
+  // RAY
+  "4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R": {
+    feedId: "91568bae053f70f0c3fbf32eb55df25ec609fb8a21cfb1a0e3b34fc3caa1eab0",
+    symbol: "RAY",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Simple in-memory cache (TTL 5 minutes)
+// ---------------------------------------------------------------------------
+
+interface CacheEntry {
+  data: OracleResolveResult;
+  expiresAt: number;
+}
+const cache = new Map<string, CacheEntry>();
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface OracleResolveResult {
+  feedId: string | null;
+  symbol: string;
+  price: number;
+  source: "pyth" | "jupiter" | "dexscreener" | "unknown";
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+function isValidBase58Pubkey(s: string): boolean {
+  try {
+    new PublicKey(s);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isUrl(s: string): boolean {
+  return s.startsWith("http://") || s.startsWith("https://") || s.includes("://");
+}
+
+// ---------------------------------------------------------------------------
+// Price fetchers
+// ---------------------------------------------------------------------------
+
+async function fetchJupiterPrice(
+  ca: string,
+): Promise<{ price: number; symbol: string | null } | null> {
+  try {
+    const resp = await fetch(`https://api.jup.ag/price/v2?ids=${ca}`, {
+      signal: AbortSignal.timeout(6000),
+      headers: { "User-Agent": "percolator/1.0" },
+    });
+    if (!resp.ok) return null;
+    const json = await resp.json();
+    const data = json.data?.[ca];
+    if (!data?.price) return null;
+    const price = parseFloat(data.price);
+    if (!isFinite(price) || price <= 0) return null;
+    return { price, symbol: data.mintSymbol ?? null };
+  } catch {
+    return null;
+  }
+}
+
+async function fetchDexScreenerInfo(
+  ca: string,
+): Promise<{ price: number; symbol: string | null } | null> {
+  try {
+    const resp = await fetch(`https://api.dexscreener.com/latest/dex/tokens/${ca}`, {
+      signal: AbortSignal.timeout(6000),
+      headers: { "User-Agent": "percolator/1.0" },
+    });
+    if (!resp.ok) return null;
+    const json = await resp.json();
+    const pairs = json.pairs as Array<{
+      priceUsd?: string;
+      baseToken?: { symbol?: string };
+      liquidity?: { usd?: number };
+      chainId?: string;
+    }>;
+    if (!pairs?.length) return null;
+
+    // Sort by liquidity, pick best Solana pair
+    const solPairs = pairs
+      .filter((p) => p.chainId === "solana" && p.priceUsd)
+      .sort((a, b) => (b.liquidity?.usd ?? 0) - (a.liquidity?.usd ?? 0));
+    if (!solPairs.length) return null;
+
+    const best = solPairs[0];
+    const price = parseFloat(best.priceUsd ?? "0");
+    if (!isFinite(price) || price <= 0) return null;
+
+    return { price, symbol: best.baseToken?.symbol ?? null };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Route handler
+// ---------------------------------------------------------------------------
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ ca: string }> },
+): Promise<NextResponse> {
+  const { ca } = await params;
+
+  // Reject URLs immediately — clear, actionable error
+  if (isUrl(ca)) {
+    return NextResponse.json(
+      { error: "Paste a valid Solana token address, not a URL" },
+      { status: 400 },
+    );
+  }
+
+  // Validate base58 format
+  if (!ca || ca.length < 32 || ca.length > 44 || !isValidBase58Pubkey(ca)) {
+    return NextResponse.json(
+      { error: "Invalid Solana mint address" },
+      { status: 400 },
+    );
+  }
+
+  // Cache hit
+  const cached = cache.get(ca);
+  if (cached && Date.now() < cached.expiresAt) {
+    return NextResponse.json({ ...cached.data, cached: true });
+  }
+
+  // --- 1. Check static Pyth feed map ---
+  const pythEntry = MINT_TO_PYTH[ca];
+
+  // Fetch price in parallel from both Jupiter and DexScreener
+  const [jupResult, dexResult] = await Promise.all([
+    fetchJupiterPrice(ca),
+    fetchDexScreenerInfo(ca),
+  ]);
+
+  // Best price: prefer DexScreener for memecoins, Jupiter as fallback
+  const priceSource = dexResult ?? jupResult;
+  const price = priceSource?.price ?? 0;
+  const symbolFromPrice = priceSource?.symbol ?? null;
+
+  let result: OracleResolveResult;
+
+  if (pythEntry) {
+    result = {
+      feedId: pythEntry.feedId,
+      symbol: pythEntry.symbol,
+      price,
+      source: "pyth",
+    };
+  } else if (jupResult) {
+    result = {
+      feedId: null,
+      symbol: symbolFromPrice ?? ca.slice(0, 6),
+      price: jupResult.price,
+      source: "jupiter",
+    };
+  } else if (dexResult) {
+    result = {
+      feedId: null,
+      symbol: symbolFromPrice ?? ca.slice(0, 6),
+      price: dexResult.price,
+      source: "dexscreener",
+    };
+  } else {
+    // No price found anywhere
+    return NextResponse.json(
+      { error: "No price feed found for this token" },
+      { status: 404 },
+    );
+  }
+
+  // Cache and return
+  cache.set(ca, { data: result, expiresAt: Date.now() + CACHE_TTL_MS });
+  return NextResponse.json({ ...result, cached: false });
+}

--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -18,7 +18,9 @@ import { StepReview } from "./StepReview";
 import { LaunchProgress } from "./LaunchProgress";
 import { LaunchSuccess } from "./LaunchSuccess";
 import { RecoverSolBanner } from "./RecoverSolBanner";
+import { SlabTierPicker } from "./SlabTierPicker";
 import { isValidBase58Pubkey, isValidHex64 } from "@/lib/createWizardUtils";
+import { useToast } from "@/hooks/useToast";
 
 type WizardStep = 1 | 2 | 3 | 4;
 
@@ -49,11 +51,13 @@ const DEFAULT_STATE: WizardState = {
   mintAddress: "",
   tokenMeta: null,
   walletBalance: null,
-  oracleType: "pyth",
+  oracleType: "admin",
   oracleFeed: "",
   dexPool: null,
   pythFeed: null,
-  slabTier: "large",  // PERC-277: default to large (4096) — matches deployed devnet program
+  // Quick mode defaults to small — cheapest tier for quick testing.
+  // Manual mode users can choose their own tier (defaults to large in the picker).
+  slabTier: "small",
   tradingFeeBps: 30,
   initialMarginBps: 1000,
   lpCollateral: "",
@@ -92,7 +96,7 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
     return () => { cancelled = true; };
   }, [publicKey, connection]);
 
-  // Apply quick launch defaults to parameters
+  // Apply quick launch defaults to parameters (fee, margin, collateral, price)
   useEffect(() => {
     if (wizard.mode !== "quick" || !quickLaunch.config) return;
     setWizard((prev) => ({
@@ -100,6 +104,8 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
       tradingFeeBps: quickLaunch.config!.tradingFeeBps,
       initialMarginBps: quickLaunch.config!.initialMarginBps,
       lpCollateral: quickLaunch.config!.lpCollateral,
+      // Apply detected oracle price as adminPrice (used if oracle ends up admin)
+      adminPrice: quickLaunch.config!.initialPrice || prev.adminPrice,
     }));
   }, [quickLaunch.config, wizard.mode]);
 
@@ -156,22 +162,9 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
     setWizard((prev) => ({ ...prev, step: 2 as WizardStep }));
   }, [wizard.mode, wizard.step, step1Valid, quickLaunch.loading, quickLaunch.config]);
 
-  // Quick Launch auto-advance: step 2 → step 3 (Pool Size) when oracle is resolved
-  // Pool size selection is NOT skipped — user must choose Small/Medium/Large
-  const quickOracleAutoAdvancedRef = useRef(false);
-  useEffect(() => {
-    if (wizard.mode !== "quick") { quickOracleAutoAdvancedRef.current = false; return; }
-    if (quickOracleAutoAdvancedRef.current) return;
-    if (wizard.step !== 2) return;
-    const oracleReady = wizard.oracleType === "admin" ||
-      (wizard.oracleType === "pyth" && isValidHex64(wizard.oracleFeed)) ||
-      (wizard.oracleType === "hyperp_ema" && isValidBase58Pubkey(wizard.oracleFeed));
-    if (!oracleReady) return;
-
-    quickOracleAutoAdvancedRef.current = true;
-    setCompletedSteps((prev) => new Set(prev).add(2));
-    setWizard((prev) => ({ ...prev, step: 3 as WizardStep }));
-  }, [wizard.mode, wizard.step, wizard.oracleType, wizard.oracleFeed]);
+  // Quick Launch: step 2 is slab selection (NOT oracle).
+  // Oracle is resolved from useQuickLaunch and applied when user clicks Continue.
+  // No auto-advance from step 2 — user must explicitly choose a slab tier.
 
   // Navigation
   const goToStep = useCallback((step: WizardStep) => {
@@ -189,11 +182,42 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
   );
 
   const goBack = useCallback(() => {
-    setWizard((prev) => ({
-      ...prev,
-      step: Math.max(1, prev.step - 1) as WizardStep,
-    }));
+    setWizard((prev) => {
+      // In quick mode, step 4 (review) goes back to step 2 (slab) — skip oracle step
+      if (prev.mode === "quick" && prev.step === 4) {
+        return { ...prev, step: 2 as WizardStep };
+      }
+      return { ...prev, step: Math.max(1, prev.step - 1) as WizardStep };
+    });
   }, []);
+
+  // Quick Launch: user confirms slab tier → apply oracle from hook → jump to review (step 4)
+  const handleQuickSlabContinue = useCallback(() => {
+    setCompletedSteps((prev) => {
+      const next = new Set(prev);
+      next.add(2);
+      next.add(3); // oracle step auto-completed in quick mode
+      return next;
+    });
+    setWizard((prev) => {
+      const base = { ...prev, step: 4 as WizardStep };
+      if (quickLaunch.oracleType === "pyth" && quickLaunch.pythFeedId) {
+        return {
+          ...base,
+          oracleType: "pyth" as const,
+          oracleFeed: quickLaunch.pythFeedId,
+          adminPrice: quickLaunch.adminPrice,
+        };
+      }
+      // Admin oracle — devnet-only or unknown token
+      return {
+        ...base,
+        oracleType: "admin" as const,
+        oracleFeed: "",
+        adminPrice: quickLaunch.adminPrice,
+      };
+    });
+  }, [quickLaunch]);
 
   // Mode change
   const handleModeChange = useCallback(
@@ -202,10 +226,12 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
         ...prev,
         mode,
         // Reset oracle fields when switching
-        oracleType: "pyth",
+        oracleType: mode === "quick" ? "admin" : "pyth",
         oracleFeed: "",
         dexPool: null,
         pythFeed: null,
+        // Reset slab tier to mode-appropriate default
+        slabTier: mode === "quick" ? "small" : "large",
       }));
     },
     []
@@ -436,7 +462,7 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
             {wizard.step === 1
               ? "Token"
               : wizard.step === 2
-                ? "Oracle"
+                ? wizard.mode === "quick" ? "Slab Tier" : "Oracle"
                 : wizard.step === 3
                   ? "Parameters"
                   : "Review"}
@@ -455,8 +481,49 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
           />
         )}
 
-        {/* Step 2: Oracle */}
-        {wizard.step === 2 && (
+        {/* Step 2: Quick mode = Slab Tier selection; Manual mode = Oracle */}
+        {wizard.step === 2 && wizard.mode === "quick" && (
+          <div className="space-y-6">
+            <div>
+              <p className="text-[11px] text-[var(--text-secondary)] mb-4">
+                Choose your market size. Larger slabs support more concurrent traders but cost more SOL to deploy.
+              </p>
+              <label className="block text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)] mb-3">
+                Slab Tier
+              </label>
+              <SlabTierPicker value={wizard.slabTier} onChange={setSlabTier} />
+            </div>
+            {/* Oracle detection status */}
+            {quickLaunch.loading ? (
+              <p className="text-[10px] text-[var(--text-dim)]">⏳ Detecting oracle...</p>
+            ) : quickLaunch.oracleType === "pyth" && quickLaunch.pythFeedId ? (
+              <p className="text-[10px] text-[var(--long)]">
+                ✓ Pyth oracle detected — price feed will be used automatically
+              </p>
+            ) : (
+              <p className="text-[10px] text-[var(--text-dim)]">
+                ℹ Admin oracle — you&apos;ll control pricing (devnet token)
+              </p>
+            )}
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={goBack}
+                className="border border-[var(--border)] bg-transparent px-5 py-3 text-[12px] font-medium uppercase tracking-[0.1em] text-[var(--text-secondary)] transition-all hud-btn-corners hover:border-[var(--accent)]/30 hover:text-[var(--text)]"
+              >
+                ← BACK
+              </button>
+              <button
+                type="button"
+                onClick={handleQuickSlabContinue}
+                className="flex-1 border border-[var(--accent)]/50 bg-[var(--accent)]/[0.08] py-3 text-[13px] font-bold uppercase tracking-[0.1em] text-[var(--accent)] transition-all duration-200 hud-btn-corners hover:border-[var(--accent)] hover:bg-[var(--accent)]/[0.15]"
+              >
+                CONTINUE →
+              </button>
+            </div>
+          </div>
+        )}
+        {wizard.step === 2 && wizard.mode === "manual" && (
           <StepOracleSelect
             mintAddress={wizard.mintAddress}
             mintValid={mintValid}

--- a/app/components/create/LaunchSuccess.tsx
+++ b/app/components/create/LaunchSuccess.tsx
@@ -116,8 +116,8 @@ export const LaunchSuccess: FC<LaunchSuccessProps> = ({
         </div>
       </div>
 
-      {/* Devnet Token Info — CA mismatch notice + airdrop confirmation */}
-      {isDevnet && (devnetMint || devnetAirdropAmount) && (
+      {/* Devnet Token Info — CA mismatch notice + airdrop confirmation + mint errors */}
+      {isDevnet && (devnetMint || devnetAirdropAmount || devnetMintError) && (
         <div className="border border-[var(--accent)]/20 bg-[var(--accent)]/[0.03] p-4 mb-6 text-left w-full max-w-sm mx-auto space-y-3">
           <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--accent)]">
             DEVNET TOKEN INFO

--- a/app/components/create/StepTokenSelect.tsx
+++ b/app/components/create/StepTokenSelect.tsx
@@ -47,7 +47,11 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
     return () => clearTimeout(timer);
   }, [inputValue, onMintChange]);
 
-  const mintValid = isValidBase58Pubkey(debounced) && debounced.length >= 32;
+  const mintIsUrl =
+    debounced.startsWith("http://") ||
+    debounced.startsWith("https://") ||
+    debounced.includes("://");
+  const mintValid = !mintIsUrl && isValidBase58Pubkey(debounced) && debounced.length >= 32;
   const mintPk = useMemo(
     () => (mintValid ? new PublicKey(debounced) : null),
     [debounced, mintValid]
@@ -117,7 +121,11 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
           }`}
         />
         {showInvalid && (
-          <p className="mt-1.5 text-[10px] text-[var(--short)]">Invalid mint address</p>
+          <p className="mt-1.5 text-[10px] text-[var(--short)]">
+            {mintIsUrl
+              ? "Paste a valid Solana token address, not a URL"
+              : "Invalid mint address — must be a base58 Solana token address"}
+          </p>
         )}
       </div>
 

--- a/app/hooks/usePriceRouter.ts
+++ b/app/hooks/usePriceRouter.ts
@@ -21,8 +21,8 @@ export interface PriceRouterState {
   error: string | null;
 }
 
-// Use Next.js proxy to avoid CORS — /api/oracle/* is rewritten to the backend
-const API_BASE = "";
+// Use Next.js API route: /api/oracle/resolve/[ca] (Next.js handles proxy/cache)
+const API_BASE = "/api";
 
 /** Maximum number of retry attempts for transient errors */
 const MAX_RETRIES = 2;
@@ -48,7 +48,17 @@ export function usePriceRouter(mintAddress: string | null): PriceRouterState {
   useEffect(() => {
     setState({ bestSource: null, allSources: [], loading: false, error: null });
 
+    // Reject URLs and non-base58 inputs immediately — don't hit the API
     if (!mintAddress || mintAddress.length < 32) return;
+    if (mintAddress.startsWith("http://") || mintAddress.startsWith("https://") || mintAddress.includes("://")) {
+      setState({
+        bestSource: null,
+        allSources: [],
+        loading: false,
+        error: "Paste a valid Solana token address, not a URL",
+      });
+      return;
+    }
 
     abortRef.current?.abort();
     const controller = new AbortController();

--- a/app/hooks/useQuickLaunch.ts
+++ b/app/hooks/useQuickLaunch.ts
@@ -25,11 +25,18 @@ export interface QuickLaunchResult {
   loading: boolean;
   error: string | null;
   poolInfo: DexPoolResult | null;
+  /** Detected oracle type for this token */
+  oracleType: "pyth" | "admin";
+  /** Pyth feed ID (hex64) if oracleType === "pyth", else null */
+  pythFeedId: string | null;
+  /** Best price string for adminPrice field */
+  adminPrice: string;
 }
 
 /**
  * Auto-detects token metadata and best DEX pool, then suggests
  * sensible market parameters based on liquidity.
+ * Also resolves oracle type: Pyth (mainnet) vs admin (devnet-only tokens).
  */
 export function useQuickLaunch(mint: string | null): QuickLaunchResult {
   const { connection } = useConnectionCompat();
@@ -38,6 +45,53 @@ export function useQuickLaunch(mint: string | null): QuickLaunchResult {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [tokenMeta, setTokenMeta] = useState<{ name: string; symbol: string; decimals: number } | null>(null);
+
+  // Oracle detection state
+  const [oracleType, setOracleType] = useState<"pyth" | "admin">("admin");
+  const [pythFeedId, setPythFeedId] = useState<string | null>(null);
+  const [adminPrice, setAdminPrice] = useState<string>("1.000000");
+
+  // Oracle resolution: call /api/oracle/resolve/[mint] after token meta loads.
+  // If Pyth feed found → pyth oracle; else → admin oracle with best available price.
+  useEffect(() => {
+    setOracleType("admin");
+    setPythFeedId(null);
+    setAdminPrice("1.000000");
+    if (!mint || mint.length < 32 || !tokenMeta) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const resp = await fetch(`/api/oracle/resolve/${mint}`, {
+          signal: AbortSignal.timeout(8000),
+        });
+        if (cancelled) return;
+        if (resp.ok) {
+          const data = await resp.json();
+          if (data.feedId) {
+            setOracleType("pyth");
+            setPythFeedId(data.feedId);
+            if (data.price > 0) setAdminPrice(data.price.toFixed(6));
+          } else {
+            setOracleType("admin");
+            setPythFeedId(null);
+            if (data.price > 0) setAdminPrice(data.price.toFixed(6));
+          }
+        } else {
+          // 404 or error — fall back to admin oracle
+          setOracleType("admin");
+          setPythFeedId(null);
+        }
+      } catch {
+        if (!cancelled) {
+          setOracleType("admin");
+          setPythFeedId(null);
+        }
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [mint, tokenMeta]);
 
   // Fetch on-chain token metadata using shared fetchTokenMeta
   // (checks cache → well-known → Metaplex on-chain → Jupiter, in that order)
@@ -132,5 +186,8 @@ export function useQuickLaunch(mint: string | null): QuickLaunchResult {
     loading: loading || poolsLoading,
     error,
     poolInfo: bestPool,
+    oracleType,
+    pythFeedId,
+    adminPrice,
   };
 }


### PR DESCRIPTION
## Summary
Fixes every bug from PM's comprehensive create market rewrite brief.

## Bugs Fixed

### Bug 1: Quick Launch skips slab selection → FIXED
- Step 2 now shows **Slab Tier selection** (Small/Medium/Large + SOL costs)  
- Oracle is auto-resolved silently from `/api/oracle/resolve/[ca]`
- `handleQuickSlabContinue`: applies oracle result, jumps directly to step 4
- Back button from step 4 in quick mode returns to step 2 (not invisible oracle step)

### Bug 2: Default slabTier was 'large' (7 SOL) → FIXED
- `DEFAULT_STATE.slabTier` changed to `'small'` (~0.44 SOL)
- Mode switch also resets: quick → 'small', manual → 'large'

### Bug 3: No mainnet vs devnet oracle detection → FIXED
- `useQuickLaunch` now calls `/api/oracle/resolve/[ca]` after token resolves
- Pyth feed found → `oracleType='pyth'`, `pythFeedId` returned
- No feed (devnet-only) → `oracleType='admin'`, price from DexScreener/Jupiter
- Hook now exports `oracleType`, `pythFeedId`, `adminPrice`

### Bug 4: /api/oracle/resolve/[ca] route missing → FIXED
- New route: `app/app/api/oracle/resolve/[ca]/route.ts`
- Pyth static feed map + Jupiter + DexScreener fallback chain
- Returns `{ feedId, symbol, price, source }`
- Handles URL inputs (400), invalid base58 (400), 5-min TTL cache

### Bug 5: Input validation missing → FIXED
- `StepTokenSelect`: URL inputs → 'Paste a valid Solana token address, not a URL'
- Invalid base58 → clear error message inline
- `devnet-mint-token` API: same validation server-side (prevents DexScreener being called with Twitter URL)

### Bug 6: Mint UI never shows → FIXED
- `LaunchSuccess` devnet block now renders when `devnetMintError` is set even if `devnetMint` is null
- Error displayed prominently with ✗ icon

## Testing
- `pnpm build` passes clean ✓
- All routes compile without errors ✓

## How to test
1. Go to /create, Quick Launch mode
2. Paste a valid devnet token CA
3. Confirm step 2 shows Slab Tier (Small selected by default)
4. Click Continue → should resolve oracle automatically and jump to Review
5. Review shows correct oracle type (Pyth for mainnet tokens, Admin for devnet-only)
6. Launch → if mint fails, error shows on success screen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added oracle price resolution with automatic fallback from multiple data sources
  * Enhanced quick launch flow with slab tier selection and automatic oracle detection

* **Bug Fixes**
  * Improved input validation with clearer error messages for token addresses
  * Added URL detection to prevent invalid address submissions
  * Enhanced error visibility for devnet token operations

* **Improvements**
  * Implemented price data caching for improved performance
  * Added exponential backoff for API retry logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->