### PR TITLE
fix: hide MusicPlayer on mobile /stake to prevent pool card overlap

### DIFF
--- a/app/components/ui/MusicPlayer.tsx
+++ b/app/components/ui/MusicPlayer.tsx
@@ -34,7 +34,7 @@ const VolDownIcon = () => (
 
 /** Routes where the floating player should be hidden on mobile (<640px)
  *  to avoid overlaying critical interactive UI (e.g. trade margin inputs). */
-const HIDE_ON_MOBILE_ROUTES = ["/trade"];
+const HIDE_ON_MOBILE_ROUTES = ["/trade", "/stake"];
 
 /**
  * Routes where the floating player should move to top-right instead of


### PR DESCRIPTION
## Problem
MusicPlayer widget overlaps pool card content on /stake at 375px viewport width when scrolled to the Available Pools section (Y ~1200-1400px). The fixed-position player at `top-[80px] right-3` covers the pool card area.

## Fix
Add `/stake` to `HIDE_ON_MOBILE_ROUTES` — the player is now hidden below 640px on /stake, matching the existing /trade treatment. Desktop top-right positioning via `MOVE_TO_TOP_ROUTES` is unchanged.

## Testing
- Mobile 375px /stake: player hidden ✅
- Desktop 1440px /stake: player visible top-right ✅
- Mobile /trade: still hidden ✅
- Other routes: no change ✅

Reported by: designer (Visual QA)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Music player positioning now intelligently adapts based on the current route, dynamically repositioning from bottom-right to top-right where beneficial for layout optimization.
  * Mobile responsiveness has been improved with refined visibility rules for designated routes, ensuring the player displays correctly across all screen sizes and navigation contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->