### PR TITLE
fix(csp): remove *.vercel.app wildcard from frame-src (#635)

### DIFF
--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -113,7 +113,9 @@ function addSecurityHeaders(response: NextResponse, nonce?: string) {
     "font-src 'self' https://fonts.gstatic.com",
     "img-src 'self' data: https: blob:",
     "connect-src 'self' https://*.solana.com wss://*.solana.com https://*.supabase.co wss://*.supabase.co https://*.vercel-insights.com https://api.coingecko.com https://*.helius-rpc.com wss://*.helius-rpc.com https://api.dexscreener.com https://hermes.pyth.network https://*.up.railway.app wss://*.up.railway.app https://token.jup.ag https://auth.privy.io https://embedded-wallets.privy.io https://*.privy.systems https://*.rpc.privy.systems https://explorer-api.walletconnect.com wss://relay.walletconnect.com wss://relay.walletconnect.org wss://www.walletlink.org blob:",
-    "frame-src 'self' https://auth.privy.io https://embedded-wallets.privy.io https://*.privy.systems https://phantom.app https://solflare.com https://verify.walletconnect.com https://verify.walletconnect.org https://*.vercel.app",
+    // Removed https://*.vercel.app wildcard (issue #635) — no legitimate use case for embedding
+    // arbitrary Vercel-hosted content in iframes. frame-src controls outbound iframe embedding.
+    "frame-src 'self' https://auth.privy.io https://embedded-wallets.privy.io https://*.privy.systems https://phantom.app https://solflare.com https://verify.walletconnect.com https://verify.walletconnect.org",
     // Removed https://*.vercel.app wildcard (issue #632) — any Vercel project could embed the app,
     // creating a clickjacking surface over wallet/sign flows. Keep only the specific preview URL.
     "frame-ancestors 'self' https://percolatorlaunch.com https://*.percolatorlaunch.com https://percolator-launch.vercel.app",


### PR DESCRIPTION
## Summary

Fixes #635.

After PR #634 removed `https://*.vercel.app` from `frame-ancestors`, the `frame-src` directive still contained the same wildcard.

## What changed

Removed `https://*.vercel.app` from `frame-src` in `app/middleware.ts`.

## Why

`frame-src` controls what external origins this app can embed in iframes. Audited all iframe usage in the codebase — no components embed Vercel-hosted content. The wildcard served no documented purpose and allowed embedding content from any Vercel project, broader than necessary.

## How to test

1. Deploy preview
2. Check response headers: `Content-Security-Policy` → `frame-src` should no longer contain `*.vercel.app`
3. Verify wallet auth flows (Privy, Phantom, Solflare, WalletConnect) still work normally — all their origins remain in `frame-src`

## Risk

Low — removing an unused wildcard. No known iframe embeds of Vercel content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted security policies for embedded content sources by eliminating wildcard patterns in favor of more specific domain allowances, improving overall application security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->