### PR TITLE
fix(trade): treat vol=0 same as null in slug sort, add OI+created_at tiebreakers (fixes #721)

### DIFF
--- a/app/app/api/markets/[slab]/route.ts
+++ b/app/app/api/markets/[slab]/route.ts
@@ -60,12 +60,19 @@ export async function GET(
         return NextResponse.json({ error: error.message }, { status: 500 });
       }
 
-      // Sort by volume_24h DESC so the most active slab wins when multiple
-      // markets share the same symbol / mint (e.g. 25 SOL devnet markets).
+      // Sort to prefer the most active slab when multiple markets share the same
+      // symbol / mint (e.g. 25 SOL devnet markets).
+      // Rule: treat volume_24h=0 and volume_24h=null identically as "no volume" (-1)
+      // so a dead slab with explicit vol=0 never beats a fresh slab with vol=null.
+      // Tiebreakers: total_open_interest DESC, then created_at DESC (newest wins).
       const sorted = (rows ?? []).slice().sort((a: Record<string, unknown>, b: Record<string, unknown>) => {
-        const va = typeof a.volume_24h === "number" ? a.volume_24h : 0;
-        const vb = typeof b.volume_24h === "number" ? b.volume_24h : 0;
-        return vb - va;
+        const va = typeof a.volume_24h === "number" && (a.volume_24h as number) > 0 ? (a.volume_24h as number) : -1;
+        const vb = typeof b.volume_24h === "number" && (b.volume_24h as number) > 0 ? (b.volume_24h as number) : -1;
+        if (vb !== va) return vb - va;
+        const oa = typeof a.total_open_interest === "number" && (a.total_open_interest as number) > 0 ? (a.total_open_interest as number) : -1;
+        const ob = typeof b.total_open_interest === "number" && (b.total_open_interest as number) > 0 ? (b.total_open_interest as number) : -1;
+        if (ob !== oa) return ob - oa;
+        return new Date(String(b.created_at ?? 0)).getTime() - new Date(String(a.created_at ?? 0)).getTime();
       });
 
       // 1. Try symbol match (e.g. DB symbol = "SOL-PERP")

--- a/app/app/trade/[slab]/page.tsx
+++ b/app/app/trade/[slab]/page.tsx
@@ -539,13 +539,23 @@ function SlugResolvePage({ slug }: { slug: string }) {
       .then((r) => r.json())
       .then((data) => {
         if (cancelled) return;
-        const markets: Array<{ slab_address: string; symbol?: string; mint_address?: string; volume_24h?: number }> = data.markets ?? [];
+        const markets: Array<{ slab_address: string; symbol?: string; mint_address?: string; volume_24h?: number | null; total_open_interest?: number | null; created_at?: string }> = data.markets ?? [];
         // Normalize: "SOL-PERP" → "SOL", then match against symbol
         const slugNorm = slug.toUpperCase().replace(/-PERP$/, "");
 
-        // Sort by volume_24h DESC so the most active slab wins when multiple
-        // markets share the same symbol / mint (e.g. 25 SOL devnet markets).
-        const sorted = [...markets].sort((a, b) => (b.volume_24h ?? 0) - (a.volume_24h ?? 0));
+        // Sort to prefer the most active slab when multiple markets share the same symbol / mint.
+        // Treat volume_24h=0 and null identically as "no volume" (-1) so a stale slab with
+        // explicit vol=0 never beats a fresh slab with vol=null (fixes issue #721).
+        // Tiebreakers: total_open_interest DESC, then created_at DESC (newest wins).
+        const sorted = [...markets].sort((a, b) => {
+          const va = typeof a.volume_24h === "number" && a.volume_24h > 0 ? a.volume_24h : -1;
+          const vb = typeof b.volume_24h === "number" && b.volume_24h > 0 ? b.volume_24h : -1;
+          if (vb !== va) return vb - va;
+          const oa = typeof a.total_open_interest === "number" && a.total_open_interest > 0 ? a.total_open_interest : -1;
+          const ob = typeof b.total_open_interest === "number" && b.total_open_interest > 0 ? b.total_open_interest : -1;
+          if (ob !== oa) return ob - oa;
+          return new Date(b.created_at ?? 0).getTime() - new Date(a.created_at ?? 0).getTime();
+        });
 
         // 1. Try matching by symbol name
         let match = sorted.find((m) => {

--- a/app/app/trade/page.tsx
+++ b/app/app/trade/page.tsx
@@ -76,10 +76,16 @@ export default function TradeRedirectPage() {
           return;
         }
 
-        // Fallback: highest 24h volume
-        const sorted = [...pool].sort(
-          (a, b) => (b.volume_24h ?? 0) - (a.volume_24h ?? 0)
-        );
+        // Fallback: sort by activity — treat vol=0 and null as dead (-1) so stale
+        // slabs don't win over fresh ones. Tiebreaker: OI DESC.
+        const sorted = [...pool].sort((a, b) => {
+          const va = typeof a.volume_24h === "number" && a.volume_24h > 0 ? a.volume_24h : -1;
+          const vb = typeof b.volume_24h === "number" && b.volume_24h > 0 ? b.volume_24h : -1;
+          if (vb !== va) return vb - va;
+          const oa = typeof a.total_open_interest === "number" && a.total_open_interest > 0 ? a.total_open_interest : -1;
+          const ob = typeof b.total_open_interest === "number" && b.total_open_interest > 0 ? b.total_open_interest : -1;
+          return ob - oa;
+        });
 
         const target = sorted[0];
         if (target?.slab_address) {


### PR DESCRIPTION
## Problem

PR #720 sorted slug resolution by `volume_24h DESC` but the sort mapped `null → 0`, so `BxJPaMaCfEGTBsjZ8wfj3Yfzf4wpasmxKAEvqZZRcGPP` (explicit `vol=0`) tied with every other SOL slab (`vol=null`) and still won by arbitrary DB order.

Closes #721.

## Root Cause

```
// Before (broken)
const va = typeof a.volume_24h === "number" ? a.volume_24h : 0;  // null → 0, ties with 0
```

| Slab | volume_24h | Old sort value | New sort value |
|------|-----------|---------------|----------------|
| BxJPaM (dead) | 0 | 0 | **-1** |
| Others | null | 0 (tie!) | **-1** (tie, but now tiebreaker kicks in) |
| Live slab (future) | >0 | wins | wins |

## Fix

Treat `volume_24h = 0` and `null` as equally dead (`-1`). Among tied slabs, sort by:
1. `total_open_interest DESC` (live markets have OI)
2. `created_at DESC` (newest slab as final tiebreaker, server route only)

```ts
// After (fixed)
const va = typeof a.volume_24h === "number" && a.volume_24h > 0 ? a.volume_24h : -1;
```

## Files Changed

- `app/app/api/markets/[slab]/route.ts` — server slug resolution
- `app/app/trade/[slab]/page.tsx` — client `SlugResolvePage`
- `app/app/trade/page.tsx` — default trade redirect fallback

## Test

1. `GET /api/markets/SOL-PERP` → should NOT return `BxJPaM...`
2. `/trade/SOL-PERP` → should redirect to newest/most active SOL slab (not `BxJPaM...`)
3. TypeScript: `pnpm tsc --noEmit` passes (zero errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced market ranking algorithm to prioritize active markets with higher trading volume and open interest, preventing inactive markets from appearing above active ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->