### PR TITLE
fix(security): bump @hono/node-server to ^1.19.11 in api + indexer (CVE-2026-29087)

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -13,7 +13,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@hono/node-server": "^1.19.10",
+    "@hono/node-server": "^1.19.11",
     "@percolator/sdk": "workspace:*",
     "@percolator/shared": "workspace:*",
     "@sentry/node": "^10.39.0",

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -13,7 +13,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@hono/node-server": "^1.13.8",
+    "@hono/node-server": "^1.19.11",
     "@percolator/sdk": "workspace:*",
     "@percolator/shared": "workspace:*",
     "@solana/web3.js": "^1.98.0",


### PR DESCRIPTION
Fixes CVE-2026-29087 in both packages. api was at ^1.19.10, indexer was still on ^1.13.8. Both bumped to ^1.19.11.

Supersedes fork PR #884. Security-approved.