### PR TITLE
fix(stake): mobile nav overlap + desktop grid clarification

### DIFF
--- a/app/app/stake/page.tsx
+++ b/app/app/stake/page.tsx
@@ -571,7 +571,7 @@ export default function StakePage() {
       </ErrorBoundary>
 
       {/* Main content */}
-      <div className="mx-auto max-w-[1100px] px-6 pb-16">
+      <div className="mx-auto max-w-[1100px] px-6 pb-24 lg:pb-16">
         <ScrollReveal>
           {/* Mobile: single-column stack (position → deposit → pools) */}
           {/* Desktop lg+: 2-column — sidebar [380px] on left, pools on right */}


### PR DESCRIPTION
## What
- Increase outer content container bottom padding to `pb-24` (96px) on mobile to clear the fixed bottom nav bar (56px + safe area inset). Desktop retains `pb-16`.

## Why
Designer visual QA flagged the bottom nav overlapping the deposit widget and pool cards on 375px mobile.

## Desktop grid clipping note
The 'third card clipping' at 1440px is likely the loading skeleton (renders 3 placeholder cells) transitioning to 2 real pool cards. With only 2 active devnet pools, the `lg:grid-cols-3` grid correctly shows 2 cards with an empty third cell. No code change needed — this resolves when pools finish loading.

## Carousel controls
No carousel controls exist in the stake page code. The ▶◀✕ buttons designer saw may be browser-injected media controls or a different component. Need screenshots to investigate further.

## How to test
1. Visit `/stake` at 375px — deposit widget and pool cards should clear the bottom nav
2. Visit `/stake` at 1440px — verify 2 pool cards render cleanly in 3-col grid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved bottom spacing on the staking page for mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->