### PR TITLE
fix: P0 — update devnet crankWallet to actual oracle keeper pubkey

### DIFF
--- a/app/hooks/useCreateMarket.ts
+++ b/app/hooks/useCreateMarket.ts
@@ -773,7 +773,9 @@ export function useCreateMarket() {
               name: params.name ?? "Unknown Token",
               decimals: params.decimals ?? 6,
               deployer: wallet.publicKey.toBase58(),
-              oracle_authority: isAdminOracle ? wallet.publicKey.toBase58() : null,
+              oracle_authority: isAdminOracle
+                ? (isDevnetEnv && getConfig().crankWallet ? getConfig().crankWallet : wallet.publicKey.toBase58())
+                : null,
               initial_price_e6: params.initialPriceE6.toString(),
               max_leverage: params.initialMarginBps > 0 ? Math.floor(10000 / Number(params.initialMarginBps)) : 1,
               trading_fee_bps: Number(params.tradingFeeBps),

--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -99,7 +99,7 @@ const CONFIGS = {
     get rpcUrl() { return getRpcEndpoint(); },
     programId: "FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD",
     matcherProgramId: "GTRgyTDfrMvBubALAqtHuQwT8tbGyXid7svXZKtWfC9k",
-    crankWallet: "2JaSzRYrf44fPpQBtRJfnCEgThwCmvpFd3FCXi45VXxm",
+    crankWallet: "FF7KFfU5Bb3Mze2AasDHCCZuyhdaSLjUZy2K3JvjdB7x",
     explorerUrl: "https://explorer.solana.com",
     // Multiple program deployments for different slab sizes (PERC-286).
     // Each tier has its own on-chain program compiled with the appropriate --features flag.


### PR DESCRIPTION
## P0 Fix: Oracle keeper can't push prices to new markets

### Root Cause
`crankWallet` in config.ts was `2JaSzRYrf44fPpQBtRJfnCEgThwCmvpFd3FCXi45VXxm` — NOT the oracle keeper. The actual keeper pubkey is `FF7KFfU5Bb3Mze2AasDHCCZuyhdaSLjUZy2K3JvjdB7x`.

This caused `SetOracleAuthority` in the market creation flow to delegate authority to the wrong key. The oracle keeper then couldn't push prices, leaving new markets stuck at price=1.

### Changes
1. **`app/lib/config.ts`**: Updated `crankWallet` to `FF7KFfU5Bb3Mze2AasDHCCZuyhdaSLjUZy2K3JvjdB7x`
2. **`app/hooks/useCreateMarket.ts`**: Record keeper pubkey (not user wallet) as `oracle_authority` in Supabase metadata on devnet

### DevOps Action Required
Run `SetOracleAuthority` on Khubair's existing market:
- Slab: `HjBePQZnoZVftg9B52gyeuHGjBvt2f8FNCVP4FeoP3YT`
- Current authority: `5Eb8PYou2Q38tuaMen3J7TV9mNXzazmDpq6VZLd6tStU` (Khubair's wallet)
- New authority: `FF7KFfU5Bb3Mze2AasDHCCZuyhdaSLjUZy2K3JvjdB7x` (oracle keeper)

### Testing
- 815 tests pass, TypeScript clean
- New markets will now correctly delegate oracle authority to the keeper