### PR TITLE
fix(api): evict expired rateMap entries in trader stats route (#833)

### DIFF
--- a/app/__tests__/api/trader-stats.test.ts
+++ b/app/__tests__/api/trader-stats.test.ts
@@ -24,7 +24,7 @@ vi.mock("@/lib/supabase", () => ({
 }));
 
 // Isolate rate limiter between tests by resetting modules
-import { GET } from "@/app/api/trader/[wallet]/stats/route";
+import { GET, rateMap } from "@/app/api/trader/[wallet]/stats/route";
 import { NextRequest } from "next/server";
 
 const VALID_WALLET = "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU";
@@ -50,6 +50,32 @@ describe("GET /api/trader/:wallet/stats", () => {
     mockSupabase.eq.mockReturnThis();
     mockSupabase.order.mockReturnThis();
     mockSupabase.limit.mockResolvedValue({ data: [], error: null });
+  });
+
+  // STATS-006: rateMap eviction prevents unbounded memory growth (issue #833)
+  it("evicts expired rateMap entries when threshold is exceeded", async () => {
+    // Pre-populate rateMap with 501 expired entries (resetAt in the past).
+    rateMap.clear();
+    const past = Date.now() - 120_000; // 2 minutes ago — well outside the 60s window
+    for (let i = 0; i < 501; i++) {
+      rateMap.set(`10.0.${Math.floor(i / 256)}.${i % 256}`, { count: 1, resetAt: past });
+    }
+    expect(rateMap.size).toBe(501);
+
+    // A request from a new IP should trigger eviction and still succeed.
+    mockSupabase.limit.mockResolvedValueOnce({ data: [], error: null });
+    const req = new NextRequest(`http://localhost/api/trader/${VALID_WALLET}/stats`, {
+      headers: { "x-forwarded-for": "99.99.99.99" },
+    });
+    const res = await GET(req, { params: Promise.resolve({ wallet: VALID_WALLET }) });
+    expect(res.status).toBe(200);
+
+    // All 501 expired entries + the new live entry should have been swept, leaving only the new one.
+    expect(rateMap.size).toBe(1);
+    expect(rateMap.has("99.99.99.99")).toBe(true);
+    expect(rateMap.get("99.99.99.99")?.count).toBe(1);
+
+    rateMap.clear();
   });
 
   // STATS-003: Invalid wallet rejected

--- a/app/app/api/trader/[wallet]/stats/route.ts
+++ b/app/app/api/trader/[wallet]/stats/route.ts
@@ -30,10 +30,24 @@ export const dynamic = "force-dynamic";
 const RATE_LIMIT = 30;
 const RATE_WINDOW_MS = 60_000;
 
-const rateMap = new Map<string, { count: number; resetAt: number }>();
+// Exported for testing only — do not import outside of test files.
+export const rateMap = new Map<string, { count: number; resetAt: number }>();
+
+// Evict expired entries when the map grows large to prevent unbounded memory growth.
+// Threshold of 500 is conservative — a typical Railway instance won't see more than a few
+// hundred unique IPs in a 60s window under normal load.
+const EVICTION_THRESHOLD = 500;
 
 function isRateLimited(ip: string): boolean {
   const now = Date.now();
+
+  // Sweep expired entries before inserting a new one.
+  if (rateMap.size > EVICTION_THRESHOLD) {
+    for (const [k, v] of rateMap) {
+      if (now > v.resetAt) rateMap.delete(k);
+    }
+  }
+
   const entry = rateMap.get(ip);
   if (!entry || now > entry.resetAt) {
     rateMap.set(ip, { count: 1, resetAt: now + RATE_WINDOW_MS });


### PR DESCRIPTION
## Summary

Fixes #833 — unbounded memory growth in `GET /api/trader/:wallet/stats` rate limiter.

## Problem

`rateMap` entries were never evicted after their 60s window expired. Each unique IP left a permanent entry in the map, causing linear memory growth proportional to unique caller count on long-running Railway instances.

## Fix

Added eviction sweep inside `isRateLimited()`: when `rateMap.size > 500`, iterate and delete all expired entries before inserting a new IP.

```ts
if (rateMap.size > EVICTION_THRESHOLD) {
  for (const [k, v] of rateMap) {
    if (now > v.resetAt) rateMap.delete(k);
  }
}
```

Threshold of 500 is conservative — well above expected unique-IP volume in a 60s window under normal load.

## Tests

- **STATS-006** (new): pre-populates 501 expired entries, triggers a request, verifies all expired entries are swept and only the new live entry remains.
- All 4 trader-stats tests pass ✅

## Impact

- Severity: LOW — no immediate security impact; prevents memory-pressure DoS under sustained unique-IP flood
- Not a deployment blocker; safe to merge at any time
- Same pattern may exist in other per-route rate maps — audit recommended (tracked in issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized rate limiting by implementing automatic eviction of expired entries to prevent memory buildup and ensure consistent API performance across all requests.

* **Tests**
  * Added comprehensive integration tests validating rate limit cleanup and proper eviction of expired cache entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->