### PR TITLE
fix(stake): mobile nav overlap + desktop pool grid clipping (PERC-447 regressions)

### DIFF
--- a/app/app/stake/page.tsx
+++ b/app/app/stake/page.tsx
@@ -488,7 +488,7 @@ function PoolList({ pools, loading }: { pools: StakePool[]; loading: boolean }) 
         <div className="mb-4 flex items-center justify-between">
           <span className="text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--accent)]/60">// available pools</span>
         </div>
-        <div className="grid grid-cols-1 gap-px overflow-hidden border border-[var(--border)] bg-[var(--border)] lg:grid-cols-3">
+        <div className="grid grid-cols-1 gap-px overflow-hidden border border-[var(--border)] bg-[var(--border)] lg:grid-cols-2 xl:grid-cols-3">
           {[0, 1, 2].map((i) => (
             <div key={i} className="bg-[var(--panel-bg)] p-4 sm:p-5 space-y-3">
               <div className="flex items-center gap-2.5 mb-4">
@@ -528,7 +528,7 @@ function PoolList({ pools, loading }: { pools: StakePool[]; loading: boolean }) 
       <div className="mb-4 flex items-center justify-between">
         <span className="text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--accent)]/60">// available pools</span>
       </div>
-      <div className="grid grid-cols-1 gap-px overflow-hidden border border-[var(--border)] bg-[var(--border)] lg:grid-cols-3">
+      <div className="grid grid-cols-1 gap-px overflow-hidden border border-[var(--border)] bg-[var(--border)] lg:grid-cols-2 xl:grid-cols-3">
         {pools.map((pool) => (
           <PoolCard key={pool.id} pool={pool} />
         ))}
@@ -588,7 +588,8 @@ export default function StakePage() {
             </div>
 
             {/* Right column: Pool list — stacks below on mobile, sidebar on lg+ */}
-            <div className="min-w-0">
+            {/* pb-24 on mobile clears the fixed bottom nav (56px + safe-area) */}
+            <div className="min-w-0 pb-24 lg:pb-0">
               <ErrorBoundary label="Pool List">
                 <PoolList pools={pools} loading={poolsLoading} />
               </ErrorBoundary>


### PR DESCRIPTION
## What
Two 🔴 visual regressions caught by designer QA after PERC-447 (#731) live deploy.

## Changes

### 1. Mobile 375px — deposit widget / nav bar overlap 🔴
Added `pb-24 lg:pb-0` to pool list right column. On mobile (single-column stack), the pool list is the last DOM element and had zero bottom padding — fixed nav (56px) was clipping it and the deposit widget above.

### 2. Desktop 1440px — pool card grid clipping 🔴
Changed `lg:grid-cols-3` → `lg:grid-cols-2 xl:grid-cols-3`. At 1024-1279px the right column is ~572px — 3 cards with overflow-hidden clips the third. Now 2 cols at lg, 3 cols at xl (1280px+); full 3-card layout at 1440px with room to spare.

## Build
`pnpm build` — clean exit 0.

Fixes PERC-447 post-deploy visual regressions.