### PR TITLE
security: oracle-keeper input hardening (#782 #783 #784)

### DIFF
--- a/app/app/api/oracle-keeper/register/route.ts
+++ b/app/app/api/oracle-keeper/register/route.ts
@@ -56,6 +56,12 @@ export async function POST(req: NextRequest) {
     try { new PublicKey(mainnetCA); } catch {
       return NextResponse.json({ error: "Invalid mainnetCA" }, { status: 400 });
     }
+    // #782: validate devnetMint if provided
+    if (devnetMint) {
+      try { new PublicKey(devnetMint); } catch {
+        return NextResponse.json({ error: "Invalid devnetMint" }, { status: 400 });
+      }
+    }
 
     // Step 1: Write mainnet_ca to Supabase so oracle service can look up the token price
     let dbResult: { slab_address: string; mainnet_ca: string; symbol?: string } | null = null;

--- a/bots/oracle-keeper/index.ts
+++ b/bots/oracle-keeper/index.ts
@@ -496,9 +496,13 @@ async function discoverNewMarkets(): Promise<MarketInfo[]> {
  * This fetches price directly using the mainnet CA via Jupiter Lite API.
  */
 async function fetchPriceByCA(mainnetCA: string): Promise<{ price: number; source: string } | null> {
+  // #783: encode CA before interpolating into URLs (defence-in-depth; Solana base58 is alphanumeric
+  // but encodeURIComponent guards against unexpected characters that could enter via DB backfill)
+  const encodedCA = encodeURIComponent(mainnetCA);
+
   try {
     const resp = await fetch(
-      `https://api.jup.ag/price/v2?ids=${mainnetCA}`,
+      `https://api.jup.ag/price/v2?ids=${encodedCA}`,
       { signal: AbortSignal.timeout(4000) },
     );
     const json = (await resp.json()) as any;
@@ -509,7 +513,7 @@ async function fetchPriceByCA(mainnetCA: string): Promise<{ price: number; sourc
   // DexScreener fallback
   try {
     const resp = await fetch(
-      `https://api.dexscreener.com/latest/dex/tokens/${mainnetCA}`,
+      `https://api.dexscreener.com/latest/dex/tokens/${encodedCA}`,
       { signal: AbortSignal.timeout(4000) },
     );
     const json = (await resp.json()) as any;

--- a/packages/keeper/src/services/oracle.ts
+++ b/packages/keeper/src/services/oracle.ts
@@ -90,7 +90,8 @@ export class OracleService {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
       
-      const res = await fetch(`https://api.dexscreener.com/latest/dex/tokens/${mint}`, {
+      // #784: encode mint before URL interpolation (defence-in-depth)
+      const res = await fetch(`https://api.dexscreener.com/latest/dex/tokens/${encodeURIComponent(mint)}`, {
         signal: controller.signal
       });
       clearTimeout(timeoutId);
@@ -131,7 +132,8 @@ export class OracleService {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
       
-      const res = await fetch(`https://api.jup.ag/price/v2?ids=${mint}`, {
+      // #784: encode mint before URL interpolation (defence-in-depth)
+      const res = await fetch(`https://api.jup.ag/price/v2?ids=${encodeURIComponent(mint)}`, {
         signal: controller.signal
       });
       clearTimeout(timeoutId);


### PR DESCRIPTION
## Summary

Addresses three LOW-severity security issues in the oracle-keeper pipeline. All are defence-in-depth hardening with no functional impact on well-formed Solana base58 addresses.

---

### #782 — devnetMint not validated in /api/oracle-keeper/register
**File:** `app/app/api/oracle-keeper/register/route.ts`

Added `PublicKey` validation for `devnetMint` alongside the existing `slabAddress` and `mainnetCA` checks. Endpoint is already auth-gated (`KEEPER_REGISTER_SECRET`) so exploitability is minimal; this closes the gap.

### #783 — mainnetCA not URL-encoded in bots/oracle-keeper fetchPriceByCA()
**File:** `bots/oracle-keeper/index.ts`

Applied `encodeURIComponent(mainnetCA)` before interpolating into Jupiter and DexScreener fetch URLs. Solana base58 is alphanumeric so real-world impact is negligible, but this guards against unexpected characters from DB backfill.

### #784 — mint not URL-encoded in packages/keeper oracle.ts
**File:** `packages/keeper/src/services/oracle.ts`

Applied `encodeURIComponent(mint)` in `fetchDexScreenerPrice` and `_fetchJupiterPriceInternal`. Note: `mainnetCA` was already validated as a valid Solana `PublicKey` in `route.ts` (PR #779), so the route-layer fix mentioned in #784 was already in place.

---

## How to Test
- POST to `/api/oracle-keeper/register` with an invalid `devnetMint` (e.g. `"not-a-pubkey"`) → expect `400 Invalid devnetMint`
- Valid Solana addresses continue to work as before
- Oracle price fetch behaviour unchanged (encodeURIComponent is a no-op for alphanumeric base58)

## Checklist
- [x] TypeScript compiles clean (`packages/keeper`, `app`)
- [x] No functional change for valid inputs
- [x] Closes #782, #783, #784

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added validation for optional devnetMint parameters with improved error handling
  * Enhanced URL parameter encoding in external API calls for better reliability and compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->