### PR TITLE
fix(F11,N8): harden WS_AUTH defaults and remove hardcoded secret from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,8 @@ API_AUTH_KEY=
 # WebSocket Authentication
 # Generate with: openssl rand -hex 32
 WS_AUTH_SECRET=
-WS_AUTH_REQUIRED=false
+# Set to false only for local development
+WS_AUTH_REQUIRED=true
 
 # CORS Configuration (comma-separated origins)
 CORS_ORIGINS=http://localhost:3000

--- a/packages/api/.env.example
+++ b/packages/api/.env.example
@@ -14,10 +14,11 @@ CORS_ORIGINS=http://localhost:3000,http://localhost:3001,https://percolator-laun
 
 # WebSocket Authentication
 # Enable authentication requirement for WebSocket connections
-WS_AUTH_REQUIRED=false
+# Set to false only for local development
+WS_AUTH_REQUIRED=true
 
-# WebSocket authentication secret (change in production!)
-WS_AUTH_SECRET=percolator-ws-secret-change-in-production
+# WebSocket authentication secret — generate with: openssl rand -base64 32
+WS_AUTH_SECRET=
 
 # WebSocket Limits
 MAX_WS_CONNECTIONS=500


### PR DESCRIPTION
## Summary

Hardens WebSocket authentication defaults in both `.env.example` files.

## Problems Fixed

### F11 — WS_AUTH_REQUIRED defaults to false

Both `.env.example` and `packages/api/.env.example` shipped with `WS_AUTH_REQUIRED=false`. Operators who copy the example file without reading it would deploy with WebSocket authentication disabled.

### N8 — WS_AUTH_SECRET hardcoded to a known value

`packages/api/.env.example` contained:
```
WS_AUTH_SECRET=percolator-ws-secret-change-in-production
```

This value is publicly visible in the repository. Any deployment that copies the example unchanged would run with a compromised WebSocket auth secret — defeating the purpose of `WS_AUTH_REQUIRED=true`.

## Fix

- `WS_AUTH_REQUIRED=false` → `WS_AUTH_REQUIRED=true` in both files
- `WS_AUTH_SECRET=percolator-ws-secret-change-in-production` → `WS_AUTH_SECRET=` (blank, forces operators to set their own)
- Added comments directing operators to generate secrets with `openssl rand`

## Changes

- `.env.example`
- `packages/api/.env.example`

## Audit Reference

Fixes audit findings **F11 (Low severity)** and **N8 (Low severity)**.
