### PR TITLE
fix(N3): remove internal error details from /api/oracle/publishers 500 response

### DIFF
--- a/app/app/api/oracle/publishers/route.ts
+++ b/app/app/api/oracle/publishers/route.ts
@@ -109,7 +109,7 @@ export async function GET(req: NextRequest) {
   } catch (err) {
     console.error("[oracle/publishers] Error:", err);
     return NextResponse.json(
-      { error: "Failed to fetch publisher data", detail: String(err) },
+      { error: "Failed to fetch publisher data" },
       { status: 500 },
     );
   }


### PR DESCRIPTION
## Summary

Removes `detail: String(err)` from the 500 error response in `/api/oracle/publishers`.

## Problem

The catch block returned internal error details directly to API callers:

```ts
return NextResponse.json(
  { error: "Failed to fetch publisher data", detail: String(err) },
  { status: 500 },
);
```

`String(err)` can expose:
- Internal service URLs (including any credentials in `ORACLE_BRIDGE_URL`)
- Pythnet RPC connection strings
- File paths from TypeScript stack traces
- Supabase error messages including table/column names

## Fix

Removed the `detail` field. The error is already logged server-side via `console.error("[oracle/publishers] Error:", err)`.

## Audit Reference

Fixes audit finding **N3 (Low severity)** — `/api/oracle/publishers` leaks `detail: String(err)` in 500 responses.
