### PR TITLE
fix: raise devnet pre-fund to 3200 tokens & fix misleading error message

### DIFF
--- a/app/app/api/devnet-pre-fund/route.ts
+++ b/app/app/api/devnet-pre-fund/route.ts
@@ -58,8 +58,18 @@ const DEVNET_ALLOWED_MINTS: Set<string> = new Set(
  */
 const MIN_INIT_MARKET_SEED = 500_000_000n;
 
-/** Fund 2× the minimum so user can retry without re-requesting */
-const FUND_AMOUNT = MIN_INIT_MARKET_SEED * 2n;
+/**
+ * Total tokens needed for full market creation (Small slab):
+ *   Vault seed:      500 tokens (MIN_INIT_MARKET_SEED)
+ *   LP collateral: 1,000 tokens
+ *   Insurance fund:  100 tokens
+ *   Total:         1,600 tokens
+ *
+ * Fund 2× the total requirement so user has headroom for retries
+ * and Medium/Large slabs which may need more.
+ */
+const FULL_MARKET_TOKEN_REQUIREMENT = 1_600_000_000n;
+const FUND_AMOUNT = FULL_MARKET_TOKEN_REQUIREMENT * 2n;
 
 /** Wrap a promise with a timeout; rejects after `ms` milliseconds. */
 function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
@@ -178,7 +188,7 @@ export async function POST(req: NextRequest) {
       // ATA doesn't exist yet
     }
 
-    if (currentBalance >= MIN_INIT_MARKET_SEED) {
+    if (currentBalance >= FULL_MARKET_TOKEN_REQUIREMENT) {
       return NextResponse.json({
         status: "sufficient",
         balance: currentBalance.toString(),

--- a/app/lib/parseMarketError.ts
+++ b/app/lib/parseMarketError.ts
@@ -35,10 +35,14 @@ export function parseMarketCreationError(error: unknown): string {
   // Insufficient SOL for rent/fees
   if (
     msg.includes("Attempt to debit an account but found no record of a prior credit") ||
-    msg.includes("insufficient funds") ||
     msg.includes("insufficient lamports")
   ) {
     return "Insufficient SOL balance. You need enough SOL to cover the slab rent and transaction fees. Check your wallet balance.";
+  }
+
+  // Insufficient token balance (generic "insufficient funds" from token program transfers)
+  if (msg.includes("insufficient funds")) {
+    return "Insufficient token balance. Your wallet may not have enough tokens to complete this step (vault seed, LP collateral, or insurance deposit). On devnet, reload the page to trigger a top-up.";
   }
 
   // Account already exists (slab already created in a previous attempt)


### PR DESCRIPTION
## Changes

### Fix #757 — devnet-pre-fund mints too few tokens
- `FUND_AMOUNT` was `MIN_INIT_MARKET_SEED * 2` = 1,000 tokens
- Full market creation needs ~1,600 tokens (500 vault + 1,000 LP + 100 insurance)
- **Changed to**: `FULL_MARKET_TOKEN_REQUIREMENT * 2` = 3,200 tokens
- Sufficiency threshold raised from 500 to 1,600 tokens

### Fix #758 — wrong error message on token shortfall
- `insufficient funds` (token program) was caught by the SOL balance handler
- Split into separate handlers: `insufficient lamports` → SOL error, `insufficient funds` → token error
- New message tells users it's a token balance issue, not SOL

### Fix #759 — depositPda buffer guard (pushed to PR #756)
- Fixup pushed to `feature/PERC-456-portfolio-lp-positions` branch
- Changed `>= 16` to `>= 80` matching the actual layout size

Closes #757, Closes #758

## Testing
1. Deploy to devnet preview
2. Create Market flow → TX4 should now succeed (pre-fund gives 3,200 tokens)
3. If token balance manually depleted below 1,600, error should say 'Insufficient token balance' not 'Insufficient SOL'