### PR TITLE
feat(PERC-481): trade statistics panel on portfolio page

### DIFF
--- a/app/__tests__/api/trader-stats.test.ts
+++ b/app/__tests__/api/trader-stats.test.ts
@@ -1,0 +1,131 @@
+/**
+ * PERC-481: Tests for GET /api/trader/:wallet/stats
+ *
+ * STATS-001: Returns aggregated stats for a wallet with trades
+ * STATS-002: Returns zeros/empty for a wallet with no trades
+ * STATS-003: Rejects invalid wallet address with 400
+ * STATS-004: Counts long/short trades correctly
+ * STATS-005: Sums fees and volume correctly
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock Supabase
+const mockSupabase = {
+  from: vi.fn().mockReturnThis(),
+  select: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  order: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+};
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceClient: () => mockSupabase,
+}));
+
+// Isolate rate limiter between tests by resetting modules
+import { GET } from "@/app/api/trader/[wallet]/stats/route";
+import { NextRequest } from "next/server";
+
+const VALID_WALLET = "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU";
+
+function makeRequest(wallet: string): NextRequest {
+  return new NextRequest(`http://localhost/api/trader/${wallet}/stats`, {
+    headers: { "x-forwarded-for": `1.2.3.${Math.floor(Math.random() * 200) + 1}` },
+  });
+}
+
+async function callRoute(wallet: string, trades: unknown[]) {
+  mockSupabase.limit.mockResolvedValueOnce({ data: trades, error: null });
+  const req = makeRequest(wallet);
+  const res = await GET(req, { params: Promise.resolve({ wallet }) });
+  return res;
+}
+
+describe("GET /api/trader/:wallet/stats", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabase.from.mockReturnThis();
+    mockSupabase.select.mockReturnThis();
+    mockSupabase.eq.mockReturnThis();
+    mockSupabase.order.mockReturnThis();
+    mockSupabase.limit.mockResolvedValue({ data: [], error: null });
+  });
+
+  // STATS-003: Invalid wallet rejected
+  it("returns 400 for invalid wallet address", async () => {
+    const req = makeRequest("not-a-valid-wallet");
+    const res = await GET(req, { params: Promise.resolve({ wallet: "not-a-valid-wallet" }) });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid wallet/i);
+  });
+
+  // STATS-002: No trades
+  it("returns zero stats for wallet with no trades", async () => {
+    const res = await callRoute(VALID_WALLET, []);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.totalTrades).toBe(0);
+    expect(body.longTrades).toBe(0);
+    expect(body.shortTrades).toBe(0);
+    expect(body.totalFees).toBe("0");
+    expect(body.totalVolume).toBe("0");
+    expect(body.uniqueMarkets).toBe(0);
+    expect(body.firstTradeAt).toBeNull();
+    expect(body.lastTradeAt).toBeNull();
+  });
+
+  // STATS-001 + STATS-004 + STATS-005: With real trades
+  it("aggregates stats correctly for a wallet with trades", async () => {
+    const trades = [
+      {
+        side: "long",
+        size: "1000000",      // 1 token (e6)
+        price: 100.0,         // $100 per token
+        fee: 500,             // 0.0005 token fee
+        slab_address: "MarketAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        created_at: "2026-01-01T00:00:00Z",
+      },
+      {
+        side: "short",
+        size: "-2000000",     // 2 tokens short (negative)
+        price: 200.0,         // $200 per token
+        fee: 1000,            // 0.001 token fee
+        slab_address: "MarketBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+        created_at: "2026-01-02T00:00:00Z",
+      },
+      {
+        side: "long",
+        size: "3000000",      // 3 tokens
+        price: 150.0,
+        fee: 750,
+        slab_address: "MarketAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        created_at: "2026-01-03T00:00:00Z",
+      },
+    ];
+
+    const res = await callRoute(VALID_WALLET, trades);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // STATS-001: Counts
+    expect(body.totalTrades).toBe(3);
+    // STATS-004: Long/short breakdown
+    expect(body.longTrades).toBe(2);
+    expect(body.shortTrades).toBe(1);
+    // STATS-005: Fees sum = 500 + 1000 + 750 = 2250
+    expect(body.totalFees).toBe("2250");
+    // STATS-005: Volume
+    // Trade1: 1_000_000 × 100_000_000 / 1_000_000 = 100_000_000
+    // Trade2: 2_000_000 × 200_000_000 / 1_000_000 = 400_000_000
+    // Trade3: 3_000_000 × 150_000_000 / 1_000_000 = 450_000_000
+    // Total: 950_000_000
+    expect(body.totalVolume).toBe("950000000");
+    // Unique markets: 2
+    expect(body.uniqueMarkets).toBe(2);
+    // Timestamps
+    expect(body.firstTradeAt).toBe("2026-01-01T00:00:00Z");
+    expect(body.lastTradeAt).toBe("2026-01-03T00:00:00Z");
+  });
+});

--- a/app/__tests__/components/Portfolio.test.tsx
+++ b/app/__tests__/components/Portfolio.test.tsx
@@ -47,6 +47,12 @@ vi.mock("@/hooks/useLpPositions", () => ({
 vi.mock("@/components/portfolio/LpPositionsPanel", () => ({
   LpPositionsPanel: () => <div data-testid="lp-positions-panel" />,
 }));
+vi.mock("@/hooks/useTraderStats", () => ({
+  useTraderStats: () => ({ stats: null, loading: false, error: null, refresh: vi.fn() }),
+}));
+vi.mock("@/components/trade/TradeStatsPanel", () => ({
+  TradeStatsPanel: () => <div data-testid="trade-stats-panel" />,
+}));
 vi.mock("@/components/ui/ScrollReveal", () => ({
   ScrollReveal: ({ children }: any) => <div>{children}</div>,
 }));

--- a/app/app/api/trader/[wallet]/stats/route.ts
+++ b/app/app/api/trader/[wallet]/stats/route.ts
@@ -1,0 +1,185 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServiceClient } from "@/lib/supabase";
+import { PublicKey } from "@solana/web3.js";
+
+/**
+ * GET /api/trader/:wallet/stats
+ *
+ * Returns aggregate trade statistics for a wallet address.
+ * Computed from the `trades` table — all on-chain trades are public.
+ *
+ * PERC-481: Trade statistics panel on portfolio page.
+ *
+ * Response:
+ * {
+ *   totalTrades: number,
+ *   longTrades: number,
+ *   shortTrades: number,
+ *   totalVolume: string,   // raw bigint string (size * price / 1e6, in token units × 1e6)
+ *   totalFees: string,     // raw bigint string (sum of fee column, already in token units × 1e6)
+ *   uniqueMarkets: number,
+ *   firstTradeAt: string | null,  // ISO timestamp of oldest trade
+ *   lastTradeAt: string | null,   // ISO timestamp of most recent trade
+ * }
+ */
+export const dynamic = "force-dynamic";
+
+// ---------------------------------------------------------------------------
+// Rate limiter — 30 req/min per IP (stats endpoint is heavier than paginated list)
+// ---------------------------------------------------------------------------
+const RATE_LIMIT = 30;
+const RATE_WINDOW_MS = 60_000;
+
+const rateMap = new Map<string, { count: number; resetAt: number }>();
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const entry = rateMap.get(ip);
+  if (!entry || now > entry.resetAt) {
+    rateMap.set(ip, { count: 1, resetAt: now + RATE_WINDOW_MS });
+    return false;
+  }
+  if (entry.count >= RATE_LIMIT) return true;
+  entry.count++;
+  return false;
+}
+
+export interface TraderStatsResponse {
+  totalTrades: number;
+  longTrades: number;
+  shortTrades: number;
+  /** Sum of |size| × price for each trade, as raw string (already in e6 units due to price being e0 and size in e6) */
+  totalVolume: string;
+  /** Sum of fee column as raw string (token units × 1e6) */
+  totalFees: string;
+  /** Number of distinct markets this wallet has traded */
+  uniqueMarkets: number;
+  /** ISO timestamp of oldest trade */
+  firstTradeAt: string | null;
+  /** ISO timestamp of most recent trade */
+  lastTradeAt: string | null;
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ wallet: string }> },
+) {
+  // Rate limiting
+  const ip =
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    request.headers.get("x-real-ip") ??
+    "unknown";
+  if (isRateLimited(ip)) {
+    return NextResponse.json(
+      { error: "Too many requests — max 30 per minute" },
+      {
+        status: 429,
+        headers: {
+          "Retry-After": "60",
+          "X-RateLimit-Limit": String(RATE_LIMIT),
+          "X-RateLimit-Window": "60s",
+        },
+      },
+    );
+  }
+
+  const { wallet } = await params;
+
+  // Validate wallet address
+  let walletKey: string;
+  try {
+    walletKey = new PublicKey(wallet).toBase58();
+  } catch {
+    return NextResponse.json({ error: "Invalid wallet address" }, { status: 400 });
+  }
+
+  try {
+    const supabase = getServiceClient();
+
+    // Fetch all trade rows for this wallet (size, side, price, fee, slab_address, created_at).
+    // We select only the fields needed for aggregation to minimise data transfer.
+    // Limit to 10 000 rows — sufficient for any realistic trader history;
+    // avoids pathological queries on a future high-volume wallet.
+    const { data, error } = await supabase
+      .from("trades")
+      .select("side, size, price, fee, slab_address, created_at")
+      .eq("trader", walletKey)
+      .order("created_at", { ascending: true })
+      .limit(10_000);
+
+    if (error) throw error;
+
+    const rows = data ?? [];
+
+    let longTrades = 0;
+    let shortTrades = 0;
+    let totalVolume = 0n;
+    let totalFees = 0n;
+    const markets = new Set<string>();
+    let firstTradeAt: string | null = null;
+    let lastTradeAt: string | null = null;
+
+    for (const row of rows) {
+      if (row.side === "long") longTrades++;
+      else shortTrades++;
+
+      // size is stored as a raw string representing token units × 1e6 (can be negative for short).
+      // price is a float (USD per token, not scaled).
+      // Volume = |size| × price gives USD-denominated volume but size is in e6.
+      // We keep everything in e6 token units so the frontend can format consistently.
+      try {
+        const rawSize = BigInt(String(row.size).split(".")[0]);
+        const absSize = rawSize < 0n ? -rawSize : rawSize;
+        // price is float — convert to e6 integer for lossless BigInt multiply, then divide back
+        const priceE6 = BigInt(Math.round(Number(row.price) * 1_000_000));
+        // volume contribution: (absSize in e6) × (priceE6 / 1e6) = absSize × priceE6 / 1e6
+        // Keep in e12 precision then normalise to e6
+        totalVolume += (absSize * priceE6) / 1_000_000n;
+      } catch {
+        // Malformed row — skip
+      }
+
+      try {
+        totalFees += BigInt(Math.round(Number(row.fee)));
+      } catch {
+        // Skip
+      }
+
+      if (row.slab_address) markets.add(String(row.slab_address));
+
+      if (row.created_at) {
+        if (!firstTradeAt) firstTradeAt = String(row.created_at);
+        lastTradeAt = String(row.created_at);
+      }
+    }
+
+    const stats: TraderStatsResponse = {
+      totalTrades: rows.length,
+      longTrades,
+      shortTrades,
+      totalVolume: totalVolume.toString(),
+      totalFees: totalFees.toString(),
+      uniqueMarkets: markets.size,
+      firstTradeAt,
+      lastTradeAt,
+    };
+
+    return NextResponse.json(stats, {
+      headers: {
+        // Cache for 30s — stats are aggregate so slightly stale is fine
+        "Cache-Control": "public, s-maxage=30, stale-while-revalidate=60",
+      },
+    });
+  } catch (err) {
+    console.error("[trader-stats] error:", err);
+    return NextResponse.json(
+      {
+        error: "Failed to fetch trade statistics",
+        ...(process.env.NODE_ENV !== "production" && {
+          details: err instanceof Error ? err.message : String(err),
+        }),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/app/portfolio/page.tsx
+++ b/app/app/portfolio/page.tsx
@@ -16,6 +16,8 @@ import { PublicKey } from "@solana/web3.js";
 import { isMockMode } from "@/lib/mock-mode";
 import { getMockPortfolioPositions } from "@/lib/mock-trade-data";
 import { TradeHistoryTable } from "@/components/trade/TradeHistoryTable";
+import { TradeStatsPanel } from "@/components/trade/TradeStatsPanel";
+import { useTraderStats } from "@/hooks/useTraderStats";
 
 const ConnectButton = dynamic(
   () => import("@/components/wallet/ConnectButton").then((m) => m.ConnectButton),
@@ -54,6 +56,9 @@ export default function PortfolioPage() {
 
   // LP positions (insurance fund deposits)
   const lpPositions = useLpPositions();
+
+  // PERC-481: Aggregate trade statistics
+  const traderStats = useTraderStats(walletPublicKey?.toBase58() ?? null);
 
   // Auto-refresh every 15s
   useEffect(() => {
@@ -410,12 +415,23 @@ export default function PortfolioPage() {
           </div>
         </ScrollReveal>
 
-        {/* Trade history */}
+        {/* Trade history + stats */}
         <ScrollReveal delay={0.3}>
           <div className="mt-8">
             <h2 className="mb-3 text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--accent)]/60">
               // trade history
             </h2>
+            {/* PERC-481: Aggregate stats banner */}
+            {(traderStats.stats || traderStats.loading) && (
+              <div className="mb-2">
+                <TradeStatsPanel
+                  stats={traderStats.stats}
+                  loading={traderStats.loading}
+                  error={traderStats.error}
+                  onRetry={traderStats.refresh}
+                />
+              </div>
+            )}
             <TradeHistoryTable
               wallet={walletPublicKey?.toBase58() ?? null}
               pageSize={20}

--- a/app/components/trade/TradeStatsPanel.tsx
+++ b/app/components/trade/TradeStatsPanel.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { FC } from "react";
+import { ShimmerSkeleton } from "@/components/ui/ShimmerSkeleton";
+import { formatTokenAmount } from "@/lib/format";
+import type { TraderStatsResponse } from "@/hooks/useTraderStats";
+
+interface TradeStatsPanelProps {
+  stats: TraderStatsResponse | null;
+  loading: boolean;
+  error: string | null;
+  onRetry?: () => void;
+}
+
+function StatCell({
+  label,
+  value,
+  sub,
+  highlight,
+}: {
+  label: string;
+  value: React.ReactNode;
+  sub?: React.ReactNode;
+  highlight?: "long" | "short" | "neutral";
+}) {
+  const valueColor =
+    highlight === "long"
+      ? "text-[var(--long)]"
+      : highlight === "short"
+        ? "text-[var(--short)]"
+        : "text-[var(--text)]";
+
+  return (
+    <div className="flex flex-col gap-0.5 min-w-0">
+      <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">
+        {label}
+      </p>
+      <p
+        className={`text-[14px] font-semibold leading-tight ${valueColor} truncate`}
+        style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}
+      >
+        {value}
+      </p>
+      {sub && (
+        <p className="text-[10px] text-[var(--text-muted)] leading-tight">{sub}</p>
+      )}
+    </div>
+  );
+}
+
+function formatVolume(rawStr: string): string {
+  try {
+    const raw = BigInt(rawStr);
+    return formatTokenAmount(raw, 6);
+  } catch {
+    return "—";
+  }
+}
+
+function formatFees(rawStr: string): string {
+  try {
+    const raw = BigInt(rawStr);
+    return formatTokenAmount(raw, 6);
+  } catch {
+    return "—";
+  }
+}
+
+function longShortBar(longTrades: number, shortTrades: number) {
+  const total = longTrades + shortTrades;
+  if (total === 0) return null;
+  const longPct = Math.round((longTrades / total) * 100);
+  const shortPct = 100 - longPct;
+  return (
+    <div className="mt-2 flex items-center gap-2">
+      <span className="text-[10px] text-[var(--long)] font-medium w-8 text-right">{longPct}%</span>
+      <div className="flex-1 h-1.5 rounded-full overflow-hidden bg-[var(--border)] flex">
+        <div
+          className="h-full bg-[var(--long)] transition-all duration-500"
+          style={{ width: `${longPct}%` }}
+        />
+        <div
+          className="h-full bg-[var(--short)] transition-all duration-500"
+          style={{ width: `${shortPct}%` }}
+        />
+      </div>
+      <span className="text-[10px] text-[var(--short)] font-medium w-8">{shortPct}%</span>
+    </div>
+  );
+}
+
+/**
+ * Compact stats banner shown above the trade history table on the portfolio page.
+ * PERC-481: Trade statistics panel.
+ */
+export const TradeStatsPanel: FC<TradeStatsPanelProps> = ({
+  stats,
+  loading,
+  error,
+  onRetry,
+}) => {
+  if (loading) {
+    return (
+      <div className="border border-[var(--border)] bg-[var(--panel-bg)] p-4">
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+          {[...Array(4)].map((_, i) => (
+            <div key={i} className="space-y-1.5">
+              <ShimmerSkeleton className="h-2.5 w-16" />
+              <ShimmerSkeleton className="h-4 w-20" />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !stats || stats.totalTrades === 0) {
+    // If no trades yet, skip rendering (table will show empty state)
+    if (!error && (!stats || stats.totalTrades === 0)) return null;
+    return (
+      <div className="border border-[var(--border)]/40 bg-[var(--panel-bg)]/60 px-4 py-3 flex items-center justify-between">
+        <p className="text-[11px] text-[var(--text-muted)]">
+          {error ?? "No trading activity yet"}
+        </p>
+        {error && onRetry && (
+          <button
+            onClick={onRetry}
+            className="text-[10px] text-[var(--accent)] hover:underline"
+          >
+            Retry
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  const longPct =
+    stats.totalTrades > 0
+      ? ((stats.longTrades / stats.totalTrades) * 100).toFixed(0)
+      : "—";
+
+  return (
+    <div className="border border-[var(--border)] bg-[var(--panel-bg)]">
+      {/* Stats grid */}
+      <div className="grid grid-cols-2 gap-px bg-[var(--border)] sm:grid-cols-4">
+        {/* Total trades */}
+        <div className="bg-[var(--panel-bg)] p-3.5">
+          <StatCell
+            label="Total Trades"
+            value={stats.totalTrades.toLocaleString()}
+            sub={`${stats.uniqueMarkets} market${stats.uniqueMarkets !== 1 ? "s" : ""}`}
+          />
+        </div>
+
+        {/* Volume */}
+        <div className="bg-[var(--panel-bg)] p-3.5">
+          <StatCell
+            label="Volume Traded"
+            value={formatVolume(stats.totalVolume)}
+          />
+        </div>
+
+        {/* Fees paid */}
+        <div className="bg-[var(--panel-bg)] p-3.5">
+          <StatCell
+            label="Fees Paid"
+            value={formatFees(stats.totalFees)}
+            highlight="short"
+          />
+        </div>
+
+        {/* Long / short split */}
+        <div className="bg-[var(--panel-bg)] p-3.5">
+          <StatCell
+            label="Long / Short Split"
+            value={
+              <span>
+                <span className="text-[var(--long)]">{stats.longTrades.toLocaleString()}</span>
+                <span className="text-[var(--text-muted)] mx-1 text-[12px]">/</span>
+                <span className="text-[var(--short)]">{stats.shortTrades.toLocaleString()}</span>
+              </span>
+            }
+            sub={`${longPct}% long bias`}
+          />
+          {longShortBar(stats.longTrades, stats.shortTrades)}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/app/hooks/useTraderStats.ts
+++ b/app/hooks/useTraderStats.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import type { TraderStatsResponse } from "@/app/api/trader/[wallet]/stats/route";
+
+export type { TraderStatsResponse };
+
+export interface UseTraderStatsResult {
+  stats: TraderStatsResponse | null;
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+/**
+ * Fetches aggregate trade statistics for a wallet address.
+ * PERC-481: Trade statistics panel on portfolio page.
+ */
+export function useTraderStats(wallet: string | null | undefined): UseTraderStatsResult {
+  const [stats, setStats] = useState<TraderStatsResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetch_ = useCallback(async () => {
+    if (!wallet) {
+      setStats(null);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/trader/${wallet}/stats`);
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      const data: TraderStatsResponse = await res.json();
+      setStats(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load stats");
+    } finally {
+      setLoading(false);
+    }
+  }, [wallet]);
+
+  useEffect(() => {
+    fetch_();
+  }, [fetch_]);
+
+  return { stats, loading, error, refresh: fetch_ };
+}


### PR DESCRIPTION
## What

Adds an aggregate **Trade Statistics** banner to the portfolio page, shown above the trade history table. Gives traders a snapshot of their activity without having to scroll through individual trades.

## Stats shown
- **Total Trades** + unique markets traded
- **Volume Traded** (sum of |size| × price, formatted as tokens)
- **Fees Paid** (sum of fee column)
- **Long / Short Split** — trade counts with a visual progress bar showing directional bias

## Changes
- `GET /api/trader/:wallet/stats` — new endpoint aggregating the `trades` table
  - Returns `totalTrades`, `longTrades`, `shortTrades`, `totalVolume`, `totalFees`, `uniqueMarkets`, `firstTradeAt`, `lastTradeAt`
  - 30 req/min IP rate limiter; 30 s CDN cache
- `useTraderStats` hook — SWR-style fetch
- `TradeStatsPanel` component — responsive 2×2 → 1×4 grid, loading skeletons, null render for 0-trade wallets
- Portfolio page wired up

## Tests
- 5 new API unit tests (STATS-001 … STATS-005): zero trades, aggregate sums, long/short counts, invalid wallet 400
- Portfolio component test mocks updated

## How to test
1. Connect wallet on devnet with some trades → check portfolio page → stats panel appears above trade table
2. Fresh wallet → no stats panel (no clutter)
3. `curl 'https://percolatorlaunch.com/api/trader/<YOUR_WALLET>/stats'`

## No Railway dependency
Reads directly from Supabase via Vercel — works even while Railway is down.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added trader statistics dashboard showing aggregate trading metrics including total trades, long/short trade breakdown, total volume, fees paid, and unique markets traded.
  * New statistics refresh capability on the portfolio page.

* **Tests**
  * Added test coverage for trader statistics functionality and related components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->