### PR TITLE
fix: idempotent guard for migration 031 (renamed from 025, safe re-apply)

### DIFF
--- a/supabase/migrations/031_fix_usdc_market_decimals.sql
+++ b/supabase/migrations/031_fix_usdc_market_decimals.sql
@@ -1,5 +1,12 @@
--- Migration 025: Fix USDC market decimals
--- 
+-- Migration 031: Fix USDC market decimals (idempotent re-apply guard)
+--
+-- HISTORY: This SQL was originally applied to prod as migration 025
+-- (025_fix_usdc_market_decimals.sql). That file was renamed to 031 in PR #687
+-- when 025 was already occupied by 025_cleanup_corrupt_insurance.sql.
+-- Supabase will now attempt to run this as a new migration — it is SAFE to
+-- re-apply because both UPDATE statements include `AND decimals != 6` guards,
+-- making them no-ops if the fix is already in place.
+--
 -- Context: The indexer's auto-registration (StatsCollector.syncMarkets) used a
 -- fallback of decimals=9 when it couldn't fetch on-chain mint info. Markets using
 -- USDC as collateral (mint EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v) should
@@ -8,10 +15,9 @@
 -- This caused the frontend to display incorrect Insurance Fund / vault values
 -- (off by 10^3 = 1000x, showing ~$1T instead of ~$1B type errors).
 --
--- This is a one-time fix. Going forward, the indexer reads decimals from on-chain
--- mint data at offset 44 (SPL Token Mint layout).
+-- This is safe to re-run: WHERE decimals != 6 ensures rows already fixed are skipped.
 
--- Fix all USDC-collateral markets to decimals=6
+-- Fix all USDC-collateral markets to decimals=6 (no-op if already correct)
 UPDATE markets
 SET decimals = 6,
     updated_at = NOW()
@@ -26,7 +32,7 @@ SET decimals = 6,
 WHERE mint_address = '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU'
   AND decimals != 6;
 
--- Log how many rows were affected (visible in migration output)
+-- Log how many rows have correct decimals=6 (0 updated = already fixed = expected on re-run)
 DO $$
 DECLARE
   affected_count INTEGER;
@@ -37,6 +43,6 @@ BEGIN
     'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
     '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU'
   ) AND decimals = 6;
-  
-  RAISE NOTICE 'USDC markets with correct decimals=6: %', affected_count;
+
+  RAISE NOTICE 'Migration 031: USDC markets with correct decimals=6: % (0 rows updated = already applied as 025, which is expected)', affected_count;
 END $$;


### PR DESCRIPTION
## Problem
Migration `031_fix_usdc_market_decimals.sql` was renamed from `025_fix_usdc_market_decimals.sql` in PR #687. Supabase tracks migrations by filename — it already has 025 applied on prod, but will now see 031 as a new unapplied migration and attempt to run it.

**Risk flagged by devops**: double-apply of the same SQL against prod.

## Why It's Already Safe (but undocumented)
Both UPDATE statements include `AND decimals != 6` in the WHERE clause. If the fix was already applied (as 025), zero rows match → both UPDATEs are no-ops. No data corruption possible.

## Fix
Added explicit comments documenting:
- The rename history (025 → 031)
- Why the SQL is safe to re-apply
- What the NOTICE output will show on re-run (0 rows updated = expected)

No SQL logic changed. Pure documentation/comment update.

## Testing
- CI green on PERC-417 lockfile fix will validate pnpm setup
- supabase db push safe to run after this merges

## Unblocks
devops can run `supabase db push` once this merges.