### PR TITLE
fix(leaderboard): use anon client + ISR — fixes #676, #677

### DIFF
--- a/app/app/api/leaderboard/route.ts
+++ b/app/app/api/leaderboard/route.ts
@@ -1,6 +1,12 @@
 import { NextResponse } from "next/server";
-import { getServiceClient } from "@/lib/supabase";
-export const dynamic = "force-dynamic";
+import { getSupabase } from "@/lib/supabase";
+
+/**
+ * ISR: recompute at most once every 30 seconds.
+ * Eliminates the need for per-IP rate limiting — repeated requests
+ * within the window are served from cache without hitting Supabase.
+ */
+export const revalidate = 30;
 
 export interface LeaderboardEntry {
   rank: number;
@@ -11,10 +17,15 @@ export interface LeaderboardEntry {
 }
 
 /**
- * GET /api/leaderboard?period=24h|alltime&limit=50
+ * GET /api/leaderboard?period=24h|7d|alltime&limit=50
  *
  * Returns top traders ranked by cumulative volume (sum of |size|).
  * Volume unit matches the `size` column in `trades` — raw token base units.
+ *
+ * Security notes (fixes #676, #677):
+ * - Uses anon Supabase client (respects RLS) instead of service-role client
+ * - Uses Next.js ISR (revalidate=30) instead of force-dynamic to prevent
+ *   cache-bypass abuse that would hammer the DB
  */
 export async function GET(request: Request) {
   const url = new URL(request.url);
@@ -23,7 +34,7 @@ export async function GET(request: Request) {
   const limit = Math.min(Math.max(1, Number.isNaN(rawLimit) ? 50 : rawLimit), 200);
 
   try {
-    const supabase = getServiceClient();
+    const supabase = getSupabase();
 
     let query = supabase
       .from("trades")
@@ -95,11 +106,6 @@ export async function GET(request: Request) {
 
     return NextResponse.json(
       { leaderboard, period, generatedAt: new Date().toISOString() },
-      {
-        headers: {
-          "Cache-Control": "public, s-maxage=30, stale-while-revalidate=60",
-        },
-      },
     );
   } catch (err) {
     console.error("[leaderboard] error:", err);


### PR DESCRIPTION
## What
Addresses both security findings from the PR #675 leaderboard review:

### Finding 1: Service-role client on public endpoint (#676)
- **Before:** `getServiceClient()` (bypasses RLS) on an unauthenticated GET endpoint
- **After:** `getSupabase()` (anon client, respects RLS). The `trades_select_anon` policy already grants anonymous SELECT.

### Finding 2: No rate limiting / cache-bypass abuse (#677)  
- **Before:** `force-dynamic` + manual `Cache-Control: s-maxage=30` — bots can bypass CDN cache and hammer the DB
- **After:** `export const revalidate = 30` (Next.js ISR). The route handler only executes on cache miss (every 30s max). No per-IP rate limiting needed.

## How to test
```bash
curl https://percolatorlaunch.com/api/leaderboard?period=alltime
```

Closes #676, closes #677