### PR TITLE
feat(stake): compute trailing APR from insurance_snapshots redemption rate

### DIFF
--- a/app/__tests__/api/stake-pool-apr.test.ts
+++ b/app/__tests__/api/stake-pool-apr.test.ts
@@ -55,7 +55,8 @@ function computeAprs(
 
     const growth = (cur.rate - old.rate) / old.rate;
     const annualized = growth * (365 * MS_PER_DAY) / elapsed;
-    result[slab] = isFinite(annualized) ? Math.round(annualized * 10_000) / 100 : 0;
+    // Clamp to 0: negative APR (insurance drawdown) would confuse stakers.
+    result[slab] = isFinite(annualized) ? Math.max(0, Math.round(annualized * 10_000) / 100) : 0;
   }
   return result;
 }
@@ -147,6 +148,17 @@ describe("computeAprs", () => {
     });
     expect(result[SLAB_A]).toBeGreaterThan(0);
     expect(result[SLAB_B]).toBe(0);
+  });
+
+  it("clamps negative APR to 0 (insurance drawdown scenario)", () => {
+    const sevenDaysAgo = ts(7);
+    // Rate decreased: drawdown scenario
+    const result = computeAprs([SLAB_A], {
+      earliest7d: [{ slab: SLAB_A, redemption_rate_e6: 1_010_000, created_at: sevenDaysAgo }],
+      earliest30d: [{ slab: SLAB_A, redemption_rate_e6: 1_010_000, created_at: sevenDaysAgo }],
+      latest: [{ slab: SLAB_A, redemption_rate_e6: 1_000_000, created_at: new Date().toISOString() }],
+    });
+    expect(result[SLAB_A]).toBe(0);
   });
 
   it("returns 0 for current rate of 0 (no LP activity)", () => {

--- a/app/app/api/stake/pools/route.ts
+++ b/app/app/api/stake/pools/route.ts
@@ -67,12 +67,15 @@ async function computeAprs(
     .gte("created_at", since30d)
     .order("created_at", { ascending: true });
 
-  // Fetch the latest snapshot per slab (current rate)
+  // Fetch the latest snapshot per slab (current rate).
+  // Limit to slabAddresses.length * 10 rows to bound result size
+  // (slab list is on-chain so not user-controlled, but avoids latency spikes).
   const { data: latestRaw } = await db
     .from("insurance_snapshots")
     .select("slab, redemption_rate_e6, created_at")
     .in("slab", slabAddresses)
-    .order("created_at", { ascending: false });
+    .order("created_at", { ascending: false })
+    .limit(slabAddresses.length * 10);
 
   const earliest7d: InsuranceSnapshotRow[] = earliest7dRaw ?? [];
   const earliest30d: InsuranceSnapshotRow[] = earliest30dRaw ?? [];
@@ -134,8 +137,9 @@ async function computeAprs(
     const growth = (cur.rate - old.rate) / old.rate;
     const annualized = growth * (365 * MS_PER_DAY) / elapsed;
 
+    // Clamp to 0: negative APR (insurance drawdown) would confuse stakers.
     result[slab] = isFinite(annualized)
-      ? Math.round(annualized * 10_000) / 100  // → percentage, 2dp
+      ? Math.max(0, Math.round(annualized * 10_000) / 100)  // → percentage, 2dp, floor 0
       : 0;
   }
 


### PR DESCRIPTION
## Problem
`GET /api/stake/pools` returned `apr: 0` hardcoded for every pool with a TODO comment. The /stake page displayed "0.0% APR" for all insurance LP pools.

## Solution
Compute a real trailing APR from the `insurance_snapshots` table already written by the indexer's `InsuranceLPService`.

**Algorithm:**
- For each slab, find the oldest snapshot in the last 7 days (boundary redemption rate)
- Compare against the latest snapshot (current redemption rate)
- Annualise: `(rate_growth * 365d / elapsed) × 100%`
- Falls back to 30-day window when 7d has < 1 day of data
- Returns 0 for new pools with fewer than 1 day of snapshots

Both systems share the same lookup key: `insurance_snapshots.slab` = `StakePool.slab` (market slab address).

## Changes
- `app/app/api/stake/pools/route.ts`: `computeAprs()` helper + parallel DB fetch
- `app/__tests__/api/stake-pool-apr.test.ts`: 8 unit tests covering all branches

## Tests
```
8 passed: empty input, no snapshots, <1d elapsed, positive APR,
no growth, 30d fallback, multi-slab, zero rate
```
TypeScript clean (`tsc --noEmit`): ✅

## Notes
- `insurance_snapshots` not yet in generated Supabase types — using `(supabase as any)` with a typed local interface
- To regenerate types: `supabase gen types typescript --project-id $PROJECT_ID > app/lib/database.types.ts`

Closes MAINNET-ROADMAP Phase 2 APY display item
