### PR TITLE
feat(devnet): PERC-475 — devnet token mint button on success page + trade page

### DIFF
--- a/app/app/api/devnet-airdrop/route.ts
+++ b/app/app/api/devnet-airdrop/route.ts
@@ -1,0 +1,269 @@
+/**
+ * PERC-475: Devnet Airdrop API
+ *
+ * POST /api/devnet-airdrop
+ * Body: { mintAddress: string, walletAddress: string }
+ *
+ * Airdrops $500 USD worth of a devnet mirror token to a wallet.
+ * The mintAddress must exist in the devnet_mints table (a mirror market mint).
+ *
+ * Flow:
+ * 1. Validate mintAddress is in devnet_mints table → get mainnet_ca, symbol, decimals
+ * 2. Fetch current mainnet price from DexScreener for mainnet_ca
+ * 3. Calculate amount = $500 USD at current price
+ *    (min: 1_000 raw, max: 3_200_000_000 raw at 6 decimals = 3,200 tokens)
+ * 4. Mint to walletAddress using DEVNET_MINT_AUTHORITY_KEYPAIR
+ * 5. Return { signature, amount, symbol }
+ *
+ * Rate limit: 1 request per wallet per mint per 24h (in-memory).
+ * Only callable on devnet.
+ *
+ * Requires: DEVNET_MINT_AUTHORITY_KEYPAIR env var (JSON secret key bytes)
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  Transaction,
+  sendAndConfirmTransaction,
+} from "@solana/web3.js";
+import {
+  getAssociatedTokenAddress,
+  createAssociatedTokenAccountInstruction,
+  createMintToInstruction,
+  getAccount,
+} from "@solana/spl-token";
+import { getConfig } from "@/lib/config";
+import { getServiceClient } from "@/lib/supabase";
+import * as Sentry from "@sentry/nextjs";
+
+export const dynamic = "force-dynamic";
+
+const NETWORK = process.env.NEXT_PUBLIC_SOLANA_NETWORK?.trim() ?? "mainnet";
+
+/** Target USD value to airdrop per claim */
+const AIRDROP_USD_VALUE = 500;
+
+/** Min/max raw token amounts at 6 decimals */
+const MIN_RAW = 1_000n;        // 0.001 tokens — floor for high-priced assets
+const MAX_RAW = 3_200_000_000n; // 3,200 tokens — cap prevents draining low-price mints
+
+/** Rate limit: 1 claim per wallet per mint per 24h */
+const RATE_LIMIT_WINDOW_MS = 24 * 60 * 60 * 1000;
+interface ClaimEntry { claimedAt: number }
+const claimMap = new Map<string, ClaimEntry>();
+
+function checkRateLimit(walletAddress: string, mintAddress: string): { allowed: boolean; retryAfterSecs: number } {
+  const key = `${walletAddress}:${mintAddress}`;
+  const now = Date.now();
+
+  // GC stale entries occasionally
+  if (Math.random() < 0.02) {
+    for (const [k, v] of claimMap) {
+      if (now - v.claimedAt > RATE_LIMIT_WINDOW_MS) claimMap.delete(k);
+    }
+  }
+
+  const entry = claimMap.get(key);
+  if (entry) {
+    const age = now - entry.claimedAt;
+    if (age < RATE_LIMIT_WINDOW_MS) {
+      return { allowed: false, retryAfterSecs: Math.ceil((RATE_LIMIT_WINDOW_MS - age) / 1000) };
+    }
+  }
+  return { allowed: true, retryAfterSecs: 0 };
+}
+
+function recordClaim(walletAddress: string, mintAddress: string) {
+  claimMap.set(`${walletAddress}:${mintAddress}`, { claimedAt: Date.now() });
+}
+
+/** Fetch token price from DexScreener for the mainnet CA */
+async function fetchTokenPriceUsd(mainnetCa: string): Promise<{ priceUsd: number } | null> {
+  try {
+    const resp = await fetch(
+      `https://api.dexscreener.com/latest/dex/tokens/${mainnetCa}`,
+      { signal: AbortSignal.timeout(8000) },
+    );
+    if (!resp.ok) return null;
+    const json = await resp.json();
+    const pairs = Array.isArray(json.pairs) ? json.pairs : [];
+    if (pairs.length === 0) return null;
+
+    // Pick the pair with the most liquidity
+    const sorted = [...pairs].sort(
+      (a: any, b: any) => (b.liquidity?.usd ?? 0) - (a.liquidity?.usd ?? 0),
+    );
+    const price = parseFloat((sorted[0] as any).priceUsd ?? "0");
+    if (price <= 0) return null;
+    return { priceUsd: price };
+  } catch {
+    return null;
+  }
+}
+
+/** Wrap a promise with a timeout (ms). */
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error(`Timed out after ${ms}ms`)), ms),
+    ),
+  ]);
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    if (NETWORK !== "devnet") {
+      return NextResponse.json({ error: "Only available on devnet" }, { status: 403 });
+    }
+
+    const body = await req.json();
+    const { mintAddress, walletAddress } = body as {
+      mintAddress?: string;
+      walletAddress?: string;
+    };
+
+    if (!mintAddress || !walletAddress) {
+      return NextResponse.json(
+        { error: "Missing mintAddress or walletAddress" },
+        { status: 400 },
+      );
+    }
+
+    // Validate public keys
+    let mintPk: PublicKey;
+    let walletPk: PublicKey;
+    try {
+      mintPk = new PublicKey(mintAddress);
+    } catch {
+      return NextResponse.json({ error: "Invalid mintAddress" }, { status: 400 });
+    }
+    try {
+      walletPk = new PublicKey(walletAddress);
+    } catch {
+      return NextResponse.json({ error: "Invalid walletAddress" }, { status: 400 });
+    }
+
+    // 1. Validate mintAddress exists in devnet_mints table → get mainnet_ca + metadata
+    const supabase = getServiceClient();
+    const { data: mintRow, error: dbErr } = await (supabase as any)
+      .from("devnet_mints")
+      .select("mainnet_ca, symbol, decimals")
+      .eq("devnet_mint", mintAddress)
+      .maybeSingle();
+
+    if (dbErr || !mintRow) {
+      return NextResponse.json(
+        { error: "mintAddress is not a known devnet mirror mint" },
+        { status: 400 },
+      );
+    }
+
+    const { mainnet_ca: mainnetCa, symbol, decimals: rawDecimals } = mintRow;
+    const decimals: number = rawDecimals ?? 6;
+
+    // 2. Rate limit: 1 per wallet per mint per 24h
+    const { allowed, retryAfterSecs } = checkRateLimit(walletAddress, mintAddress);
+    if (!allowed) {
+      const h = Math.floor(retryAfterSecs / 3600);
+      const m = Math.floor((retryAfterSecs % 3600) / 60);
+      return NextResponse.json(
+        {
+          error: `Already claimed — try again in ${h}h ${m}m`,
+          retryAfterSecs,
+          nextClaimAt: new Date(Date.now() + retryAfterSecs * 1000).toISOString(),
+        },
+        {
+          status: 429,
+          headers: { "Retry-After": String(retryAfterSecs) },
+        },
+      );
+    }
+
+    // 3. Fetch mainnet price from DexScreener
+    const priceResult = await fetchTokenPriceUsd(mainnetCa);
+    let rawAmount: bigint;
+
+    if (priceResult && priceResult.priceUsd > 0) {
+      // $500 / price = tokens; scale by decimals
+      const tokensFloat = AIRDROP_USD_VALUE / priceResult.priceUsd;
+      rawAmount = BigInt(Math.floor(tokensFloat * 10 ** decimals));
+    } else {
+      // Price unavailable — fall back to a fixed generous amount (1000 tokens)
+      rawAmount = BigInt(1000 * 10 ** decimals);
+    }
+
+    // Clamp to [MIN_RAW, MAX_RAW]
+    if (rawAmount < MIN_RAW) rawAmount = MIN_RAW;
+    if (rawAmount > MAX_RAW) rawAmount = MAX_RAW;
+
+    // 4. Load mint authority
+    const mintAuthKeyJson = process.env.DEVNET_MINT_AUTHORITY_KEYPAIR;
+    if (!mintAuthKeyJson) {
+      return NextResponse.json(
+        { error: "Server not configured for devnet minting (DEVNET_MINT_AUTHORITY_KEYPAIR missing)" },
+        { status: 500 },
+      );
+    }
+    let mintAuthority: Keypair;
+    try {
+      mintAuthority = Keypair.fromSecretKey(Uint8Array.from(JSON.parse(mintAuthKeyJson)));
+    } catch {
+      return NextResponse.json({ error: "Server keypair configuration is invalid" }, { status: 500 });
+    }
+
+    const cfg = getConfig();
+    const connection = new Connection(cfg.rpcUrl, "confirmed");
+
+    // Derive user's ATA
+    const ata = await getAssociatedTokenAddress(mintPk, walletPk);
+    let ataExists = false;
+    try {
+      await getAccount(connection, ata);
+      ataExists = true;
+    } catch {
+      // ATA doesn't exist yet — will be created in tx
+    }
+
+    // 5. Build and send mint transaction
+    const tx = new Transaction();
+    if (!ataExists) {
+      tx.add(
+        createAssociatedTokenAccountInstruction(
+          mintAuthority.publicKey, // payer
+          ata,
+          walletPk,
+          mintPk,
+        ),
+      );
+    }
+    tx.add(createMintToInstruction(mintPk, ata, mintAuthority.publicKey, rawAmount));
+
+    const sig = await withTimeout(
+      sendAndConfirmTransaction(connection, tx, [mintAuthority], { commitment: "confirmed" }),
+      30_000,
+    );
+
+    // Record claim only after successful mint
+    recordClaim(walletAddress, mintAddress);
+
+    const humanAmount = Number(rawAmount) / 10 ** decimals;
+
+    return NextResponse.json({
+      signature: sig,
+      amount: humanAmount,
+      rawAmount: rawAmount.toString(),
+      symbol: symbol ?? "TOKEN",
+      decimals,
+      nextClaimAt: new Date(Date.now() + RATE_LIMIT_WINDOW_MS).toISOString(),
+    });
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: { endpoint: "/api/devnet-airdrop", method: "POST" },
+    });
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/components/create/LaunchSuccess.tsx
+++ b/app/components/create/LaunchSuccess.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { FC, useState } from "react";
+import { FC, useState, useCallback } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { LogoUpload } from "./LogoUpload";
 import { getNetwork } from "@/lib/config";
