### PR TITLE
fix(N2a): remove fail-open devnet default from faucet/auto-fund/airdrop routes

### DIFF
--- a/app/app/api/airdrop/route.ts
+++ b/app/app/api/airdrop/route.ts
@@ -26,7 +26,7 @@ import * as Sentry from "@sentry/nextjs";
 
 export const dynamic = "force-dynamic";
 
-const NETWORK = process.env.NEXT_PUBLIC_SOLANA_NETWORK ?? "devnet";
+const NETWORK = process.env.NEXT_PUBLIC_SOLANA_NETWORK;
 const AIRDROP_USD_VALUE = 500;
 const RATE_LIMIT_HOURS = 24;
 const ORACLE_BRIDGE_URL = process.env.ORACLE_BRIDGE_URL ?? "http://127.0.0.1:18802";

--- a/app/app/api/auto-fund/route.ts
+++ b/app/app/api/auto-fund/route.ts
@@ -24,8 +24,8 @@ import * as Sentry from "@sentry/nextjs";
 
 export const dynamic = "force-dynamic";
 
-// Only enable on devnet
-const NETWORK = process.env.NEXT_PUBLIC_SOLANA_NETWORK ?? "devnet";
+// Only enable on devnet — no fallback default; missing env var is treated as non-devnet (fail-closed)
+const NETWORK = process.env.NEXT_PUBLIC_SOLANA_NETWORK;
 const MIN_SOL_BALANCE = 0.1 * LAMPORTS_PER_SOL; // 0.1 SOL threshold
 const AIRDROP_AMOUNT = 2 * LAMPORTS_PER_SOL; // 2 SOL
 const USDC_MINT_AMOUNT = 1_000_000_000; // 1,000 USDC (6 decimals) — PERC-372

--- a/app/app/api/faucet/route.ts
+++ b/app/app/api/faucet/route.ts
@@ -30,7 +30,7 @@ import * as Sentry from "@sentry/nextjs";
 
 export const dynamic = "force-dynamic";
 
-const NETWORK = process.env.NEXT_PUBLIC_SOLANA_NETWORK ?? "devnet";
+const NETWORK = process.env.NEXT_PUBLIC_SOLANA_NETWORK;
 const USDC_MINT_AMOUNT = 10_000_000_000; // 10,000 USDC (6 decimals)
 const RATE_LIMIT_HOURS = 24;
 


### PR DESCRIPTION
## Summary

Removes the fail-open `?? "devnet"` default from three devnet-spending API routes.

## Problem

`/api/faucet`, `/api/auto-fund`, and `/api/airdrop` all used:

```ts
const NETWORK = process.env.NEXT_PUBLIC_SOLANA_NETWORK ?? "devnet";
```

If `NEXT_PUBLIC_SOLANA_NETWORK` was accidentally omitted from a Vercel deployment, the routes would silently treat the environment as devnet and allow minting operations — even when running against mainnet infrastructure.

## Fix

Removed the `?? "devnet"` fallback. When the env var is unset, `NETWORK` is `undefined`, which does not equal `"devnet"`, so the guard returns 403 (fail-closed behaviour).

```ts
// Before
const NETWORK = process.env.NEXT_PUBLIC_SOLANA_NETWORK ?? "devnet";

// After
const NETWORK = process.env.NEXT_PUBLIC_SOLANA_NETWORK;
```

## Changes

- `app/app/api/faucet/route.ts`
- `app/app/api/auto-fund/route.ts`
- `app/app/api/airdrop/route.ts`

## Audit Reference

Fixes audit finding **N2a (Medium severity)** — *faucet/auto-fund/airdrop fail-open network default*.

Note: N2b (no per-request authentication on these endpoints) is tracked separately.
