### PR TITLE
feat(PERC-426): /stake Insurance LP page

### DIFF
--- a/app/app/api/stake/pools/route.ts
+++ b/app/app/api/stake/pools/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+
+export interface StakePoolData {
+  id: string;
+  symbol: string;
+  token: string;
+  tvl_usd: number;
+  apr_pct: number;
+  cap_usd: number;
+  deposited_usd: number;
+  cooldown_slots: number;
+}
+
+const POOLS: StakePoolData[] = [
+  {
+    id: "sol-perp-pool",
+    symbol: "SOL-PERP-POOL",
+    token: "SOL",
+    tvl_usd: 50_000_000,
+    apr_pct: 12.4,
+    cap_usd: 5_000_000,
+    deposited_usd: 4_250_000,
+    cooldown_slots: 3200,
+  },
+  {
+    id: "btc-perp-pool",
+    symbol: "BTC-PERP-POOL",
+    token: "BTC",
+    tvl_usd: 12_300_000,
+    apr_pct: 9.2,
+    cap_usd: 10_000_000,
+    deposited_usd: 2_300_000,
+    cooldown_slots: 3200,
+  },
+  {
+    id: "eth-perp-pool",
+    symbol: "ETH-PERP-POOL",
+    token: "ETH",
+    tvl_usd: 8_100_000,
+    apr_pct: 7.8,
+    cap_usd: 10_000_000,
+    deposited_usd: 6_100_000,
+    cooldown_slots: 3200,
+  },
+];
+
+export async function GET() {
+  const total_staked_usd = POOLS.reduce((s, p) => s + p.tvl_usd, 0);
+  const active_pools = POOLS.length;
+  const avg_apr_pct =
+    POOLS.length > 0
+      ? POOLS.reduce((s, p) => s + p.apr_pct, 0) / POOLS.length
+      : 0;
+
+  return NextResponse.json({
+    pools: POOLS,
+    total_staked_usd,
+    active_pools,
+    avg_apr_pct: Math.round(avg_apr_pct * 10) / 10,
+  });
+}

