### PR TITLE
fix(music-player): hide player on mobile for /stake — prevent pool card overlap

### DIFF
--- a/app/components/ui/MusicPlayer.tsx
+++ b/app/components/ui/MusicPlayer.tsx
@@ -33,8 +33,9 @@ const VolDownIcon = () => (
 );
 
 /** Routes where the floating player should be hidden on mobile (<640px)
- *  to avoid overlaying critical interactive UI (e.g. trade margin inputs). */
-const HIDE_ON_MOBILE_ROUTES = ["/trade"];
+ *  to avoid overlaying critical interactive UI (e.g. trade margin inputs,
+ *  stake pool cards that scroll under the player at 370-640px widths). */
+const HIDE_ON_MOBILE_ROUTES = ["/trade", "/stake"];
 
 /**
  * Routes where the floating player should move to top-right instead of


### PR DESCRIPTION
## Problem
Designer QA fail: on mobile 375px, the MusicPlayer widget (fixed `top-[80px] right-3`) overlaps pool card content when scrolled to the Available Pools section (~Y=1200-1400px scroll depth).

**Root cause:** `/stake` is in `MOVE_TO_TOP_ROUTES` to avoid a desktop-width collision at 1024-1376px. That fix works on desktop but on mobile single-column layout the pool cards span full-width and scroll into the same viewport area as the fixed player.

**QA results before fix:**
- Desktop 1440px: ✅ PASS
- Mobile no-scroll: ✅ PASS
- Mobile scrolled to pools: ❌ FAIL (player over 6nqUQuD2 pool card)

## Fix
Add `/stake` to `HIDE_ON_MOBILE_ROUTES` — the same treatment already applied to `/trade`.

- Mobile (<640px) on /stake: player hidden → no overlap ✅
- Desktop (sm+) on /stake: player visible at `top-[72px] right-5` (top-right) ✅
- All other routes: unchanged ✅

## How to test
1. Open /stake at 375px viewport width
2. Scroll to Available Pools section
3. Verify no MusicPlayer widget visible on mobile
4. Resize to 1440px — verify player appears top-right, no overlap with pool cards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile responsive behavior by expanding the floating music player hide rule to include the stake route, preventing visual overlap with content on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->