### PR TITLE
fix(N1): scrub keypair JSON from process.env after materialization (devnet-mm)

### DIFF
--- a/bots/devnet-mm/src/index.ts
+++ b/bots/devnet-mm/src/index.ts
@@ -73,6 +73,9 @@ function materializeKeypairFromEnv(
   if (!process.env[pathEnvVar]) {
     process.env[pathEnvVar] = filePath;
   }
+  // Scrub the raw key bytes from the environment so crash reporters,
+  // child processes, and /proc/<PID>/environ cannot read them.
+  delete process.env[envVar];
   console.log(`✅ Materialized ${envVar} → ${filePath}`);
 }
 


### PR DESCRIPTION
## Summary

After writing keypair JSON env vars to disk, the raw 64-byte private key arrays (`FILLER_KEYPAIR_JSON`, `MAKER_KEYPAIR_JSON`, `BOOTSTRAP_KEYPAIR_JSON`) remained in `process.env` for the entire lifetime of the bot process.

## Problem

Any code path that can read environment variables — crash reporters (Sentry, Datadog), debug loggers, child processes, or `/proc/<PID>/environ` on Linux — could access the full keypair private keys after startup.

## Fix

Add `delete process.env[envVar]` immediately after materializing each keypair to disk and setting the path env var.

This mirrors the existing pattern in `bots/oracle-keeper/index.ts` which already calls `delete process.env.ADMIN_KEYPAIR` after constructing the `Keypair` object.

## Changes

- `bots/devnet-mm/src/index.ts`: added `delete process.env[envVar]` inside `materializeKeypairFromEnv()` after the path env var is set

## Audit Reference

Fixes audit finding **N1 (Medium severity)** — *bots/devnet-mm keypair JSON not scrubbed from process.env after materialization*.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved security by preventing sensitive key data from remaining in the environment after materialization, reducing exposure to crash reports, spawned processes, and system inspection tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->