### PR TITLE
fix(PERC-446): validate mint exists on-chain before Step 2 (bug #725)

### DIFF
--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -86,6 +86,9 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
   const quickMintForHook = wizard.mode === "quick" && wizard.mintAddress.length >= 32 ? wizard.mintAddress : null;
   const quickLaunch = useQuickLaunch(quickMintForHook);
 
+  // On-chain mint network validation (set by StepTokenSelect)
+  const [mintExistsOnNetwork, setMintExistsOnNetwork] = useState(false);
+
   // SOL balance for cost check in review step
   const [solBalance, setSolBalance] = useState<number | null>(null);
   useEffect(() => {
@@ -120,7 +123,7 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
   const symbol = wizard.tokenMeta?.symbol ?? "Token";
 
   // Step validation
-  const step1Valid = mintValid && wizard.tokenMeta !== null && (wizard.tokenMeta.decimals <= 12);
+  const step1Valid = mintValid && wizard.tokenMeta !== null && (wizard.tokenMeta.decimals <= 12) && mintExistsOnNetwork;
   const step2Valid = (() => {
     if (wizard.oracleType === "admin") return true;
     if (wizard.oracleType === "pyth") return isValidHex64(wizard.oracleFeed);
@@ -243,6 +246,8 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
   // Updaters (memoized to avoid unnecessary re-renders in children)
   const setMintAddress = useCallback((mint: string) => {
     setWizard((prev) => ({ ...prev, mintAddress: mint }));
+    // Reset network validation when mint changes
+    setMintExistsOnNetwork(false);
   }, []);
 
   const setTokenMeta = useCallback(
@@ -479,6 +484,7 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
             onMintChange={setMintAddress}
             onTokenResolved={setTokenMeta}
             onBalanceChange={setWalletBalance}
+            onMintNetworkValidChange={setMintExistsOnNetwork}
             onContinue={() => advanceStep(1)}
             canContinue={step1Valid}
           />

--- a/app/components/create/StepTokenSelect.tsx
+++ b/app/components/create/StepTokenSelect.tsx
@@ -3,10 +3,12 @@
 import { FC, useState, useEffect, useMemo } from "react";
 import { PublicKey } from "@solana/web3.js";
 import { useWalletCompat, useConnectionCompat } from "@/hooks/useWalletCompat";
-import { getAssociatedTokenAddress, getAccount } from "@solana/spl-token";
+import { getAssociatedTokenAddress, getAccount, TOKEN_PROGRAM_ID, TOKEN_2022_PROGRAM_ID } from "@solana/spl-token";
 import { useTokenMeta } from "@/hooks/useTokenMeta";
 import { formatHumanAmount } from "@/lib/parseAmount";
 import { isValidBase58Pubkey } from "@/lib/createWizardUtils";
+
+type MintNetworkStatus = "idle" | "loading" | "valid" | "invalid";
 
 interface StepTokenSelectProps {
   mintAddress: string;
@@ -14,6 +16,7 @@ interface StepTokenSelectProps {
   onTokenResolved: (meta: { name: string; symbol: string; decimals: number } | null) => void;
   onBalanceChange: (balance: bigint | null) => void;
   onDexPoolDetected?: (pool: { priceUsd: number; pairLabel: string } | null) => void;
+  onMintNetworkValidChange?: (valid: boolean) => void;
   onContinue: () => void;
   canContinue: boolean;
 }
@@ -27,6 +30,7 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
   onMintChange,
   onTokenResolved,
   onBalanceChange,
+  onMintNetworkValidChange,
   onContinue,
   canContinue,
 }) => {
@@ -36,6 +40,7 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
   const [debounced, setDebounced] = useState(mintAddress);
   const [balance, setBalance] = useState<bigint | null>(null);
   const [balanceLoading, setBalanceLoading] = useState(false);
+  const [mintNetworkStatus, setMintNetworkStatus] = useState<MintNetworkStatus>("idle");
 
   // Debounce mint input
   useEffect(() => {
@@ -57,6 +62,47 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
     [debounced, mintValid]
   );
   const tokenMeta = useTokenMeta(mintPk);
+
+  // On-chain mint existence validation — ensures the CA exists on the current network
+  useEffect(() => {
+    if (!mintPk) {
+      setMintNetworkStatus("idle");
+      onMintNetworkValidChange?.(false);
+      return;
+    }
+    let cancelled = false;
+    setMintNetworkStatus("loading");
+    (async () => {
+      try {
+        const accountInfo = await connection.getAccountInfo(mintPk);
+        if (cancelled) return;
+        if (!accountInfo) {
+          // Account does not exist on this network
+          setMintNetworkStatus("invalid");
+          onMintNetworkValidChange?.(false);
+          return;
+        }
+        // Verify the account is owned by a Token program (SPL Token or Token-2022)
+        const ownerKey = accountInfo.owner.toBase58();
+        const isTokenMint =
+          ownerKey === TOKEN_PROGRAM_ID.toBase58() ||
+          ownerKey === TOKEN_2022_PROGRAM_ID.toBase58();
+        if (!isTokenMint) {
+          setMintNetworkStatus("invalid");
+          onMintNetworkValidChange?.(false);
+          return;
+        }
+        setMintNetworkStatus("valid");
+        onMintNetworkValidChange?.(true);
+      } catch {
+        if (!cancelled) {
+          setMintNetworkStatus("invalid");
+          onMintNetworkValidChange?.(false);
+        }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [mintPk, connection, onMintNetworkValidChange]);
 
   // Propagate token meta changes
   useEffect(() => {
@@ -96,7 +142,10 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
   }, [connection, publicKey, debounced, mintValid, onBalanceChange]);
 
   const showInvalid = debounced.length > 0 && !mintValid;
-  const showResolved = mintValid && tokenMeta;
+  const showResolved = mintValid && tokenMeta && mintNetworkStatus === "valid";
+  // Block continue if mint doesn't exist on the current network or is still being checked
+  const mintNetworkBlocked = mintValid && (mintNetworkStatus === "loading" || mintNetworkStatus === "invalid");
+  const effectiveCanContinue = canContinue && !mintNetworkBlocked;
 
   return (
     <div className="space-y-5">
@@ -125,6 +174,17 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
             {mintIsUrl
               ? "Paste a valid Solana token address, not a URL"
               : "Invalid mint address — must be a base58 Solana token address"}
+          </p>
+        )}
+        {/* Network-level mint validation feedback */}
+        {mintValid && mintNetworkStatus === "loading" && (
+          <p className="mt-1.5 text-[10px] text-[var(--text-dim)] animate-pulse">
+            ⏳ Checking mint on network...
+          </p>
+        )}
+        {mintValid && mintNetworkStatus === "invalid" && (
+          <p className="mt-1.5 text-[10px] text-[var(--short)]">
+            ✗ Mint not found on this network — use a token that exists on the current cluster (devnet/mainnet)
           </p>
         )}
       </div>
@@ -189,10 +249,10 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
       <button
         type="button"
         onClick={onContinue}
-        disabled={!canContinue}
+        disabled={!effectiveCanContinue}
         className="w-full border border-[var(--accent)]/50 bg-[var(--accent)]/[0.08] py-3 text-[13px] font-bold uppercase tracking-[0.1em] text-[var(--accent)] transition-all duration-200 hud-btn-corners hover:border-[var(--accent)] hover:bg-[var(--accent)]/[0.15] disabled:cursor-not-allowed disabled:border-[var(--border)] disabled:bg-transparent disabled:text-[var(--text-dim)] disabled:opacity-50"
       >
-        CONTINUE →
+        {mintNetworkStatus === "loading" ? "VALIDATING..." : "CONTINUE →"}
       </button>
     </div>
   );


### PR DESCRIPTION
## Problem
Bug #725: CREATE MARKET wizard accepted any base58 token CA — including mainnet Pump.fun tokens — completed all 4 steps, then failed on-chain with `IncorrectProgramId`. No validation that the mint actually exists on the current network (devnet/mainnet).

## Root Cause
`StepTokenSelect` only validated that the input was a valid base58 pubkey. Token metadata was resolved from Jupiter/registry APIs (network-agnostic), so a mainnet token appeared resolved even on devnet. The on-chain failure only surfaced at tx submission.

## Fix
**`StepTokenSelect.tsx`**
- Added `mintNetworkStatus: 'idle' | 'loading' | 'valid' | 'invalid'` state
- After debounce resolves a valid base58 address, calls `connection.getAccountInfo(mintPk)`
- Validates account exists AND owner is `TOKEN_PROGRAM_ID` or `TOKEN_2022_PROGRAM_ID`
- Shows `⏳ Checking mint on network...` while in-flight
- Shows `✗ Mint not found on this network` with actionable copy on failure
- Continue button disabled during check (`VALIDATING...`) and on invalid result
- Added `onMintNetworkValidChange?: (valid: boolean) => void` prop to surface state

**`CreateMarketWizard.tsx`**
- Added `mintExistsOnNetwork` boolean state (default `false`, reset on mint change)
- Included in `step1Valid` — blocks both the Continue button AND quick-launch auto-advance
- Passes `onMintNetworkValidChange={setMintExistsOnNetwork}` to `StepTokenSelect`

## Testing
- Enter mainnet Pump.fun CA on devnet → wizard blocks at Step 1 with clear error
- Enter valid devnet mint → validation passes, wizard proceeds normally
- TypeScript: `pnpm tsc --noEmit` — clean
- Test suite: 797 passed, 0 failures

Closes #725

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
* Added on-chain mint validation to verify tokens exist on the current network during token selection
* Implemented real-time validation feedback with loading indicators and error messaging when tokens are not found on the current network
* Updated token selection flow to require successful network validation before proceeding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->