### PR TITLE
feat(PERC-415): leaderboard competition countdown timer + prize banner

### DIFF
--- a/app/app/leaderboard/page.tsx
+++ b/app/app/leaderboard/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import Link from "next/link";
+import CompetitionBanner from "@/components/CompetitionBanner";
 
 /* ── Types ────────────────────────────────────────────────── */
 interface LeaderboardEntry {
@@ -99,6 +100,9 @@ export default function LeaderboardPage() {
   return (
     <main className="min-h-screen pt-20 pb-24">
       <div className="max-w-3xl mx-auto px-4 sm:px-6">
+
+        {/* ── Competition Banner ─────────────────────────────────── */}
+        <CompetitionBanner />
 
         {/* ── Header ─────────────────────────────────────────────── */}
         <div className="mb-8">

--- a/app/components/CompetitionBanner.tsx
+++ b/app/components/CompetitionBanner.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/** S2 sprint end: March 21, 2026 23:59:59 UTC */
+const COMPETITION_END = new Date("2026-03-21T23:59:59Z").getTime();
+
+interface TimeLeft {
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+  expired: boolean;
+}
+
+function calcTimeLeft(): TimeLeft {
+  const diff = COMPETITION_END - Date.now();
+  if (diff <= 0) return { days: 0, hours: 0, minutes: 0, seconds: 0, expired: true };
+  return {
+    days: Math.floor(diff / 86_400_000),
+    hours: Math.floor((diff % 86_400_000) / 3_600_000),
+    minutes: Math.floor((diff % 3_600_000) / 60_000),
+    seconds: Math.floor((diff % 60_000) / 1_000),
+    expired: false,
+  };
+}
+
+function Digit({ value, label }: { value: number; label: string }) {
+  return (
+    <div className="flex flex-col items-center">
+      <span
+        className="text-2xl sm:text-3xl font-bold tabular-nums leading-none"
+        style={{
+          fontFamily: "var(--font-mono)",
+          color: "var(--text)",
+          minWidth: "2.5ch",
+          textAlign: "center",
+        }}
+      >
+        {String(value).padStart(2, "0")}
+      </span>
+      <span
+        className="text-[10px] uppercase tracking-widest mt-1"
+        style={{ color: "var(--text-muted)" }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function Separator() {
+  return (
+    <span
+      className="text-xl sm:text-2xl font-bold self-start mt-0.5"
+      style={{ color: "var(--text-muted)", opacity: 0.4 }}
+    >
+      :
+    </span>
+  );
+}
+
+export default function CompetitionBanner() {
+  const [time, setTime] = useState<TimeLeft>(calcTimeLeft);
+
+  useEffect(() => {
+    const id = setInterval(() => setTime(calcTimeLeft()), 1_000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div
+      className="relative overflow-hidden border mb-8"
+      style={{
+        background:
+          "linear-gradient(135deg, rgba(153,69,255,0.08) 0%, rgba(153,69,255,0.02) 100%)",
+        borderColor: "rgba(153,69,255,0.25)",
+      }}
+    >
+      {/* Accent line */}
+      <div
+        className="absolute top-0 left-0 right-0 h-px"
+        style={{
+          background:
+            "linear-gradient(90deg, transparent, rgba(153,69,255,0.6), transparent)",
+        }}
+      />
+
+      <div className="px-5 py-5 sm:px-6 sm:py-6">
+        {/* Top row: badges */}
+        <div className="flex items-center gap-2 mb-3">
+          <span
+            className="text-[10px] font-mono font-bold px-2 py-0.5 tracking-widest"
+            style={{
+              background: "var(--accent)",
+              color: "#fff",
+            }}
+          >
+            BETA
+          </span>
+          <span
+            className="text-[10px] font-mono px-2 py-0.5 tracking-wider border"
+            style={{
+              color: "var(--accent)",
+              borderColor: "rgba(153,69,255,0.3)",
+              background: "rgba(153,69,255,0.06)",
+            }}
+          >
+            S2 DEVNET COMPETITION
+          </span>
+        </div>
+
+        {/* Title */}
+        <h2
+          className="text-sm sm:text-base font-semibold mb-1"
+          style={{ color: "var(--text)", fontFamily: "var(--font-display)" }}
+        >
+          {time.expired
+            ? "Competition Ended"
+            : "Devnet Trading Competition — Sprint 2"}
+        </h2>
+        <p
+          className="text-xs font-mono mb-4"
+          style={{ color: "var(--text-secondary)" }}
+        >
+          {time.expired
+            ? "Final rankings are locked. Stay tuned for S3."
+            : "Trade to climb the leaderboard. Top performers earn early access + rewards."}
+        </p>
+
+        {/* Countdown */}
+        {!time.expired && (
+          <div className="flex items-center gap-2 sm:gap-3">
+            <Digit value={time.days} label="Days" />
+            <Separator />
+            <Digit value={time.hours} label="Hrs" />
+            <Separator />
+            <Digit value={time.minutes} label="Min" />
+            <Separator />
+            <Digit value={time.seconds} label="Sec" />
+
+            <span
+              className="ml-auto text-[10px] font-mono hidden sm:block"
+              style={{ color: "var(--text-muted)" }}
+            >
+              Ends Mar 21, 2026
+            </span>
+          </div>
+        )}
+
+        {time.expired && (
+          <div
+            className="text-xs font-mono px-3 py-2 inline-block border"
+            style={{
+              color: "var(--text-muted)",
+              borderColor: "var(--border)",
+              background: "var(--panel-bg)",
+            }}
+          >
+            ✓ COMPETITION COMPLETE — RANKINGS FINAL
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What
Adds a competition banner with live countdown to the S2 sprint end (Mar 21, 2026) at the top of the leaderboard page.

### New: `CompetitionBanner` component
- Live DD:HH:MM:SS countdown (updates every second)
- **BETA** + **S2 DEVNET COMPETITION** badges
- Prize/rewards copy: "Top performers earn early access + rewards"
- Expired state: shows "Competition Ended" + locked rankings message
- Uses existing CSS vars (`--accent`, `--text`, `--panel-bg`, etc.)

### Changes to `/leaderboard` page
- Imports and renders `CompetitionBanner` above the header

## How to test
1. Visit `/leaderboard` — countdown should be ticking
2. Temporarily change `COMPETITION_END` to a past date → should show expired state

Closes PERC-415

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a competition countdown banner to the Leaderboard page showing live countdown of days, hours, minutes, and seconds until competition end. The banner automatically updates and displays a completion message when the competition expires.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->