### PR TITLE
fix(#813): validate oracle_mode enum and dex_pool_address pubkey server-side

### DIFF
--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -77,6 +77,29 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  // #813: Validate oracle_mode enum
+  const VALID_ORACLE_MODES = ["pyth", "hyperp", "admin"] as const;
+  type OracleMode = typeof VALID_ORACLE_MODES[number];
+  const resolvedOracleMode: OracleMode = oracle_mode ?? "admin";
+  if (!VALID_ORACLE_MODES.includes(resolvedOracleMode)) {
+    return NextResponse.json(
+      { error: `Invalid oracle_mode. Must be one of: ${VALID_ORACLE_MODES.join(", ")}` },
+      { status: 400 }
+    );
+  }
+
+  // #813: Validate dex_pool_address is a valid Solana pubkey (when provided)
+  if (dex_pool_address) {
+    try {
+      new PublicKey(dex_pool_address);
+    } catch {
+      return NextResponse.json(
+        { error: "Invalid dex_pool_address: must be a valid Solana public key" },
+        { status: 400 }
+      );
+    }
+  }
+
   // Verify slab account exists on-chain and is owned by our program
   try {
     const cfg = getConfig();
@@ -130,7 +153,7 @@ export async function POST(req: NextRequest) {
       matcher_context,
       logo_url: logo_url || null,
       mainnet_ca: mainnet_ca || null,
-      oracle_mode: oracle_mode || "admin",
+      oracle_mode: resolvedOracleMode,
       dex_pool_address: dex_pool_address || null,
     })
     .select()

--- a/supabase/migrations/036_markets_oracle_mode_check.sql
+++ b/supabase/migrations/036_markets_oracle_mode_check.sql
@@ -1,0 +1,7 @@
+-- #813: Add CHECK constraint to markets.oracle_mode
+-- Ensures only valid oracle modes can be stored at DB level.
+-- oracle_mode column already exists from migration 035.
+
+ALTER TABLE markets
+  ADD CONSTRAINT markets_oracle_mode_check
+  CHECK (oracle_mode IN ('pyth', 'hyperp', 'admin'));


### PR DESCRIPTION
## Summary
Closes #813 — server-side validation gaps from PERC-470.

## Changes
- **`app/app/api/markets/route.ts`**: Add enum guard for `oracle_mode` (must be `pyth`|`hyperp`|`admin`); add `PublicKey` validation for `dex_pool_address` before insert
- **`supabase/migrations/036_markets_oracle_mode_check.sql`**: Adds `CHECK (oracle_mode IN ('pyth','hyperp','admin'))` constraint at DB level

## How to Test
- POST `/api/markets` with `oracle_mode: 'invalid'` → 400 with clear error
- POST with `dex_pool_address: 'not-a-pubkey'` → 400 with clear error
- POST with valid `oracle_mode: 'hyperp'` and valid pubkey → 201 success

## Security
LOW severity — metadata only, no fund risk. Fixes the two LOWs filed by security in issue #813.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input validation for market configuration to reject invalid oracle modes and pool addresses
  * Added database-level constraints to ensure data integrity for market operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->