### PR TITLE
fix(N7): restrict bug_reports PII columns from authenticated Supabase role

### DIFF
--- a/supabase/migrations/034_fix_pii_authenticated_role.sql
+++ b/supabase/migrations/034_fix_pii_authenticated_role.sql
@@ -1,0 +1,12 @@
+-- Migration: 034_fix_pii_authenticated_role.sql
+-- Fixes audit finding N7 (Medium): bug_reports RLS column-level restrictions
+-- only applied to the 'anon' role (migration 026_fix_pii_exposure.sql).
+-- The 'authenticated' Supabase role could read ip and admin_notes columns
+-- directly via PostgREST using the existing USING(true) SELECT policy.
+
+-- Revoke unrestricted SELECT from authenticated users
+REVOKE SELECT ON bug_reports FROM authenticated;
+
+-- Grant only the same safe columns as the anon role
+GRANT SELECT (id, title, description, status, severity, created_at, updated_at)
+  ON bug_reports TO authenticated;


### PR DESCRIPTION
## Summary

Migration `026_fix_pii_exposure.sql` fixed PII leakage in `bug_reports` for unauthenticated users, but left a gap for authenticated users.

## Problem

`026_fix_pii_exposure.sql` revoked unrestricted `SELECT` from the `anon` role and granted only safe columns. However, the `authenticated` role was not restricted. The original migration `006_bug_reports.sql` created a universal SELECT policy (`USING(true)`), meaning any Supabase-authenticated user could call:

```
GET /rest/v1/bug_reports
Authorization: Bearer <valid JWT>
```

...and receive the full table, including:
- `ip` — submitter IP address
- `admin_notes` — internal moderation notes

Since Supabase allows open account registration by default, any attacker could register a free account and read all PII.

## Fix

New migration `034_fix_pii_authenticated_role.sql`:

```sql
REVOKE SELECT ON bug_reports FROM authenticated;
GRANT SELECT (id, title, description, status, severity, created_at, updated_at)
  ON bug_reports TO authenticated;
```

This applies the same column-level restriction as the existing `anon` grant.

## Audit Reference

Fixes audit finding **N7 (Medium severity)** — *bug_reports RLS: authenticated role can read ip/admin_notes*.
