### PR TITLE
feat(PERC-419): P1 UX polish — liq price danger colors, homepage stat skeleton, leverage touch targets

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -11,6 +11,7 @@ import { GradientText } from "@/components/ui/GradientText";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
 import { OnboardingIcon } from "@/components/icons/OnboardingIcons";
 import { HeroSection } from "@/components/marketing/HeroSection";
+import { ShimmerSkeleton } from "@/components/ui/ShimmerSkeleton";
 
 /** Format large numbers compactly: 1.2T / 3.4B / 5.6M / 7.8K */
 function formatCompact(n: number): string {
@@ -220,16 +221,32 @@ export default function Home() {
             <ScrollReveal stagger={0.08}>
               <div className="grid grid-cols-2 gap-px overflow-hidden border border-[var(--border)] bg-[var(--border)] md:grid-cols-4">
                 {[
-                  { label: "Markets Live", value: statsLoaded ? String(stats.markets) : "—", color: "text-[var(--accent)]" },
-                  { label: "24h Volume", value: statsLoaded ? (stats.volume > 0 ? formatCompact(stats.volume) : "— (devnet)") : "—", color: stats.volume > 0 ? "text-[var(--long)]" : "text-[var(--text-secondary)]" },
-                  { label: "Insurance Fund", value: statsLoaded ? formatCompact(stats.insurance) : "—", color: "text-[var(--accent)]" },
+                  {
+                    label: "Markets Live",
+                    value: statsLoaded ? String(stats.markets) : null,
+                    color: "text-[var(--accent)]",
+                  },
+                  {
+                    label: "24h Volume",
+                    value: statsLoaded ? (stats.volume > 0 ? formatCompact(stats.volume) : "— (devnet)") : null,
+                    color: stats.volume > 0 ? "text-[var(--long)]" : "text-[var(--text-secondary)]",
+                  },
+                  {
+                    label: "Insurance Fund",
+                    value: statsLoaded ? formatCompact(stats.insurance) : null,
+                    color: "text-[var(--accent)]",
+                  },
                   { label: "Access", value: "Open", color: "text-[var(--long)]" },
                 ].map((stat) => (
                   <div key={stat.label} className="bg-[var(--panel-bg)] p-4 sm:p-5 transition-colors duration-200 hover:bg-[var(--bg-elevated)]">
                     <p className="mb-2 text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-secondary)]">{stat.label}</p>
-                    <p className={`text-lg sm:text-xl font-semibold tracking-tight tabular-nums ${stat.color}`} style={{ fontFamily: "var(--font-heading)" }}>
-                      {stat.value}
-                    </p>
+                    {stat.value === null ? (
+                      <ShimmerSkeleton className="h-6 w-14 mt-1" />
+                    ) : (
+                      <p className={`text-lg sm:text-xl font-semibold tracking-tight tabular-nums ${stat.color}`} style={{ fontFamily: "var(--font-heading)" }}>
+                        {stat.value}
+                      </p>
+                    )}
                   </div>
                 ))}
               </div>

--- a/app/components/trade/PositionPanel.tsx
+++ b/app/components/trade/PositionPanel.tsx
@@ -94,6 +94,17 @@ export const PositionPanel: FC<{ slabAddress: string }> = ({ slabAddress }) => {
     maintenanceBps,
   );
 
+  // Liq price danger color: amber when mark is within 10% of liq, red within 5%
+  const liqPriceColor = (() => {
+    if (liqPriceE6 <= 0n || !hasValidMark || currentPriceE6 <= 0n) return "text-[var(--warning)]";
+    const markNum = Number(currentPriceE6);
+    const liqNum = Number(liqPriceE6);
+    const distPct = Math.abs(markNum - liqNum) / markNum;
+    if (distPct < 0.05) return "text-[var(--short)]";   // <5% — critical red
+    if (distPct < 0.10) return "text-[var(--warning)]"; // <10% — amber
+    return "text-[var(--text-secondary)]";               // safe — muted
+  })();
+
   const pnlColor =
     pnlTokens === 0n
       ? "text-[var(--text-muted)]"
@@ -237,7 +248,7 @@ export const PositionPanel: FC<{ slabAddress: string }> = ({ slabAddress }) => {
             </div>
             <div className="flex items-center justify-between py-1.5">
               <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Liq. Price</span>
-              <span className="text-[11px] text-[var(--warning)]" style={{ fontFamily: "var(--font-mono)" }}>
+              <span className={`text-[11px] font-medium ${liqPriceColor}`} style={{ fontFamily: "var(--font-mono)" }}>
                 {formatLiqPrice(liqPriceE6)}
               </span>
             </div>

--- a/app/components/trade/PositionsTable.tsx
+++ b/app/components/trade/PositionsTable.tsx
@@ -114,6 +114,17 @@ export const PositionsTable: FC<{ slabAddress: string }> = ({ slabAddress }) => 
     maintenanceBps,
   );
 
+  // Liq price danger color: amber when mark is within 10% of liq, red within 5%
+  const liqPriceColor = (() => {
+    if (liqPriceE6 <= 0n || !hasValidMark || currentPriceE6 <= 0n) return "text-[var(--warning)]";
+    const markNum = Number(currentPriceE6);
+    const liqNum = Number(liqPriceE6);
+    const distPct = Math.abs(markNum - liqNum) / markNum;
+    if (distPct < 0.05) return "text-[var(--short)]";
+    if (distPct < 0.10) return "text-[var(--warning)]";
+    return "text-[var(--text-secondary)]";
+  })();
+
   const pnlColor =
     pnlTokens === 0n
       ? "text-[var(--text-muted)]"
@@ -199,7 +210,7 @@ export const PositionsTable: FC<{ slabAddress: string }> = ({ slabAddress }) => 
               </td>
 
               {/* Liq. Price */}
-              <td className="whitespace-nowrap px-3 py-2.5 text-right text-[var(--warning)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
+              <td className={`whitespace-nowrap px-3 py-2.5 text-right font-medium ${liqPriceColor}`} style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
                 {formatLiqPrice(liqPriceE6)}
               </td>
 

--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -373,7 +373,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
             <button
               key={l}
               onClick={() => setLeverage(l)}
-              className={`flex-1 rounded-none py-1 text-[10px] font-medium transition-all duration-150 focus-visible:ring-1 focus-visible:ring-[var(--accent)]/30 ${
+              className={`flex-1 rounded-none py-1.5 min-h-[44px] text-[10px] font-medium transition-all duration-150 focus-visible:ring-1 focus-visible:ring-[var(--accent)]/30 touch-manipulation ${
                 leverage === l
                   ? "bg-[var(--accent)] text-white"
                   : "border border-[var(--border)]/30 text-[var(--text-muted)] hover:border-[var(--accent)]/30 hover:text-[var(--text-secondary)]"


### PR DESCRIPTION
## Summary

Addresses **3 P1 items** from DESIGN-BRIEF-PERC-351 — all pure frontend, no backend changes.

---

### 1. Liquidation Price Danger Color Coding (P1 #8)

**PositionPanel + PositionsTable:** liq price now changes color based on proximity to mark price:
- `text-secondary` (muted) — safe, >10% away from mark
- `text-warning` (amber) — caution, within 10% of liq price
- `text-short` (red) — critical, within 5% of liq price

Traders can now glance at the liq price and immediately see their danger level without mental math.

### 2. Homepage Stats Bar Skeleton (P1 #9)

**app/page.tsx:** Replaced raw `—` em-dash placeholders with `ShimmerSkeleton` blocks while stats are loading. Affected fields: Markets Live, 24h Volume, Insurance Fund. The "Access: Open" stat is static and unchanged.

Before: loading state showed `—` dashes
After: clean shimmer animation matching the dark theme

### 3. Leverage Preset Chips Touch Targets (P1 #6)

**TradeForm.tsx:** Changed leverage preset buttons from `py-1` (~24px height) to `py-1.5 min-h-[44px]` + `touch-manipulation` to meet Apple HIG / WCAG 2.5.5 minimum 44x44px touch target. Removes 300ms tap delay on mobile.

---

## How to Test

1. **Liq colors** — open a position at high leverage (10x+); check liq price changes from muted to amber to red as price approaches liq
2. **Homepage skeleton** — throttle network in DevTools, reload /; stats should shimmer instead of showing dashes
3. **Leverage chips** — on mobile (or emulated), verify leverage presets are comfortably tappable

## Files Changed
- `app/app/page.tsx` — skeleton import + conditional render
- `app/components/trade/PositionPanel.tsx` — liqPriceColor logic
- `app/components/trade/PositionsTable.tsx` — liqPriceColor logic
- `app/components/trade/TradeForm.tsx` — touch target fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added skeleton loading placeholders for stats displays.
  * Implemented dynamic color indicators for liquidation prices—red when critically close (<5% distance), amber when at warning threshold (<10%), muted otherwise.

* **Style**
  * Enhanced leverage button sizing and touch responsiveness for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->