### PR TITLE
fix(tests): replace 45-char PROGRAM_ID fixture with valid 44-char base58 address

### DIFF
--- a/packages/shared/tests/networkValidation.test.ts
+++ b/packages/shared/tests/networkValidation.test.ts
@@ -13,7 +13,7 @@ import {
 describe("validateNetworkConfig", () => {
   // The source regex is [1-9A-HJ-NP-Z]{40,45} — uppercase+digits only.
   // Use a test ID that matches this pattern.
-  const validProgramId = "123456789ABCDEFGHJKLMNPQRSTUVWXYZ123456789ABC";
+  const validProgramId = "FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD";
   const validDevnetEnv = {
     NETWORK: "devnet",
     PROGRAM_ID: validProgramId,
@@ -176,7 +176,7 @@ describe("ensureNetworkConfigValid", () => {
   it("does not throw for valid devnet config", () => {
     const env = {
       NETWORK: "devnet",
-      PROGRAM_ID: "123456789ABCDEFGHJKLMNPQRSTUVWXYZ123456789ABC",
+      PROGRAM_ID: "FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD",
     } as unknown as NodeJS.ProcessEnv;
     expect(() => ensureNetworkConfigValid(env)).not.toThrow();
   });


### PR DESCRIPTION
## Problem

CI on `main` is broken (run 22782133342) — Security Tests failing in `packages/shared`.

Root cause: the test fixture `validProgramId = '123456789ABCDEFGHJKLMNPQRSTUVWXYZ123456789ABC'` is **45 characters** long. After the F10/N4 regex anchor hardening landed (#804), the validator enforces `/^[1-9A-HJ-NP-Za-km-z]{32,44}$/` — 45 chars fails the `{32,44}` length constraint.

Two occurrences affected:
- Line 16: `const validProgramId` (shared across most tests)
- Line 179: inline fixture in `ensureNetworkConfigValid` test

## Fix

Replace both with `FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD` — a valid 44-char base58 Solana address (same address used as the example in the validator's own error message).

## Verification

```
pnpm --filter @percolator/shared test
✓ tests/networkValidation.test.ts (29 tests) 5ms
Test Files: 14 passed (14)
Tests: 280 passed | 1 skipped (281)
```

## Impact
Unblocks `main` CI immediately. No logic change — test fixture only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure with new validation constants to ensure continued test coverage accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->