### PR TITLE
fix(api): sanitize indexPrice with same bounds check as lastPrice/markPrice (#881)

### DIFF
--- a/packages/api/src/routes/markets.ts
+++ b/packages/api/src/routes/markets.ts
@@ -58,7 +58,9 @@ export function marketRoutes(): Hono {
           lastCrankSlot: m.last_crank_slot ?? null,
           lastPrice: (m.last_price != null && Number.isFinite(m.last_price) && m.last_price > 0 && m.last_price <= 1_000_000) ? m.last_price : null,
           markPrice: (m.mark_price != null && Number.isFinite(m.mark_price) && m.mark_price > 0 && m.mark_price <= 1_000_000) ? m.mark_price : null,
-          indexPrice: m.index_price ?? null,
+          // #881: Apply same bounds check as lastPrice/markPrice — index_price is the same
+          // DB column type and subject to the same corruption vector (uninitialized slab values).
+          indexPrice: (m.index_price != null && Number.isFinite(m.index_price) && m.index_price > 0 && m.index_price <= 1_000_000) ? m.index_price : null,
           fundingRate: (m.funding_rate != null && Number.isFinite(m.funding_rate) && Math.abs(m.funding_rate) <= 10_000) ? m.funding_rate : null,
           netLpPos: m.net_lp_pos ?? null,
         }));

--- a/packages/api/tests/routes/markets.test.ts
+++ b/packages/api/tests/routes/markets.test.ts
@@ -227,6 +227,56 @@ describe("markets routes", () => {
       expect(market).toHaveProperty("fundingRate", 3);
     });
 
+    it("should sanitize corrupt indexPrice values to null (#881)", async () => {
+      const mockMarketsWithStats = [
+        {
+          slab_address: "44444444444444444444444444444444",
+          mint_address: "Mint4444444444444444444444444444",
+          symbol: "TEST-PERP",
+          name: "Test Perpetual",
+          decimals: 6,
+          deployer: "Deployer44444444444444444444444444",
+          oracle_authority: "Oracle444444444444444444444444444",
+          initial_price_e6: 1000000,
+          max_leverage: 10,
+          trading_fee_bps: 5,
+          lp_collateral: "1000000",
+          matcher_context: null,
+          status: "active",
+          logo_url: null,
+          created_at: "2025-01-01T00:00:00Z",
+          updated_at: "2025-01-01T00:00:00Z",
+          total_open_interest: null,
+          total_accounts: null,
+          last_crank_slot: null,
+          // Corrupt garbage value (like unscaled u64) — should be sanitized to null
+          last_price: null,
+          mark_price: null,
+          index_price: 900_000_000, // >$1M ceiling — should be nulled
+          funding_rate: null,
+          net_lp_pos: null,
+        },
+      ];
+
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === "markets_with_stats") {
+          return {
+            select: vi.fn().mockResolvedValue({ data: mockMarketsWithStats, error: null }),
+          };
+        }
+        return mockSupabase;
+      });
+
+      const app = marketRoutes();
+      const res = await app.request("/markets");
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.markets).toHaveLength(1);
+      // Corrupt index_price above cap must be returned as null
+      expect(data.markets[0].indexPrice).toBeNull();
+    });
+
     it("should return 400 for malformed slab address in /:slab route", async () => {
       const app = marketRoutes();
       // All /:slab routes should reject garbage inputs


### PR DESCRIPTION
## Summary
Fixes #881

indexPrice was returned raw (m.index_price ?? null) with no validation, while lastPrice and markPrice already had bounds checks (> 0, <= 1_000_000, Number.isFinite). This inconsistency meant a corrupt index_price DB value could still reach API consumers.

## Changes
- **packages/api/src/routes/markets.ts**: Apply the same guard to indexPrice:
  \\\	s
  indexPrice: (m.index_price != null && Number.isFinite(m.index_price) && m.index_price > 0 && m.index_price <= 1_000_000) ? m.index_price : null,
  \\\
- **packages/api/tests/routes/markets.test.ts**: Regression test asserting that index_price > 1_000_000 is returned as 
ull.

## Testing
All 107 existing tests pass + new regression test added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for the indexPrice field to sanitize corrupt values. The field now only passes through if it meets specific bounds criteria; otherwise, it is set to null, ensuring consistency with existing validation applied to other price fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->