### PR TITLE
fix(#869): prevent WS reconnect storm on Vercel

### DIFF
--- a/app/hooks/useWalletCompat.ts
+++ b/app/hooks/useWalletCompat.ts
@@ -108,7 +108,9 @@ export function useConnectionCompat() {
 
     return new Connection(url, {
       commitment: "confirmed",
-      ...(wsEndpoint ? { wsEndpoint } : {}),
+      // #869: Must always pass wsEndpoint — omitting it lets @solana/web3.js
+      // auto-derive wss:// from the HTTP proxy URL, causing reconnect storms on Vercel.
+      wsEndpoint: wsEndpoint ?? "wss://0.0.0.0",
       // Disable web3.js built-in retry — our batch transport handles retries
       // with proper exponential backoff instead of flat 500ms delays
       ...(isClient ? { disableRetryOnRateLimit: true } : {}),

--- a/app/lib/connection.ts
+++ b/app/lib/connection.ts
@@ -1,14 +1,24 @@
 import { Connection } from "@solana/web3.js";
 import { getConfig, getWsEndpoint } from "./config";
 
+/**
+ * Sentinel WSS URL used when no Helius WS key is configured.
+ * @solana/web3.js Connection auto-derives wss:// from the HTTP endpoint
+ * using `wsEndpoint || makeWebsocketUrl(endpoint)` — any falsy value
+ * (false, undefined, "") falls through. We must provide a truthy string.
+ * This non-routable address fails the TCP handshake immediately without
+ * triggering the aggressive reconnect loop that wss://percolatorlaunch.com
+ * causes on Vercel (which can't upgrade WebSockets). (#869)
+ */
+const WS_DISABLED_SENTINEL = "wss://0.0.0.0";
+
 let _connection: Connection | null = null;
 
 export function getConnection(): Connection {
   if (!_connection) {
-    const wsEndpoint = getWsEndpoint();
     _connection = new Connection(getConfig().rpcUrl, {
       commitment: "confirmed",
-      ...(wsEndpoint ? { wsEndpoint } : {}),
+      wsEndpoint: getWsEndpoint() ?? WS_DISABLED_SENTINEL,
     });
   }
   return _connection;


### PR DESCRIPTION
## Problem
`@solana/web3.js` Connection auto-derives `wss://` from the HTTP endpoint via `wsEndpoint || makeWebsocketUrl(endpoint)`. When no explicit WS endpoint is configured, this creates `wss://percolatorlaunch.com/api/rpc` — Vercel can't upgrade WebSockets, causing an infinite reconnect loop at ~1.2s intervals on every page.

## Fix
Always pass an explicit `wsEndpoint`:
- When `NEXT_PUBLIC_HELIUS_WS_API_KEY` is set → direct Helius WSS URL
- When not set → `wss://0.0.0.0` sentinel (fails TCP handshake immediately, no retry storm)

Applied to both Connection creation sites:
- `app/lib/connection.ts` (`getConnection` singleton)
- `app/hooks/useWalletCompat.ts` (`useConnectionCompat` hook)

## Long-term fix
Set `NEXT_PUBLIC_HELIUS_WS_API_KEY` on Vercel so real WS subscriptions work via direct Helius WSS.

Closes #869