### PR TITLE
Require authentication for GET job applications

### DIFF
--- a/app/app/api/applications/route.ts
+++ b/app/app/api/applications/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServiceClient } from "@/lib/supabase";
+import { requireAuth, UNAUTHORIZED } from "@/lib/api-auth";
 
 export const dynamic = 'force-dynamic';
 
@@ -23,11 +24,15 @@ function sanitize(str: string): string {
 
 const TABLE = "job_applications";
 
-export async function GET() {
+export async function GET(req: NextRequest) {
+  if (!requireAuth(req)) return UNAUTHORIZED;
+
   try {
     const sb = getServiceClient();
-    const { data, error } = await (sb.from as any)(TABLE)
-      .select("id, name, twitter_handle, discord, telegram, email, desired_role, experience_level, about, portfolio_links, cv_filename, availability, solana_wallet, status, created_at")
+    const { data, error } = await (sb.from as any)("job_applications")
+      .select(
+        "id, name, twitter_handle, discord, telegram, email, desired_role, experience_level, about, portfolio_links, cv_filename, availability, solana_wallet, status, created_at"
+      )
       .order("created_at", { ascending: false })
       .limit(50);
 


### PR DESCRIPTION
This pull request adds authentication to the job applications API route, ensuring that only authorized users can access the endpoint. The most important changes are:

**Authentication and Security:**

* Added an authentication check using `requireAuth` to the `GET` handler in `app/app/api/applications/route.ts`, returning `UNAUTHORIZED` if the request is not authenticated. [[1]](diffhunk://#diff-42e9fa77e38c5e45311aba1ebdb812219a2586c8047c4f795ca12900df56384aR3) [[2]](diffhunk://#diff-42e9fa77e38c5e45311aba1ebdb812219a2586c8047c4f795ca12900df56384aL26-R35)

**API Handler Update:**

* Modified the `GET` function to accept the `NextRequest` object, enabling authentication checks on incoming requests.Added authentication check to GET request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * The applications endpoint now enforces authentication requirements to ensure secure access to application data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->