### PR TITLE
fix(security): isDevnetEnv uses getNetwork() not params.mainnetCA — issue #835

### DIFF
--- a/app/hooks/useCreateMarket.ts
+++ b/app/hooks/useCreateMarket.ts
@@ -46,7 +46,7 @@ import {
   derivePythPushOraclePDA,
 } from "@percolator/sdk";
 import { sendTx } from "@/lib/tx";
-import { getConfig } from "@/lib/config";
+import { getConfig, getNetwork } from "@/lib/config";
 import { parseMarketCreationError } from "@/lib/parseMarketError";
 
 import { SLAB_TIERS, slabDataSize, deriveLpPda } from "@percolator/sdk";
@@ -226,9 +226,11 @@ export function useCreateMarket() {
       const isAdminOracle = oracleMode === "admin";
       const isHyperpOracle = oracleMode === "hyperp";
       // PERC-devnet: isDevnetEnv must be runtime-detected, not build-time.
-      // Users toggle devnet via localStorage — NEXT_PUBLIC_SOLANA_NETWORK is always "mainnet" on Vercel prod.
-      // params.mainnetCA is only set for devnet mirror markets, making it a reliable runtime signal.
-      const isDevnetEnv = !!params.mainnetCA || connection.rpcEndpoint.includes("devnet");
+      // Users toggle devnet via localStorage — NEXT_PUBLIC_DEFAULT_NETWORK is always "mainnet" on Vercel prod.
+      // Use getNetwork() which reads localStorage("percolator-network") first, then env var, then defaults
+      // to "mainnet" (fail-closed). DO NOT use params.mainnetCA as a devnet proxy — it signals
+      // "this is a devnet mirror market" not "the user is connected to devnet" (issue #835).
+      const isDevnetEnv = getNetwork() === "devnet";
 
       // PERC-470: Resolve DEX pool vault addresses for hyperp mode
       // If vaults weren't provided, fetch the pool account on-chain
@@ -894,7 +896,7 @@ export function useCreateMarket() {
         // PERC-465: Post-creation hooks — register with oracle keeper + mint devnet token
         const slabAddr = slabPk.toBase58();
         const mintAddr = params.mint.toBase58();
-        const isDevnet = (process.env.NEXT_PUBLIC_SOLANA_NETWORK?.trim() ?? "mainnet") === "devnet";
+        const isDevnet = getNetwork() === "devnet";
 
         if (isDevnet && slabAddr) {
           // PERC-465: mainnet_ca is already written to the markets table via /api/markets POST above.


### PR DESCRIPTION
## Summary

Fixes #835 — MEDIUM security finding.

## Problem

`isDevnetEnv` was incorrectly computed as:
```typescript
const isDevnetEnv = !!params.mainnetCA || connection.rpcEndpoint.includes('devnet');
```

`params.mainnetCA` means "this market has a mainnet counterpart" — it does **not** mean the user is connected to devnet. A mainnet user navigating to a devnet mirror market URL would have `mainnetCA` set, making `isDevnetEnv = true` despite a mainnet RPC connection. Devnet-only code paths (pre-fund, faucet, devnet token mint) would then execute (and fail) on mainnet.

Also: the secondary `isDevnet` variable at line 897 still used `NEXT_PUBLIC_SOLANA_NETWORK` which is always `"mainnet"` on Vercel prod — so devnet token minting never ran even on devnet.

## Fix

Use `getNetwork()` for both checks. This utility already handles the correct priority order:
1. `localStorage('percolator-network')` — user's explicit toggle
2. `NEXT_PUBLIC_DEFAULT_NETWORK` env var
3. Default: `'mainnet'` (fail-closed)

`params.mainnetCA` is preserved where it belongs: mirror market oracle mode override (`isDevnetMirror`), Jupiter price lookups, and `mainnet_ca` DB writes.

## Changes

- `import { getConfig, getNetwork }` (add `getNetwork`)
- `isDevnetEnv = getNetwork() === 'devnet'` (was `!!params.mainnetCA || rpcEndpoint.includes('devnet')`)
- `isDevnet = getNetwork() === 'devnet'` (was `process.env.NEXT_PUBLIC_SOLANA_NETWORK === 'devnet'`)
- Update misleading comment to explain the correct logic

## Testing

- `pnpm tsc --noEmit` in `app/`: ✅ no errors
- Devnet user with localStorage override: `getNetwork() === 'devnet'` → devnet paths active ✅
- Mainnet user with devnet mirror market URL (`mainnetCA` set): `getNetwork() === 'mainnet'` → devnet paths skip ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal network detection logic for better code maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->