### PR TITLE
fix(stake): move music player to top-right to prevent pool card overlap

### DIFF
--- a/app/components/ui/MusicPlayer.tsx
+++ b/app/components/ui/MusicPlayer.tsx
@@ -36,6 +36,14 @@ const VolDownIcon = () => (
  *  to avoid overlaying critical interactive UI (e.g. trade margin inputs). */
 const HIDE_ON_MOBILE_ROUTES = ["/trade"];
 
+/**
+ * Routes where the floating player should move to top-right instead of
+ * bottom-right to avoid visually overlapping main content.
+ * e.g. /stake pool cards extend close to the right viewport edge at ~1024–1376px
+ * and the bottom-right player collides with the rightmost pool card.
+ */
+const MOVE_TO_TOP_ROUTES = ["/stake"];
+
 export function MusicPlayer() {
   const [playing, setPlaying] = useState(false);
   const [volume, setVolume] = useState(0.5);
@@ -49,6 +57,9 @@ export function MusicPlayer() {
 
   /* Determine if the player should be hidden on mobile for this route */
   const hideOnMobile = HIDE_ON_MOBILE_ROUTES.some((r) => pathname?.startsWith(r));
+
+  /* Determine if the player should move to top-right to avoid content overlap */
+  const moveToTop = MOVE_TO_TOP_ROUTES.some((r) => pathname?.startsWith(r));
 
   useEffect(() => {
     if (audioRef.current) audioRef.current.volume = volume;
@@ -110,7 +121,11 @@ export function MusicPlayer() {
   return (
     <div
       ref={containerRef}
-      className={`fixed bottom-3 right-3 z-[90] sm:bottom-5 sm:right-5 gsap-fade${hideOnMobile ? " hidden sm:block" : ""}`}
+      className={`fixed z-[90] gsap-fade${hideOnMobile ? " hidden sm:block" : ""}${
+        moveToTop
+          ? " top-[80px] right-3 sm:top-[72px] sm:right-5"
+          : " bottom-3 right-3 sm:bottom-5 sm:right-5"
+      }`}
       style={{ opacity: 0 }}
     >
       <audio


### PR DESCRIPTION
## Root Cause

The MusicPlayer widget (`fixed bottom-3 right-3 z-[90]`) was colliding with the rightmost pool card at viewport widths 1024–1376px. At these widths, the `lg:grid-cols-3` pool grid extends close to the right viewport edge inside the `max-w-[1100px]` container, putting the pool card directly under the floating player.

Designer visual QA confirmed: the custom play/pause/volume/close controls appeared visually "inside" the 6nQUQuD2 pool card on the PR #734 preview screenshot at ~1080px viewport.

## Fix

Added a `MOVE_TO_TOP_ROUTES` pattern (mirrors the existing `HIDE_ON_MOBILE_ROUTES` pattern). On `/stake`, the player repositions from `bottom-3 right-3` → `top-[80px] right-3` (just below the sticky header), eliminating all collision with pool card content across the full 1024–1376px viewport range.

## How to Test
1. Visit `/stake` at 1080px or 1440px viewport
2. Confirm MusicPlayer appears top-right (below the header/nav) — NOT at bottom-right overlapping the pool cards
3. Visit `/trade` and other pages — confirm player remains at bottom-right as before

## Impact
- Only `/stake` route is affected
- Build passes ✅
- No other pages touched