### PR TITLE
fix(F7): remove skipPreflight: true from auto-crank-service and oracle-keeper

### DIFF
--- a/bots/oracle-keeper/index.ts
+++ b/bots/oracle-keeper/index.ts
@@ -380,7 +380,6 @@ async function pushAndCrank(market: MarketInfo, programId: PublicKey): Promise<v
 
   const sig = await sendAndConfirmTransaction(conn, tx, [admin], {
     commitment: "confirmed",
-    skipPreflight: true,
   });
 
   s.lastPrice = price;

--- a/scripts/auto-crank-service.ts
+++ b/scripts/auto-crank-service.ts
@@ -124,7 +124,6 @@ async function crankMarket(market: DiscoveredMarket): Promise<string> {
 
   return sendAndConfirmTransaction(connection, tx, [payer], {
     commitment: "confirmed",
-    skipPreflight: true,
   });
 }
 


### PR DESCRIPTION
## Summary

Removes `skipPreflight: true` from production transaction send calls in two scripts.

## Problem

`skipPreflight: true` disables Solana's local transaction simulation step before broadcast. Consequences:
- Invalid transactions (wrong accounts, mismatched program state, insufficient compute budget) are submitted on-chain and fail **after** fee payment
- Program log errors are only visible post-failure via RPC, not before send
- For the oracle keeper running in a continuous loop, repeated preflight-skipped failures silently burn SOL priority fees

## Fix

Removed `skipPreflight: true` from `sendAndConfirmTransaction` calls in both files, restoring the default preflight simulation behaviour.

## Changes

- `scripts/auto-crank-service.ts` (line 127): removed `skipPreflight: true`
- `bots/oracle-keeper/index.ts` (line 383): removed `skipPreflight: true`

## Audit Reference

Fixes audit finding **F7 (Medium severity)** — `skipPreflight: true` on production on-chain transactions.
