### PR TITLE
fix(oracle): PERC-476 — Hyperp staleness tracking + suppress 0 publishers label

### DIFF
--- a/app/app/api/oracle/publishers/route.ts
+++ b/app/app/api/oracle/publishers/route.ts
@@ -40,8 +40,9 @@ interface PublisherInfo {
 
 interface PublishersResponse {
   mode: string;
-  publisherCount: number;
-  publisherTotal: number;
+  /** null means concept is not applicable (e.g. hyperp DEX oracle — no publisher model) */
+  publisherCount: number | null;
+  publisherTotal: number | null;
   publishers: PublisherInfo[];
 }
 
@@ -253,11 +254,12 @@ async function fetchHyperpPublishers(): Promise<PublishersResponse> {
     // Oracle bridge not available
   }
 
-  // HyperP uses on-chain DEX liquidity — no traditional publishers
+  // HyperP uses on-chain DEX liquidity — publisher concept doesn't apply.
+  // Return null (not 0) so UI knows to suppress the publisher count entirely.
   return {
     mode: "hyperp",
-    publisherCount: 0,
-    publisherTotal: 0,
+    publisherCount: null,
+    publisherTotal: null,
     publishers: [],
   };
 }

--- a/app/components/oracle/OracleFreshnessIndicator.tsx
+++ b/app/components/oracle/OracleFreshnessIndicator.tsx
@@ -44,8 +44,10 @@ export const OracleFreshnessIndicator: FC = () => {
       ? `${elapsedSecs}s ago`
       : `${Math.floor(elapsedSecs / 60)}m ${elapsedSecs % 60}s ago`;
 
+  // Hyperp markets use on-chain DEX liquidity — "publishers" is meaningless.
+  // Only show publisher count for pyth-pinned and admin modes.
   const publisherText =
-    publisherCount !== null && publisherTotal !== null
+    mode !== "hyperp" && publisherCount !== null && publisherTotal !== null
       ? `${publisherCount} publisher${publisherCount !== 1 ? "s" : ""}`
       : null;
 

--- a/app/hooks/useOracleFreshness.ts
+++ b/app/hooks/useOracleFreshness.ts
@@ -82,7 +82,9 @@ export function useOracleFreshness(): OracleFreshnessState {
     const currentMode = detectOracleMode(config);
 
     if (currentMode === "admin") {
-      // Admin mode: authorityTimestamp is a real unix timestamp
+      // Admin mode: authorityTimestamp is a real unix timestamp.
+      // NOTE: For hyperp mode, authorityTimestamp stores the funding rate — NOT a timestamp.
+      // This branch is only entered for admin mode, so authorityTimestamp is safe to use here.
       const ts = config.authorityTimestamp;
       if (ts > 0n) {
         setLastUpdateMs(Number(ts) * 1000);
@@ -105,8 +107,14 @@ export function useOracleFreshness(): OracleFreshnessState {
         }
       }
     } else {
-      // Hyperp / Pyth: track when the price value changes
-      const currentPrice = config.lastEffectivePriceE6;
+      // Hyperp / Pyth: track when the price value changes.
+      // IMPORTANT: For hyperp mode, UpdateHyperpMark writes to authorityPriceE6 (mark price).
+      // lastEffectivePriceE6 is only updated by KeeperCrank — on fresh markets with no trades,
+      // KeeperCrank never runs so lastEffectivePriceE6 never changes → staleness never resets.
+      // Pyth-pinned: lastEffectivePriceE6 is correct (updated by KeeperCrank / price feed).
+      const currentPrice = currentMode === "hyperp"
+        ? config.authorityPriceE6
+        : config.lastEffectivePriceE6;
       if (prevPriceRef.current !== null && currentPrice !== prevPriceRef.current) {
         setLastUpdateMs(Date.now());
       } else if (prevPriceRef.current === null && currentPrice > 0n) {


### PR DESCRIPTION
## PERC-476 — Oracle Freshness Fixes (3 targeted bugs)

### Bug 1 — Wrong field tracked for staleness in Hyperp mode (HIGH)
**File:** `app/hooks/useOracleFreshness.ts`

In the `else` branch (Hyperp/Pyth), the hook was tracking `lastEffectivePriceE6` for freshness detection for all modes. For Hyperp, `UpdateHyperpMark` writes to `authorityPriceE6` — `lastEffectivePriceE6` is only updated by KeeperCrank. On fresh markets with no trades, KeeperCrank never runs → timer never resets → always showed stale.

**Fix:** Split by mode in the else branch:
```ts
const currentPrice = currentMode === "hyperp"
  ? config.authorityPriceE6   // UpdateHyperpMark writes here
  : config.lastEffectivePriceE6; // KeeperCrank writes here
```

### Bug 2 — authorityTimestamp guard comment (MEDIUM)
**File:** `app/hooks/useOracleFreshness.ts`

Added explicit comment clarifying that `authorityTimestamp` stores the funding rate for Hyperp mode (not a timestamp). The admin branch is already gated by `currentMode === "admin"` so no code risk existed, but the guard comment prevents future confusion.

### Bug 3 — "0 publishers" shown for Hyperp mode (LOW)
**Files:** `app/components/oracle/OracleFreshnessIndicator.tsx`, `app/app/api/oracle/publishers/route.ts`

Hyperp is a permissionless DEX oracle — the publisher model doesn't apply. Two-part fix:
1. UI suppresses publisher text entirely when `mode === "hyperp"` (only shows HYPERP badge)
2. API returns `publisherCount: null` (not `0`) in Hyperp fallback — UI can distinguish "not applicable" from "zero active publishers"

### Testing
- Create a Hyperp oracle market on devnet
- Confirm freshness indicator goes green (not permanently stale)
- Confirm no "0 publishers" text shown — only HYPERP badge
- Verify Pyth-pinned markets still show publisher counts correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced HyperP mode to accurately track price staleness using the correct mark price source.
  * Publisher count display now properly hidden in HyperP mode, as publisher metrics are not applicable to this market type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->