### PR TITLE
fix(PERC-422): resolve market slugs in /trade/[slab] route

### DIFF
--- a/app/app/api/markets/[slab]/route.ts
+++ b/app/app/api/markets/[slab]/route.ts
@@ -1,9 +1,24 @@
 import { NextRequest, NextResponse } from "next/server";
+import { PublicKey } from "@solana/web3.js";
 import { getServiceClient } from "@/lib/supabase";
 import * as Sentry from "@sentry/nextjs";
 export const dynamic = "force-dynamic";
 
-// GET /api/markets/[slab] — get single market with stats
+function isValidPublicKey(s: string): boolean {
+  try {
+    new PublicKey(s);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * GET /api/markets/[slab]
+ * Accepts either a base58 slab address OR a market slug (e.g. "SOL-PERP", "SOL").
+ * When a slug is given, resolves it by matching the `symbol` column (case-insensitive,
+ * with optional "-PERP" suffix stripped).
+ */
 export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ slab: string }> }
@@ -11,19 +26,46 @@ export async function GET(
   const { slab } = await params;
   try {
     const supabase = getServiceClient();
+    let data: Record<string, unknown> | null = null;
 
-    const { data, error } = await supabase
-      .from("markets_with_stats")
-      .select("*")
-      .eq("slab_address", slab)
-      .maybeSingle();
+    if (isValidPublicKey(slab)) {
+      // Standard lookup by slab address
+      const { data: row, error } = await supabase
+        .from("markets_with_stats")
+        .select("*")
+        .eq("slab_address", slab)
+        .maybeSingle();
 
-    if (error) {
-      Sentry.captureException(error, {
-        tags: { endpoint: "/api/markets/[slab]", method: "GET", slab },
+      if (error) {
+        Sentry.captureException(error, {
+          tags: { endpoint: "/api/markets/[slab]", method: "GET", slab },
+        });
+        return NextResponse.json({ error: error.message }, { status: 500 });
+      }
+      data = row;
+    } else {
+      // Slug resolution: strip "-PERP" suffix and match symbol case-insensitively
+      const slugNorm = slab.toUpperCase().replace(/-PERP$/, "");
+
+      // Fetch all markets and filter in JS to avoid needing ilike + function indexes
+      const { data: rows, error } = await supabase
+        .from("markets_with_stats")
+        .select("*");
+
+      if (error) {
+        Sentry.captureException(error, {
+          tags: { endpoint: "/api/markets/[slab]", method: "GET", slab },
+        });
+        return NextResponse.json({ error: error.message }, { status: 500 });
+      }
+
+      const match = (rows ?? []).find((m: Record<string, unknown>) => {
+        const sym = String(m.symbol ?? "").toUpperCase().replace(/-PERP$/, "");
+        return sym === slugNorm || String(m.symbol ?? "").toUpperCase() === slab.toUpperCase();
       });
-      return NextResponse.json({ error: error.message }, { status: 500 });
+      data = match ?? null;
     }
+
     if (!data) {
       return NextResponse.json({ error: "Market not found" }, { status: 404 });
     }

--- a/app/app/trade/[slab]/page.tsx
+++ b/app/app/trade/[slab]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use, useState, useRef, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import gsap from "gsap";
 import { PublicKey } from "@solana/web3.js";
 import { SlabProvider, useSlabState } from "@/components/providers/SlabProvider";
@@ -508,9 +509,9 @@ function InvalidAddressPage({ address }: { address: string }) {
   return (
     <div className="min-h-[calc(100vh-48px)] flex flex-col items-center justify-center gap-3">
       <div className="border border-[var(--short)]/30 bg-[var(--short)]/5 p-6 text-center max-w-md">
-        <p className="text-sm font-medium text-[var(--short)]">Invalid market address</p>
+        <p className="text-sm font-medium text-[var(--short)]">Market not found</p>
         <p className="mt-2 text-[11px] text-[var(--text-secondary)]">
-          The address in the URL is not a valid Solana public key.
+          No market exists for this address or symbol.
         </p>
         <p className="mt-2 text-[10px] text-[var(--text-dim)] break-all" style={{ fontFamily: "var(--font-mono)" }}>{address}</p>
         <a
@@ -524,11 +525,58 @@ function InvalidAddressPage({ address }: { address: string }) {
   );
 }
 
+/**
+ * Handles slugs like "SOL-PERP" or "SOL" that are not valid Solana public keys.
+ * Fetches the markets index and redirects to the resolved slab address.
+ */
+function SlugResolvePage({ slug }: { slug: string }) {
+  const router = useRouter();
+  const [resolveError, setResolveError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/markets")
+      .then((r) => r.json())
+      .then((data) => {
+        if (cancelled) return;
+        const markets: Array<{ slab_address: string; symbol?: string }> = data.markets ?? [];
+        // Normalize: "SOL-PERP" → "SOL", then match against symbol
+        const slugNorm = slug.toUpperCase().replace(/-PERP$/, "");
+        const match = markets.find((m) => {
+          const sym = (m.symbol ?? "").toUpperCase().replace(/-PERP$/, "");
+          return sym === slugNorm || (m.symbol ?? "").toUpperCase() === slug.toUpperCase();
+        });
+        if (match) {
+          router.replace(`/trade/${match.slab_address}`);
+        } else {
+          setResolveError(true);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setResolveError(true);
+      });
+    return () => { cancelled = true; };
+  }, [slug, router]);
+
+  if (resolveError) {
+    return <InvalidAddressPage address={slug} />;
+  }
+
+  return (
+    <div className="min-h-[calc(100vh-48px)] flex flex-col items-center justify-center gap-3">
+      <div className="h-8 w-8 animate-spin rounded-full border-2 border-[var(--accent)] border-t-transparent" />
+      <p className="text-[11px] text-[var(--text-muted)] uppercase tracking-[0.15em]">Resolving market…</p>
+      <p className="text-[10px] text-[var(--text-dim)]" style={{ fontFamily: "var(--font-mono)" }}>{slug}</p>
+    </div>
+  );
+}
+
 export default function TradePage({ params }: { params: Promise<{ slab: string }> }) {
   const { slab } = use(params);
 
   if (!isValidPublicKey(slab)) {
-    return <InvalidAddressPage address={slab} />;
+    // Not a valid base58 pubkey — try slug resolution (e.g. "SOL-PERP" → actual slab address)
+    return <SlugResolvePage slug={slab} />;
   }
 
   return (


### PR DESCRIPTION
## Problem
`/trade/SOL-PERP` throws **"Invalid market address"** because the route param `slab` is validated as a Solana base58 pubkey, and slugs like `SOL-PERP` fail that check immediately.

## Fix
**Client-side slug resolution (`SlugResolvePage`):**
- When the `slab` param is not a valid pubkey, renders a loading state
- Fetches `/api/markets`, finds the market whose `symbol` matches the slug (case-insensitive, strips `-PERP` suffix)
- Redirects to `/trade/<slab_address>` if found, or shows a clean error if not

**Server-side (`/api/markets/[slab]`):**
- Same resolution logic on the API side — slug inputs now return the matching market instead of 404

## Testing
- `/trade/SOL-PERP` → resolves to `/trade/<pubkey>`
- `/trade/SOL` → same
- `/trade/<invalid-garbage>` → shows "Market not found" error with Browse Markets link
- `/trade/<valid-pubkey>` → unchanged behavior

## Unblocks
PERC-418 visual QA (MarketStatsCard 3×3 grid) which requires the trade page to load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for market slug lookups (e.g., SOL-PERP) alongside slab address lookups, with automatic resolution to the corresponding market.
  * Added loading state with spinner while resolving market slugs.

* **Improvements**
  * Enhanced error messaging to clearly indicate when a market is not found by address or symbol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->