### PR TITLE
fix: remove global overflow-x:hidden from html element

### DIFF
--- a/app/app/globals.css
+++ b/app/app/globals.css
@@ -40,7 +40,6 @@
 
 html {
   scroll-behavior: smooth;
-  overflow-x: hidden; /* prevent horizontal scroll at viewport level */
 }
 
 /* Account for fixed bottom nav on mobile so anchor-scroll doesn't hide content */


### PR DESCRIPTION
## What
Remove `overflow-x: hidden` from the global `html` rule in `globals.css`.

## Why
Added in PR #728 for the stake mobile layout fix, but it clips horizontal scroll on **CommitHeatmap**, **TradeHistory**, and **CodeBlock** components site-wide. The stake route already scopes `overflow-x-hidden` on its own wrapper (`<div class="... overflow-x-hidden">`), so the global rule is redundant there and harmful elsewhere.

Flagged by CodeRabbit on PR #728.

## How to test
1. Visit `/` — confirm CommitHeatmap scrolls horizontally on narrow viewports
2. Visit `/stake` on 375px mobile — confirm no horizontal overflow regression
3. Check TradeHistory table on narrow screens — horizontal scroll works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enabled horizontal scrolling at the viewport level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->