### PR TITLE
fix: type programsBySlabTier to fix devnet market creation

### DIFF
--- a/app/hooks/useCreateMarket.ts
+++ b/app/hooks/useCreateMarket.ts
@@ -155,10 +155,10 @@ export function useCreateMarket() {
       // PERC-277: Default to 4096 (large) — the main devnet program binary is compiled for
       // MAX_ACCOUNTS=4096. Using a smaller tier against a 4096-account program causes
       // InvalidSlabLen (error 0x4) because the program's hardcoded SLAB_LEN won't match.
-      const tierMap: Record<number, string> = { 256: "small", 1024: "medium", 4096: "large" };
-      const tierKey = tierMap[params.maxAccounts ?? 4096] ?? "large";
-      const programsByTier = (cfg as Record<string, unknown>).programsBySlabTier as Record<string, string> | undefined;
-      const selectedProgramId = programsByTier?.[tierKey] ?? cfg.programId;
+      type SlabTier = "small" | "medium" | "large";
+      const tierMap: Record<number, SlabTier> = { 256: "small", 1024: "medium", 4096: "large" };
+      const tierKey: SlabTier = tierMap[params.maxAccounts ?? 4096] ?? "large";
+      const selectedProgramId = cfg.programsBySlabTier?.[tierKey] ?? cfg.programId;
       const programId = new PublicKey(selectedProgramId);
       const isAdminOracle = params.oracleFeed === ALL_ZEROS_FEED;
       const startStep = retryFromStep ?? 0;

--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -107,7 +107,7 @@ const CONFIGS = {
       small: "FwfBKZXbYr4vTK23bMFkbgKq3npJ3MSDxEaKmq9Aj4Qn",   // 256 slots
       medium: "g9msRSV3sJmmE3r5Twn9HuBsxzuuRGTjKCVTKudm9in",   // 1024 slots
       large: "FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD",    // 4096 slots (confirmed working)
-    } as Record<string, string>,
+    } satisfies Record<string, string>,
     // PERC-356: Test USDC mint for auto-fund on wallet connect
     testUsdcMint: process.env.NEXT_PUBLIC_TEST_USDC_MINT ?? "DvH13uxzTzo1xVFwkbJ6YASkZWs6bm3vFDH4xu7kUYTs",
   },
@@ -164,6 +164,10 @@ export function getConfig() {
     slabSize: 992_560,
     matcherCtxSize: 320,
     priorityFee: 50_000,
+    // Expose programsBySlabTier with proper typing (devnet has it, mainnet doesn't yet)
+    programsBySlabTier: "programsBySlabTier" in baseConfig
+      ? (baseConfig as typeof CONFIGS.devnet).programsBySlabTier
+      : undefined,
   };
 }
 


### PR DESCRIPTION
## Problem
Market creation on devnet broken — Quick Launch defaults to small slab tier but `useCreateMarket.ts` did an unsafe cast `(cfg as Record<string, unknown>).programsBySlabTier` that resolved to `undefined` on the union return type of `getConfig()`, falling back to `cfg.programId` (the large/4096-slot program). This caused `incorrect program id for instruction 3` errors.

## Fix
1. **`app/lib/config.ts`**: Replace `as Record<string, string>` with `satisfies` to preserve literal types. Expose `programsBySlabTier` explicitly in `getConfig()` return with proper narrowing.
2. **`app/hooks/useCreateMarket.ts`**: Remove unsafe cast, access `cfg.programsBySlabTier` directly. Add `SlabTier` type for `tierMap`/`tierKey`.

## Testing
- `tsc --noEmit` passes clean
- Small tier market creation now correctly selects `FwfBKZ...` (256-slot program) instead of `FxfD37...` (4096-slot)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety and configuration structure for market tier program selection, ensuring more robust handling of tier-based program mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->