### PR TITLE
fix(prices): add mainnet guard + refuse silent prod fallback on devnet

### DIFF
--- a/app/app/api/prices/route.ts
+++ b/app/app/api/prices/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getBackendUrl } from "@/lib/config";
+import { getBackendUrl, getNetwork } from "@/lib/config";
 import { getServiceClient } from "@/lib/supabase";
 import * as Sentry from "@sentry/nextjs";
 
@@ -25,10 +25,15 @@ export const dynamic = "force-dynamic";
  *     }
  *   }
  *
- * Security note: this route is BLOCKED from serving on mainnet.
- * The cluster guard sits in TraderFleetBot.start() upstream.
+ * Security note: this route is only available on devnet.
+ * An explicit runtime guard below enforces this; do not rely solely on upstream callers.
  */
 export async function GET() {
+  // Explicit mainnet guard — do not serve price data on mainnet (#658)
+  if (getNetwork() === "mainnet") {
+    return NextResponse.json({ error: "Not available on mainnet" }, { status: 403 });
+  }
+
   try {
     // ── Primary: Supabase market_stats ─────────────────────────
     const db = getServiceClient();
@@ -68,6 +73,16 @@ export async function GET() {
 
     // ── Fallback: proxy to backend /prices ─────────────────────
     const backendUrl = getBackendUrl();
+    // Guard: refuse to proxy to the production fallback when BACKEND_URL env is not explicitly
+    // set — prevents silent devnet→production data leakage (#659)
+    const hasExplicitBackendUrl =
+      !!process.env.NEXT_PUBLIC_API_URL || !!process.env.NEXT_PUBLIC_BACKEND_URL;
+    if (!hasExplicitBackendUrl) {
+      console.error(
+        "[/api/prices] BACKEND_URL not configured; refusing to proxy to production default from devnet",
+      );
+      return NextResponse.json({ prices: {} }, { status: 502 });
+    }
     const res = await fetch(`${backendUrl}/prices`, {
       headers: { "Content-Type": "application/json" },
       signal: AbortSignal.timeout(5000),


### PR DESCRIPTION
## Summary

Two CodeRabbit MEDIUM findings from PR #655 2nd-pass review, both in `app/app/api/prices/route.ts`.

### Issue #658 — Mainnet guard was comment-only, no runtime enforcement

The route contained a comment claiming it was blocked on mainnet, but the handler itself had no guard. If the upstream caller failed to prevent it, the route would proxy freely on mainnet.

**Fix:** Added explicit check at the top of `GET()`:
```ts
if (getNetwork() === 'mainnet') {
  return NextResponse.json({ error: 'Not available on mainnet' }, { status: 403 });
}
```

### Issue #659 — `getBackendUrl()` silently falls back to production Railway URL

When `NEXT_PUBLIC_API_URL` and `NEXT_PUBLIC_BACKEND_URL` are both unset, `getBackendUrl()` returns the hardcoded production URL. On devnet this causes the fallback proxy path to silently query production backend data.

**Fix:** In the fallback proxy path, check whether an explicit backend URL was configured. If not, return `502` with a clear error log rather than proxying to production.

### Testing
- `getNetwork()` reads `NEXT_PUBLIC_DEFAULT_NETWORK` server-side; the guard is deterministic per deploy
- The `hasExplicitBackendUrl` check is a simple env-var presence check — no side effects
- Primary Supabase path is unaffected; guard only applies to the fallback proxy path

Fixes #658 Fixes #659