### PR TITLE
fix(stake): Deposit Now hero CTA — solid bg-violet-700 (PERC-489)

### DIFF
--- a/app/app/stake/page.tsx
+++ b/app/app/stake/page.tsx
@@ -161,7 +161,7 @@ function StakeHero({ pools, totalUserDeposited }: { pools: StakePool[]; totalUse
           <div className="mb-10 flex flex-wrap items-center gap-3">
             <a
               href="#deposit"
-              className="group inline-flex items-center gap-2 rounded-md border border-[var(--accent)]/50 bg-[var(--accent)]/[0.10] px-6 py-3 text-sm font-semibold text-[var(--accent)] transition-all duration-200 hover:border-[var(--accent)] hover:bg-[var(--accent)]/[0.18]"
+              className="group inline-flex items-center gap-2 rounded-md bg-violet-700 px-6 py-3 text-sm font-semibold text-white transition-all duration-200 hover:bg-violet-600"
             >
               Deposit Now
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="transition-transform group-hover:translate-y-0.5">


### PR DESCRIPTION
## Summary
Fixes PERC-489. The Deposit Now hero CTA on `/stake` was using semi-transparent ghost style (`bg-[var(--accent)]/[0.10]`) instead of the solid filled primary style required by design spec.

## Change
```diff
- className="group inline-flex items-center gap-2 rounded-md border border-[var(--accent)]/50 bg-[var(--accent)]/[0.10] px-6 py-3 text-sm font-semibold text-[var(--accent)] transition-all duration-200 hover:border-[var(--accent)] hover:bg-[var(--accent)]/[0.18]"
+ className="group inline-flex items-center gap-2 rounded-md bg-violet-700 px-6 py-3 text-sm font-semibold text-white transition-all duration-200 hover:bg-violet-600"
```

## Why
Designer flagged this during visual QA of PR #875: primary CTA should match homepage hero CTAs — solid `bg-violet-700` / `hover:bg-violet-600` / `text-white`.

## How to Test
1. Navigate to `/stake`
2. Hero section should show a solid violet "Deposit Now" button (not ghost/transparent)
3. Hover shows `bg-violet-600` darkening

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the "Deposit Now" button with a new solid violet background and white text design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->