### PR TITLE
fix(stake): add AbortController timeout to pool fetch — prevent stuck skeleton (#711)

### DIFF
--- a/app/app/stake/page.tsx
+++ b/app/app/stake/page.tsx
@@ -34,18 +34,27 @@ export default function StakePage() {
   }, []);
 
   useEffect(() => {
-    fetch("/api/stake/pools")
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 8_000);
+
+    fetch("/api/stake/pools", { signal: controller.signal })
       .then((r) => r.json())
-      .then((data) => {
-        setPools(data.pools);
-        setTotalStaked(data.total_staked_usd);
-        setActivePools(data.active_pools);
-        setAvgApr(data.avg_apr_pct);
-        if (data.pools.length > 0 && !selectedPoolId) {
+      .then((data: { pools: StakePoolData[]; total_staked_usd: number; active_pools: number; avg_apr_pct: number }) => {
+        setPools(data.pools ?? []);
+        setTotalStaked(data.total_staked_usd ?? 0);
+        setActivePools(data.active_pools ?? 0);
+        setAvgApr(data.avg_apr_pct ?? 0);
+        if ((data.pools ?? []).length > 0 && !selectedPoolId) {
           setSelectedPoolId(data.pools[0].id);
         }
       })
-      .finally(() => setLoading(false));
+      .catch(() => {})
+      .finally(() => {
+        clearTimeout(timeout);
+        setLoading(false);
+      });
+
+    return () => { clearTimeout(timeout); controller.abort(); };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
## What the issue was

On the /stake page (PR #710 preview), the hero skeleton boxes between the nav and the heading content stayed stuck indefinitely. The fetch to /api/stake/pools had no timeout, so if the Vercel cold-start delayed the response even briefly, loading could remain 	rue and the \ShimmerSkeleton\ boxes never resolved.

## What was changed

**\pp/app/stake/page.tsx\**
- Wrap the \etch('/api/stake/pools')\ call in an \AbortController\ with an **8-second timeout**. \setLoading(false)\ is called in \inally\, which fires regardless of success, error, or abort — so the skeleton always resolves.
- Add cleanup in the \useEffect\ return to cancel in-flight requests on unmount.
- Guard response fields with \?? []\ / \?? 0\ so a partial/malformed response cannot crash the component.
- Add \.catch(() => {})\ to suppress unhandled rejection noise on abort; \inally\ handles the state reset.

## Why the fix is safe and minimal

One file changed, one \useEffect\ block touched. No new dependencies. The timeout (8s) is generous for an API route that returns static mock data in <1ms locally but may be slow on a cold Vercel serverless boot. Existing behaviour when the API responds normally is identical — \inally\ still resolves \loading=false\ immediately after the successful \.then\.

Closes #711