### PR TITLE
fix(api): market blocklist + WS auth-flood rate limiter (#837 #839)

### DIFF
--- a/packages/api/src/routes/markets.ts
+++ b/packages/api/src/routes/markets.ts
@@ -8,6 +8,16 @@ import { getConnection, getSupabase, createLogger, sanitizeSlabAddress } from "@
 
 const logger = createLogger("api:markets");
 
+// Markets to exclude from public API responses.
+// Populated from BLOCKED_MARKET_ADDRESSES env var (comma-separated slab addresses).
+// Use this to hide markets with wrong oracle_authority or corrupt state (e.g. issue #837).
+const BLOCKED_MARKET_ADDRESSES: ReadonlySet<string> = new Set(
+  (process.env.BLOCKED_MARKET_ADDRESSES ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean),
+);
+
 export function marketRoutes(): Hono {
   const app = new Hono();
 
@@ -23,7 +33,9 @@ export function marketRoutes(): Hono {
 
         if (error) throw error;
 
-        return (data ?? []).map((m) => ({
+        return (data ?? [])
+          .filter((m) => !BLOCKED_MARKET_ADDRESSES.has(m.slab_address))
+          .map((m) => ({
           slabAddress: m.slab_address,
           mintAddress: m.mint_address,
           symbol: m.symbol,

--- a/packages/api/src/routes/ws.ts
+++ b/packages/api/src/routes/ws.ts
@@ -66,6 +66,70 @@ let globalSubscriptionCount = 0;
 // Track connections per IP
 const connectionsPerIp = new Map<string, number>();
 
+// Auth failure rate limiting per IP (issue #839: connection flood from repeat auth failures)
+// Tracks recent auth failures to temporarily ban repeat offenders.
+const AUTH_FAILURE_WINDOW_MS = 60_000;   // 60-second rolling window
+const AUTH_FAILURE_BAN_THRESHOLD = 10;   // ban after 10 failures in the window
+const AUTH_FAILURE_BAN_DURATION_MS = 300_000; // 5-minute ban
+
+interface AuthFailureRecord {
+  count: number;
+  windowStart: number;  // start of current counting window
+  bannedUntil: number;  // timestamp after which ban is lifted (0 = not banned)
+}
+const authFailuresPerIp = new Map<string, AuthFailureRecord>();
+
+/**
+ * Record an auth failure for an IP. Returns true if the IP should now be banned.
+ */
+function recordAuthFailure(ip: string): void {
+  const now = Date.now();
+  let rec = authFailuresPerIp.get(ip);
+  if (!rec) {
+    rec = { count: 0, windowStart: now, bannedUntil: 0 };
+    authFailuresPerIp.set(ip, rec);
+  }
+  // Reset window if expired
+  if (now - rec.windowStart > AUTH_FAILURE_WINDOW_MS) {
+    rec.count = 0;
+    rec.windowStart = now;
+  }
+  rec.count++;
+  if (rec.count >= AUTH_FAILURE_BAN_THRESHOLD) {
+    rec.bannedUntil = now + AUTH_FAILURE_BAN_DURATION_MS;
+    logger.warn("IP temporarily banned for repeated auth failures", {
+      ip,
+      failures: rec.count,
+      banUntil: new Date(rec.bannedUntil).toISOString(),
+    });
+  }
+}
+
+/**
+ * Returns true if the IP is currently banned due to too many auth failures.
+ */
+function isAuthBanned(ip: string): boolean {
+  const rec = authFailuresPerIp.get(ip);
+  if (!rec || rec.bannedUntil === 0) return false;
+  if (Date.now() >= rec.bannedUntil) {
+    // Ban expired — clear it
+    authFailuresPerIp.delete(ip);
+    return false;
+  }
+  return true;
+}
+
+// Periodically sweep stale auth failure records to prevent unbounded growth
+setInterval(() => {
+  const now = Date.now();
+  for (const [ip, rec] of authFailuresPerIp.entries()) {
+    const stale = rec.bannedUntil > 0
+      ? now >= rec.bannedUntil + AUTH_FAILURE_BAN_DURATION_MS
+      : now - rec.windowStart > AUTH_FAILURE_WINDOW_MS * 2;
+    if (stale) authFailuresPerIp.delete(ip);
+  }
+}, AUTH_FAILURE_BAN_DURATION_MS);
+
 // Track connections per slab (for per-slab limits)
 const connectionsPerSlab = new Map<string, Set<WsClient>>();
 
@@ -410,6 +474,13 @@ export function setupWebSocket(server: Server): WebSocketServer {
       return;
     }
     
+    // Reject IPs temporarily banned for repeated auth failures (issue #839)
+    if (isAuthBanned(clientIp)) {
+      logger.warn("Rejected connection from auth-banned IP", { ip: clientIp });
+      ws.close(1008, "Too many authentication failures — try again later");
+      return;
+    }
+
     // Check connections per IP
     const ipConnections = connectionsPerIp.get(clientIp) || 0;
     if (ipConnections >= MAX_CONNECTIONS_PER_IP) {
@@ -464,6 +535,8 @@ export function setupWebSocket(server: Server): WebSocketServer {
       client.authTimeout = setTimeout(() => {
         if (!client.authenticated) {
           logger.warn("Client failed to authenticate within timeout", { ip: clientIp });
+          // Record auth failure for rate limiting (issue #839: flood protection)
+          recordAuthFailure(clientIp);
           ws.close(1008, "Authentication timeout");
         }
       }, AUTH_TIMEOUT_MS);
@@ -548,6 +621,8 @@ export function setupWebSocket(server: Server): WebSocketServer {
             }));
           } else {
             logger.warn("Invalid auth token in message", { ip: client.ip });
+            // Record auth failure for rate limiting (issue #839)
+            recordAuthFailure(client.ip);
             ws.send(JSON.stringify({ type: "error", message: "Invalid authentication token" }));
           }
           return;


### PR DESCRIPTION
## Summary

### Issue #837 — SECURITY: Wrong oracle_authority on devnet market HjBePQZ

`/api/markets` now filters out any slab address in the `BLOCKED_MARKET_ADDRESSES` env var.

**Action required:** Add this to Railway API env:
```
BLOCKED_MARKET_ADDRESSES=HjBePQZnoZVftg9B52gyeuHGjBvt2f8FNCVP4FeoP3YT
```

This market has `oracle_authority = 5Eb8PY...` (not the keeper), a hardcoded $1 price, and is unpaused. Adding it to the blocklist hides it from users and excludes it from the keeper scanner (same env var in percolator-keeper PR).

### Issue #839 — WS connection flood from 88.97.223.158

Added per-IP auth-failure rate limiter to the WS handler:
- After **10 failed auth attempts within 60s**, the IP is rejected for **5 minutes**
- Failures counted on: auth timeout (no token within 5s) OR explicit invalid token
- A sweep timer clears stale records every 5 min

This stops the `88.97.223.158` reconnect-loop from spamming logs and consuming WS slots. If that IP is a legitimate Vercel edge that didn't get PR #828's WS fix, it will stop failing once the token is sent correctly.

## Tests

All API tests: 106 pass. App-suite: 824 pass / 8 fail (pre-existing LaunchSuccess failures, unrelated to this PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Implemented IP-based rate limiting for WebSocket authentication connections to enhance security against brute-force attacks and unauthorized access attempts. IPs that exceed configured failure thresholds are automatically temporarily banned.

* **Features**
  * Added market filtering capability through environment configuration, allowing administrators to control which markets are included in API responses by specifying blocked markets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->