--- a/app/app/stake/page.tsx
+++ b/app/app/stake/page.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import dynamic from "next/dynamic";
+import type { StakePoolData } from "@/app/api/stake/pools/route";
+import type { PositionData } from "@/components/stake/YourPosition";
+
+const StakeHero = dynamic(() => import("@/components/stake/StakeHero").then((m) => ({ default: m.StakeHero })), { ssr: false });
+const PoolList = dynamic(() => import("@/components/stake/PoolList").then((m) => ({ default: m.PoolList })), { ssr: false });
+const DepositWidget = dynamic(() => import("@/components/stake/DepositWidget").then((m) => ({ default: m.DepositWidget })), { ssr: false });
+const YourPosition = dynamic(() => import("@/components/stake/YourPosition").then((m) => ({ default: m.YourPosition })), { ssr: false });
+
+const MOCK_POSITION: PositionData = {
+  pool_symbol: "SOL-PERP-POOL",
+  lp_balance: 24_800,
+  est_value_usd: 25_100,
+  deposited_usd: 24_000,
+  pnl_usd: 1_100,
+  pnl_pct: 4.58,
+  cooldown_elapsed_slots: 2400,
+  cooldown_total_slots: 3200,
+};
+
+export default function StakePage() {
+  const [pools, setPools] = useState<StakePoolData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedPoolId, setSelectedPoolId] = useState<string | undefined>();
+  const [totalStaked, setTotalStaked] = useState(0);
+  const [activePools, setActivePools] = useState(0);
+  const [avgApr, setAvgApr] = useState(0);
+
+  useEffect(() => {
+    document.title = "Stake — Percolator";
+  }, []);
+
+  useEffect(() => {
+    fetch("/api/stake/pools")
+      .then((r) => r.json())
+      .then((data) => {
+        setPools(data.pools);
+        setTotalStaked(data.total_staked_usd);
+        setActivePools(data.active_pools);
+        setAvgApr(data.avg_apr_pct);
+        if (data.pools.length > 0 && !selectedPoolId) {
+          setSelectedPoolId(data.pools[0].id);
+        }
+      })
+      .finally(() => setLoading(false));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function handleDeposit(poolId: string) {
+    setSelectedPoolId(poolId);
+    document.getElementById("deposit")?.scrollIntoView({ behavior: "smooth" });
+  }
+
+  return (
+    <div className="relative min-h-screen">
+      <div className="absolute inset-x-0 top-0 h-48 bg-grid pointer-events-none" />
+
+      <div className="relative mx-auto max-w-7xl px-4 pb-16">
+        {/* Hero — full width */}
+        <StakeHero
+          totalStaked={totalStaked}
+          yourDeposits={MOCK_POSITION.est_value_usd}
+          activePools={activePools}
+          avgApr={avgApr}
+          loading={loading}
+        />
+
+        {/* Desktop: 3/5 PoolList + 2/5 DepositWidget + YourPosition */}
+        {/* Mobile: YourPosition -> DepositWidget -> PoolList */}
+        <div className="mt-8 grid grid-cols-1 gap-6 lg:grid-cols-5">
+          {/* Mobile-only: YourPosition first */}
+          <div className="lg:hidden space-y-4">
+            <YourPosition position={MOCK_POSITION} />
+            <DepositWidget pools={pools} selectedPoolId={selectedPoolId} onPoolChange={setSelectedPoolId} />
+          </div>
+
+          {/* Left column: Pool list (3/5) */}
+          <div className="lg:col-span-3">
+            <PoolList pools={pools} loading={loading} onDeposit={handleDeposit} />
+          </div>
+
+          {/* Right column: Deposit + Position (2/5) — desktop only */}
+          <div className="hidden lg:col-span-2 lg:block space-y-4">
+            <DepositWidget pools={pools} selectedPoolId={selectedPoolId} onPoolChange={setSelectedPoolId} />
+            <YourPosition position={MOCK_POSITION} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/stake/DepositWidget.tsx
+++ b/app/components/stake/DepositWidget.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState } from "react";
+import { useWalletCompat } from "@/hooks/useWalletCompat";
+import { ProgressBar } from "@/components/ui/ProgressBar";
+import type { StakePoolData } from "@/app/api/stake/pools/route";
+
+function formatUsd(n: number): string {
+  if (n >= 1_000_000_000) return `$${(n / 1_000_000_000).toFixed(1)}B`;
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}K`;
+  return `$${n.toFixed(2)}`;
+}
+
+function slotsToTime(slots: number): string {
+  const seconds = Math.round(slots * 0.4);
+  if (seconds < 60) return `~${seconds}s`;
+  return `~${Math.round(seconds / 60)} min`;
+}
+
+interface DepositWidgetProps {
+  pools: StakePoolData[];
+  selectedPoolId?: string;
+  onPoolChange?: (poolId: string) => void;
+}
+
+export function DepositWidget({ pools, selectedPoolId, onPoolChange }: DepositWidgetProps) {
+  const { connected } = useWalletCompat();
+  const [localPoolId, setLocalPoolId] = useState(pools[0]?.id ?? "");
+  const [amount, setAmount] = useState("");
+
+  const activePoolId = selectedPoolId ?? localPoolId;
+  const pool = pools.find((p) => p.id === activePoolId) ?? pools[0];
+  const amountNum = parseFloat(amount) || 0;
+
+  // LP estimate: price_per_lp = deposited / total_lp (default 1.0 for mock)
+  const pricePerLp = 1.0;
+  const lpEstimate = amountNum / pricePerLp;
+
+  const capRatio = pool ? pool.deposited_usd / pool.cap_usd : 0;
+
+  function handlePoolChange(id: string) {
+    setLocalPoolId(id);
+    onPoolChange?.(id);
+  }
+
+  return (
+    <div id="deposit" className="border border-[var(--border)] bg-[var(--panel-bg)]">
+      <div className="px-4 py-2 border-b border-[var(--border)]/30">
+        <span className="text-[10px] font-medium uppercase tracking-[0.2em] text-[var(--text-secondary)]">// DEPOSIT</span>
+      </div>
+      <div className="p-4 space-y-4">
+        {/* Pool selector */}
+        <div>
+          <label className="mb-1.5 block text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-secondary)]">Select Pool</label>
+          <select
+            value={activePoolId}
+            onChange={(e) => handlePoolChange(e.target.value)}
+            className="w-full border border-[var(--border)] bg-[var(--bg-surface)] px-3 py-2.5 text-[13px] text-[var(--text)] outline-none transition-colors focus:border-[var(--accent)]/50"
+            style={{ fontFamily: "var(--font-jetbrains-mono)" }}
+          >
+            {pools.map((p) => (
+              <option key={p.id} value={p.id}>{p.symbol}</option>
+            ))}
+          </select>
+        </div>
+
+        {/* Amount input */}
+        <div>
+          <label className="mb-1.5 block text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-secondary)]">Amount</label>
+          <div className="flex gap-2">
+            <input
+              type="number"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+              placeholder="0.00"
+              min="0"
+              step="any"
+              className="flex-1 border border-[var(--border)] bg-[var(--bg-surface)] px-3 py-2.5 text-[13px] text-[var(--text)] placeholder:text-[var(--text-muted)] outline-none transition-colors focus:border-[var(--accent)]/50 tabular-nums"
+              style={{ fontFamily: "var(--font-jetbrains-mono)" }}
+            />
+            <button className="border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-secondary)] transition-colors hover:border-[var(--accent)]/30 hover:text-[var(--accent)]">
+              MAX
+            </button>
+          </div>
+        </div>
+
+        {/* LP estimate */}
+        {amountNum > 0 && (
+          <div className="text-[12px] text-[var(--text-secondary)]">
+            You will receive ≈{" "}
+            <span className="font-medium text-[var(--text)] tabular-nums" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
+              {lpEstimate.toLocaleString(undefined, { maximumFractionDigits: 2 })} {pool?.symbol}-LP
+            </span>
+          </div>
+        )}
+
+        {/* Pool cap bar */}
+        {pool && (
+          <div>
+            <div className="flex items-center justify-between mb-1.5">
+              <span className="text-[10px] text-[var(--text-secondary)]">Pool cap</span>
+              <span className="text-[10px] text-[var(--text-muted)] tabular-nums" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
+                {formatUsd(pool.deposited_usd)} / {formatUsd(pool.cap_usd)} ({Math.round(capRatio * 100)}%)
+              </span>
+            </div>
+            <ProgressBar value={capRatio} height={6} />
+          </div>
+        )}
+
+        {/* Cooldown info */}
+        {pool && (
+          <p className="text-[10px] text-[var(--text-muted)]">
+            Cooldown period: {pool.cooldown_slots.toLocaleString()} slots ({slotsToTime(pool.cooldown_slots)} before withdrawal)
+          </p>
+        )}
+
+        {/* CTA */}
+        {!connected ? (
+          <button className="w-full py-3 border border-[var(--border)] bg-[var(--bg)] text-[12px] font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)] cursor-not-allowed">
+            Connect Wallet
+          </button>
+        ) : (
+          <button
+            disabled={amountNum <= 0}
+            className={`w-full py-3 text-[12px] font-semibold uppercase tracking-[0.1em] transition-all duration-200 ${
+              amountNum > 0
+                ? "border border-[var(--accent)]/50 bg-[var(--accent)]/[0.10] text-[var(--accent)] hover:border-[var(--accent)] hover:bg-[var(--accent)]/[0.18]"
+                : "border border-[var(--border)] bg-[var(--bg)] text-[var(--text-muted)] cursor-not-allowed"
+            }`}
+          >
+            Deposit →
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/stake/PoolCard.tsx
+++ b/app/components/stake/PoolCard.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { ProgressBar } from "@/components/ui/ProgressBar";
+import type { StakePoolData } from "@/app/api/stake/pools/route";
+
+function formatUsd(n: number): string {
+  if (n >= 1_000_000_000) return `$${(n / 1_000_000_000).toFixed(1)}B`;
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}K`;
+  return `$${n.toFixed(2)}`;
+}
+
+const POOL_COLORS: Record<string, string> = {
+  SOL: "var(--accent)",
+  BTC: "var(--warning)",
+  ETH: "var(--cyan)",
+};
+
+interface PoolCardProps {
+  pool: StakePoolData;
+  onDeposit: (poolId: string) => void;
+}
+
+export function PoolCard({ pool, onDeposit }: PoolCardProps) {
+  const capRatio = pool.cap_usd > 0 ? pool.deposited_usd / pool.cap_usd : 0;
+  const initials = pool.token.slice(0, 2);
+  const iconColor = POOL_COLORS[pool.token] ?? "var(--accent)";
+
+  return (
+    <article className="group relative border border-[var(--border)] bg-[var(--panel-bg)] p-4 sm:p-5 transition-colors duration-200 hover:bg-[var(--bg-elevated)] hover:border-[var(--border-hover)]">
+      <div className="mb-4 flex items-center justify-between">
+        <div className="flex items-center gap-2.5">
+          <div
+            className="flex h-8 w-8 items-center justify-center rounded-full text-[11px] font-bold"
+            style={{ backgroundColor: `color-mix(in srgb, ${iconColor} 15%, transparent)`, color: iconColor }}
+          >
+            {initials}
+          </div>
+          <div>
+            <h3 className="text-[13px] font-semibold text-[var(--text)]">{pool.symbol}</h3>
+            <p className="text-[10px] text-[var(--text-muted)]">POOL</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-2 text-[12px]">
+        <div className="flex justify-between">
+          <span className="text-[var(--text-secondary)]">TVL</span>
+          <span className="font-medium text-[var(--text)] tabular-nums" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>{formatUsd(pool.tvl_usd)}</span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-[var(--text-secondary)]">APR</span>
+          <span className="font-semibold text-[var(--cyan)] tabular-nums" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>{pool.apr_pct.toFixed(1)}%</span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-[var(--text-secondary)]">Cap</span>
+          <span className="text-[var(--text-muted)] tabular-nums" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>{Math.round(capRatio * 100)}% full</span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-[var(--text-secondary)]">Cooldown</span>
+          <span className="text-[var(--text-muted)] tabular-nums" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>{pool.cooldown_slots.toLocaleString()} slots</span>
+        </div>
+      </div>
+
+      <div className="mt-3">
+        <ProgressBar value={capRatio} height={4} />
+      </div>
+
+      <button
+        onClick={() => onDeposit(pool.id)}
+        className="mt-4 flex w-full items-center justify-center gap-1.5 border border-[var(--accent)]/30 bg-transparent py-2 text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--accent)] transition-all duration-200 hover:border-[var(--accent)]/60 hover:bg-[var(--accent)]/[0.06]"
+      >
+        Deposit
+      </button>
+
+      <div className="absolute bottom-0 left-0 right-0 h-px bg-[var(--accent)]/0 transition-all duration-300 group-hover:bg-[var(--accent)]/30" />
+    </article>
+  );
+}

--- a/app/components/stake/PoolList.tsx
+++ b/app/components/stake/PoolList.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { PoolCard } from "./PoolCard";
+import { ShimmerSkeleton } from "@/components/ui/ShimmerSkeleton";
+import type { StakePoolData } from "@/app/api/stake/pools/route";
+
+type SortKey = "apr" | "tvl" | "cap";
+
+interface PoolListProps {
+  pools: StakePoolData[];
+  loading: boolean;
+  onDeposit: (poolId: string) => void;
+}
+
+export function PoolList({ pools, loading, onDeposit }: PoolListProps) {
+  const [search, setSearch] = useState("");
+  const [sortBy, setSortBy] = useState<SortKey>("apr");
+
+  const filtered = useMemo(() => {
+    let result = pools;
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      result = result.filter(
+        (p) => p.symbol.toLowerCase().includes(q) || p.token.toLowerCase().includes(q),
+      );
+    }
+    return [...result].sort((a, b) => {
+      if (sortBy === "apr") return b.apr_pct - a.apr_pct;
+      if (sortBy === "tvl") return b.tvl_usd - a.tvl_usd;
+      return (b.deposited_usd / b.cap_usd) - (a.deposited_usd / a.cap_usd);
+    });
+  }, [pools, search, sortBy]);
+
+  return (
+    <section id="pools">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <span className="text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--text-secondary)]">
+          // AVAILABLE POOLS
+        </span>
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search pools..."
+            className="border border-[var(--border)] bg-[var(--bg-surface)] px-3 py-1.5 text-[12px] text-[var(--text)] placeholder:text-[var(--text-muted)] outline-none transition-colors focus:border-[var(--accent)]/50 w-36"
+          />
+          <select
+            value={sortBy}
+            onChange={(e) => setSortBy(e.target.value as SortKey)}
+            className="border border-[var(--border)] bg-[var(--bg-surface)] px-2 py-1.5 text-[12px] text-[var(--text-secondary)] outline-none"
+          >
+            <option value="apr">Sort: APR</option>
+            <option value="tvl">Sort: TVL</option>
+            <option value="cap">Sort: Cap</option>
+          </select>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="border border-[var(--border)] bg-[var(--panel-bg)] p-5 space-y-3">
+              <div className="flex items-center gap-2.5">
+                <ShimmerSkeleton className="h-8 w-8 rounded-full" />
+                <div>
+                  <ShimmerSkeleton className="h-4 w-24 mb-1" />
+                  <ShimmerSkeleton className="h-3 w-12" />
+                </div>
+              </div>
+              <ShimmerSkeleton className="h-3 w-full" />
+              <ShimmerSkeleton className="h-3 w-full" />
+              <ShimmerSkeleton className="h-3 w-full" />
+              <ShimmerSkeleton className="h-8 w-full" />
+            </div>
+          ))}
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="border border-[var(--border)] bg-[var(--panel-bg)] p-10 text-center">
+          <p className="text-[11px] uppercase tracking-[0.15em] text-[var(--text-muted)]">No pools found</p>
+          <p className="mt-1 text-[10px] text-[var(--text-muted)]">Try adjusting your search.</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {filtered.map((pool) => (
+            <PoolCard key={pool.id} pool={pool} onDeposit={onDeposit} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/components/stake/StakeHero.tsx
+++ b/app/components/stake/StakeHero.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { ScrollReveal } from "@/components/ui/ScrollReveal";
+import { AnimatedNumber } from "@/components/ui/AnimatedNumber";
+import { ShimmerSkeleton } from "@/components/ui/ShimmerSkeleton";
+
+interface StakeHeroProps {
+  totalStaked: number;
+  yourDeposits: number;
+  activePools: number;
+  avgApr: number;
+  loading: boolean;
+}
+
+export function StakeHero({ totalStaked, yourDeposits, activePools, avgApr, loading }: StakeHeroProps) {
+  const metrics = [
+    { label: "Total Staked", value: totalStaked, prefix: "$", decimals: 0, color: "text-[var(--accent)]" },
+    { label: "Your Deposits", value: yourDeposits, prefix: "$", decimals: 2, color: "text-[var(--text-secondary)]" },
+    { label: "Active Pools", value: activePools, prefix: "", decimals: 0, color: "text-[var(--accent)]" },
+    { label: "Avg APR", value: avgApr, prefix: "", suffix: "%", decimals: 1, color: "text-[var(--cyan)]" },
+  ];
+
+  return (
+    <section className="relative overflow-hidden py-12 lg:py-16">
+      <ScrollReveal>
+        <p className="mb-2 text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-secondary)]">
+          // INSURANCE LP
+        </p>
+        <h1
+          className="mb-4 text-4xl font-medium tracking-[-0.02em] sm:text-5xl lg:text-[56px]"
+          style={{ fontFamily: "var(--font-heading)" }}
+        >
+          <span className="text-[var(--text)]">Stake. Earn.</span>
+          <br />
+          <span className="text-[var(--cyan)]">Back the Fund.</span>
+        </h1>
+        <p className="mb-8 max-w-[520px] text-base leading-[1.6] text-[var(--text-secondary)]">
+          Deposit collateral into insurance pools to earn LP rewards and back the Percolator insurance fund.
+        </p>
+
+        <div className="mb-10 flex flex-wrap items-center gap-3">
+          <a
+            href="#deposit"
+            className="inline-flex items-center gap-2 rounded-full bg-[var(--accent)] px-6 py-3 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+          >
+            Deposit Now
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M12 5v14M5 12l7 7 7-7" />
+            </svg>
+          </a>
+          <a
+            href="/guide"
+            className="inline-flex items-center gap-1 rounded-full border border-[var(--cyan)]/40 px-6 py-3 text-sm font-medium text-[var(--cyan)] transition-colors hover:border-[var(--cyan)]/70 hover:bg-[var(--cyan)]/[0.06]"
+          >
+            Learn More
+          </a>
+        </div>
+
+        <div className="grid grid-cols-2 gap-px overflow-hidden border border-[var(--border)] bg-[var(--border)] md:grid-cols-4">
+          {metrics.map((m) => (
+            <div key={m.label} className="bg-[var(--panel-bg)] p-4 sm:p-5 transition-colors duration-200 hover:bg-[var(--bg-elevated)]">
+              <p className="mb-2 text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-muted)]">{m.label}</p>
+              {loading ? (
+                <ShimmerSkeleton className="h-6 w-24" />
+              ) : (
+                <span className={`text-lg sm:text-xl font-semibold tracking-tight ${m.color}`} style={{ fontFamily: "var(--font-heading)" }}>
+                  <AnimatedNumber value={m.value} prefix={m.prefix} suffix={m.suffix} decimals={m.decimals} />
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      </ScrollReveal>
+    </section>
+  );
+}

--- a/app/components/stake/YourPosition.tsx
+++ b/app/components/stake/YourPosition.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useWalletCompat } from "@/hooks/useWalletCompat";
+import { ProgressBar } from "@/components/ui/ProgressBar";
+
+export interface PositionData {
+  pool_symbol: string;
+  lp_balance: number;
+  est_value_usd: number;
+  deposited_usd: number;
+  pnl_usd: number;
+  pnl_pct: number;
+  cooldown_elapsed_slots: number;
+  cooldown_total_slots: number;
+}
+
+function formatUsd(n: number): string {
+  if (n >= 1_000_000_000) return `$${(n / 1_000_000_000).toFixed(1)}B`;
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}K`;
+  return `$${n.toFixed(2)}`;
+}
+
+function slotsToTime(slots: number): string {
+  const seconds = Math.round(slots * 0.4);
+  if (seconds < 60) return `~${seconds}s`;
+  return `~${Math.round(seconds / 60)} min`;
+}
+
+interface YourPositionProps {
+  position?: PositionData | null;
+}
+
+export function YourPosition({ position }: YourPositionProps) {
+  const { connected } = useWalletCompat();
+
+  if (!connected) {
+    return (
+      <div className="border border-[var(--border)] bg-[var(--panel-bg)] p-6 text-center">
+        <p className="text-[11px] uppercase tracking-[0.15em] text-[var(--text-muted)]">
+          Connect wallet to view your position
+        </p>
+      </div>
+    );
+  }
+
+  if (!position) {
+    return (
+      <div className="border border-[var(--border)] bg-[var(--panel-bg)] p-6 text-center">
+        <p className="text-[11px] uppercase tracking-[0.15em] text-[var(--text-muted)]">No open positions</p>
+        <p className="mt-1 text-[10px] text-[var(--text-muted)]">Deposit into a pool to get started</p>
+      </div>
+    );
+  }
+
+  const cooldownRemaining = position.cooldown_total_slots - position.cooldown_elapsed_slots;
+  const cooldownComplete = cooldownRemaining <= 0;
+  const cooldownPct = position.cooldown_total_slots > 0
+    ? position.cooldown_elapsed_slots / position.cooldown_total_slots
+    : 1;
+  const pnlPositive = position.pnl_usd >= 0;
+
+  return (
+    <div className="border border-[var(--border)] bg-[var(--panel-bg)]">
+      <div className="px-4 py-2 border-b border-[var(--border)]/30">
+        <span className="text-[10px] font-medium uppercase tracking-[0.2em] text-[var(--text-secondary)]">// YOUR POSITION</span>
+      </div>
+      <div className="p-4 space-y-3">
+        <div className="grid grid-cols-2 gap-3 text-[12px]">
+          <div>
+            <span className="text-[var(--text-secondary)]">Pool</span>
+            <p className="font-medium text-[var(--text)]">{position.pool_symbol}</p>
+          </div>
+          <div>
+            <span className="text-[var(--text-secondary)]">LP Balance</span>
+            <p className="font-medium text-[var(--text)] tabular-nums" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
+              {position.lp_balance.toLocaleString()} LP
+            </p>
+          </div>
+          <div>
+            <span className="text-[var(--text-secondary)]">Est. Value</span>
+            <p className="font-medium text-[var(--text)] tabular-nums" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
+              {formatUsd(position.est_value_usd)}
+            </p>
+          </div>
+          <div>
+            <span className="text-[var(--text-secondary)]">Deposited</span>
+            <p className="font-medium text-[var(--text)] tabular-nums" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
+              {formatUsd(position.deposited_usd)}
+            </p>
+          </div>
+        </div>
+
+        {/* PnL */}
+        <div className="text-[12px]">
+          <span className="text-[var(--text-secondary)]">PnL</span>
+          <p
+            className={`font-semibold tabular-nums ${pnlPositive ? "text-[var(--long)]" : "text-[var(--short)]"}`}
+            style={{ fontFamily: "var(--font-jetbrains-mono)" }}
+          >
+            {pnlPositive ? "+" : ""}{formatUsd(position.pnl_usd)} ({pnlPositive ? "+" : ""}{position.pnl_pct.toFixed(2)}%)
+          </p>
+        </div>
+
+        {/* Cooldown */}
+        <div>
+          <div className="flex items-center justify-between mb-1.5">
+            <span className="text-[10px] text-[var(--text-secondary)]">Cooldown</span>
+            <span className="text-[10px] text-[var(--text-muted)] tabular-nums" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
+              {cooldownComplete
+                ? "Complete"
+                : `${cooldownRemaining.toLocaleString()} slots (${slotsToTime(cooldownRemaining)})`}
+            </span>
+          </div>
+          <ProgressBar value={cooldownPct} height={8} />
+        </div>
+
+        {/* Withdraw button */}
+        <button
+          disabled={!cooldownComplete}
+          className={`w-full py-2.5 text-[12px] font-semibold uppercase tracking-[0.1em] transition-all duration-200 ${
+            cooldownComplete
+              ? "border border-[var(--cyan)]/50 bg-[var(--cyan)]/[0.10] text-[var(--cyan)] hover:border-[var(--cyan)] hover:bg-[var(--cyan)]/[0.18]"
+              : "border border-[var(--border)] bg-[var(--bg)] text-[var(--text-muted)] cursor-not-allowed"
+          }`}
+        >
+          {cooldownComplete ? "Withdraw LP →" : `Withdraw in ${cooldownRemaining.toLocaleString()} slots`}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/components/ui/ProgressBar.tsx
+++ b/app/components/ui/ProgressBar.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+interface ProgressBarProps {
+  /** 0-1 fill ratio */
+  value: number;
+  /** Height in pixels (default 8) */
+  height?: number;
+  className?: string;
+}
+
+export function ProgressBar({ value, height = 8, className = "" }: ProgressBarProps) {
+  const clamped = Math.max(0, Math.min(1, value));
+  const pct = clamped * 100;
+
+  const fillColor =
+    clamped < 0.8
+      ? "var(--accent)"
+      : clamped < 0.95
+        ? "var(--warning)"
+        : "var(--short)";
+
+  return (
+    <div
+      className={`w-full overflow-hidden rounded-full bg-[var(--border)] ${className}`}
+      style={{ height }}
+      role="progressbar"
+      aria-valuenow={Math.round(pct)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+    >
+      <div
+        className="h-full rounded-full transition-all duration-500 ease-out"
+        style={{ width: `${pct}%`, backgroundColor: fillColor }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Implements the full `/stake` Insurance LP staking page per designer spec at `~/.openclaw/percolator/designer/specs/percolator-stake-ui-spec.md`.

## Files added (8 files, 710 insertions)
| File | Description |
|------|-------------|
| `app/app/api/stake/pools/route.ts` | Mock GET API returning 3 pools (SOL/BTC/ETH) with aggregate stats |
| `app/components/ui/ProgressBar.tsx` | Reusable progress bar with auto-color (accent→warning→danger) |
| `app/components/stake/StakeHero.tsx` | Hero section with heading, CTAs, 4-stat row using AnimatedNumber |
| `app/components/stake/PoolCard.tsx` | Pool card with TVL, APR, cap bar, deposit button |
| `app/components/stake/PoolList.tsx` | Pool grid with search + sort (APR/TVL/Cap), loading skeletons |
| `app/components/stake/DepositWidget.tsx` | Deposit form with pool selector, amount input, LP estimate, cap bar |
| `app/components/stake/YourPosition.tsx` | Position panel with PnL, cooldown progress, withdraw button state machine |
| `app/app/stake/page.tsx` | Main page with dynamic imports, API fetch, responsive layout |

## Design
- All CSS vars — no hardcoded hex
- Desktop: hero full-width → 3/5 pool list + 2/5 deposit+position sidebar
- Mobile: hero → position → deposit → pool list
- Wallet-gated states: connect/deposit/cooldown/withdraw
- TypeScript check passes cleanly

## Testing
- `/stake` route renders with mock pool data
- Deposit widget shows LP estimate
- YourPosition shows sample position with cooldown
- Pool list searchable + sortable by APR/TVL/Cap

Closes PERC-426