### PR TITLE
fix(api): sanitize funding_rate in Hono API service (#817)

### DIFF
--- a/packages/api/src/routes/funding.ts
+++ b/packages/api/src/routes/funding.ts
@@ -20,6 +20,17 @@ import {
 
 const logger = createLogger("api:funding");
 
+/**
+ * Maximum valid funding rate in bps/slot (matches on-chain guard).
+ * Raw DB values outside [-MAX, MAX] are garbage from uninitialized slabs.
+ * Returns 0 for garbage values to avoid rendering astronomical percentages.
+ */
+const MAX_FUNDING_RATE_BPS = 10_000;
+function sanitizeFundingRateBps(raw: number): number {
+  if (!Number.isFinite(raw) || Math.abs(raw) > MAX_FUNDING_RATE_BPS) return 0;
+  return raw;
+}
+
 export function fundingRoutes(): Hono {
   const app = new Hono();
 
@@ -41,7 +52,7 @@ export function fundingRoutes(): Hono {
       const SLOTS_PER_DAY = 216000;
 
       const markets = (allStats ?? []).map((stats) => {
-        const rateBps = Number(stats.funding_rate ?? 0);
+        const rateBps = sanitizeFundingRateBps(Number(stats.funding_rate ?? 0));
         return {
           slabAddress: stats.slab_address,
           currentRateBpsPerSlot: rateBps,
@@ -119,7 +130,7 @@ export function fundingRoutes(): Hono {
       const SLOTS_PER_DAY = 216000;
       const SLOTS_PER_YEAR = 78840000;
 
-      const rateBps = Number(currentRateBpsPerSlot);
+      const rateBps = sanitizeFundingRateBps(Number(currentRateBpsPerSlot));
       const hourlyRatePercent = (rateBps / 10000.0) * SLOTS_PER_HOUR;
       const dailyRatePercent = (rateBps / 10000.0) * SLOTS_PER_DAY;
       const annualizedPercent = (rateBps / 10000.0) * SLOTS_PER_YEAR;

--- a/packages/api/src/routes/markets.ts
+++ b/packages/api/src/routes/markets.ts
@@ -47,7 +47,7 @@ export function marketRoutes(): Hono {
           lastPrice: m.last_price ?? null,
           markPrice: m.mark_price ?? null,
           indexPrice: m.index_price ?? null,
-          fundingRate: m.funding_rate ?? null,
+          fundingRate: (m.funding_rate != null && Number.isFinite(m.funding_rate) && Math.abs(m.funding_rate) <= 10_000) ? m.funding_rate : null,
           netLpPos: m.net_lp_pos ?? null,
         }));
       },


### PR DESCRIPTION
## Root Cause
PRs #815-818 fixed the Next.js API routes, but production traffic for `/api/funding/:slab` is served by the **packages/api Hono service** via Railway rewrite rules. This service had NO funding rate sanitization — raw DB garbage values (e.g. `17733189824741436`) were passed through and multiplied into `+1595987084267292.0000%` hourly rates.

## Fix
Add `sanitizeFundingRateBps()` guard (`abs > 10,000 → 0`) to:
- `GET /funding/:slab` — single market
- `GET /funding/global` — all markets
- `GET /markets` — markets list `fundingRate` field

## Testing
- 828 app tests pass (34 pre-existing skips)
- Production API will return `0` instead of garbage for uninitialized slabs

Relates to #817