### PR TITLE
fix(api): emit Sentry warning when price cap sanitizes a value to null (#882)

### DIFF
--- a/packages/api/src/routes/markets.ts
+++ b/packages/api/src/routes/markets.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { PublicKey } from "@solana/web3.js";
+import * as Sentry from "@sentry/node";
 import { validateSlab } from "../middleware/validateSlab.js";
 import { cacheMiddleware } from "../middleware/cache.js";
 import { withDbCacheFallback } from "../middleware/db-cache-fallback.js";
@@ -7,6 +8,39 @@ import { fetchSlab, parseHeader, parseConfig, parseEngine } from "@percolator/sd
 import { getConnection, getSupabase, createLogger, sanitizeSlabAddress } from "@percolator/shared";
 
 const logger = createLogger("api:markets");
+
+/**
+ * Maximum sane price in USD (float) stored in the DB.
+ * Prices are stored as USD floats (e.g. 42500 = $42,500).
+ * Cap at $1M — well above any real crypto today but well below
+ * unscaled admin-set garbage values (e.g. 900,000,000 = $900M). (#882, #856)
+ * If price units ever change (e.g. micro-USD, or BTC > $1M) this constant
+ * must be revisited — do NOT silently change it without a comment update.
+ */
+const MAX_SANE_PRICE_USD = 1_000_000;
+
+/**
+ * Sanitize a price field from the DB view.
+ * Returns the value when valid; null when out-of-range or non-finite.
+ * Emits a Sentry warning when a non-null value is rejected so that any
+ * corruption reaching the API surface is observable. (#882)
+ */
+function sanitizeMarketPrice(
+  value: number | null | undefined,
+  field: string,
+  slabAddress: string,
+): number | null {
+  if (value == null) return null;
+  if (!Number.isFinite(value) || value <= 0 || value > MAX_SANE_PRICE_USD) {
+    Sentry.captureMessage(
+      `[markets] Corrupt ${field} sanitized to null — slab: ${slabAddress}, value: ${value}`,
+      { level: "warning", tags: { field, slab: slabAddress } },
+    );
+    logger.warn(`Corrupt ${field} sanitized to null`, { slab: slabAddress, value });
+    return null;
+  }
+  return value;
+}
 
 // Markets to exclude from public API responses.
 // Populated from BLOCKED_MARKET_ADDRESSES env var (comma-separated slab addresses).
@@ -56,9 +90,10 @@ export function marketRoutes(): Hono {
           totalOpenInterest: m.total_open_interest ?? null,
           totalAccounts: m.total_accounts ?? null,
           lastCrankSlot: m.last_crank_slot ?? null,
-          lastPrice: (m.last_price != null && Number.isFinite(m.last_price) && m.last_price > 0 && m.last_price <= 1_000_000) ? m.last_price : null,
-          markPrice: (m.mark_price != null && Number.isFinite(m.mark_price) && m.mark_price > 0 && m.mark_price <= 1_000_000) ? m.mark_price : null,
-          indexPrice: m.index_price ?? null,
+          lastPrice: sanitizeMarketPrice(m.last_price, "last_price", m.slab_address),
+          markPrice: sanitizeMarketPrice(m.mark_price, "mark_price", m.slab_address),
+          // #881/#882: Apply same guard to indexPrice — same DB column type and corruption vector.
+          indexPrice: sanitizeMarketPrice(m.index_price, "index_price", m.slab_address),
           fundingRate: (m.funding_rate != null && Number.isFinite(m.funding_rate) && Math.abs(m.funding_rate) <= 10_000) ? m.funding_rate : null,
           netLpPos: m.net_lp_pos ?? null,
         }));

--- a/packages/api/tests/routes/markets.test.ts
+++ b/packages/api/tests/routes/markets.test.ts
@@ -4,6 +4,13 @@ import { marketRoutes } from "../../src/routes/markets.js";
 import { clearCache } from "../../src/middleware/cache.js";
 import { clearDbCache } from "../../src/middleware/db-cache-fallback.js";
 
+// Mock Sentry so captureMessage calls can be asserted in tests (#882)
+// Use vi.hoisted so the variable is initialised before vi.mock hoisting.
+const { mockCaptureMessage } = vi.hoisted(() => ({ mockCaptureMessage: vi.fn() }));
+vi.mock("@sentry/node", () => ({
+  captureMessage: mockCaptureMessage,
+}));
+
 // Mock dependencies
 vi.mock("@percolator/shared", () => ({
   getSupabase: vi.fn(),
@@ -40,6 +47,7 @@ describe("markets routes", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCaptureMessage.mockReset();
     // Clear both caches to prevent cross-test cache pollution
     clearCache();
     clearDbCache();
@@ -225,6 +233,60 @@ describe("markets routes", () => {
       expect(market).toHaveProperty("lastPrice", 42500);
       expect(market).toHaveProperty("markPrice", 42500);
       expect(market).toHaveProperty("fundingRate", 3);
+    });
+
+    it("should emit a Sentry warning when a price is sanitized to null (#882)", async () => {
+      const corruptSlab = "55555555555555555555555555555555";
+      const mockMarketsWithStats = [
+        {
+          slab_address: corruptSlab,
+          mint_address: "Mint5555555555555555555555555555",
+          symbol: "CORRUPT-PERP",
+          name: "Corrupt Perpetual",
+          decimals: 6,
+          deployer: "Deployer55555555555555555555555555",
+          oracle_authority: "Oracle555555555555555555555555555",
+          initial_price_e6: 1000000,
+          max_leverage: 10,
+          trading_fee_bps: 5,
+          lp_collateral: "1000000",
+          matcher_context: null,
+          status: "active",
+          logo_url: null,
+          created_at: "2025-01-01T00:00:00Z",
+          updated_at: "2025-01-01T00:00:00Z",
+          total_open_interest: null,
+          total_accounts: null,
+          last_crank_slot: null,
+          last_price: 999_999_999, // out-of-range — should trigger Sentry warning
+          mark_price: null,
+          index_price: null,
+          funding_rate: null,
+          net_lp_pos: null,
+        },
+      ];
+
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === "markets_with_stats") {
+          return {
+            select: vi.fn().mockResolvedValue({ data: mockMarketsWithStats, error: null }),
+          };
+        }
+        return mockSupabase;
+      });
+
+      const app = marketRoutes();
+      const res = await app.request("/markets");
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      // Corrupt price must be nulled
+      expect(data.markets[0].lastPrice).toBeNull();
+      // And a Sentry warning must have been emitted (#882)
+      expect(mockCaptureMessage).toHaveBeenCalledWith(
+        expect.stringContaining("last_price"),
+        expect.objectContaining({ level: "warning" }),
+      );
     });
 
     it("should return 400 for malformed slab address in /:slab route", async () => {


### PR DESCRIPTION
## Summary
Fixes #882

The price-cap introduced in PR #878 silently nulled out-of-range values with zero telemetry.

## Changes
- Extracts sanitizeMarketPrice() helper that calls Sentry.captureMessage (warning) + logger.warn when a non-null value is rejected
- Documents MAX_SANE_PRICE_USD constant with unit assumption (USD float, cap at 1M USD)
- Applies consistently to lastPrice, markPrice, and indexPrice
- Adds regression test asserting Sentry warning fires on corrupt input

## Testing
All 107 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced market price validation: price fields now reject invalid, negative, or excessively large values (exceeding $1,000,000)
  * Invalid price data is properly nullified and logged for monitoring visibility

* **Tests**
  * Expanded test coverage to verify proper handling of out-of-range market price data and error logging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->