### PR TITLE
fix(PERC-811): hyperp pool resolution + dexPoolAddress fallback for Quick Launch

### DIFF
--- a/app/app/api/oracle/resolve/[ca]/route.ts
+++ b/app/app/api/oracle/resolve/[ca]/route.ts
@@ -155,10 +155,12 @@ async function fetchDexScreenerInfo(
       baseToken?: { symbol?: string };
       liquidity?: { usd?: number };
       chainId?: string;
+      dexId?: string;
+      pairAddress?: string;
     }>;
     if (!pairs?.length) return null;
 
-    // Sort by liquidity, pick best Solana pair
+    // Sort by liquidity, pick best Solana pair (for price/symbol — most liquid wins)
     const solPairs = pairs
       .filter((p) => p.chainId === "solana" && p.priceUsd)
       .sort((a, b) => (b.liquidity?.usd ?? 0) - (a.liquidity?.usd ?? 0));
@@ -168,11 +170,17 @@ async function fetchDexScreenerInfo(
     const price = parseFloat(best.priceUsd ?? "0");
     if (!isFinite(price) || price <= 0) return null;
 
-    // PERC-470: Also return pool address and DEX ID for hyperp mode
+    // PERC-470/#811: For hyperp pool address, find the highest-liquidity pair on a
+    // *supported* DEX — not just the most liquid pair overall. The best overall pair
+    // may be on Orca/other unsupported venues, causing poolAddress to be incorrectly
+    // null even when a valid PumpSwap/Raydium/Meteora pool exists lower in the list.
     const SUPPORTED_DEX_IDS = new Set(["pumpswap", "raydium", "meteora"]);
-    const dexId = (best as any).dexId?.toLowerCase() ?? null;
-    let poolAddress: string | null = SUPPORTED_DEX_IDS.has(dexId ?? "") ? (best as any).pairAddress ?? null : null;
-    // PERC-470 security: validate pool address is a valid Solana pubkey before returning
+    const bestSupported = solPairs.find(
+      (p) => SUPPORTED_DEX_IDS.has(p.dexId?.toLowerCase() ?? "") && p.pairAddress
+    ) ?? null;
+    const dexId = bestSupported?.dexId?.toLowerCase() ?? null;
+    let poolAddress: string | null = bestSupported?.pairAddress ?? null;
+    // Security: validate pool address is a valid Solana pubkey before returning
     if (poolAddress) {
       try { new PublicKey(poolAddress); } catch { poolAddress = null; }
     }

--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -377,9 +377,12 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
       decimals,
       mainnetCA: wizard.mintAddress !== effectiveMint ? wizard.mintAddress : undefined,
       oracleMode,
-      // PERC-470: Pass DEX pool info for hyperp mode
-      ...(oracleMode === "hyperp" && wizard.dexPool ? {
-        dexPoolAddress: wizard.dexPool.poolAddress,
+      // PERC-470/#811: Pass DEX pool address for hyperp mode.
+      // wizard.dexPool is set when the user selects a pool from the UI.
+      // For Quick Launch, poolInfo may be null while oracleFeed holds the pool address —
+      // use oracleFeed as fallback so the pool address is never silently dropped.
+      ...(oracleMode === "hyperp" ? {
+        dexPoolAddress: wizard.dexPool?.poolAddress ?? wizard.oracleFeed,
       } : {}),
     };
     create(params);
@@ -413,8 +416,10 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
       decimals,
       mainnetCA: wizard.mintAddress !== effectiveMint ? wizard.mintAddress : undefined,
       oracleMode,
-      ...(oracleMode === "hyperp" && wizard.dexPool ? {
-        dexPoolAddress: wizard.dexPool.poolAddress,
+      // PERC-470/#811: Same fallback as handleLaunch — oracleFeed holds pool address
+      // for Quick Launch when wizard.dexPool is null.
+      ...(oracleMode === "hyperp" ? {
+        dexPoolAddress: wizard.dexPool?.poolAddress ?? wizard.oracleFeed,
       } : {}),
     };
     create(params, createState.step);


### PR DESCRIPTION
## Summary
Two functional bugs in the PERC-470 hyperp oracle flow (post-merge follow-up).

## Bug 1: oracle/resolve picks wrong pair for poolAddress

**File:** `app/app/api/oracle/resolve/[ca]/route.ts`

Was taking `solPairs[0]` (most liquid overall) and checking if *that* pair's DEX is supported. If the deepest Solana pair is on Orca or another unsupported venue, `poolAddress` was set to `null` — even when a PumpSwap/Raydium/Meteora pool exists lower in the list. This would cause hyperp auto-detection to silently fall back to admin oracle mode for any token whose best liquidity is on an unsupported DEX.

**Fix:** Use `solPairs.find()` to get the highest-liquidity pair on a *supported* DEX for `poolAddress`/`dexId`. Price and symbol still come from the most liquid pair overall (best accuracy).

Also adds `dexId?: string; pairAddress?: string` to the pairs type definition — removes the `as any` casts that were masking this.

## Bug 2: dexPoolAddress silently dropped in Quick Launch

**File:** `app/components/create/CreateMarketWizard.tsx`

Both `handleLaunch` and `handleRetry` were guarded by:
```ts
...(oracleMode === 'hyperp' && wizard.dexPool ? { dexPoolAddress: wizard.dexPool.poolAddress } : {})
```

For Quick Launch, `wizard.dexPool` can be null when `useQuickLaunch.poolInfo` hasn't resolved yet — but `wizard.oracleFeed` already holds the pool address string. The `&& wizard.dexPool` guard silently dropped `dexPoolAddress`, causing market creation to proceed without the required pool account.

**Fix:** In hyperp mode, use `wizard.dexPool?.poolAddress ?? wizard.oracleFeed` as fallback.

## Tests
- 828 tests passing (34 skipped, pre-existing)
- TypeScript: clean

## Closes
Flagged by CodeRabbit in PR #808 review (outside diff / major comments).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced oracle price resolution with support for multiple DEX venues.
  * Improved pool address selection logic based on highest liquidity.
  * Added fallback mechanism for more robust oracle data handling during market creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->