### PR TITLE
fix(api): fallback to initial_price_e6 when mark_price is null — fixes #846

### DIFF
--- a/packages/api/src/routes/markets.ts
+++ b/packages/api/src/routes/markets.ts
@@ -57,7 +57,14 @@ export function marketRoutes(): Hono {
           totalAccounts: m.total_accounts ?? null,
           lastCrankSlot: m.last_crank_slot ?? null,
           lastPrice: (m.last_price != null && Number.isFinite(m.last_price) && m.last_price > 0 && m.last_price <= 1_000_000) ? m.last_price : null,
-          markPrice: (m.mark_price != null && Number.isFinite(m.mark_price) && m.mark_price > 0 && m.mark_price <= 1_000_000) ? m.mark_price : null,
+          // Fallback chain: mark_price → initial_price_e6 (converted from E6 to USD).
+          // Markets that haven't been cranked yet have null mark_price in the stats view,
+          // but still have a valid initial_price_e6 from market creation.
+          markPrice: (m.mark_price != null && Number.isFinite(m.mark_price) && m.mark_price > 0 && m.mark_price <= 1_000_000)
+            ? m.mark_price
+            : (m.initial_price_e6 != null && m.initial_price_e6 > 0)
+              ? Number(m.initial_price_e6) / 1_000_000
+              : null,
           indexPrice: (m.index_price != null && Number.isFinite(m.index_price) && m.index_price > 0 && m.index_price <= 1_000_000) ? m.index_price : null,
           fundingRate: (m.funding_rate != null && Number.isFinite(m.funding_rate) && Math.abs(m.funding_rate) <= 10_000) ? m.funding_rate : null,
           netLpPos: m.net_lp_pos ?? null,


### PR DESCRIPTION
## Problem
47/168 markets return `mark_price: null` from `GET /api/markets` because they haven't been successfully cranked yet (uninit slab issue). The market list page shows no price for 28% of markets.

## Fix
When `mark_price` is null in the `markets_with_stats` view, fall back to `initial_price_e6` (converted from E6 integer to USD float). Every market has this value set at creation time, so no market will show a null price.

This is a **display-layer mitigation** — the root cause (uninit slabs preventing cranks) is being addressed separately with devops.

## Testing
- `GET /api/markets` should return non-null `markPrice` for all markets
- Markets page should show a price for every listed market

Fixes #846