### PR TITLE
fix(trade): sort by volume_24h DESC in slug resolution to prefer active slab

### DIFF
--- a/app/app/api/markets/[slab]/route.ts
+++ b/app/app/api/markets/[slab]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { PublicKey } from "@solana/web3.js";
 import { getServiceClient } from "@/lib/supabase";
+import { SLUG_ALIASES } from "@/lib/symbol-utils";
 import * as Sentry from "@sentry/nextjs";
 export const dynamic = "force-dynamic";
 
@@ -59,10 +60,28 @@ export async function GET(
         return NextResponse.json({ error: error.message }, { status: 500 });
       }
 
-      const match = (rows ?? []).find((m: Record<string, unknown>) => {
+      // Sort by volume_24h DESC so the most active slab wins when multiple
+      // markets share the same symbol / mint (e.g. 25 SOL devnet markets).
+      const sorted = (rows ?? []).slice().sort((a: Record<string, unknown>, b: Record<string, unknown>) => {
+        const va = typeof a.volume_24h === "number" ? a.volume_24h : 0;
+        const vb = typeof b.volume_24h === "number" ? b.volume_24h : 0;
+        return vb - va;
+      });
+
+      // 1. Try symbol match (e.g. DB symbol = "SOL-PERP")
+      let match = sorted.find((m: Record<string, unknown>) => {
         const sym = String(m.symbol ?? "").toUpperCase().replace(/-PERP$/, "");
         return sym === slugNorm || String(m.symbol ?? "").toUpperCase() === slab.toUpperCase();
       });
+
+      // 2. Fallback: well-known mint alias (e.g. SOL → So111...)
+      if (!match) {
+        const aliasMint = SLUG_ALIASES[slugNorm];
+        if (aliasMint) {
+          match = sorted.find((m: Record<string, unknown>) => m.mint_address === aliasMint);
+        }
+      }
+
       data = match ?? null;
     }
 

--- a/app/app/trade/[slab]/page.tsx
+++ b/app/app/trade/[slab]/page.tsx
@@ -539,12 +539,16 @@ function SlugResolvePage({ slug }: { slug: string }) {
       .then((r) => r.json())
       .then((data) => {
         if (cancelled) return;
-        const markets: Array<{ slab_address: string; symbol?: string; mint_address?: string }> = data.markets ?? [];
+        const markets: Array<{ slab_address: string; symbol?: string; mint_address?: string; volume_24h?: number }> = data.markets ?? [];
         // Normalize: "SOL-PERP" → "SOL", then match against symbol
         const slugNorm = slug.toUpperCase().replace(/-PERP$/, "");
 
+        // Sort by volume_24h DESC so the most active slab wins when multiple
+        // markets share the same symbol / mint (e.g. 25 SOL devnet markets).
+        const sorted = [...markets].sort((a, b) => (b.volume_24h ?? 0) - (a.volume_24h ?? 0));
+
         // 1. Try matching by symbol name
-        let match = markets.find((m) => {
+        let match = sorted.find((m) => {
           const sym = (m.symbol ?? "").toUpperCase().replace(/-PERP$/, "");
           return sym === slugNorm || (m.symbol ?? "").toUpperCase() === slug.toUpperCase();
         });
@@ -553,7 +557,7 @@ function SlugResolvePage({ slug }: { slug: string }) {
         if (!match) {
           const aliasMint = SLUG_ALIASES[slugNorm];
           if (aliasMint) {
-            match = markets.find((m) => m.mint_address === aliasMint);
+            match = sorted.find((m) => m.mint_address === aliasMint);
           }
         }
         if (match) {


### PR DESCRIPTION
## Problem

`/trade/SOL-PERP` resolves to `BxJPaMaCfEGTBsjZ8wfj3Yfzf4wpasmxKAEvqZZRcGPP` — a dead/stale devnet slab — because there are 25 SOL markets with the same mint and `find()` picks whichever the DB returns first (arbitrary ordering).

Root cause identified by devops: PR #715 added SLUG_ALIASES but didn't sort before matching, so any of the 25 SOL slabs could win.

## Fix

**Both slug resolution paths** now sort by `volume_24h DESC` before `find()`:

1. **`SlugResolvePage` (client)** — sort `/api/markets` response before symbol/mint match  
2. **`/api/markets/[slab]` (server)** — same sort + add SLUG_ALIASES mint-fallback (was absent server-side despite PR #715 adding it to the frontend)

The most actively traded SOL slab (highest volume) wins, not a random stale one.

## Test

1. Visit `/trade/SOL-PERP` → should redirect to the highest-volume SOL slab (not `BxJPaM...`)
2. Visit `/trade/sol-perp` (lowercase) → same
3. `GET /api/markets/SOL-PERP` → returns the highest-volume SOL market
4. All existing pubkey-based URLs unchanged

## Notes

If no SOL market has any volume (all zero), the fix degrades gracefully — order is still deterministic (0 == 0) and at minimum avoids the previously identified bad slab once volume data is present. A follow-up to mark a specific canonical slab as `featured` in the DB is tracked separately.