### PR TITLE
fix(F10,N4): add anchors to Solana pubkey validation regexes

### DIFF
--- a/packages/shared/src/networkValidation.ts
+++ b/packages/shared/src/networkValidation.ts
@@ -81,7 +81,7 @@ export function validateNetworkConfig(env: {
   }
 
   // 5. Validate program ID looks like a valid Solana address (base58, ~44 chars)
-  if (!/[1-9A-HJ-NP-Za-km-z]{40,45}/.test(programIdEnv)) {
+  if (!/^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(programIdEnv)) {
     throw new Error(
       `❌ PROGRAM_ID does not look like a valid Solana address.\n` +
       `Got: ${programIdEnv}\n` +

--- a/packages/shared/src/sealedKeypair.ts
+++ b/packages/shared/src/sealedKeypair.ts
@@ -137,7 +137,7 @@ export function validateSigner(
   const publicKey = signer.publicKey();
 
   // Basic validation: public key looks like a Solana address
-  if (!/[1-9A-HJ-NP-Z]{40,45}/.test(publicKey)) {
+  if (!/^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(publicKey)) {
     throw new Error(
       `❌ Invalid public key from signer: ${publicKey}. ` +
       `Expected base58-encoded Solana address.`


### PR DESCRIPTION
## Summary

Adds `^` and `$` anchors to Solana public key validation regexes in two files, preventing partial-match bypass.

## Problem

Both `sealedKeypair.ts` and `networkValidation.ts` validated Solana public keys with unanchored regexes:

```ts
// sealedKeypair.ts
if (!/[1-9A-HJ-NP-Z]{40,45}/.test(publicKey)) { ... }

// networkValidation.ts
if (!/[1-9A-HJ-NP-Za-km-z]{40,45}/.test(programIdEnv)) { ... }
```

Without `^` (start) and `$` (end) anchors, a crafted string like `INVALID!!!FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKd!!!INVALID` passes validation because it contains a valid-looking 40-character base58 substring.

## Fix

```ts
// Both files now use:
if (!/^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(value)) { ... }
```

Changes:
- Added `^` and `$` anchors to fully anchor the match
- Unified the character class to the correct base58 alphabet (`[1-9A-HJ-NP-Za-km-z]`)
- Corrected the length range from `{40,45}` to `{32,44}` (standard Solana pubkey bounds)

## Changes

- `packages/shared/src/sealedKeypair.ts`
- `packages/shared/src/networkValidation.ts`

## Audit Reference

Fixes audit findings **F10 (Low severity)** and **N4 (Low severity)** — non-anchored public key validation regexes.
