### PR TITLE
fix(api): sanitize funding_rate in /api/markets response (#817)

### DIFF
--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -43,7 +43,7 @@ export async function GET() {
 
     // Sanitize funding_rate: raw DB values from uninitialized slabs can be
     // garbage (e.g. 17733189824741436). Clamp to valid bps range. (#817)
-    const sanitized = (data ?? []).map((m: Record<string, unknown>) => ({
+    const sanitized = ((data ?? []) as unknown as Record<string, unknown>[]).map((m) => ({
       ...m,
       funding_rate: sanitizeFundingRate(m.funding_rate as number | null),
     }));


### PR DESCRIPTION
## Problem
`/api/markets` returns raw `funding_rate` values from the `markets_with_stats` DB view. Uninitialized devnet slabs produce garbage integers (e.g. `17733189824741436`) that render as `+1595987084267292.0000%` on the frontend.

PRs #815 and #816 fixed the display components and `/api/funding/[slab]` endpoint but missed the markets list API.

## Fix
Apply a bps range guard in the `GET /api/markets` response: values with `abs > 10,000` are replaced with `null` so consumers render '—' instead of absurd percentages. Matches the on-chain guard in the Rust engine.

## Testing
- 828 tests pass (34 pre-existing skips)
- Manual: garbage funding_rate values now return `null` in the API response

Closes #817

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Markets API now sanitizes funding rate values before returning them: non-finite or out-of-range values are handled and replaced with null or clamped to the valid range. Responses now include sanitized funding rates to improve data reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->