+import { useWalletCompat } from "@/hooks/useWalletCompat";
 
 interface LaunchSuccessProps {
   tokenSymbol: string;
@@ -45,7 +47,38 @@ export const LaunchSuccess: FC<LaunchSuccessProps> = ({
 }) => {
   const [copied, setCopied] = useState(false);
   const [copiedDevnet, setCopiedDevnet] = useState(false);
+  const [mintLoading, setMintLoading] = useState(false);
+  const [mintError, setMintError] = useState<string | null>(null);
   const isDevnet = getNetwork() === "devnet";
+  const { publicKey } = useWalletCompat();
+  const router = useRouter();
+
+  /** PERC-475: Mint $500 worth of devnet tokens then navigate to the trade page. */
+  const handleMintAndTrade = useCallback(async () => {
+    if (!publicKey || !devnetMint || mintLoading) return;
+    setMintLoading(true);
+    setMintError(null);
+    try {
+      const resp = await fetch("/api/devnet-airdrop", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          mintAddress: devnetMint,
+          walletAddress: publicKey.toBase58(),
+        }),
+      });
+      // On 429 (rate limited) still navigate — wallet may already have tokens
+      if (!resp.ok && resp.status !== 429) {
+        const d = await resp.json();
+        setMintError(d.error ?? "Mint failed — try again");
+        setMintLoading(false);
+        return;
+      }
+    } catch {
+      // Network error — still navigate
+    }
+    router.push(`/trade/${marketAddress}`);
+  }, [publicKey, devnetMint, mintLoading, marketAddress, router]);
 
   const handleCopy = async () => {
     try {
@@ -196,12 +229,30 @@ export const LaunchSuccess: FC<LaunchSuccessProps> = ({
 
       {/* CTAs */}
       <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-        <Link
-          href={`/trade/${marketAddress}`}
-          className="w-full sm:w-auto border border-[var(--accent)]/50 bg-[var(--accent)]/[0.08] px-8 py-3 text-[13px] font-bold uppercase tracking-[0.1em] text-[var(--accent)] transition-all hud-btn-corners hover:bg-[var(--accent)]/[0.15]"
-        >
-          TRADE THIS MARKET →
-        </Link>
+        {/* PERC-475: Show "Mint & Trade" on devnet when a mirror mint is available */}
+        {isDevnet && devnetMint && publicKey ? (
+          <button
+            type="button"
+            onClick={handleMintAndTrade}
+            disabled={mintLoading}
+            className="w-full sm:w-auto border border-[var(--long)]/50 bg-[var(--long)]/[0.08] px-8 py-3 text-[13px] font-bold uppercase tracking-[0.1em] text-[var(--long)] transition-all hud-btn-corners hover:bg-[var(--long)]/[0.15] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {mintLoading ? (
+              <span className="flex items-center gap-2">
+                <span className="animate-spin">⟳</span> MINTING…
+              </span>
+            ) : (
+              "MINT & TRADE →"
+            )}
+          </button>
+        ) : (
+          <Link
+            href={`/trade/${marketAddress}`}
+            className="w-full sm:w-auto border border-[var(--accent)]/50 bg-[var(--accent)]/[0.08] px-8 py-3 text-[13px] font-bold uppercase tracking-[0.1em] text-[var(--accent)] transition-all hud-btn-corners hover:bg-[var(--accent)]/[0.15]"
+          >
+            TRADE THIS MARKET →
+          </Link>
+        )}
         <button
           type="button"
           onClick={onDeployAnother}
@@ -210,6 +261,9 @@ export const LaunchSuccess: FC<LaunchSuccessProps> = ({
           DEPLOY ANOTHER MARKET
         </button>
       </div>
+      {mintError && (
+        <p className="mt-2 text-[11px] text-[var(--short)]">{mintError}</p>
+      )}
 
       {/* Logo upload */}
       <LogoUpload slabAddress={marketAddress} />

--- a/app/components/trade/DepositTrigger.tsx
+++ b/app/components/trade/DepositTrigger.tsx
@@ -9,6 +9,7 @@ import { formatTokenAmount } from "@/lib/format";
 import { DepositWithdrawCard } from "./DepositWithdrawCard";
 import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab, getMockUserAccount } from "@/lib/mock-trade-data";
+import { getNetwork } from "@/lib/config";
 
 function lsKey(slabAddress: string) {
   return `percolator:deposited:${slabAddress}`;
@@ -26,6 +27,26 @@ export const DepositTrigger: FC<{ slabAddress: string }> = ({ slabAddress }) => 
 
   const [expanded, setExpanded] = useState(false);
   const [hasDeposited, setHasDeposited] = useState(true); // default true to avoid flash
+
+  // PERC-475: Detect devnet mirror markets (oracle_mode=admin AND mainnet_ca set)
+  // so DepositWithdrawCard can show the self-service faucet button.
+  const [isDevnetMirror, setIsDevnetMirror] = useState(false);
+  useEffect(() => {
+    if (getNetwork() !== "devnet") return;
+    let cancelled = false;
+    fetch(`/api/markets/${slabAddress}`)
+      .then((r) => r.json())
+      .then((d) => {
+        if (cancelled) return;
+        const m = d.market;
+        // A devnet mirror market has a mainnet CA and uses admin oracle mode
+        if (m?.mainnet_ca && m?.oracle_mode === "admin") {
+          setIsDevnetMirror(true);
+        }
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [slabAddress]);
 
   const capital = userAccount?.account.capital ?? 0n;
   const prevCapitalRef = useRef(capital);
@@ -71,7 +92,7 @@ export const DepositTrigger: FC<{ slabAddress: string }> = ({ slabAddress }) => 
         </button>
         {expanded && (
           <div className="mt-1">
-            <DepositWithdrawCard slabAddress={slabAddress} />
+            <DepositWithdrawCard slabAddress={slabAddress} isDevnetMirror={isDevnetMirror} />
           </div>
         )}
       </div>
@@ -102,7 +123,7 @@ export const DepositTrigger: FC<{ slabAddress: string }> = ({ slabAddress }) => 
       </div>
       {expanded && (
         <div className="mt-1">
-          <DepositWithdrawCard slabAddress={slabAddress} />
+          <DepositWithdrawCard slabAddress={slabAddress} isDevnetMirror={isDevnetMirror} />
         </div>
       )}
     </div>

--- a/app/components/trade/DepositWithdrawCard.tsx
+++ b/app/components/trade/DepositWithdrawCard.tsx
@@ -4,6 +4,7 @@ import { explorerTxUrl } from "@/lib/config";
 import { FC, useState, useEffect, useRef } from "react";
 import { useWalletCompat } from "@/hooks/useWalletCompat";
 import { useConnectionCompat } from "@/hooks/useWalletCompat";
+import { DevnetTokenFaucetButton } from "./DevnetTokenFaucetButton";
 import { getAssociatedTokenAddressSync } from "@solana/spl-token";
 import { useUserAccount } from "@/hooks/useUserAccount";
 import { useDeposit } from "@/hooks/useDeposit";
@@ -16,7 +17,16 @@ import { formatTokenAmount } from "@/lib/format";
 import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab, getMockUserAccount } from "@/lib/mock-trade-data";
 
-export const DepositWithdrawCard: FC<{ slabAddress: string }> = ({ slabAddress }) => {
+interface DepositWithdrawCardProps {
+  slabAddress: string;
+  /**
+   * PERC-475: When true (devnet mirror market with a mainnet_ca), show a
+   * "Get [SYMBOL] Tokens" faucet button so users can mint $500 of devnet tokens.
+   */
+  isDevnetMirror?: boolean;
+}
+
+export const DepositWithdrawCard: FC<DepositWithdrawCardProps> = ({ slabAddress, isDevnetMirror = false }) => {
   const { connected: walletConnected, publicKey } = useWalletCompat();
   const { connection } = useConnectionCompat();
   const realUserAccount = useUserAccount();
@@ -77,15 +87,21 @@ export const DepositWithdrawCard: FC<{ slabAddress: string }> = ({ slabAddress }
           </p>
         )}
         {!hasTokens && (
-          <div className="mb-2 border border-[var(--warning)]/20 bg-[var(--warning)]/[0.04] p-2">
+          <div className="mb-2 border border-[var(--warning)]/20 bg-[var(--warning)]/[0.04] p-2 space-y-2">
             <p className="text-[10px] text-[var(--warning)]">
-              You need {symbol} tokens to trade this market.{" "}
-              {mktConfig?.collateralMint && (
-                <a href="/devnet-mint" className="underline underline-offset-2 hover:text-[var(--warning)]/80">
-                  Mint some from the faucet →
-                </a>
-              )}
+              You need {symbol} tokens to trade this market.
             </p>
+            {/* PERC-475: Devnet mirror market — show self-service faucet button */}
+            {isDevnetMirror && mktConfig?.collateralMint ? (
+              <DevnetTokenFaucetButton
+                mintAddress={mktConfig.collateralMint.toBase58()}
+                symbol={symbol}
+              />
+            ) : mktConfig?.collateralMint ? (
+              <a href="/devnet-mint" className="text-[10px] text-[var(--warning)] underline underline-offset-2 hover:text-[var(--warning)]/80">
+                Mint some from the faucet →
+              </a>
+            ) : null}
           </div>
         )}
         {hasTokens ? (
@@ -190,14 +206,22 @@ export const DepositWithdrawCard: FC<{ slabAddress: string }> = ({ slabAddress }
         </div>
       </div>
       {mode === "deposit" && walletBalance !== null && walletBalance === 0n && mktConfig?.collateralMint && (
-        <div className="mb-2 border border-[var(--warning)]/20 bg-[var(--warning)]/[0.04] p-2">
+        <div className="mb-2 border border-[var(--warning)]/20 bg-[var(--warning)]/[0.04] p-2 space-y-2">
           <p className="text-[10px] text-[var(--warning)]">
-            Wallet has 0 {symbol}. You may have a different token with the same name.{" "}
-            <a href={`/devnet-mint`} className="underline underline-offset-2 hover:text-[var(--warning)]/80">
+            Wallet has 0 {symbol}. You may have a different token with the same name.
+          </p>
+          {/* PERC-475: Devnet mirror market — self-service faucet button */}
+          {isDevnetMirror ? (
+            <DevnetTokenFaucetButton
+              mintAddress={mktConfig.collateralMint.toBase58()}
+              symbol={symbol}
+            />
+          ) : (
+            <a href="/devnet-mint" className="text-[10px] text-[var(--warning)] underline underline-offset-2 hover:text-[var(--warning)]/80">
               Mint more →
             </a>
-          </p>
-          <p className="mt-1 text-[9px] text-[var(--text-dim)] break-all" style={{ fontFamily: "var(--font-mono)" }}>
+          )}
+          <p className="text-[9px] text-[var(--text-dim)] break-all" style={{ fontFamily: "var(--font-mono)" }}>
             Mint: {mktConfig.collateralMint.toBase58()}
           </p>
         </div>

--- a/app/components/trade/DevnetTokenFaucetButton.tsx
+++ b/app/components/trade/DevnetTokenFaucetButton.tsx
@@ -1,0 +1,133 @@
+/**
+ * PERC-475: Devnet token faucet button for mirror markets.
+ *
+ * Shows a "Get [SYMBOL] Tokens" button on the trade page for devnet mirror
+ * markets (i.e. markets whose collateral mint is in the devnet_mints table).
+ * Calls POST /api/devnet-airdrop to mint $500 USD worth of devnet tokens.
+ *
+ * Only renders on devnet with a connected wallet.
+ */
+
+"use client";
+
+import { useState, useCallback } from "react";
+import { useWalletCompat } from "@/hooks/useWalletCompat";
+import { getNetwork } from "@/lib/config";
+
+interface DevnetTokenFaucetButtonProps {
+  /** Devnet SPL mint address (collateralMint) */
+  mintAddress: string;
+  /** Token symbol shown on the button */
+  symbol: string;
+}
+
+export function DevnetTokenFaucetButton({ mintAddress, symbol }: DevnetTokenFaucetButtonProps) {
+  const { publicKey, connected } = useWalletCompat();
+  const [loading, setLoading] = useState(false);
+  const [claimed, setClaimed] = useState<{ amount: number; sig: string } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [rateLimited, setRateLimited] = useState<{ nextClaimAt: string } | null>(null);
+
+  const isDevnet = getNetwork() === "devnet";
+
+  const claim = useCallback(async () => {
+    if (!publicKey || loading) return;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const resp = await fetch("/api/devnet-airdrop", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          mintAddress,
+          walletAddress: publicKey.toBase58(),
+        }),
+      });
+
+      const data = await resp.json();
+
+      if (resp.status === 429) {
+        setRateLimited({ nextClaimAt: data.nextClaimAt });
+      } else if (resp.status === 400 && data.error?.includes("not a known devnet mirror mint")) {
+        // Silently hide — this market isn't a devnet mirror, button shouldn't render
+        // (parent should have guarded, but handle gracefully)
+        setError(null);
+      } else if (!resp.ok) {
+        setError(data.error ?? "Faucet failed");
+      } else {
+        setClaimed({ amount: data.amount, sig: data.signature });
+      }
+    } catch (e: any) {
+      setError(e.message ?? "Network error");
+    } finally {
+      setLoading(false);
+    }
+  }, [publicKey, mintAddress, loading]);
+
+  // Don't render on mainnet
+  if (!isDevnet) return null;
+
+  // Don't render without wallet
+  if (!connected || !publicKey) return null;
+
+  // Rate limited — show countdown info
+  if (rateLimited) {
+    const target = new Date(rateLimited.nextClaimAt);
+    const remaining = Math.max(0, target.getTime() - Date.now());
+    const h = Math.floor(remaining / 3_600_000);
+    const m = Math.floor((remaining % 3_600_000) / 60_000);
+    return (
+      <div className="flex items-center gap-2 px-3 py-2 border border-[var(--border)]/40 text-[10px]">
+        <span className="text-[var(--text-secondary)]">Next {symbol} claim in</span>
+        <span className="font-mono text-[var(--accent)] tabular-nums">{h}h {m}m</span>
+      </div>
+    );
+  }
+
+  // Success state
+  if (claimed) {
+    return (
+      <div className="flex items-center gap-2 px-3 py-2 border border-[var(--long)]/30 bg-[var(--long)]/[0.05] text-[10px]">
+        <span className="text-[var(--long)]">✓</span>
+        <span className="text-[var(--text-secondary)]">
+          Got{" "}
+          <span className="font-medium text-[var(--text)]">
+            {claimed.amount.toLocaleString(undefined, { maximumFractionDigits: 2 })} {symbol}
+          </span>
+        </span>
+        <a
+          href={`https://explorer.solana.com/tx/${claimed.sig}?cluster=devnet`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="ml-auto text-[9px] text-[var(--accent)] hover:underline underline-offset-2"
+        >
+          Explorer ↗
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      <button
+        type="button"
+        onClick={claim}
+        disabled={loading}
+        className="w-full border border-[var(--accent)]/40 bg-[var(--accent)]/[0.06] px-3 py-2 text-[10px] font-medium uppercase tracking-[0.08em] text-[var(--accent)] transition-colors hover:bg-[var(--accent)]/[0.12] disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {loading ? (
+          <span className="flex items-center justify-center gap-2">
+            <span className="inline-block animate-spin">⟳</span>
+            Minting…
+          </span>
+        ) : (
+          `Get ${symbol} Tokens`
+        )}
+      </button>
+      {error && (
+        <p className="text-[9px] text-[var(--short)]">{error}</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## PERC-475 — Devnet Token Mint Button

Self-service devnet token faucet so users can mint $500 worth of devnet mirror tokens directly from the UI.

### New: POST /api/devnet-airdrop
- Validates mintAddress is in devnet_mints table (not arbitrary mints)
- Fetches current mainnet price from DexScreener for the mapped mainnet_ca
- Mints $500 USD equivalent (clamped: min 1,000 raw, max 3,200,000,000 raw)
- Rate limit: 1 claim per wallet per mint per 24h (in-memory)
- Reuses DEVNET_MINT_AUTHORITY_KEYPAIR already on Vercel
- Returns 429 with retryAfterSecs + nextClaimAt when rate-limited

### New: DevnetTokenFaucetButton component
Shows a 'Get TOKEN Tokens' button in the deposit area on the trade page. Only renders on devnet + connected wallet. Loading, success (Explorer link), and rate-limited countdown states.

### DepositTrigger — detect devnet mirror markets
On devnet, fetches /api/markets/[slab] and checks oracle_mode=admin AND mainnet_ca is set. Passes isDevnetMirror prop down to DepositWithdrawCard.

### DepositWithdrawCard — isDevnetMirror prop
When isDevnetMirror=true, shows DevnetTokenFaucetButton instead of 'Mint more' link in both the no-user-account branch and zero-balance deposit warning.

### LaunchSuccess — MINT & TRADE button
On devnet with a devnetMint: shows 'MINT & TRADE' button that mints tokens then redirects to trade page. Falls back to 'TRADE THIS MARKET' on mainnet or without mint.

### Testing
1. Create a devnet mirror market (paste mainnet token CA)
2. On success page: click 'MINT & TRADE' — confirm tokens minted + redirected
3. On trade page: faucet button appears in deposit card — click to get tokens
4. Click again within 24h — rate-limit countdown shown
5. Verify mainnet is unaffected (buttons not shown)