### PR TITLE
fix(stake): designer follow-up — nav overlap, cooldown spacing, wallet hint (PERC-445)

### DIFF
--- a/app/app/globals.css
+++ b/app/app/globals.css
@@ -42,6 +42,13 @@ html {
   scroll-behavior: smooth;
 }
 
+/* Account for fixed bottom nav on mobile so anchor-scroll doesn't hide content */
+@media (max-width: 767px) {
+  html {
+    scroll-padding-bottom: 80px;
+  }
+}
+
 @theme {
   --color-background: var(--bg);
   --color-foreground: var(--text);

--- a/app/app/stake/page.tsx
+++ b/app/app/stake/page.tsx
@@ -110,6 +110,7 @@ function slotsToTime(slots: number): string {
 /* ── Hero Section ── */
 
 function StakeHero({ pools }: { pools: StakePool[] }) {
+  const { connected } = useWalletCompat();
   const totalStaked = pools.reduce((s, p) => s + p.tvl, 0);
   const activePools = pools.length;
   const avgApr = pools.length > 0
@@ -118,7 +119,11 @@ function StakeHero({ pools }: { pools: StakePool[] }) {
 
   const metrics = [
     { label: "Total Staked", value: formatUsd(totalStaked), color: "text-[var(--accent)]" },
-    { label: "Your Deposits", value: "$—", color: "text-[var(--text-secondary)]" },
+    {
+      label: "Your Deposits",
+      value: connected ? "$—" : "Connect wallet",
+      color: connected ? "text-[var(--text-secondary)]" : "text-[var(--text-muted)] text-[11px]",
+    },
     { label: "Active Pools", value: String(activePools), color: "text-[var(--accent)]" },
     { label: "Avg APR", value: avgApr > 0 ? `${avgApr.toFixed(1)}%` : "—%", color: "text-[var(--cyan)]" },
   ];
@@ -455,9 +460,9 @@ function PoolCard({ pool }: { pool: StakePool }) {
           <span className="text-[var(--text-secondary)]">Cap</span>
           <span className="text-[var(--text-muted)] tabular-nums" style={{ fontFamily: "var(--font-mono)" }}>{Math.round(capRatio * 100)}% full</span>
         </div>
-        <div className="flex justify-between">
-          <span className="text-[var(--text-secondary)]">Cooldown</span>
-          <span className="text-[var(--text-muted)] tabular-nums" style={{ fontFamily: "var(--font-mono)" }}>{pool.cooldownSlots.toLocaleString()} slots ({slotsToTime(pool.cooldownSlots)})</span>
+        <div className="flex justify-between gap-x-2">
+          <span className="shrink-0 text-[var(--text-secondary)]">Cooldown</span>
+          <span className="text-right text-[var(--text-muted)] tabular-nums" style={{ fontFamily: "var(--font-mono)" }}>{pool.cooldownSlots.toLocaleString()} slots ({slotsToTime(pool.cooldownSlots)})</span>
         </div>
       </div>
 
@@ -527,7 +532,8 @@ export default function StakePage() {
           {/* Desktop lg+: 2-column — sidebar [380px] on left, pools on right */}
           <div className="grid grid-cols-1 gap-6 lg:grid-cols-[380px_1fr]">
             {/* Left column: Position + Deposit — full-width on mobile, sidebar on lg+ */}
-            <div className="order-first space-y-4 lg:order-none w-full">
+            {/* pb-24 on mobile ensures deposit widget clears the fixed bottom nav (56px) */}
+            <div className="order-first space-y-4 pb-24 lg:order-none lg:pb-0 w-full">
               <ErrorBoundary label="Your Position">
                 <YourPositionPanel position={position} />
               </ErrorBoundary>


### PR DESCRIPTION
## What
Follow-up to PR #723 — addressing designer visual QA feedback on /stake at 375px.

## Changes

### 🔴 Critical (blocking)
- **Nav bar overlap fix**: Added `pb-24 lg:pb-0` to the left column wrapper on mobile — ensures the deposit widget (SELECT POOL dropdown) clears the 56px fixed bottom nav. Added `scroll-padding-bottom: 80px` to globals.css for mobile so anchor-scroll (#deposit) also accounts for the nav.

### 🟡 Minor
- **Cooldown label spacing**: Added `gap-x-2` and `shrink-0` to the Cooldown stat row in PoolCard — prevents label and value from visually colliding on narrow cards (`Cooldown3,200 slots` → `Cooldown  3,200 slots`).

### 🟢 Nice-to-have
- **Your Deposits hint**: StakeHero now reads wallet connection state via `useWalletCompat()` and shows `Connect wallet` (muted, smaller) in the YOUR DEPOSITS metric tile when the wallet is not connected, instead of bare `$—`.

## Testing
- At 375px: SELECT POOL dropdown is fully visible above the bottom nav ✓
- Cooldown row in all 3 pool cards shows correct spacing ✓  
- Disconnected wallet shows 'Connect wallet' hint in hero metrics ✓

## Task
PERC-445 (designer follow-up)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dynamic wallet connection state indication in the staking interface.

* **Bug Fixes**
  * Improved mobile anchor link visibility when using fixed bottom navigation.
  * Fixed deposit widget positioning on mobile to prevent overlap with bottom navigation.
  * Refined layout spacing for staking pool information display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->