### PR TITLE
fix(ui): PERC-487 mobile responsive + stat cell fixes (#860, #864, #866)

### DIFF
--- a/app/app/create/loading.tsx
+++ b/app/app/create/loading.tsx
@@ -27,8 +27,8 @@ export default function CreateLoading() {
             ))}
           </div>
 
-          {/* Form content */}
-          <div className="space-y-6">
+          {/* Form content — single-column fields only, matching wizard step 1 layout (#866) */}
+          <div className="space-y-5">
             <div>
               <ShimmerSkeleton className="h-4 w-32 mb-2" />
               <ShimmerSkeleton className="h-12 w-full" />
@@ -37,15 +37,9 @@ export default function CreateLoading() {
               <ShimmerSkeleton className="h-4 w-40 mb-2" />
               <ShimmerSkeleton className="h-12 w-full" />
             </div>
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <ShimmerSkeleton className="h-4 w-24 mb-2" />
-                <ShimmerSkeleton className="h-12 w-full" />
-              </div>
-              <div>
-                <ShimmerSkeleton className="h-4 w-24 mb-2" />
-                <ShimmerSkeleton className="h-12 w-full" />
-              </div>
+            <div>
+              <ShimmerSkeleton className="h-4 w-28 mb-2" />
+              <ShimmerSkeleton className="h-12 w-full" />
             </div>
           </div>
 

--- a/app/app/trade/[slab]/page.tsx
+++ b/app/app/trade/[slab]/page.tsx
@@ -92,20 +92,23 @@ function Tabs({ tabs, children, defaultTab }: { tabs: string[]; children: React.
   const [active, setActive] = useState(defaultTab ?? 0);
   return (
     <div>
-      <div className="flex border-b border-[var(--border)]/50 bg-transparent">
-        {tabs.map((label, i) => (
-          <button
-            key={label}
-            onClick={() => setActive(i)}
-            className={`px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.15em] transition-colors border-b-2 ${
-              active === i
-                ? "border-[var(--accent)] text-[var(--accent)]"
-                : "border-transparent text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:border-[var(--border)]"
-            }`}
-          >
-            {label}
-          </button>
-        ))}
+      {/* overflow-x-auto + whitespace-nowrap prevents 5-tab bar from overflowing at 375px (#860) */}
+      <div className="overflow-x-auto border-b border-[var(--border)]/50 bg-transparent">
+        <div className="flex whitespace-nowrap">
+          {tabs.map((label, i) => (
+            <button
+              key={label}
+              onClick={() => setActive(i)}
+              className={`shrink-0 px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.15em] transition-colors border-b-2 ${
+                active === i
+                  ? "border-[var(--accent)] text-[var(--accent)]"
+                  : "border-transparent text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:border-[var(--border)]"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
       </div>
       <div>{children[active]}</div>
     </div>

--- a/app/components/trade/MarketStatsCard.tsx
+++ b/app/components/trade/MarketStatsCard.tsx
@@ -233,9 +233,10 @@ export const MarketStatsCard: FC = () => {
           {stats.map((s) => (
             <div
               key={s.label}
-              className="px-1.5 py-1 overflow-hidden border-b border-r border-[var(--border)]/20 [&:nth-child(3n)]:border-r-0 [&:nth-last-child(-n+3)]:border-b-0"
+              /* min-w-0 prevents the grid cell from overflowing its track (#864) */
+              className="min-w-0 px-1.5 py-1 overflow-hidden border-b border-r border-[var(--border)]/20 [&:nth-child(3n)]:border-r-0 [&:nth-last-child(-n+3)]:border-b-0"
             >
-              <p className="text-[8px] uppercase tracking-[0.1em] text-[var(--text-muted)] truncate">{s.label}</p>
+              <p className="text-[8px] uppercase tracking-[0.05em] text-[var(--text-muted)] truncate" title={s.label}>{s.label}</p>
               <p
                 className={`text-[11px] font-medium truncate ${s.valueClass ?? "text-[var(--text)]"}`}
                 title={s.tooltip ?? s.value}

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -222,9 +222,9 @@ export const TradingChart: FC<{ slabAddress: string }> = ({ slabAddress }) => {
 
   return (
     <div className="rounded-none border border-[var(--border)] bg-[var(--bg)] p-3">
-      {/* Header */}
-      <div className="mb-3 flex items-center justify-between">
-        <div>
+      {/* Header — wraps on small mobile so controls don't overflow viewport (#860) */}
+      <div className="mb-3 flex flex-wrap items-start justify-between gap-y-2">
+        <div className="min-w-0">
           <div className="text-2xl font-bold" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums", color: isUp ? "var(--long)" : "var(--short)" }}>
             ${currentPrice.toFixed(currentPrice < 1 ? 4 : 2)}
           </div>
@@ -233,8 +233,8 @@ export const TradingChart: FC<{ slabAddress: string }> = ({ slabAddress }) => {
           </div>
         </div>
 
-        {/* Controls */}
-        <div className="flex items-center gap-2">
+        {/* Controls — shrink-wrap so they don't force parent wider than viewport */}
+        <div className="flex flex-wrap items-center gap-2">
           {/* Chart type */}
           <div className="flex gap-1 rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] p-0.5">
             <button


### PR DESCRIPTION
## Summary
Closes #860, #864, #866 (Visual Consistency Audit — PERC-487)

## Changes

### #860 (P1) — /trade mobile layout 375px
**Root cause:** `Tabs` tab bar had no horizontal scroll — 5 tabs (Stats/Trades/Health/Risk/Book) at `tracking-[0.15em]` overflowed the 375px viewport. TradingChart header used rigid `justify-between` flex, causing price + chart controls to collide on narrow screens.

**Fix:**
- `Tabs`: wraps tab bar in `overflow-x-auto` container with inner `whitespace-nowrap` flex row; each button gets `shrink-0`
- `TradingChart`: header becomes `flex-wrap` + `gap-y-2` so controls drop below price on mobile

### #864 — FUNDING/HR stat cell truncated at 1440px
**Root cause:** `grid-cols-3 gap-px` cells in MarketStatsCard lacked `min-w-0`, allowing the grid track to expand past the cell. Label tracking was 0.1em which made "FUNDING/HR" visually tight.

**Fix:** Added `min-w-0` to every stat cell; tightened label tracking to `0.05em`.

### #866 — /create shimmer row inconsistent with other pages
**Root cause:** `loading.tsx` showed a `grid-cols-2` stats row that doesn't exist in the actual wizard step-1 content, creating a visual mismatch.

**Fix:** Replaced the two-column stat shimmer with a third single-column field shimmer matching real wizard layout.

## Test Plan
- `pnpm test`: 824 pass / 8 pre-existing LaunchSuccess failures (useRouter/App Router context — unrelated)
- Manual: resize /trade to 375px — tab bar scrolls, chart controls wrap
- Manual: check /trade stats card at 1440px desktop — Funding/hr label visible
- Manual: navigate /create — loading state matches wizard form shape