### PR TITLE
fix(ws): pass wsEndpoint to Connection to prevent broken WS upgrade on Vercel (#827)

### DIFF
--- a/app/lib/connection.ts
+++ b/app/lib/connection.ts
@@ -1,11 +1,15 @@
 import { Connection } from "@solana/web3.js";
-import { getConfig } from "./config";
+import { getConfig, getWsEndpoint } from "./config";
 
 let _connection: Connection | null = null;
 
 export function getConnection(): Connection {
   if (!_connection) {
-    _connection = new Connection(getConfig().rpcUrl, "confirmed");
+    const wsEndpoint = getWsEndpoint();
+    _connection = new Connection(getConfig().rpcUrl, {
+      commitment: "confirmed",
+      ...(wsEndpoint ? { wsEndpoint } : {}),
+    });
   }
   return _connection;
 }


### PR DESCRIPTION
## What
`getConnection()` creates a `Connection` without `wsEndpoint`, causing `@solana/web3.js` to auto-derive `wss://percolatorlaunch.com/api/rpc`. Vercel can't handle WS upgrades → infinite retry loop on every page load.

## Fix
Pass `getWsEndpoint()` (direct Helius WSS) to the Connection constructor, matching `useConnectionCompat()`.

## Testing
`pnpm build` passes. One-line fix.

Closes #827

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated connection initialization to support dynamic WebSocket endpoint configuration through environment variables, replacing hardcoded options with a flexible configuration-driven approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->