### PR TITLE
fix(F3): require RPC_URL in crank-generic.ts — remove silent mainnet fallback

### DIFF
--- a/scripts/crank-generic.ts
+++ b/scripts/crank-generic.ts
@@ -51,7 +51,12 @@ const ALL_ZEROS = new PublicKey("11111111111111111111111111111111");
 const keypairPath = process.env.ADMIN_KEYPAIR_PATH || "./admin-keypair.json";
 const raw = fs.readFileSync(keypairPath, "utf-8");
 const payer = Keypair.fromSecretKey(Uint8Array.from(JSON.parse(raw)));
-const connection = new Connection(process.env.RPC_URL || "https://api.mainnet-beta.solana.com", "confirmed");
+const rpcUrl = process.env.RPC_URL;
+if (!rpcUrl) {
+  console.error("❌ RPC_URL env var is required. Refusing to start without an explicit RPC endpoint.");
+  process.exit(1);
+}
+const connection = new Connection(rpcUrl, "confirmed");
 
 // Per-market price cache
 const priceCache = new Map<string, { priceE6: number; fetchedAt: number }>();


### PR DESCRIPTION
## Summary

Removes the hardcoded fallback to `https://api.mainnet-beta.solana.com` in `scripts/crank-generic.ts` when `RPC_URL` is not set.

Previously, if an operator ran `crank-generic.ts` on a devnet machine without setting `RPC_URL`, the crank would silently connect to **mainnet-beta** and attempt to crank production markets with a devnet keypair.

The fix replaces the silent fallback with an explicit startup guard — the process prints a clear error message and exits with code 1 if `RPC_URL` is not set.

## Changes

- `scripts/crank-generic.ts`: replaced `process.env.RPC_URL || "https://api.mainnet-beta.solana.com"` with a mandatory env var check + `process.exit(1)` on missing value

## Audit Reference

Fixes audit finding **F3 (High severity)** — *crank-generic.ts defaults to mainnet-beta RPC when RPC_URL is unset*.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated script configuration to require explicit RPC endpoint specification via environment variable. Scripts will now fail with a clear error message if the required configuration is not provided, replacing the previous implicit default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->