### PR TITLE
fix(N5): document DEVNET_MINT_AUTHORITY_KEYPAIR in app/.env.example

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -35,6 +35,12 @@ PROGRAM_ID=
 # Indexer API key (for prices/trades/stats endpoints)
 INDEXER_API_KEY=
 
+# Devnet mint authority keypair — JSON array of 64 bytes — KEEP SECRET, never commit
+# Required for: /api/faucet, /api/auto-fund, /api/airdrop, /api/devnet-mint-token,
+#               /api/devnet-pre-fund, /api/devnet-mirror-mint
+# Generate: solana-keygen new --no-bip39-passphrase --outfile /tmp/mint-auth.json && cat /tmp/mint-auth.json
+DEVNET_MINT_AUTHORITY_KEYPAIR=
+
 
 # ── Sentry Error Tracking ──
 # Frontend DSN (client-side, safe to expose)


### PR DESCRIPTION
## Summary

Adds a documented entry for `DEVNET_MINT_AUTHORITY_KEYPAIR` to `app/.env.example`, which was previously absent despite being required by six API routes.

## Problem

`DEVNET_MINT_AUTHORITY_KEYPAIR` is used in:
- `/api/faucet`
- `/api/auto-fund`
- `/api/airdrop`
- `/api/devnet-mint-token`
- `/api/devnet-pre-fund`
- `/api/devnet-mirror-mint`

No entry existed in `app/.env.example`, so developers setting up a new deployment had no guidance that this variable needs to be provisioned, what format it expects (64-byte JSON array), or that it holds a private key and must never be committed.

## Fix

Added a blank, documented entry to `app/.env.example` including:
- Comment listing the routes that require it
- `solana-keygen` command to generate the keypair
- Warning that it must be kept secret

## Audit Reference

Fixes audit finding **N5 (Low severity)** — `DEVNET_MINT_AUTHORITY_KEYPAIR` undocumented in `app/.env.example`.
