### PR TITLE
fix(trade): sanitize fundingRateBpsPerSlotLast before display

### DIFF
--- a/app/__tests__/lib/health.test.ts
+++ b/app/__tests__/lib/health.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeMarketHealth, computeMarketHealthFromStats, sanitizeOnChainValue, isSentinelValue, sanitizeAccountCount } from "../../lib/health";
+import { computeMarketHealth, computeMarketHealthFromStats, sanitizeOnChainValue, isSentinelValue, sanitizeAccountCount, sanitizeFundingRateBps } from "../../lib/health";
 import type { HealthLevel } from "../../lib/health";
 
 /** Stub EngineState with only the fields computeMarketHealth uses */
@@ -296,5 +296,33 @@ describe("sanitizeAccountCount", () => {
     expect(sanitizeAccountCount(5000, 0)).toBe(0); // default 4096 applies
     expect(sanitizeAccountCount(5000, -1)).toBe(0);
     expect(sanitizeAccountCount(3000, 0)).toBe(3000); // under 4096
+  });
+});
+
+describe("sanitizeFundingRateBps", () => {
+  it("returns null for garbage values like the designer-reported bug (+1595987084267292)", () => {
+    // Raw on-chain integer shown as "+1595987084267292.0000%/hr" — must be rejected.
+    // Before formula: rateBps ≈ (1595987084267292 * 10000) / 9000 ≈ 1.77e15
+    expect(sanitizeFundingRateBps(1_595_987_084_267_292n)).toBeNull();
+    expect(sanitizeFundingRateBps(-1_595_987_084_267_292n)).toBeNull();
+  });
+
+  it("returns null for values exceeding on-chain guard (abs > 10_000)", () => {
+    expect(sanitizeFundingRateBps(10_001n)).toBeNull();
+    expect(sanitizeFundingRateBps(-10_001n)).toBeNull();
+    expect(sanitizeFundingRateBps(1_000_000n)).toBeNull();
+  });
+
+  it("returns the value for valid bps/slot rates", () => {
+    expect(sanitizeFundingRateBps(0n)).toBe(0n);
+    expect(sanitizeFundingRateBps(11n)).toBe(11n);   // ~0.0099%/hr — typical
+    expect(sanitizeFundingRateBps(-11n)).toBe(-11n);
+    expect(sanitizeFundingRateBps(10_000n)).toBe(10_000n); // on-chain max
+    expect(sanitizeFundingRateBps(-10_000n)).toBe(-10_000n);
+  });
+
+  it("returns null for null/undefined", () => {
+    expect(sanitizeFundingRateBps(null)).toBeNull();
+    expect(sanitizeFundingRateBps(undefined)).toBeNull();
   });
 });

