### PR TITLE
fix(PERC-652): guard against NULL/zero mark_price_e6 in prices endpoint

### DIFF
--- a/app/app/api/markets/[slab]/prices/route.ts
+++ b/app/app/api/markets/[slab]/prices/route.ts
@@ -51,11 +51,21 @@ export async function GET(
       .limit(1);
 
     if (stats && stats.length > 0) {
+      const markPriceE6 = stats[0].mark_price_e6 as number | null | undefined;
+      if (
+        typeof markPriceE6 !== "number" ||
+        !Number.isFinite(markPriceE6) ||
+        markPriceE6 <= 0
+      ) {
+        return NextResponse.json({ prices: [] }); // no valid mark price
+      }
       return NextResponse.json({
         prices: [
           {
-            price_e6: String(stats[0].mark_price_e6),
-            timestamp: new Date(stats[0].last_updated).getTime(),
+            price_e6: String(markPriceE6),
+            timestamp: stats[0].last_updated
+              ? new Date(stats[0].last_updated).getTime()
+              : Date.now(),
           },
         ],
       });


### PR DESCRIPTION
## Problem
When `market_stats` has a row but `mark_price_e6` is NULL, the prices endpoint returned `price_e6: '0'` and a bogus timestamp. Zero mark price would cause downstream margin checks to compute zero equity → mass liquidation trigger.

## Fix
Validate `mark_price_e6` before returning: if it's not a finite positive number, return `prices: []` (same as no-data case). Also guard `last_updated` with a fallback to `Date.now()`.

## Testing
- NULL mark_price_e6 → `{ prices: [] }`
- mark_price_e6 = 0 → `{ prices: [] }`
- mark_price_e6 = NaN → `{ prices: [] }`
- Valid mark_price_e6 → works as before

Closes #652

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation in the market prices endpoint to filter out invalid price values and handle missing timestamps appropriately, ensuring more reliable data in API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->