### PR TITLE
fix(app/api): sanitize index_price in Next.js /api/markets route (#855)

### DIFF
--- a/app/__tests__/api/markets-price-sanitize.test.ts
+++ b/app/__tests__/api/markets-price-sanitize.test.ts
@@ -171,4 +171,30 @@ describe("GET /api/markets — price sanitization (#856)", () => {
     expect(symbols).not.toContain("BLOCKED");
     expect(symbols).toContain("GOOD");
   });
+
+  it("sanitizes index_price with same bounds as last_price/mark_price (#855)", async () => {
+    mockMarkets = [
+      // Corrupt index_price — should be nulled
+      mkMarket({ symbol: "A", index_price: 900_000_000 } as Record<string, unknown>),
+      // Legit index_price — should pass through
+      mkMarket({ symbol: "B", index_price: 42_500 } as Record<string, unknown>),
+      // Null index_price — stays null
+      mkMarket({ symbol: "C", index_price: null } as Record<string, unknown>),
+    ];
+
+    vi.resetModules();
+    const { GET } = await import("@/app/api/markets/route");
+    const res = await GET();
+    const body = (await res.json()) as {
+      markets: { symbol: string; index_price: number | null }[];
+    };
+
+    const a = body.markets.find((m) => m.symbol === "A");
+    const b = body.markets.find((m) => m.symbol === "B");
+    const c = body.markets.find((m) => m.symbol === "C");
+
+    expect(a?.index_price).toBeNull();   // corrupt value nulled
+    expect(b?.index_price).toBe(42_500); // legit value preserved
+    expect(c?.index_price).toBeNull();   // already-null preserved
+  });
 });

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -93,6 +93,10 @@ export async function GET() {
         // Matches Rust MAX_ORACLE_PRICE = $1B USD ceiling.
         last_price: sanitizePrice(m.last_price as number | null),
         mark_price: sanitizePrice(m.mark_price as number | null),
+        // #855: Apply same sanitization to index_price — same DB column type and
+        // corruption vector as last_price/mark_price. Inconsistent sanitization
+        // means a corrupt index price still reaches consumers.
+        index_price: sanitizePrice(m.index_price as number | null),
       };
     });
 


### PR DESCRIPTION
## Summary
Fixes #855 (code portion)

The Next.js /api/markets route (app/app/api/markets/route.ts) already sanitized last_price and mark_price via sanitizePrice(), but index_price was spread through raw from the DB record, allowing corrupt values to reach API consumers.

## Changes
- app/app/api/markets/route.ts: Add index_price: sanitizePrice(...) to the sanitized spread, consistent with last_price and mark_price
- app/__tests__/api/markets-price-sanitize.test.ts: New test asserting corrupt index_price (>1M USD) is nulled while legit values pass through unchanged

## Testing
All 7 tests in markets-price-sanitize.test.ts pass.

Note: The env var deployment (setting BLOCKED_MARKET_ADDRESSES in Vercel) is a DevOps/infra action that cannot be done via code PR.