### PR TITLE
fix(ws): use getBackendUrl() for live price WebSocket — fixes #854

### DIFF
--- a/app/hooks/useLivePrice.ts
+++ b/app/hooks/useLivePrice.ts
@@ -3,14 +3,21 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { resolveMarketPriceE6, sanitizePriceE6 } from "@/lib/oraclePrice";
+import { getBackendUrl } from "@/lib/config";
 
 // Derive WebSocket URL from API URL: https://... → wss://...
 function getWsUrl(): string {
   const explicit = process.env.NEXT_PUBLIC_WS_URL;
   if (explicit) return explicit;
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? process.env.NEXT_PUBLIC_BACKEND_URL ?? "";
-  if (!apiUrl) return "";
-  return apiUrl.replace(/^https:\/\//, "wss://").replace(/^http:\/\//, "ws://");
+  // Use getBackendUrl() which has the Railway production fallback,
+  // instead of reading env vars directly (which returns "" in production
+  // when NEXT_PUBLIC_API_URL is not explicitly set).
+  try {
+    const apiUrl = getBackendUrl();
+    return apiUrl.replace(/^https:\/\//, "wss://").replace(/^http:\/\//, "ws://");
+  } catch {
+    return "";
+  }
 }
 const WS_URL = getWsUrl();
 if (!WS_URL && typeof window !== "undefined") {


### PR DESCRIPTION
## Problem
WebSocket connection to `wss://percolatorlaunch.com/api/rpc` fails continuously because the Next.js app doesn't support WebSocket upgrades. The `useLivePrice` hook was deriving the WS URL from `NEXT_PUBLIC_API_URL` which points to the Next.js proxy, not the actual API service.

## Fix
Use `getBackendUrl()` from `@/lib/config` which resolves to the Railway API service directly (`percolator-api-production.up.railway.app`) where the WebSocket server (`packages/api/src/routes/ws.ts`) actually runs.

## Testing
- Verify WebSocket connects to Railway API URL, not Next.js proxy
- Mark price should update in real-time on /trade pages
- Console should stop showing rapid WebSocket error spam

Fixes #854

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced error handling for live price connection setup, improving reliability when configuration fallback is needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->