### PR TITLE
fix(hooks): add pool account owner validation in useStakeDeposit/Withdraw

### DIFF
--- a/app/hooks/useStakeDeposit.ts
+++ b/app/hooks/useStakeDeposit.ts
@@ -82,6 +82,9 @@ export function useStakeDeposit() {
         if (!poolInfo || poolInfo.data.length < 186) {
           throw new Error('Stake pool not initialized for this market. Contact admin.');
         }
+        if (!poolInfo.owner.equals(STAKE_PROGRAM_ID)) {
+          throw new Error('Stake pool account owner mismatch — possible network misconfiguration.');
+        }
 
         // Parse lpMint and vault from pool account (offsets from struct layout)
         const poolData = Buffer.from(poolInfo.data);

--- a/app/hooks/useStakeWithdraw.ts
+++ b/app/hooks/useStakeWithdraw.ts
@@ -82,6 +82,9 @@ export function useStakeWithdraw() {
         if (!poolInfo || poolInfo.data.length < 186) {
           throw new Error('Stake pool not initialized for this market.');
         }
+        if (!poolInfo.owner.equals(STAKE_PROGRAM_ID)) {
+          throw new Error('Stake pool account owner mismatch — possible network misconfiguration.');
+        }
 
         const poolData = Buffer.from(poolInfo.data);
         const lpMint = new PublicKey(poolData.subarray(65, 97));


### PR DESCRIPTION
## What
Adds `STAKE_PROGRAM_ID` owner validation on pool accounts in `useStakeDeposit` and `useStakeWithdraw` hooks, matching the existing checks in `useStakeDepositByPool` and `useStakeWithdrawByPool`.

## Why
Defense-in-depth: prevents client from deserializing data from a spoofed account owned by a different program. The on-chain program enforces this, but catching it client-side surfaces misconfigurations early.

## How to test
1. Stake deposit/withdraw flows should work unchanged on devnet
2. If a pool PDA were somehow pointing at a non-stake-program account, the hook now throws a clear error

Closes #743