### PR TITLE
fix: skip token checks on devnet for Create Market launch

### DIFF
--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -8,6 +8,7 @@ import { useQuickLaunch } from "@/hooks/useQuickLaunch";
 import { type DexPoolResult } from "@/hooks/useDexPoolSearch";
 import { parseHumanAmount, formatHumanAmount } from "@/lib/parseAmount";
 import { SLAB_TIERS, type SlabTierKey } from "@percolator/sdk";
+import { getNetwork } from "@/lib/config";
 
 import { ModeSelector } from "./ModeSelector";
 import { WizardProgress } from "./WizardProgress";
@@ -145,7 +146,9 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
     return slabRentSol + tokenAccountRentSol + TX_FEE_ESTIMATE_SOL;
   }, [wizard.slabTier]);
   const hasSufficientSol = solBalance !== null && solBalance >= requiredSol;
-  const allValid = step1Valid && step2Valid && step3Valid && hasTokens && hasSufficientTokensForSeed && hasSufficientSol;
+  // On devnet, tokens are auto-airdropped after market creation — skip token balance checks
+  const isDevnet = getNetwork() === "devnet";
+  const allValid = step1Valid && step2Valid && step3Valid && (isDevnet || (hasTokens && hasSufficientTokensForSeed)) && hasSufficientSol;
 
   // Quick Launch auto-advance: step 1 → step 2 when token is resolved and params ready
   const quickAutoAdvancedRef = useRef(false);

--- a/app/components/create/StepReview.tsx
+++ b/app/components/create/StepReview.tsx
@@ -82,14 +82,17 @@ export const StepReview: FC<StepReviewProps> = ({
         ? "HyperpEMA"
         : "Admin";
 
+  const isDevnet = getNetwork() === "devnet";
+
   const launchButtonLabel = useMemo(() => {
     if (!walletConnected) return "Connect Wallet to Launch";
-    if (!hasTokens) return "No Tokens — Mint First";
-    if (!hasSufficientTokensForSeed) return "Insufficient Tokens for Vault Seed (500)";
+    if (!isDevnet && !hasTokens) return "No Tokens — Mint First";
+    if (!isDevnet && !hasSufficientTokensForSeed) return "Insufficient Tokens for Vault Seed (500)";
     if (feeConflict) return "Fix Parameters to Continue";
     if (!hasSufficientBalance) return "Insufficient SOL";
-    return "LAUNCH MARKET";
-  }, [walletConnected, hasTokens, hasSufficientTokensForSeed, feeConflict, hasSufficientBalance]);
+    if (isDevnet) return "LAUNCH & MINT TOKENS →";
+    return "LAUNCH MARKET →";
+  }, [walletConnected, hasTokens, hasSufficientTokensForSeed, feeConflict, hasSufficientBalance, isDevnet]);
 
   return (
     <div className="space-y-5">
@@ -167,21 +170,15 @@ export const StepReview: FC<StepReviewProps> = ({
         </div>
       )}
 
-      {/* Devnet: no tokens — guide to mint first */}
-      {walletConnected && !hasTokens && getNetwork() === "devnet" && (
-        <div className="border border-[var(--short)]/20 bg-[var(--short)]/[0.04] px-4 py-3 space-y-2">
+      {/* Devnet: tokens are auto-minted after market creation */}
+      {walletConnected && isDevnet && (
+        <div className="border border-[var(--long)]/20 bg-[var(--long)]/[0.04] px-4 py-3 space-y-1">
           <p className="text-[11px] text-[var(--text)]">
-            <span className="text-[var(--short)] font-medium">No tokens found.</span>{" "}
-            On devnet, you need to mint tokens first before creating a market.
+            <span className="text-[var(--long)] font-medium">✓ Devnet mode.</span>{" "}
+            Your wallet will receive devnet {tokenSymbol} tokens automatically after the market is created.
           </p>
-          <Link
-            href="/devnet-mint"
-            className="inline-block border border-[var(--accent)]/50 bg-[var(--accent)]/[0.08] px-4 py-2 text-[11px] font-bold uppercase tracking-[0.1em] text-[var(--accent)] transition-all hover:bg-[var(--accent)]/[0.15]"
-          >
-            MINT DEVNET TOKENS →
-          </Link>
           <p className="text-[9px] text-[var(--text-dim)]">
-            After minting, come back here to launch your market. Your settings will be preserved.
+            No tokens needed upfront — tokens are airdropped post-launch for testing.
           </p>
         </div>
       )}


### PR DESCRIPTION
## P0 Fix — Devnet Create Market Blocked by Token Check

**Problem:** On devnet, tokens are minted *after* market creation (auto-airdrop). The Create Market wizard was gating the Launch button on `hasTokens` and `hasSufficientTokensForSeed`, which are always false before launch on devnet.

**Changes:**

### StepReview.tsx
- Token-gate labels (`No Tokens — Mint First`, `Insufficient Tokens for Vault Seed`) now only show on mainnet
- Devnet launch button reads **LAUNCH & MINT TOKENS →**
- Replaced the 'mint first' banner with a devnet info banner: *'Your wallet will receive devnet tokens automatically after the market is created'*

### CreateMarketWizard.tsx
- Added `getNetwork` import and `isDevnet` flag
- `allValid` now skips `hasTokens` and `hasSufficientTokensForSeed` checks on devnet: `(isDevnet || (hasTokens && hasSufficientTokensForSeed))`

**Testing:** Connect wallet on devnet with 0 tokens → Create Market wizard → Step 4 Review → Launch button should be enabled (green) showing 'LAUNCH & MINT TOKENS →'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added devnet mode with relaxed token balance requirements
  * Dynamic launch button labels based on network type
  * Automatic token distribution after market creation on devnet
  * Visual devnet mode indicator added

* **Style**
  * Updated styling for devnet-specific UI elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->