### PR TITLE
fix(trade): resolve SOL-PERP slug via mint alias map

### DIFF
--- a/app/app/trade/[slab]/page.tsx
+++ b/app/app/trade/[slab]/page.tsx
@@ -30,7 +30,7 @@ import { computeMarketHealth } from "@/lib/health";
 import { useLivePrice } from "@/hooks/useLivePrice";
 import { useTokenMeta } from "@/hooks/useTokenMeta";
 import { useToast } from "@/hooks/useToast";
-import { isPlaceholderSymbol } from "@/lib/symbol-utils";
+import { isPlaceholderSymbol, SLUG_ALIASES } from "@/lib/symbol-utils";
 import { OracleBadge } from "@/components/oracle/OracleBadge";
 import { useOracleFreshness } from "@/hooks/useOracleFreshness";
 import { AutoDepositProvider } from "@/components/providers/AutoDepositProvider";
@@ -539,13 +539,23 @@ function SlugResolvePage({ slug }: { slug: string }) {
       .then((r) => r.json())
       .then((data) => {
         if (cancelled) return;
-        const markets: Array<{ slab_address: string; symbol?: string }> = data.markets ?? [];
+        const markets: Array<{ slab_address: string; symbol?: string; mint_address?: string }> = data.markets ?? [];
         // Normalize: "SOL-PERP" → "SOL", then match against symbol
         const slugNorm = slug.toUpperCase().replace(/-PERP$/, "");
-        const match = markets.find((m) => {
+
+        // 1. Try matching by symbol name
+        let match = markets.find((m) => {
           const sym = (m.symbol ?? "").toUpperCase().replace(/-PERP$/, "");
           return sym === slugNorm || (m.symbol ?? "").toUpperCase() === slug.toUpperCase();
         });
+
+        // 2. If no symbol match, try well-known slug aliases (e.g. SOL → mint address)
+        if (!match) {
+          const aliasMint = SLUG_ALIASES[slugNorm];
+          if (aliasMint) {
+            match = markets.find((m) => m.mint_address === aliasMint);
+          }
+        }
         if (match) {
           router.replace(`/trade/${match.slab_address}`);
         } else {

--- a/app/lib/symbol-utils.ts
+++ b/app/lib/symbol-utils.ts
@@ -4,6 +4,20 @@
  */
 
 /**
+ * Well-known slug aliases that map human-friendly ticker names to their
+ * canonical mint addresses. Used by slug resolution (e.g. /trade/SOL-PERP)
+ * when the DB `symbol` column contains a truncated address instead of
+ * a recognisable name.
+ */
+export const SLUG_ALIASES: Record<string, string> = {
+  SOL: "So11111111111111111111111111111111111111112",
+  WSOL: "So11111111111111111111111111111111111111112",
+  USDC: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  USDT: "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+  BONK: "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263",
+};
+
+/**
  * Returns true if the given symbol looks like a placeholder / truncated address
  * rather than a real human-readable token name.
  */


### PR DESCRIPTION
## Problem
`/trade/SOL-PERP` returns "Market not found" because the DB `symbol` column contains a truncated mint address (`So111111`) instead of `SOL`.

## Solution
- Add `SLUG_ALIASES` map in `lib/symbol-utils.ts` mapping well-known tickers (SOL, USDC, USDT, BONK) to canonical mint addresses
- Update `SlugResolvePage` to fall back to mint-based matching when symbol matching fails

## How to test
1. Visit `/trade/SOL-PERP` — should redirect to the SOL market slab
2. Visit `/trade/sol-perp` (lowercase) — same redirect
3. Existing pubkey-based URLs unchanged

Root cause identified by devops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced market resolution to reliably identify assets using fallback alias matching when standard symbol matching fails, improving data accuracy and consistency across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->