### PR TITLE
fix: add // prefix to Insurance LP Positions header

### DIFF
--- a/app/components/portfolio/LpPositionsPanel.tsx
+++ b/app/components/portfolio/LpPositionsPanel.tsx
@@ -199,7 +199,7 @@ export function LpPositionsPanel({
       {/* Section heading */}
       <div className="mb-3 flex items-center justify-between">
         <h2 className="text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--cyan)]/70">
-          Insurance LP Positions
+          // Insurance LP Positions
         </h2>
         {positions.length > 0 && !loading && (
           <span


### PR DESCRIPTION
## What
Adds `//` prefix to the Insurance LP Positions section header in `LpPositionsPanel` to match the `// trade history` style used across the app.

## Why
Designer QA on PR #774 flagged this as the only remaining issue — DOM shows "Insurance LP Positions" (CSS uppercase) without the // prefix, should read "// INSURANCE LP POSITIONS".

## Change
`LpPositionsPanel.tsx` line 202: `Insurance LP Positions` → `// Insurance LP Positions`

## Testing
Visual check — header should render as `// INSURANCE LP POSITIONS` after CSS uppercasing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Insurance LP Positions panel heading text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->