### PR TITLE
fix(app/api): sanitize index_price in /api/markets route (#855)

### DIFF
--- a/app/__tests__/api/markets-price-sanitize.test.ts
+++ b/app/__tests__/api/markets-price-sanitize.test.ts
@@ -171,4 +171,30 @@ describe("GET /api/markets — price sanitization (#856)", () => {
     expect(symbols).not.toContain("BLOCKED");
     expect(symbols).toContain("GOOD");
   });
+
+  it("sanitizes index_price with same bounds as last_price/mark_price (#855)", async () => {
+    mockMarkets = [
+      // Corrupt index_price — should be nulled
+      mkMarket({ symbol: "A", index_price: 900_000_000 } as Record<string, unknown>),
+      // Legit index_price — should pass through
+      mkMarket({ symbol: "B", index_price: 42_500 } as Record<string, unknown>),
+      // Null index_price — stays null
+      mkMarket({ symbol: "C", index_price: null } as Record<string, unknown>),
+    ];
+
+    vi.resetModules();
+    const { GET } = await import("@/app/api/markets/route");
+    const res = await GET();
+    const body = (await res.json()) as {
+      markets: { symbol: string; index_price: number | null }[];
+    };
+
+    const a = body.markets.find((m) => m.symbol === "A");
+    const b = body.markets.find((m) => m.symbol === "B");
+    const c = body.markets.find((m) => m.symbol === "C");
+
+    expect(a?.index_price).toBeNull();   // corrupt value nulled
+    expect(b?.index_price).toBe(42_500); // legit value preserved
+    expect(c?.index_price).toBeNull();   // already-null preserved
+  });
 });

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -102,6 +102,10 @@ export async function GET() {
         // Matches Rust MAX_ORACLE_PRICE = $1B USD ceiling.
         last_price: sanitizePrice(m.last_price as number | null, "last_price", m.slab_address as string),
         mark_price: sanitizePrice(m.mark_price as number | null, "mark_price", m.slab_address as string),
+        // #855: Apply same sanitization to index_price — same DB column type and
+        // corruption vector as last_price/mark_price. Inconsistent sanitization
+        // means a corrupt index price still reaches consumers.
+        index_price: sanitizePrice(m.index_price as number | null, "index_price", m.slab_address as string),
       };
     });
 


### PR DESCRIPTION
Apply same `sanitizePrice()` bounds check to `index_price` that already covers `last_price` and `mark_price`. Corrupt DB values (≥ MAX_ORACLE_PRICE = $1B) are nulled before reaching consumers. Includes test.

Supersedes fork PR #889. Security-approved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Applied price field sanitization to index_price data. Invalid price values are nulled while valid values are preserved, matching the validation logic applied to other market price fields.

* **Tests**
  * Added comprehensive test coverage for index_price sanitization behavior, including edge cases with boundary validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->