### PR TITLE
fix: scope overflow-x:hidden to /stake wrapper, not global html

### DIFF
--- a/app/app/globals.css
+++ b/app/app/globals.css
@@ -40,7 +40,6 @@
 
 html {
   scroll-behavior: smooth;
-  overflow-x: hidden; /* prevent horizontal scroll at viewport level */
 }
 
 /* Account for fixed bottom nav on mobile so anchor-scroll doesn't hide content */


### PR DESCRIPTION
## What changed

Removes `overflow-x: hidden` from the `html` rule in `globals.css` (added in PR #728).

## Why

CodeRabbit flagged that global `overflow-x: hidden` on `html` may regress horizontal scroll in components like **CommitHeatmap**, **TradeHistory**, and **CodeBlock** on other routes.

The `/stake` page root div already has `overflow-x-hidden` via Tailwind (`className="relative min-h-screen overflow-x-hidden"`), so viewport-level containment via the `html` selector is redundant.

## Fix

- Removed `overflow-x: hidden` from `html` in `globals.css`
- `/stake` mobile overflow is still contained by the page-level wrapper div (no behaviour change there)
- All other routes (trade, dashboard, etc.) regain proper horizontal scroll where needed

## How to test

- Open `/stake` at 375px — no horizontal scroll should appear ✅
- Open `/trade` at any width — TradeHistory / OrderBook horizontal scroll works ✅
- Open any page with a `CodeBlock` component — horizontal scroll within the block works ✅