### PR TITLE
fix(oracle): fix Hyperp freshness staleness + suppress publishers (PERC-476)

### DIFF
--- a/app/__tests__/api/oracle-publishers.test.ts
+++ b/app/__tests__/api/oracle-publishers.test.ts
@@ -159,6 +159,7 @@ describe("GET /api/oracle/publishers", () => {
 
     const body = await resp.json();
     expect(body.mode).toBe("hyperp");
-    expect(body.publisherCount).toBe(0);
+    // Hyperp fallback returns null (not 0) so UI suppresses "0 publishers" text
+    expect(body.publisherCount).toBeNull();
   });
 });

--- a/app/app/api/oracle/publishers/route.ts
+++ b/app/app/api/oracle/publishers/route.ts
@@ -40,8 +40,8 @@ interface PublisherInfo {
 
 interface PublishersResponse {
   mode: string;
-  publisherCount: number;
-  publisherTotal: number;
+  publisherCount: number | null;
+  publisherTotal: number | null;
   publishers: PublisherInfo[];
 }
 
@@ -253,11 +253,12 @@ async function fetchHyperpPublishers(): Promise<PublishersResponse> {
     // Oracle bridge not available
   }
 
-  // HyperP uses on-chain DEX liquidity — no traditional publishers
+  // HyperP uses on-chain DEX liquidity — no traditional publishers.
+  // Return null (not 0) so the UI knows to suppress "0 publishers" text.
   return {
     mode: "hyperp",
-    publisherCount: 0,
-    publisherTotal: 0,
+    publisherCount: null,
+    publisherTotal: null,
     publishers: [],
   };
 }

--- a/app/components/oracle/OracleFreshnessIndicator.tsx
+++ b/app/components/oracle/OracleFreshnessIndicator.tsx
@@ -44,8 +44,9 @@ export const OracleFreshnessIndicator: FC = () => {
       ? `${elapsedSecs}s ago`
       : `${Math.floor(elapsedSecs / 60)}m ${elapsedSecs % 60}s ago`;
 
+  // Hyperp uses permissionless DEX liquidity — "publishers" is meaningless
   const publisherText =
-    publisherCount !== null && publisherTotal !== null
+    mode !== "hyperp" && publisherCount !== null && publisherTotal !== null
       ? `${publisherCount} publisher${publisherCount !== 1 ? "s" : ""}`
       : null;
 

--- a/app/hooks/useOracleFreshness.ts
+++ b/app/hooks/useOracleFreshness.ts
@@ -105,8 +105,13 @@ export function useOracleFreshness(): OracleFreshnessState {
         }
       }
     } else {
-      // Hyperp / Pyth: track when the price value changes
-      const currentPrice = config.lastEffectivePriceE6;
+      // Hyperp: track authorityPriceE6 (updated by UpdateHyperpMark instruction).
+      // Pyth-pinned: track lastEffectivePriceE6 (updated by KeeperCrank).
+      // NOTE: Do NOT use authorityTimestamp here — for Hyperp mode that field
+      // stores the funding rate, not a unix timestamp.
+      const currentPrice = currentMode === "hyperp"
+        ? config.authorityPriceE6
+        : config.lastEffectivePriceE6;
       if (prevPriceRef.current !== null && currentPrice !== prevPriceRef.current) {
         setLastUpdateMs(Date.now());
       } else if (prevPriceRef.current === null && currentPrice > 0n) {


### PR DESCRIPTION
## Bugs Fixed

**Bug 1 (HIGH)** — `useOracleFreshness` tracked `lastEffectivePriceE6` for Hyperp, but `UpdateHyperpMark` writes to `authorityPriceE6`. Fresh markets showed permanent stale indicator. Fix: track `authorityPriceE6` for hyperp.

**Bug 2 (MEDIUM)** — Added guard comment for `authorityTimestamp` (stores funding rate in Hyperp, not a timestamp).

**Bug 3 (LOW)** — Hyperp fallback returned `publisherCount: 0` → "0 publishers" in UI. Fix: return `null` + suppress text for hyperp.

828 tests pass.