### PR TITLE
fix(security): Input validation for oracle keeper URLs (#782, #783, #784)

### DIFF
--- a/app/app/api/oracle-keeper/register/route.ts
+++ b/app/app/api/oracle-keeper/register/route.ts
@@ -56,6 +56,11 @@ export async function POST(req: NextRequest) {
     try { new PublicKey(mainnetCA); } catch {
       return NextResponse.json({ error: "Invalid mainnetCA" }, { status: 400 });
     }
+    if (devnetMint) {
+      try { new PublicKey(devnetMint); } catch {
+        return NextResponse.json({ error: "Invalid devnetMint" }, { status: 400 });
+      }
+    }
 
     // Step 1: Write mainnet_ca to Supabase so oracle service can look up the token price
     let dbResult: { slab_address: string; mainnet_ca: string; symbol?: string } | null = null;

--- a/bots/oracle-keeper/index.ts
+++ b/bots/oracle-keeper/index.ts
@@ -496,9 +496,13 @@ async function discoverNewMarkets(): Promise<MarketInfo[]> {
  * This fetches price directly using the mainnet CA via Jupiter Lite API.
  */
 async function fetchPriceByCA(mainnetCA: string): Promise<{ price: number; source: string } | null> {
+  // Validate as base58 Solana address before using in external URLs (#783, #784)
+  if (!/^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(mainnetCA)) return null;
+  const encoded = encodeURIComponent(mainnetCA);
+
   try {
     const resp = await fetch(
-      `https://api.jup.ag/price/v2?ids=${mainnetCA}`,
+      `https://api.jup.ag/price/v2?ids=${encoded}`,
       { signal: AbortSignal.timeout(4000) },
     );
     const json = (await resp.json()) as any;
@@ -509,7 +513,7 @@ async function fetchPriceByCA(mainnetCA: string): Promise<{ price: number; sourc
   // DexScreener fallback
   try {
     const resp = await fetch(
-      `https://api.dexscreener.com/latest/dex/tokens/${mainnetCA}`,
+      `https://api.dexscreener.com/latest/dex/tokens/${encoded}`,
       { signal: AbortSignal.timeout(4000) },
     );
     const json = (await resp.json()) as any;

--- a/packages/keeper/src/services/oracle.ts
+++ b/packages/keeper/src/services/oracle.ts
@@ -90,7 +90,8 @@ export class OracleService {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
       
-      const res = await fetch(`https://api.dexscreener.com/latest/dex/tokens/${mint}`, {
+      // Encode mint to prevent URL injection (#783)
+      const res = await fetch(`https://api.dexscreener.com/latest/dex/tokens/${encodeURIComponent(mint)}`, {
         signal: controller.signal
       });
       clearTimeout(timeoutId);
@@ -131,7 +132,8 @@ export class OracleService {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
       
-      const res = await fetch(`https://api.jup.ag/price/v2?ids=${mint}`, {
+      // Encode mint to prevent query param injection (#783)
+      const res = await fetch(`https://api.jup.ag/price/v2?ids=${encodeURIComponent(mint)}`, {
         signal: controller.signal
       });
       clearTimeout(timeoutId);


### PR DESCRIPTION
## Summary
Fixes three LOW-severity security findings from PERC-465 PR review.

### #782: devnetMint not validated
Added PublicKey validation for optional `devnetMint` param in `/api/oracle-keeper/register`.

### #783: mainnetCA not URL-encoded in external API calls
Added `encodeURIComponent` for mainnetCA in oracle-keeper's `fetchPriceByCA()` Jupiter and DexScreener URLs. Also added base58 regex pre-check to reject obviously invalid values before any external call.

### #784: Same issue in keeper oracle service
Added `encodeURIComponent` for mint parameter in `packages/keeper/src/services/oracle.ts` Jupiter and DexScreener fetch calls.

## Testing
- 815 tests pass, TypeScript clean
- No functional change for valid Solana addresses (base58 encodes to itself)