### PR TITLE
fix: LP panel design polish (4 items from designer review)

### DIFF
--- a/app/app/portfolio/page.tsx
+++ b/app/app/portfolio/page.tsx
@@ -149,9 +149,8 @@ export default function PortfolioPage() {
               },
               {
                 label: "LP Value",
-                value: lpPositions.loading ? "\u2026" : lpPositions.totalRedeemable > 0
-                  ? `$${lpPositions.totalRedeemable.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
-                  : "—",
+                value: lpPositions.loading ? "\u2026"
+                  : `$${lpPositions.totalRedeemable.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
                 color: lpPositions.totalRedeemable > 0 ? "text-[var(--cyan)]" : "text-[var(--text-dim)]",
                 sub: lpPositions.positions.length > 0
                   ? `${lpPositions.positions.length} pool${lpPositions.positions.length > 1 ? "s" : ""}`
@@ -164,8 +163,8 @@ export default function PortfolioPage() {
                 sub: atRiskCount > 0 ? `${atRiskCount} at risk` : undefined,
                 subColor: atRiskCount > 0 ? "text-[var(--short)]" : undefined,
               },
-            ].map((stat) => (
-              <div key={stat.label} className="bg-[var(--panel-bg)] p-5 transition-colors duration-200 hover:bg-[var(--bg-elevated)]">
+            ].map((stat, i, arr) => (
+              <div key={stat.label} className={`bg-[var(--panel-bg)] p-5 transition-colors duration-200 hover:bg-[var(--bg-elevated)]${arr.length % 2 !== 0 && i === arr.length - 1 ? " col-span-2 sm:col-span-1" : ""}`}>
                 <p className="mb-2 text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-dim)]">{stat.label}</p>
                 <p className={`text-xl font-bold tabular-nums ${stat.color}`} style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>
                   {stat.value}

--- a/app/components/portfolio/LpPositionsPanel.tsx
+++ b/app/components/portfolio/LpPositionsPanel.tsx
@@ -197,7 +197,7 @@ export function LpPositionsPanel({
       {/* Section heading */}
       <div className="mb-3 flex items-center justify-between">
         <h2 className="text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--cyan)]/70">
-          Insurance LP Positions
+          // Insurance LP Positions
         </h2>
         {positions.length > 0 && !loading && (
           <span
@@ -234,8 +234,20 @@ export function LpPositionsPanel({
           ))}
         </div>
       ) : error ? (
-        <div className="border border-[var(--border)] bg-[var(--panel-bg)] p-6 text-center">
-          <p className="text-[12px] text-[var(--short)]">Failed to load LP positions</p>
+        <div className="border border-[var(--border)] bg-[var(--panel-bg)] p-6 flex flex-col items-center justify-center gap-3 text-center">
+          <div className="flex items-center gap-2">
+            <svg className="h-4 w-4 text-[var(--warning)] flex-shrink-0" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M8 1a7 7 0 110 14A7 7 0 018 1zm0 9.5a.75.75 0 100 1.5.75.75 0 000-1.5zM8 4a.75.75 0 00-.75.75v3.5a.75.75 0 001.5 0v-3.5A.75.75 0 008 4z" />
+            </svg>
+            <p className="text-[12px] font-semibold text-[var(--text-secondary)]">Unable to load LP positions</p>
+          </div>
+          <p className="text-[11px] text-[var(--text-dim)]">Please try refreshing</p>
+          <button
+            onClick={() => window.location.reload()}
+            className="border border-[var(--cyan)]/40 px-4 py-1.5 text-[11px] font-semibold text-[var(--cyan)] transition-colors hover:border-[var(--cyan)]/80 hover:bg-[var(--cyan)]/5"
+          >
+            Retry
+          </button>
         </div>
       ) : positions.length === 0 ? (
         <div className="border border-[var(--border)] bg-[var(--panel-bg)] p-6 flex items-center justify-between gap-4">


### PR DESCRIPTION
## Changes

Addresses 4 design polish items from designer review of the LP panel:

1. **Section header consistency** — Added `// ` prefix to match other sections (EarnHeader pattern)
2. **Styled error state** — Replaced raw red text with warning icon + "Unable to load LP positions" heading + "Please try refreshing" copy + Retry button (matches existing button style)
3. **LP Value zero state** — Shows "$0.00" instead of "—" when user has no LP positions
4. **375px stats grid** — Orphaned 5th cell (Positions) now spans 2 columns on mobile (`col-span-2 sm:col-span-1`)

## Files Changed
- `app/components/portfolio/LpPositionsPanel.tsx` — items 1, 2
- `app/app/portfolio/page.tsx` — items 3, 4

## Testing
- `tsc --noEmit` passes
- Visual: check portfolio page at 375px and desktop widths
- Check error state by disconnecting wallet mid-load