### PR TITLE
fix: add // prefix to LP section header

### DIFF
--- a/app/components/portfolio/LpPositionsPanel.tsx
+++ b/app/components/portfolio/LpPositionsPanel.tsx
@@ -199,7 +199,7 @@ export function LpPositionsPanel({
       {/* Section heading */}
       <div className="mb-3 flex items-center justify-between">
         <h2 className="text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--cyan)]/70">
-          Insurance LP Positions
+          // Insurance LP Positions
         </h2>
         {positions.length > 0 && !loading && (
           <span


### PR DESCRIPTION
Designer QA feedback from PR #774: section heading should read `// INSURANCE LP POSITIONS` to match `// TRADE HISTORY` convention.

Single-line text change in LpPositionsPanel.tsx.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated heading text display in the LP positions panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->