### PR TITLE
fix(#881,#882): sanitize indexPrice + Sentry warning on price nulling

### DIFF
--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -27,10 +27,19 @@ function sanitizeFundingRate(v: number | null | undefined): number | null {
  */
 const MAX_SANE_PRICE_USD = 1_000_000; // $1M
 
-/** Sanitize a price field from the DB (USD float). Returns null for corrupt/garbage values. */
-function sanitizePrice(v: number | null | undefined): number | null {
+/**
+ * Sanitize a price field from the DB (USD float). Returns null for corrupt/garbage values.
+ * Logs a Sentry warning when sanitization fires so we can track data quality. (#882)
+ */
+function sanitizePrice(v: number | null | undefined, field?: string, slabAddress?: string): number | null {
   if (v == null) return null;
-  if (!Number.isFinite(v) || v <= 0 || v > MAX_SANE_PRICE_USD) return null;
+  if (!Number.isFinite(v) || v <= 0 || v > MAX_SANE_PRICE_USD) {
+    Sentry.captureMessage(`Price sanitization: ${field ?? "price"} = ${v} nulled for slab ${slabAddress ?? "unknown"}`, {
+      level: "warning",
+      tags: { endpoint: "/api/markets", sanitization: "price" },
+    });
+    return null;
+  }
   return v;
 }
 
@@ -91,8 +100,8 @@ export async function GET() {
         funding_rate: sanitizeFundingRate(m.funding_rate as number | null),
         // #856: Null out corrupt admin-set test prices (raw unscaled u64 values or billions/trillions).
         // Matches Rust MAX_ORACLE_PRICE = $1B USD ceiling.
-        last_price: sanitizePrice(m.last_price as number | null),
-        mark_price: sanitizePrice(m.mark_price as number | null),
+        last_price: sanitizePrice(m.last_price as number | null, "last_price", m.slab_address as string),
+        mark_price: sanitizePrice(m.mark_price as number | null, "mark_price", m.slab_address as string),
       };
     });
 

--- a/packages/api/src/routes/markets.ts
+++ b/packages/api/src/routes/markets.ts
@@ -58,7 +58,7 @@ export function marketRoutes(): Hono {
           lastCrankSlot: m.last_crank_slot ?? null,
           lastPrice: (m.last_price != null && Number.isFinite(m.last_price) && m.last_price > 0 && m.last_price <= 1_000_000) ? m.last_price : null,
           markPrice: (m.mark_price != null && Number.isFinite(m.mark_price) && m.mark_price > 0 && m.mark_price <= 1_000_000) ? m.mark_price : null,
-          indexPrice: m.index_price ?? null,
+          indexPrice: (m.index_price != null && Number.isFinite(m.index_price) && m.index_price > 0 && m.index_price <= 1_000_000) ? m.index_price : null,
           fundingRate: (m.funding_rate != null && Number.isFinite(m.funding_rate) && Math.abs(m.funding_rate) <= 10_000) ? m.funding_rate : null,
           netLpPos: m.net_lp_pos ?? null,
         }));


### PR DESCRIPTION
## Fixes
**#881**: `indexPrice` in Railway route was missing the same bounds check applied to `lastPrice`/`markPrice`. Added `Number.isFinite && > 0 && <= 1_000_000` guard.

**#882**: `sanitizePrice()` now logs a Sentry warning (level: warning) when it nulls a corrupt value, including the field name and slab address. This provides observability into data quality issues without blocking the response.

Closes #881, closes #882