### PR TITLE
Refactor market stats retrieval and price formatting

### DIFF
--- a/app/app/api/markets/[slab]/prices/route.ts
+++ b/app/app/api/markets/[slab]/prices/route.ts
@@ -42,28 +42,28 @@ export async function GET(
       });
     }
 
-    // 2. Fallback: market_stats for the most recent price
-    const { data: stats } = await (db as any)
-      .from("market_stats")
-      .select("mark_price_e6, last_updated")
-      .eq("slab_address", slab)
-      .order("last_updated", { ascending: false })
-      .limit(1);
+   // 2. Fallback: market_stats for the most recent price
+const { data: stats } = await (db as any)
+  .from("market_stats")
+  .select("mark_price, updated_at")
+  .eq("slab_address", slab)
+  .order("updated_at", { ascending: false })
+  .limit(1);
 
-    if (stats && stats.length > 0) {
-      return NextResponse.json({
-        prices: [
-          {
-            price_e6: String(stats[0].mark_price_e6),
-            timestamp: new Date(stats[0].last_updated).getTime(),
-          },
-        ],
-      });
-    }
+if (stats && stats.length > 0) {
+  const markPriceUsd = stats[0].mark_price as number | null | undefined;
+  const updatedAt = stats[0].updated_at as string | null | undefined;
 
-    return NextResponse.json({ prices: [] });
-  } catch (err) {
-    console.error("[prices] Error:", err);
-    return NextResponse.json({ prices: [] });
-  }
+  // Convert USD price -> e6 integer string (match oracle_prices schema)
+  const priceE6 =
+    typeof markPriceUsd === "number" && Number.isFinite(markPriceUsd)
+      ? String(Math.round(markPriceUsd * 1_000_000))
+      : "0";
+
+  const ts =
+    updatedAt ? new Date(updatedAt).getTime() : 0;
+
+  return NextResponse.json({
+    prices: [{ price_e6: priceE6, timestamp: ts }],
+  });
 }


### PR DESCRIPTION
This pull request updates the fallback logic for retrieving market prices in the `GET` API endpoint for market slabs. The main change involves switching to use USD prices from the `market_stats` table, converting them to the expected e6 integer format, and updating the timestamp handling to match the new schema.

**Market price retrieval and formatting:**

* Changed the selection in the `market_stats` query to use `mark_price` and `updated_at` fields instead of `mark_price_e6` and `last_updated` to align with the updated schema. ([app/app/api/markets/[slab]/prices/route.tsL48-L69](diffhunk://#diff-3faa9f38cd3fb8382c4e740acaafda40fd890ad6e64c1a4afb9acbe9087a7eeaL48-L69))
* Added logic to convert the USD `mark_price` to an e6 integer string to match the expected format in the API response. ([app/app/api/markets/[slab]/prices/route.tsL48-L69](diffhunk://#diff-3faa9f38cd3fb8382c4e740acaafda40fd890ad6e64c1a4afb9acbe9087a7eeaL48-L69))
* Updated timestamp handling to use the new `updated_at` field, ensuring correct conversion to milliseconds since epoch. ([app/app/api/markets/[slab]/prices/route.tsL48-L69](diffhunk://#diff-3faa9f38cd3fb8382c4e740acaafda40fd890ad6e64c1a4afb9acbe9087a7eeaL48-L69))Refactor fallback logic to retrieve market stats with updated field names and handle price conversion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced market price data accuracy by optimizing price data retrieval to consistently fetch the most recent information and ensure proper timestamp handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->