### PR TITLE
fix(prefund): pre-flight mint authority check for #754

### DIFF
--- a/app/app/api/devnet-pre-fund/route.ts
+++ b/app/app/api/devnet-pre-fund/route.ts
@@ -28,6 +28,7 @@ import {
   createAssociatedTokenAccountInstruction,
   createMintToInstruction,
   getAccount,
+  getMint,
 } from "@solana/spl-token";
 import { getConfig } from "@/lib/config";
 import * as Sentry from "@sentry/nextjs";
@@ -130,6 +131,38 @@ export async function POST(req: NextRequest) {
 
     const cfg = getConfig();
     const connection = new Connection(cfg.rpcUrl, "confirmed");
+
+    // Pre-flight: verify the configured keypair is actually the mint authority
+    // This catches env misconfigurations early with a clear error instead of
+    // a generic "Internal server error" from a failed mintTo instruction.
+    try {
+      const mintInfo = await getMint(connection, mintPk);
+      if (
+        !mintInfo.mintAuthority ||
+        !mintInfo.mintAuthority.equals(mintAuthority.publicKey)
+      ) {
+        const configuredAuth = mintAuthority.publicKey.toBase58().slice(0, 8);
+        const onChainAuth = mintInfo.mintAuthority
+          ? mintInfo.mintAuthority.toBase58().slice(0, 8)
+          : "none";
+        Sentry.captureMessage(
+          `Mint authority mismatch for ${mintAddress}: configured=${configuredAuth}… on-chain=${onChainAuth}…`,
+          { level: "error", tags: { endpoint: "/api/devnet-pre-fund" } },
+        );
+        return NextResponse.json(
+          {
+            error: "Mint authority mismatch — server keypair is not the authority for this mint. Contact team.",
+            detail: `configured=${configuredAuth}… on-chain=${onChainAuth}…`,
+          },
+          { status: 500 },
+        );
+      }
+    } catch (e) {
+      // If we can't fetch mint info, proceed and let the tx fail naturally
+      Sentry.captureException(e, {
+        tags: { endpoint: "/api/devnet-pre-fund", phase: "authority-check" },
+      });
+    }
 
     // Derive user's ATA
     const ata = await getAssociatedTokenAddress(mintPk, walletPk);


### PR DESCRIPTION
## What
Adds a pre-flight check in `/api/devnet-pre-fund` that verifies the configured `DEVNET_MINT_AUTHORITY_KEYPAIR` matches the on-chain mint authority **before** attempting the mintTo instruction.

## Why
Bug #754: the endpoint returns a generic 'Internal server error' when the keypair and allowed mints are misconfigured. This makes it impossible to diagnose without server logs.

## Changes
- Fetch mint info via `getMint()` and compare `mintAuthority` to configured keypair
- Return a descriptive error with truncated pubkey prefixes on mismatch
- Report to Sentry with both configured and on-chain authority info
- Gracefully falls through if mint info fetch fails (lets tx fail naturally)

## Root fix
The actual env mismatch (DEVNET_MINT_AUTHORITY_KEYPAIR vs DEVNET_ALLOWED_MINTS) needs devops to either create new mints with the current authority or update the keypair. This PR just improves diagnostics.

Closes #754 (code-side)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added pre-flight verification of mint authority before processing devnet pre-fund transactions, improving transaction reliability.
  * Enhanced error handling with clearer error messages when configuration mismatches are detected.
  * Improved error tracking and logging for troubleshooting failed authorization attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->