### PR TITLE
fix(stake): pool cards invisible + mobile overflow + stats bar clipping (PERC-445)

### DIFF
--- a/app/app/globals.css
+++ b/app/app/globals.css
@@ -40,6 +40,7 @@
 
 html {
   scroll-behavior: smooth;
+  overflow-x: hidden; /* prevent horizontal scroll at viewport level */
 }
 
 /* Account for fixed bottom nav on mobile so anchor-scroll doesn't hide content */

--- a/app/app/stake/page.tsx
+++ b/app/app/stake/page.tsx
@@ -169,9 +169,9 @@ function StakeHero({ pools }: { pools: StakePool[] }) {
           {/* Metrics row */}
           <div className="grid grid-cols-2 gap-px overflow-hidden border border-[var(--border)] bg-[var(--border)] md:grid-cols-4">
             {metrics.map((m) => (
-              <div key={m.label} className="bg-[var(--panel-bg)] p-4 sm:p-5 transition-colors duration-200 hover:bg-[var(--bg-elevated)]">
-                <p className="mb-2 text-[10px] font-medium uppercase tracking-[0.2em] text-[#9ca3af]">{m.label}</p>
-                <p className={`text-lg sm:text-xl font-semibold tracking-tight tabular-nums ${m.color}`} style={{ fontFamily: "var(--font-heading)" }}>
+              <div key={m.label} className="min-w-0 overflow-hidden bg-[var(--panel-bg)] p-3 sm:p-5 transition-colors duration-200 hover:bg-[var(--bg-elevated)]">
+                <p className="mb-1.5 truncate text-[9px] font-medium uppercase tracking-[0.15em] text-[#9ca3af] sm:text-[10px] sm:tracking-[0.2em]">{m.label}</p>
+                <p className={`truncate text-base font-semibold tracking-tight tabular-nums sm:text-xl ${m.color}`} style={{ fontFamily: "var(--font-heading)" }}>
                   {m.value}
                 </p>
               </div>
@@ -502,7 +502,7 @@ function PoolList({ pools }: { pools: StakePool[] }) {
       <div className="mb-4 flex items-center justify-between">
         <span className="text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--accent)]/60">// available pools</span>
       </div>
-      <div className="grid grid-cols-1 gap-px overflow-hidden border border-[var(--border)] bg-[var(--border)] sm:grid-cols-3">
+      <div className="grid grid-cols-1 gap-px overflow-hidden border border-[var(--border)] bg-[var(--border)] lg:grid-cols-3">
         {pools.map((pool) => (
           <PoolCard key={pool.id} pool={pool} />
         ))}
@@ -533,7 +533,7 @@ export default function StakePage() {
           <div className="grid grid-cols-1 gap-6 lg:grid-cols-[380px_1fr]">
             {/* Left column: Position + Deposit — full-width on mobile, sidebar on lg+ */}
             {/* pb-24 on mobile ensures deposit widget clears the fixed bottom nav (56px) */}
-            <div className="order-first space-y-4 pb-24 lg:order-none lg:pb-0 w-full">
+            <div className="space-y-4 pb-24 lg:pb-0">
               <ErrorBoundary label="Your Position">
                 <YourPositionPanel position={position} />
               </ErrorBoundary>
@@ -542,8 +542,8 @@ export default function StakePage() {
               </ErrorBoundary>
             </div>
 
-            {/* Right column: Pool list — order-last on mobile */}
-            <div className="order-last min-w-0 lg:order-none">
+            {/* Right column: Pool list — stacks below on mobile, sidebar on lg+ */}
+            <div className="min-w-0">
               <ErrorBoundary label="Pool List">
                 <PoolList pools={pools} />
               </ErrorBoundary>


### PR DESCRIPTION
## What changed

Designer re-review of PR #724 found 3 remaining failures. This fixes all of them.

### 🔴 Pool cards invisible at all viewports (CRITICAL)
- **Root cause**: `sm:grid-cols-3` on the pool card grid conflicted with the parent `lg:grid-cols-[380px_1fr]` layout, per designer's diagnosis
- **Fix**: Revert to `lg:grid-cols-3` — cards are single-column at mobile/tablet, 3-col only at desktop where the right sidebar has proper width (~648px)
- **Also**: Removed `order-first` / `order-last` / `lg:order-none` cascade from both columns. DOM order already has deposit first and pool list second at all breakpoints — the order classes were redundant and potentially misfiring at lg+ breakpoint

### 🔴 Mobile overflow (body scrollWidth 488px at 375px)
- **Fix**: Added `overflow-x: hidden` to `html` element in globals.css
- The page-wrapper's `overflow-x-hidden` wasn't propagating up to body level; viewport-level containment on `html` is the proper fix

### 🟡 Stats bar columns truncated/clipped on mobile
- **Fix**: Added `min-w-0 overflow-hidden truncate` to each metric cell
- Reduced mobile padding to `p-3` (`sm:p-5` at 640px+)
- Shrunk label to `text-[9px]` on mobile (`sm:text-[10px]`)
- Value: `text-base` on mobile (`sm:text-xl` at 640px+)

## How to test
- Open /stake at 375px: pool cards should stack vertically below deposit widget, no horizontal scroll
- Open /stake at 1440px: 2-column layout renders with SOL-PERP/BTC-PERP/ETH-PERP cards visible in right column
- Stats bar: all 4 metrics legible and non-clipped at 375px

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Prevented unwanted horizontal scrolling at viewport level
  * Updated metrics display styling with improved text truncation, sizing, and color treatment
  * Adjusted responsive grid layout breakpoint for better mobile-to-desktop scaling
  * Refined staking page column layout, spacing, and ordering for improved mobile and desktop views

<!-- end of auto-generated comment: release notes by coderabbit.ai -->