### PR TITLE
fix(PERC-821): extract SUPPORTED_DEX_IDS to shared constant + oracle fallback guard

### DIFF
--- a/app/app/api/launch/route.ts
+++ b/app/app/api/launch/route.ts
@@ -5,7 +5,7 @@ import { getRpcEndpoint } from "@/lib/config";
 
 export const dynamic = 'force-dynamic';
 
-const SUPPORTED_DEX_IDS = new Set(["pumpswap", "raydium", "meteora"]);
+import { SUPPORTED_DEX_IDS } from "@/lib/dex-constants";
 
 interface DexPoolDetection {
   poolAddress: string;

--- a/app/app/api/oracle/resolve/[ca]/route.ts
+++ b/app/app/api/oracle/resolve/[ca]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { PublicKey } from "@solana/web3.js";
+import { SUPPORTED_DEX_IDS } from "@/lib/dex-constants";
 
 export const dynamic = "force-dynamic";
 
@@ -174,7 +175,6 @@ async function fetchDexScreenerInfo(
     // *supported* DEX — not just the most liquid pair overall. The best overall pair
     // may be on Orca/other unsupported venues, causing poolAddress to be incorrectly
     // null even when a valid PumpSwap/Raydium/Meteora pool exists lower in the list.
-    const SUPPORTED_DEX_IDS = new Set(["pumpswap", "raydium", "meteora"]);
     const bestSupported = solPairs.find(
       (p) => SUPPORTED_DEX_IDS.has(p.dexId?.toLowerCase() ?? "") && p.pairAddress
     ) ?? null;

--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -380,9 +380,11 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
       // PERC-470/#811: Pass DEX pool address for hyperp mode.
       // wizard.dexPool is set when the user selects a pool from the UI.
       // For Quick Launch, poolInfo may be null while oracleFeed holds the pool address —
-      // use oracleFeed as fallback so the pool address is never silently dropped.
+      // use oracleFeed as fallback ONLY when it's a valid base58 pubkey (pool address),
+      // not a Pyth feed hex64 — prevents confusing on-chain rejection (security LOW fix).
       ...(oracleMode === "hyperp" ? {
-        dexPoolAddress: wizard.dexPool?.poolAddress ?? wizard.oracleFeed,
+        dexPoolAddress: wizard.dexPool?.poolAddress ??
+          (isValidBase58Pubkey(wizard.oracleFeed) ? wizard.oracleFeed : undefined),
       } : {}),
     };
     create(params);
@@ -418,8 +420,10 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
       oracleMode,
       // PERC-470/#811: Same fallback as handleLaunch — oracleFeed holds pool address
       // for Quick Launch when wizard.dexPool is null.
+      // Guard: only use oracleFeed as fallback if it's a valid base58 pubkey (pool address).
       ...(oracleMode === "hyperp" ? {
-        dexPoolAddress: wizard.dexPool?.poolAddress ?? wizard.oracleFeed,
+        dexPoolAddress: wizard.dexPool?.poolAddress ??
+          (isValidBase58Pubkey(wizard.oracleFeed) ? wizard.oracleFeed : undefined),
       } : {}),
     };
     create(params, createState.step);

--- a/app/hooks/useDexPoolSearch.ts
+++ b/app/hooks/useDexPoolSearch.ts
@@ -10,7 +10,7 @@ export interface DexPoolResult {
   priceUsd: number;
 }
 
-const SUPPORTED_DEX_IDS = new Set(["pumpswap", "raydium", "meteora"]);
+import { SUPPORTED_DEX_IDS } from "@/lib/dex-constants";
 
 /**
  * Search DexScreener for DEX pools containing a given token mint.

--- a/app/lib/dex-constants.ts
+++ b/app/lib/dex-constants.ts
@@ -1,0 +1,7 @@
+/**
+ * Shared DEX constants used across API routes and client hooks.
+ * Single source of truth — update here to affect all consumers.
+ */
+
+/** DEX IDs supported for Hyperp EMA oracle mode. */
+export const SUPPORTED_DEX_IDS = new Set(["pumpswap", "raydium", "meteora"]);


### PR DESCRIPTION
## Summary

Two follow-up fixes from PR #820 review (security LOW + CodeRabbit nitpick).

### 1. refactor: `SUPPORTED_DEX_IDS` → shared `app/lib/dex-constants.ts`

Previously duplicated in 3 files:
- `app/app/api/oracle/resolve/[ca]/route.ts`
- `app/app/api/launch/route.ts`
- `app/hooks/useDexPoolSearch.ts`

Now a single export — update one place, all consumers stay in sync.

### 2. fix(security LOW): oracle fallback guard in `CreateMarketWizard`

**Problem:** When `wizard.dexPool` is null (e.g. Quick Launch path before pool resolves), `dexPoolAddress` fell back to `wizard.oracleFeed`. If `oracleFeed` is a Pyth hex64 feed ID (not a base58 pool address), the on-chain program rejects it with a confusing validation error. No fund-loss risk, but bad UX.

**Fix:** Guard the fallback with `isValidBase58Pubkey(wizard.oracleFeed)` — only use `oracleFeed` as `dexPoolAddress` when it's actually a valid Solana pubkey. Applied to both `handleLaunch` and `handleRetry` paths.

## How to test
- Quick Launch with a Pyth-only token (e.g. SOL): confirm hyperp path is not reached
- Quick Launch with a PumpSwap token: confirm dexPoolAddress resolves correctly
- Manual hyperp mode: DEX pool still passes through correctly

## Checklist
- [x] TypeScript clean (`tsc --noEmit` passes)
- [x] All 815 tests passing
- [x] Addresses security LOW from PR #820 review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent invalid pool addresses from being used during market creation, reducing the risk of on-chain transaction rejections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->