### PR TITLE
fix(#775): call mirror-mint on devnet instead of early-returning

### DIFF
--- a/app/components/create/StepTokenSelect.tsx
+++ b/app/components/create/StepTokenSelect.tsx
@@ -9,6 +9,11 @@ import { formatHumanAmount } from "@/lib/parseAmount";
 import { isValidBase58Pubkey } from "@/lib/createWizardUtils";
 import { getNetwork } from "@/lib/config";
 
+/** Derive whether we're on devnet from the live RPC endpoint (not build-time env var). */
+function isDevnetEndpoint(rpcEndpoint: string): boolean {
+  return rpcEndpoint.includes("devnet") || rpcEndpoint.includes("127.0.0.1") || rpcEndpoint.includes("localhost");
+}
+
 type MintNetworkStatus = "idle" | "loading" | "valid" | "invalid" | "mirroring" | "mirror-failed";
 
 interface StepTokenSelectProps {
@@ -47,7 +52,8 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
   const [mintNetworkStatus, setMintNetworkStatus] = useState<MintNetworkStatus>("idle");
   const [mirrorError, setMirrorError] = useState<string | null>(null);
   const [mirrorMeta, setMirrorMeta] = useState<{ name: string; symbol: string; decimals: number } | null>(null);
-  const isDevnet = getNetwork() === "devnet";
+  // Use live RPC endpoint to detect devnet (not build-time env var which may be wrong in prod).
+  const isDevnet = isDevnetEndpoint(connection.rpcEndpoint) || getNetwork() === "devnet";
 
   // Debounce mint input
   useEffect(() => {
@@ -79,16 +85,55 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
       onMintNetworkValidChange?.(false);
       return;
     }
-    // Devnet: accept any valid pubkey — mirror endpoint handles devnet mint creation
-    if (isDevnet) {
-      setMintNetworkStatus("valid");
-      onMintNetworkValidChange?.(true);
-      return;
-    }
     let cancelled = false;
-    setMintNetworkStatus("loading");
     setMirrorError(null);
     setMirrorMeta(null);
+
+    if (isDevnet) {
+      // DEVNET: Always call mirror-mint to get/create the canonical devnet mint address.
+      // Do NOT early-return — devnetMintAddress must be resolved before the wizard can proceed.
+      setMintNetworkStatus("mirroring");
+      (async () => {
+        try {
+          const resp = await fetch("/api/devnet-mirror-mint", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ mainnetCA: debounced }),
+          });
+          if (cancelled) return;
+          const data = await resp.json();
+          if (!resp.ok) {
+            setMintNetworkStatus("mirror-failed");
+            setMirrorError(data.error ?? `Mirror failed (HTTP ${resp.status})`);
+            onMintNetworkValidChange?.(false);
+            return;
+          }
+          // Mirror succeeded — notify parent with the devnet mint + metadata
+          const resolvedMirrorMeta = {
+            name: data.name ?? `Token ${debounced.slice(0, 6)}`,
+            symbol: data.symbol ?? debounced.slice(0, 4).toUpperCase(),
+            decimals: data.decimals ?? 6,
+          };
+          setMirrorMeta(resolvedMirrorMeta);
+          // Wire devnet mint CA up to CreateMarketWizard (effectiveMint in handleLaunch)
+          onDevnetMintResolved?.(data.devnetMint, resolvedMirrorMeta);
+          // Also push metadata to parent (useTokenMeta won't find mainnet token on devnet)
+          onTokenResolved(resolvedMirrorMeta);
+          setMintNetworkStatus("valid");
+          onMintNetworkValidChange?.(true);
+        } catch {
+          if (!cancelled) {
+            setMintNetworkStatus("mirror-failed");
+            setMirrorError("Network error — could not reach mirror-mint endpoint");
+            onMintNetworkValidChange?.(false);
+          }
+        }
+      })();
+      return () => { cancelled = true; };
+    }
+
+    // MAINNET: Check on-chain mint existence
+    setMintNetworkStatus("loading");
     (async () => {
       try {
         const accountInfo = await connection.getAccountInfo(mintPk);
@@ -108,43 +153,9 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
           onMintNetworkValidChange?.(true);
           return;
         }
-
-        // Account does not exist on this network
-        if (!isDevnet) {
-          // On mainnet, just block — no mirroring
-          setMintNetworkStatus("invalid");
-          onMintNetworkValidChange?.(false);
-          return;
-        }
-
-        // DEVNET: Auto-mirror the mainnet CA
-        setMintNetworkStatus("mirroring");
-        const resp = await fetch("/api/devnet-mirror-mint", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ mainnetCA: debounced }),
-        });
-        if (cancelled) return;
-        const data = await resp.json();
-        if (!resp.ok) {
-          setMintNetworkStatus("mirror-failed");
-          setMirrorError(data.error ?? `Mirror failed (HTTP ${resp.status})`);
-          onMintNetworkValidChange?.(false);
-          return;
-        }
-
-        // Mirror succeeded — notify parent with devnet mint + metadata
-        const resolvedMirrorMeta = {
-          name: data.name ?? `Token ${debounced.slice(0, 6)}`,
-          symbol: data.symbol ?? debounced.slice(0, 4).toUpperCase(),
-          decimals: data.decimals ?? 6,
-        };
-        setMirrorMeta(resolvedMirrorMeta);
-        onDevnetMintResolved?.(data.devnetMint, resolvedMirrorMeta);
-        // Also push metadata to parent (useTokenMeta won't find it on devnet)
-        onTokenResolved(resolvedMirrorMeta);
-        setMintNetworkStatus("valid");
-        onMintNetworkValidChange?.(true);
+        // Account does not exist on mainnet — block
+        setMintNetworkStatus("invalid");
+        onMintNetworkValidChange?.(false);
       } catch {
         if (!cancelled) {
           setMintNetworkStatus("invalid");


### PR DESCRIPTION
## Bug
P0 bug #775 — StepTokenSelect.tsx early-returned `"valid"` on `isDevnet=true` without ever calling `/api/devnet-mirror-mint`. This left `devnetMintAddress` null in CreateMarketWizard, so `handleLaunch` computed `effectiveMint = devnetMintAddress ?? wizard.mintAddress` and passed the **raw mainnet CA** into the on-chain InitMarket + pre-fund transactions — pre-fund rejected it, completely blocking Create Market E2E.

## Root Cause
Commit `24cb871d` (hotfix: skip mint network check on devnet) intended to bypass the on-chain account check but left the path as a bare early-return. When PR #763 was merged it brought in the new `isDevnet` guard block, which preserved that early-return and never called the mirror-mint API.

## Fix
- **On devnet**: always POST `/api/devnet-mirror-mint` to get/create the canonical devnet mint before allowing Continue
- Call `onDevnetMintResolved(data.devnetMint)` so CreateMarketWizard sets `devnetMintAddress` and `effectiveMint` resolves to the correct devnet CA
- Also derive `isDevnet` from `connection.rpcEndpoint` (not build-time env var) so prod deployments stay in sync with the actual RPC target
- On mainnet: unchanged — check on-chain existence, block if absent

## How to Test
1. Go to percolatorlaunch.com/create on devnet
2. Paste mainnet CA: `8PzFWyLpCVEmbZmVJcaRTU5r69XKJx1rd7YGpWvnpump`
3. Step 1 shows 🪞 mirroring... then resolves to devnet mint
4. Continue → oracle → slab → TX signs and confirms with devnet CA (not mainnet CA)
5. Market appears on /trade/[slug]

## Tests
63/65 test files pass (2 skipped: bigint native binding). 815 tests passing.

Closes #775. Unblocks PERC-460.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced devnet detection at runtime for more accurate network identification
  * Revised devnet token mirroring process with explicit creation flow and improved error handling
  * Added distinct user feedback states during token validation (mirroring, mirror-failed, invalid, loading)
  * Improved token metadata retrieval to work with both on-chain and devnet mirror sources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->