### PR TITLE
fix(ws): add ±25% jitter to WS reconnect backoff — prevent thundering herd on Railway recovery

### DIFF
--- a/app/hooks/useLivePrice.ts
+++ b/app/hooks/useLivePrice.ts
@@ -18,6 +18,9 @@ if (!WS_URL && typeof window !== "undefined") {
 }
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 30_000;
+// Jitter: randomise within ±25% of the computed delay to prevent thundering-herd
+// reconnects when the Railway API recovers and hundreds of clients retry in unison.
+const jitter = (ms: number) => ms * (0.75 + Math.random() * 0.5);
 
 interface PriceState {
   price: number | null;
@@ -167,10 +170,11 @@ export function useLivePrice(): PriceState {
 
     function scheduleReconnect() {
       if (!mountedRef.current) return;
+      const delay = jitter(reconnectDelay.current);
       reconnectTimer.current = setTimeout(() => {
         reconnectDelay.current = Math.min(reconnectDelay.current * 2, RECONNECT_MAX_MS);
         connect();
-      }, reconnectDelay.current);
+      }, delay);
     }
 
     connect();


### PR DESCRIPTION
## What
When the Railway price-streaming API goes down and recovers, all connected clients had the same exponential backoff delay and would retry in tight synchrony — causing a reconnect burst that could overwhelm the restarted service.

## Fix
Added a ±25% random jitter to `scheduleReconnect()` in `useLivePrice.ts`:
```ts
const jitter = (ms: number) => ms * (0.75 + Math.random() * 0.5);
```
No change to the backoff curve shape (1s → 2s → … → 30s max). Just spreads retries over time.

## Context
- Issue #830: Railway API completely down (PERC-479 — DevOps must fix Railway env/redeploy)
- Issue #829: Vercel not redeployed post PR #828 (PERC-480 — DevOps must trigger redeploy)
- This is the code-side partial fix; infrastructure tracked separately

## Testing
`pnpm build` ✅ | 820 tests passing (8 pre-existing LaunchSuccess failures from PERC-475, unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket reconnection behavior to distribute reconnection attempts over time, enhancing stability and preventing connection storms during network recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->