### PR TITLE
fix(stake): show human-readable time alongside cooldown slots in pool cards (PERC-439)

### DIFF
--- a/app/app/stake/page.tsx
+++ b/app/app/stake/page.tsx
@@ -398,7 +398,7 @@ function PoolCard({ pool }: { pool: StakePool }) {
         </div>
         <div className="flex justify-between">
           <span className="text-[var(--text-secondary)]">Cooldown</span>
-          <span className="text-[var(--text-muted)] tabular-nums" style={{ fontFamily: "var(--font-mono)" }}>{pool.cooldownSlots.toLocaleString()} slots</span>
+          <span className="text-[var(--text-muted)] tabular-nums" style={{ fontFamily: "var(--font-mono)" }}>{pool.cooldownSlots.toLocaleString()} slots ({slotsToTime(pool.cooldownSlots)})</span>
         </div>
       </div>
 


### PR DESCRIPTION
## What changed

Pool cards displayed `3,200 slots` for cooldown with no human-readable equivalent. Users had no idea how long that was.

**Before:** `3,200 slots`
**After:** `3,200 slots (~21 min)`

## How

One-line change: passed `pool.cooldownSlots` through the existing `slotsToTime()` helper (already used in the deposit widget and positions panel) and appended the result inline.

```tsx
// Before
{pool.cooldownSlots.toLocaleString()} slots

// After
{pool.cooldownSlots.toLocaleString()} slots ({slotsToTime(pool.cooldownSlots)})
```

## Why it's safe

- Zero logic changes — `slotsToTime()` was already tested in the deposit widget and positions panel
- 1 file, 1 line changed
- TypeScript clean

Closes PERC-439. Requested by designer after PERC-426 review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cooldown display in pool card now includes estimated time in addition to slot count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->