### PR TITLE
fix(prefund): raise token cap for full market creation — fixes #757 #758

### DIFF
--- a/app/app/api/devnet-pre-fund/route.ts
+++ b/app/app/api/devnet-pre-fund/route.ts
@@ -58,8 +58,18 @@ const DEVNET_ALLOWED_MINTS: Set<string> = new Set(
  */
 const MIN_INIT_MARKET_SEED = 500_000_000n;
 
-/** Fund 2× the minimum so user can retry without re-requesting */
-const FUND_AMOUNT = MIN_INIT_MARKET_SEED * 2n;
+/**
+ * Total tokens needed for full market creation (Small slab):
+ *   Vault seed:      500 tokens (MIN_INIT_MARKET_SEED)
+ *   LP collateral: 1,000 tokens
+ *   Insurance fund:  100 tokens
+ *   Total:         1,600 tokens
+ *
+ * Fund 2× the total requirement so user has headroom for retries
+ * and Medium/Large slabs which may need more. Fixes #757.
+ */
+const FULL_MARKET_TOKEN_REQUIREMENT = 1_600_000_000n;
+const FUND_AMOUNT = FULL_MARKET_TOKEN_REQUIREMENT * 2n;
 
 /** Wrap a promise with a timeout; rejects after `ms` milliseconds. */
 function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
@@ -178,7 +188,7 @@ export async function POST(req: NextRequest) {
       // ATA doesn't exist yet
     }
 
-    if (currentBalance >= MIN_INIT_MARKET_SEED) {
+    if (currentBalance >= FULL_MARKET_TOKEN_REQUIREMENT) {
       return NextResponse.json({
         status: "sufficient",
         balance: currentBalance.toString(),

--- a/app/hooks/useCreateMarket.ts
+++ b/app/hooks/useCreateMarket.ts
@@ -588,6 +588,46 @@ export function useCreateMarket() {
 
           const userAta = await getAssociatedTokenAddress(params.mint, wallet.publicKey);
 
+          // Pre-flight: verify user has enough tokens for LP deposit + insurance top-up.
+          // Fixes #757/#758 — pre-fund only checked seed amount (500), but TX4 also
+          // needs lpCollateral + insuranceAmount (default 1,000 + 100 = 1,100 more).
+          const tx4Required = params.lpCollateral + params.insuranceAmount;
+          let tx4Balance = 0n;
+          try {
+            const tx4Acct = await getAccount(connection, userAta);
+            tx4Balance = tx4Acct.amount;
+          } catch {
+            // ATA doesn't exist — balance stays 0
+          }
+          if (tx4Balance < tx4Required) {
+            if (isDevnetEnv) {
+              setState((s) => ({ ...s, stepLabel: "Funding devnet wallet for deposit..." }));
+              const fundResp4 = await fetch("/api/devnet-pre-fund", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  mintAddress: params.mint.toBase58(),
+                  walletAddress: wallet.publicKey.toBase58(),
+                }),
+              });
+              if (!fundResp4.ok) {
+                const err4 = await fundResp4.json().catch(() => ({ error: "Unknown error" }));
+                throw new Error(`Devnet pre-fund failed at deposit step: ${err4.error ?? fundResp4.status}`);
+              }
+              setState((s) => ({ ...s, stepLabel: STEP_LABELS[3] }));
+            } else {
+              const decimals = params.decimals ?? 6;
+              const needed = Number(tx4Required) / 10 ** decimals;
+              const have = Number(tx4Balance) / 10 ** decimals;
+              throw new Error(
+                `Insufficient token balance for deposit. ` +
+                `You need ${needed.toLocaleString()} tokens for LP collateral and insurance ` +
+                `but your wallet holds ${have.toLocaleString()}. ` +
+                `Please add tokens to your wallet before continuing.`
+              );
+            }
+          }
+
           const depositData = encodeDepositCollateral({
             userIdx: 0,
             amount: params.lpCollateral.toString(),

--- a/app/lib/parseMarketError.ts
+++ b/app/lib/parseMarketError.ts
@@ -32,11 +32,22 @@ export function parseMarketCreationError(error: unknown): string {
     return "Transaction cancelled — you rejected the signing request in your wallet. Click Retry to try again.";
   }
 
+  // Insufficient SPL token balance (token program error 0x1 or transfer failure).
+  // Must be checked BEFORE the SOL/lamports branch — Solana simulation errors for
+  // token transfers also include "insufficient funds" but are not a SOL problem. Fixes #758.
+  if (
+    msg.includes("insufficient funds for transfer") ||
+    (msg.includes("insufficient funds") && !msg.includes("lamports")) ||
+    (msg.includes("custom program error: 0x1") && msg.includes("TokenkegQ"))
+  ) {
+    return "Insufficient token balance. Your wallet doesn't have enough collateral tokens to complete this step. On devnet, refresh the page and retry — the faucet will top up your balance.";
+  }
+
   // Insufficient SOL for rent/fees
   if (
     msg.includes("Attempt to debit an account but found no record of a prior credit") ||
-    msg.includes("insufficient funds") ||
-    msg.includes("insufficient lamports")
+    msg.includes("insufficient lamports") ||
+    msg.includes("insufficient funds")
   ) {
     return "Insufficient SOL balance. You need enough SOL to cover the slab rent and transaction fees. Check your wallet balance.";
   }


### PR DESCRIPTION
## Problem

Pre-fund API was capping the 'sufficient' check at **500 tokens** (MIN_INIT_MARKET_SEED only), but full market creation needs **1,600 tokens** total:
- Vault seed: 500 tokens (TX1)
- LP collateral: 1,000 tokens (TX4)
- Insurance fund: 100 tokens (TX4)

Result: wallet with 1,000 tokens → pre-fund returned `{status:sufficient}` → TX4 failed with misleading 'Insufficient SOL balance' error.

## Root Cause
- `route.ts`: `FUND_AMOUNT = MIN_INIT_MARKET_SEED * 2n` = 1,000 tokens; sufficient check at 500
- `useCreateMarket.ts`: no pre-flight token check before TX4 (deposit + insurance step)
- `parseMarketError.ts`: SPL token insufficient funds matched the 'Insufficient SOL' branch

## Fix

### `devnet-pre-fund/route.ts`
- `FULL_MARKET_TOKEN_REQUIREMENT = 1_600_000_000n` (1,600 tokens)
- `FUND_AMOUNT = 3_200_000_000n` (2× headroom for retries and larger slabs)
- Sufficient check now requires 1,600 tokens before skipping mint

### `useCreateMarket.ts`
- Pre-flight balance check before Step 3 (deposit + insurance TX)
- On devnet: auto-calls `/api/devnet-pre-fund` if balance < `lpCollateral + insuranceAmount`
- On mainnet: surfaces clear 'Insufficient token balance for deposit' error

### `parseMarketError.ts`
- Detects SPL token insufficient funds (`insufficient funds for transfer`, `custom program error: 0x1` from token program) before the SOL/lamports branch
- Shows 'Insufficient token balance' instead of 'Insufficient SOL balance' — fixes #758

## Testing
TX1–TX3 already passing per QA. TX4 blocked by #757 — this fix should unblock E2E.

Closes #757, #758