### PR TITLE
fix(music-player): hide player on mobile for /stake (follow-up to #735)

### DIFF
--- a/app/components/ui/MusicPlayer.tsx
+++ b/app/components/ui/MusicPlayer.tsx
@@ -33,8 +33,9 @@ const VolDownIcon = () => (
 );
 
 /** Routes where the floating player should be hidden on mobile (<640px)
- *  to avoid overlaying critical interactive UI (e.g. trade margin inputs). */
-const HIDE_ON_MOBILE_ROUTES = ["/trade"];
+ *  to avoid overlaying critical interactive UI (e.g. trade margin inputs,
+ *  stake pool cards that scroll under the player at 370-640px widths). */
+const HIDE_ON_MOBILE_ROUTES = ["/trade", "/stake"];
 
 /**
  * Routes where the floating player should move to top-right instead of


### PR DESCRIPTION
## Problem
Post-#735 regression: music player mini controls still visible at 375px on /stake.

PR #735 moved the player to top-right on /stake but did not add mobile hide treatment.
HIDE_ON_MOBILE_ROUTES only contained ["/trade"] — /stake was missing.

## Root Cause
The compiled production bundle had:
```js
const d = ["/trade"]; // hideOnMobile routes
const u = ["/stake"]; // moveToTop routes
```
So on /stake, the player moved to top-right but was never hidden on mobile (< 640px).
The 4 visible touch buttons [▶][🔉][🔊][✕] at top-[80px] right-3 are the "mini controls" reported.

## Fix
Added "/stake" to HIDE_ON_MOBILE_ROUTES:
```ts
const HIDE_ON_MOBILE_ROUTES = ["/trade", "/stake"];
```
Both conditions can be true simultaneously — the outer div gets both `hidden sm:block` (mobile hide) and `top-[80px] right-3` (top-right positioning on desktop).

## Test
- [ ] /stake at 375px: player invisible
- [ ] /stake at 640px+: player visible at top-right
- [ ] /trade at 375px: player still hidden
- [ ] other routes at 375px: player still visible bottom-right

QA + designer sign-off needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the music player would overlap with stake pool content on mobile devices by hiding it on the stake page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->