### PR TITLE
fix(#762): devnet-mint-token network check fails on devnet

### DIFF
--- a/app/app/api/devnet-mint-token/route.ts
+++ b/app/app/api/devnet-mint-token/route.ts
@@ -35,7 +35,8 @@ import * as Sentry from "@sentry/nextjs";
 
 export const dynamic = "force-dynamic";
 
-const NETWORK = process.env.NEXT_PUBLIC_SOLANA_NETWORK ?? "devnet";
+// Default to 'mainnet' so misconfigured deployments fail closed, not open
+const NETWORK = process.env.NEXT_PUBLIC_SOLANA_NETWORK?.trim() ?? "mainnet";
 const AIRDROP_USD_VALUE = 500; // $500 worth of tokens
 // ORACLE_BRIDGE_URL removed — unreachable from Vercel serverless.
 // Price fetching uses DexScreener API directly via fetchTokenInfo().


### PR DESCRIPTION
Fixes #762 — post-launch auto-mint shows 'Only available on devnet' when on devnet.

**Root cause:** `NETWORK` var didn't `.trim()` whitespace and defaulted to `'devnet'` (fail-open). If env had trailing whitespace, `'devnet ' !== 'devnet'` → 403.

**Fix:** Trim + default to `'mainnet'` (fail-closed), matching `devnet-pre-fund` pattern.