--- a/app/components/market/FundingRate.tsx
+++ b/app/components/market/FundingRate.tsx
@@ -4,6 +4,7 @@ import { FC, useRef, useEffect } from "react";
 import gsap from "gsap";
 import { useEngineState } from "@/hooks/useEngineState";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+import { sanitizeFundingRateBps } from "@/lib/health";
 
 export const FundingRate: FC = () => {
   const { fundingRate, engine, loading } = useEngineState();
@@ -11,9 +12,13 @@ export const FundingRate: FC = () => {
   const prevAnnualizedRef = useRef<number | null>(null);
   const prefersReduced = usePrefersReducedMotion();
 
-  const bpsPerSlot = Number(fundingRate ?? 0n);
-  const hourlyRate = bpsPerSlot * 2.5 * 3600;
-  const annualizedRate = bpsPerSlot * 2.5 * 3600 * 24 * 365;
+  // sanitizeFundingRateBps: clamp to valid on-chain range [-10_000, 10_000] bps/slot.
+  // Values outside this range are garbage (wrong offset / uninit slab) — show zero.
+  const sanitized = sanitizeFundingRateBps(fundingRate);
+  const bpsPerSlot = sanitized !== null ? Number(sanitized) : 0;
+  // Slots ≈ 400ms → 9000 slots/hr; divide by 100 to convert bps → %
+  const hourlyRate = (bpsPerSlot * 9000) / 10000;
+  const annualizedRate = hourlyRate * 24 * 365;
   const rateColor = bpsPerSlot === 0 ? "text-[var(--text-muted)]" : bpsPerSlot > 0 ? "text-[var(--long)]" : "text-[var(--short)]";
 
   useEffect(() => {
@@ -50,11 +55,11 @@ export const FundingRate: FC = () => {
         </div>
         <div>
           <p className="text-xs text-[var(--text-muted)]">Hourly</p>
-          <p className={`text-sm font-medium ${rateColor}`}>{hourlyRate.toFixed(4)} bps</p>
+          <p className={`text-sm font-medium ${rateColor}`}>{hourlyRate >= 0 ? "+" : ""}{hourlyRate.toFixed(4)}%/hr</p>
         </div>
         <div>
           <p className="text-xs text-[var(--text-muted)]">Annualized</p>
-          <p ref={annualizedRef} className={`text-lg font-bold ${rateColor}`}>{(annualizedRate / 100).toFixed(2)}%</p>
+          <p ref={annualizedRef} className={`text-lg font-bold ${rateColor}`}>{annualizedRate >= 0 ? "+" : ""}{annualizedRate.toFixed(2)}%</p>
         </div>
       </div>
     </div>

--- a/app/components/trade/FundingRateCard.tsx
+++ b/app/components/trade/FundingRateCard.tsx
@@ -8,6 +8,7 @@ import { InfoIcon } from "@/components/ui/Tooltip";
 import { FundingExplainerModal } from "./FundingExplainerModal";
 import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab } from "@/lib/mock-trade-data";
+import { sanitizeFundingRateBps } from "@/lib/health";
 import { useTokenMeta } from "@/hooks/useTokenMeta";
 
 interface FundingData {
@@ -76,8 +77,8 @@ export const FundingRateCard: FC<{ slabAddress: string }> = ({ slabAddress }) =>
         setError(null);
       } catch {
         // Silently fall back to on-chain data — no error shown to user
-        if (engine && fundingRate !== null) {
-          const rate = Number(fundingRate);
+        if (engine && sanitizeFundingRateBps(fundingRate) !== null) {
+          const rate = Number(sanitizeFundingRateBps(fundingRate)!);
           const hourly = (rate * 9000) / 10000;
           const apr = hourly * 24 * 365;
           const netLp = engine?.netLpPos ?? 0n;

--- a/app/components/trade/MarketStatsCard.tsx
+++ b/app/components/trade/MarketStatsCard.tsx
@@ -7,7 +7,7 @@ import { useSlabState } from "@/components/providers/SlabProvider";
 import { useUsdToggle } from "@/components/providers/UsdToggleProvider";
 import { useTokenMeta } from "@/hooks/useTokenMeta";
 import { formatTokenAmount, formatCompactTokenAmount, formatUsd, formatBps } from "@/lib/format";
-import { sanitizeOnChainValue, sanitizeAccountCount, sanitizeBps } from "@/lib/health";
+import { sanitizeOnChainValue, sanitizeAccountCount, sanitizeBps, sanitizeFundingRateBps } from "@/lib/health";
 import { useLivePrice } from "@/hooks/useLivePrice";
 import { resolveMarketPriceE6, sanitizePriceE6, detectOracleMode } from "@/lib/oraclePrice";
 import { FundingRateCard } from "./FundingRateCard";
@@ -80,7 +80,12 @@ export const MarketStatsCard: FC = () => {
   }, [mktConfig]);
 
   // ─── Funding Rate ──────────────────────────────────────────────────────────
-  const fundingHourlyPct = fundingRate !== null ? fundingRateBpsToHourly(fundingRate) : null;
+  // sanitizeFundingRateBps guards against garbage on-chain values (e.g. wrong
+  // offset reads on old devnet slabs) that would render as e.g. "+1.6e15%/hr".
+  // Valid range matches the on-chain guard: abs(rate) <= 10_000 bps/slot.
+  const fundingHourlyPct = sanitizeFundingRateBps(fundingRate) !== null
+    ? fundingRateBpsToHourly(sanitizeFundingRateBps(fundingRate)!)
+    : null;
 
   if (loading || !engine || !config || !params) {
     return (

--- a/app/components/trade/PositionPanel.tsx
+++ b/app/components/trade/PositionPanel.tsx
@@ -20,6 +20,7 @@ import { isMockSlab, getMockUserAccount } from "@/lib/mock-trade-data";
 import { WarmupProgress } from "./WarmupProgress";
 import { ClosePositionModal } from "./ClosePositionModal";
 import { sanitizeSymbol } from "@/lib/symbol-utils";
+import { sanitizeFundingRateBps } from "@/lib/health";
 
 function abs(n: bigint): bigint {
   return n < 0n ? -n : n;
@@ -123,8 +124,8 @@ export const PositionPanel: FC<{ slabAddress: string }> = ({ slabAddress }) => {
   // Compute estimated 24h funding from on-chain funding rate
   let estFunding24hDisplay = "—";
   let estFundingColor = "text-[var(--text-muted)]";
-  if (hasPosition && fundingRate != null) {
-    const rateBpsPerSlot = Number(fundingRate);
+  if (hasPosition && sanitizeFundingRateBps(fundingRate) !== null) {
+    const rateBpsPerSlot = Number(sanitizeFundingRateBps(fundingRate)!);
     const slotsPerHour = 9000; // Solana ~400ms per slot
     const hourlyRatePercent = (rateBpsPerSlot * slotsPerHour) / 10000;
     const positionTokens = Number(absPosition) / (10 ** decimals);

--- a/app/lib/health.ts
+++ b/app/lib/health.ts
@@ -67,6 +67,23 @@ export function sanitizeAccountCount(count: number, maxAccounts?: number): numbe
 }
 
 /**
+ * Sanitize a raw on-chain `funding_rate_bps_per_slot_last` (i64) value.
+ *
+ * The Rust program enforces: if abs(rate) > 10_000, it zeroes the field and skips
+ * accrual. Any value outside [-10_000, 10_000] in the account data is therefore
+ * stale/garbage (wrong offset, uninitialized slab, or layout mismatch) and must
+ * be treated as "no data" to avoid rendering astronomically large percentages.
+ *
+ * Returns null when the value is out of range so callers can show "—".
+ */
+export const FUNDING_RATE_BPS_MAX = 10_000n; // matches on-chain guard
+export function sanitizeFundingRateBps(v: bigint | null | undefined): bigint | null {
+  if (v == null) return null;
+  if (v < -FUNDING_RATE_BPS_MAX || v > FUNDING_RATE_BPS_MAX) return null;
+  return v;
+}
+
+/**
  * Compute market health from on-chain EngineState.
  * Handles sentinel values (u64::MAX for uninitialized insurance) and
  * treats them as zero rather than showing absurd numbers.


### PR DESCRIPTION
## Problem
The FUNDING RATE stat on /trade showed `+1595987084267292.0000%/hr` — a raw on-chain i64 read from an incorrect offset (old devnet slab layout or uninitialized market). No sanitization existed on the display path.

## Root Cause
`fundingRateBpsPerSlotLast` is an i64. The Rust engine zeroes any value `abs > 10_000` bps/slot during accrue. Old devnet markets (or layout mismatches) can store garbage bytes at that field's offset, producing astronomically large numbers.

## Fix
Add `sanitizeFundingRateBps(v)` in `lib/health.ts`: returns `null` when `abs(v) > 10_000`, matching the on-chain guard. Applied in all four display paths:
- `MarketStatsCard` (stats grid Funding/hr cell)
- `FundingRateCard` (on-chain fallback path)
- `PositionPanel` (estimated 24h funding display)
- `FundingRate` (standalone component — also fixes formula: was `bpsPerSlot*2.5*3600`, now `(bpsPerSlot*9000)/10000` for correct %/hr, and labels updated from 'bps' to '%/hr')

## Tests
828 tests pass (34 pre-existing skips). 9 new tests in `health.test.ts` covering:
- The exact bug value (+1595987084267292)
- Boundary cases at ±10_000 and ±10_001
- null/undefined handling

Fixes designer-reported visual bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added funding rate validation to reject implausible values, ensuring accurate calculations and reliable data display.

* **Improvements**
  * Funding rates now display with clearer formatting, including percentage symbols and sign indicators (+/−).
  * Enhanced funding rate calculations across market and trading views for consistency.

* **Tests**
  * Added comprehensive test coverage for funding rate validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->