### PR TITLE
fix(create): validate mint exists on-chain before wizard proceeds (PERC-446)

### DIFF
--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -32,6 +32,7 @@ interface WizardState {
   mintAddress: string;
   tokenMeta: { name: string; symbol: string; decimals: number } | null;
   walletBalance: bigint | null;
+  mintExistsOnChain: boolean | null;
   // Step 2
   oracleType: "pyth" | "hyperp_ema" | "admin";
   oracleFeed: string;
@@ -52,6 +53,7 @@ const DEFAULT_STATE: WizardState = {
   mintAddress: "",
   tokenMeta: null,
   walletBalance: null,
+  mintExistsOnChain: null,
   oracleType: "admin",
   oracleFeed: "",
   dexPool: null,
@@ -120,7 +122,7 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
   const symbol = wizard.tokenMeta?.symbol ?? "Token";
 
   // Step validation
-  const step1Valid = mintValid && wizard.tokenMeta !== null && (wizard.tokenMeta.decimals <= 12);
+  const step1Valid = mintValid && wizard.tokenMeta !== null && (wizard.tokenMeta.decimals <= 12) && wizard.mintExistsOnChain === true;
   const step2Valid = (() => {
     if (wizard.oracleType === "admin") return true;
     if (wizard.oracleType === "pyth") return isValidHex64(wizard.oracleFeed);
@@ -254,6 +256,10 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
 
   const setWalletBalance = useCallback((balance: bigint | null) => {
     setWizard((prev) => ({ ...prev, walletBalance: balance }));
+  }, []);
+
+  const setMintExistsOnChain = useCallback((exists: boolean | null) => {
+    setWizard((prev) => ({ ...prev, mintExistsOnChain: exists }));
   }, []);
 
   const setOracleType = useCallback(
@@ -479,6 +485,7 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
             onMintChange={setMintAddress}
             onTokenResolved={setTokenMeta}
             onBalanceChange={setWalletBalance}
+            onMintExistsChange={setMintExistsOnChain}
             onContinue={() => advanceStep(1)}
             canContinue={step1Valid}
           />

--- a/app/components/create/StepTokenSelect.tsx
+++ b/app/components/create/StepTokenSelect.tsx
@@ -14,6 +14,7 @@ interface StepTokenSelectProps {
   onTokenResolved: (meta: { name: string; symbol: string; decimals: number } | null) => void;
   onBalanceChange: (balance: bigint | null) => void;
   onDexPoolDetected?: (pool: { priceUsd: number; pairLabel: string } | null) => void;
+  onMintExistsChange?: (exists: boolean | null) => void;
   onContinue: () => void;
   canContinue: boolean;
 }
@@ -27,6 +28,7 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
   onMintChange,
   onTokenResolved,
   onBalanceChange,
+  onMintExistsChange,
   onContinue,
   canContinue,
 }) => {
@@ -36,6 +38,8 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
   const [debounced, setDebounced] = useState(mintAddress);
   const [balance, setBalance] = useState<bigint | null>(null);
   const [balanceLoading, setBalanceLoading] = useState(false);
+  const [mintExists, setMintExists] = useState<boolean | null>(null);
+  const [mintCheckLoading, setMintCheckLoading] = useState(false);
 
   // Debounce mint input
   useEffect(() => {
@@ -57,6 +61,32 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
     [debounced, mintValid]
   );
   const tokenMeta = useTokenMeta(mintPk);
+
+  // Validate mint account exists on-chain (current network)
+  useEffect(() => {
+    if (!mintPk) {
+      setMintExists(null);
+      return;
+    }
+    let cancelled = false;
+    setMintCheckLoading(true);
+    (async () => {
+      try {
+        const info = await connection.getAccountInfo(mintPk);
+        if (!cancelled) setMintExists(info !== null);
+      } catch {
+        if (!cancelled) setMintExists(false);
+      } finally {
+        if (!cancelled) setMintCheckLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [connection, mintPk]);
+
+  // Propagate mint existence status
+  useEffect(() => {
+    onMintExistsChange?.(mintExists);
+  }, [mintExists, onMintExistsChange]);
 
   // Propagate token meta changes
   useEffect(() => {
@@ -125,6 +155,16 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
             {mintIsUrl
               ? "Paste a valid Solana token address, not a URL"
               : "Invalid mint address — must be a base58 Solana token address"}
+          </p>
+        )}
+        {mintValid && !mintCheckLoading && mintExists === false && (
+          <p className="mt-1.5 text-[10px] text-[var(--short)]">
+            Token mint not found on this network. Make sure you&apos;re using a devnet token address.
+          </p>
+        )}
+        {mintValid && mintCheckLoading && (
+          <p className="mt-1.5 text-[10px] text-[var(--text-dim)]">
+            Verifying mint on-chain…
           </p>
         )}
       </div>


### PR DESCRIPTION
## What
Fixes #725 — CREATE MARKET wizard accepted mainnet-only token CAs on devnet, proceeded through all 4 steps, then failed on-chain with a confusing `IncorrectProgramId` error.

## Changes
**StepTokenSelect.tsx:**
- Added `getAccountInfo` check after mint address resolves — validates the mint account exists on the current network RPC
- Shows "Token mint not found on this network" error when mint doesn't exist
- Shows "Verifying mint on-chain…" loading state during check
- New `onMintExistsChange` callback propagates result to parent

**CreateMarketWizard.tsx:**
- Added `mintExistsOnChain` to wizard state
- `step1Valid` now requires `mintExistsOnChain === true` — Continue button disabled until on-chain validation passes

## Testing
- Build passes ✅
- Enter mainnet CA on devnet → "Token mint not found on this network" error, Continue disabled
- Enter valid devnet CA → resolves normally, Continue enabled
- Handles RPC errors gracefully (treats as not found)

## Task
PERC-446 | Closes #725