### PR TITLE
fix(api): cast Supabase data type to resolve TS2322 in PR #818

### DIFF
--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -43,7 +43,7 @@ export async function GET() {
 
     // Sanitize funding_rate: raw DB values from uninitialized slabs can be
     // garbage (e.g. 17733189824741436). Clamp to valid bps range. (#817)
-    const sanitized = (data ?? []).map((m: Record<string, unknown>) => ({
+    const sanitized = ((data ?? []) as unknown as Record<string, unknown>[]).map((m) => ({
       ...m,
       funding_rate: sanitizeFundingRate(m.funding_rate as number | null),
     }));


### PR DESCRIPTION
## Problem
PR #818 (fix/markets-api-sanitize-funding-rate) fixes the garbage funding_rate values but CI is failing with a TypeScript error on line 46.

The Supabase client infers a specific row type from `.from('markets_with_stats').select()`. Annotating the map callback with `(m: Record<string, unknown>)` causes **TS2322** because the inferred type and the annotation are incompatible.

## Fix
Cast `(data ?? [])` via `as unknown as Record<string, unknown>[]` before the map — TypeScript is satisfied and runtime behaviour is unchanged.

```ts
// Before (TS error)
const sanitized = (data ?? []).map((m: Record<string, unknown>) => ({

// After (compiles clean)
const sanitized = ((data ?? []) as unknown as Record<string, unknown>[]).map((m) => ({
```

`npx tsc --noEmit` passes with no errors.

## Note
This is a companion fix to #818. The funding_rate sanitisation logic itself is unchanged. The garbage +1595987084267292.0000% value visible on /trade/SOL-PERP should be resolved once this (or #818 with this fix cherry-picked) merges.

Closes the CI failure on #818.