### PR TITLE
fix(hooks): align client isDevnet default to 'mainnet'

### DIFF
--- a/app/hooks/useCreateMarket.ts
+++ b/app/hooks/useCreateMarket.ts
@@ -657,7 +657,7 @@ export function useCreateMarket() {
         // PERC-361: Post-creation hooks — register oracle bridge + mint devnet token
         const slabAddr = slabPk.toBase58();
         const mintAddr = params.mint.toBase58();
-        const isDevnet = (process.env.NEXT_PUBLIC_SOLANA_NETWORK?.trim() || "devnet") === "devnet";
+        const isDevnet = (process.env.NEXT_PUBLIC_SOLANA_NETWORK?.trim() ?? "mainnet") === "devnet";
 
         if (isDevnet && slabAddr) {
           // Register with oracle bridge (fire-and-forget)


### PR DESCRIPTION
## What
Changes `useCreateMarket.ts` client-side network default from `"devnet"` to `"mainnet"` when `NEXT_PUBLIC_SOLANA_NETWORK` is unset.

## Why
Server-side `route.ts` already defaults to `"mainnet"` (fail-closed). Client defaulting to `"devnet"` creates a mismatch: on a misconfigured prod deployment, the UI would attempt devnet auto-fund flows that the server correctly blocks, causing confusing errors.

Follow-up from security review of PR #746.

## How to test
- On devnet (env set to `devnet`): no behavior change
- With env unset: client now treats as mainnet (no devnet auto-fund UI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default network configuration to mainnet when the network environment variable is not explicitly set, affecting which market creation steps execute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->