### PR TITLE
fix(markets): unify market count — header now uses activeMarkets.length (#847)

### DIFF
--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -99,15 +99,9 @@ function MarketsPageInner() {
   const { markets: discovered, loading: discoveryLoading } = useMarketDiscovery();
   const { statsMap, loading: statsLoading } = useAllMarketStats();
 
-  // Canonical "active markets" count from Supabase (single source of truth)
-  // Uses shared isActiveMarket filter — consistent with homepage & /api/stats
-  const totalActiveMarkets = useMemo(() => {
-    let count = 0;
-    for (const m of statsMap.values()) {
-      if (isActiveMarket(m)) count++;
-    }
-    return count;
-  }, [statsMap]);
+  // NOTE: totalActiveMarkets (Supabase-only count) removed — was inconsistent with
+  // activeMarkets.length which includes on-chain discovered markets (#847).
+  // Use activeMarkets.length as single source of truth for header + footer counts.
   
   // P-MED-2: Read filters from URL params
   const [search, setSearch] = useState(searchParams.get("q") || "");
@@ -534,11 +528,11 @@ function MarketsPageInner() {
               </button>
             )}
 
-            {/* Results count — show filtered/total when filters are active */}
+            {/* Results count — use activeMarkets.length as single source of truth (#847) */}
             <span className="ml-auto text-[10px] text-[var(--text-dim)]" style={{ fontFamily: "var(--font-mono)" }}>
-              {(hasSearch || hasActiveFilters) && filtered.length !== totalActiveMarkets
-                ? `${filtered.length} / ${totalActiveMarkets} market${totalActiveMarkets !== 1 ? "s" : ""}`
-                : `${totalActiveMarkets} market${totalActiveMarkets !== 1 ? "s" : ""}`}
+              {(hasSearch || hasActiveFilters) && filtered.length !== activeMarkets.length
+                ? `${filtered.length} / ${activeMarkets.length} market${activeMarkets.length !== 1 ? "s" : ""}`
+                : `${activeMarkets.length} market${activeMarkets.length !== 1 ? "s" : ""}`}
             </span>
           </div>
         </ScrollReveal>


### PR DESCRIPTION
## Problem
The /markets page showed 3 different market counts simultaneously:
- API: 168 markets (raw DB)
- Header: 136 markets (`totalActiveMarkets` from `statsMap` via Supabase `isActiveMarket` filter)
- Footer: 147 markets (`filtered.length` — merged on-chain + Supabase)

The discrepancy confused users and eroded trust in the data.

## Root Cause
`totalActiveMarkets` was computed from `statsMap` using the `isActiveMarket` predicate (Supabase-only). This excluded markets discovered on-chain but not yet in Supabase stats — a stricter, narrower count than what was actually displayed.

## Fix
- Remove the separate `totalActiveMarkets` memo
- Use `activeMarkets.length` (the merged, deduplicated list already displayed) as single source of truth for both header and footer
- When filters are active: shows `filtered / activeMarkets.length`
- When no filters: shows `activeMarkets.length` in both header and footer ✓

No data-layer changes — purely a display consistency fix.

## Testing
- Load /markets — header and footer should show the same count
- Apply a filter — header should show `X / Y markets`, footer `all X markets loaded`

Closes #847