### PR TITLE
fix(discovery): layout-aware V0/V1 engine parsing + discover V1 slabs

### DIFF
--- a/packages/core/src/solana/discovery.ts
+++ b/packages/core/src/solana/discovery.ts
@@ -3,16 +3,18 @@ import {
   parseHeader,
   parseConfig,
   parseParams,
-  ENGINE_OFF as SLAB_ENGINE_OFF,
-  ENGINE_MARK_PRICE_OFF,
+  detectSlabLayout,
   type SlabHeader,
   type MarketConfig,
   type EngineState,
   type RiskParams,
+  type SlabLayout,
 } from "./slab.js";
 
-/** Bitmap offset within engine struct (updated for PERC-120/121/122 struct changes) */
+/** V1 bitmap offset within engine struct (updated for PERC-120/121/122 struct changes) */
 const ENGINE_BITMAP_OFF = 656; // Updated for PERC-299 (608 + 24 emergency OI fields)
+/** V0 bitmap offset within engine struct (deployed devnet program) */
+const ENGINE_BITMAP_OFF_V0 = 320;
 
 /**
  * A discovered Percolator market from on-chain program accounts.
@@ -126,8 +128,6 @@ const SLAB_DATA_SIZE = SLAB_TIERS.large.dataSize;
 /** We need header(104) + config(536) + engine up to nextAccountId (~1200). Total ~1840. Use 1940 for margin. */
 const HEADER_SLICE_LENGTH = 1940;
 
-const ENGINE_OFF = SLAB_ENGINE_OFF; // single source of truth from slab.ts
-
 function dv(data: Uint8Array): DataView {
   return new DataView(data.buffer, data.byteOffset, data.byteLength);
 }
@@ -156,35 +156,92 @@ function readI128LE(buf: Uint8Array, offset: number): bigint {
 
 /**
  * Light engine parser that works with partial slab data (dataSlice, no accounts array).
- * @param maxAccounts — the tier's max accounts (256/1024/4096) to compute correct bitmap offsets
+ * Requires a layout hint (from detectSlabLayout on the actual slab size) to use correct offsets.
+ *
+ * @param data        — partial slab slice (HEADER_SLICE_LENGTH bytes)
+ * @param layout      — SlabLayout from detectSlabLayout(actualDataSize). If null, falls back to V0.
+ * @param maxAccounts — tier's max accounts for bitmap offset calculation
  */
-function parseEngineLight(data: Uint8Array, maxAccounts: number = 4096): EngineState {
-  const base = ENGINE_OFF;
-  const minLen = base + ENGINE_BITMAP_OFF; // need at least fixed engine fields
+function parseEngineLight(
+  data: Uint8Array,
+  layout: SlabLayout | null,
+  maxAccounts: number = 4096,
+): EngineState {
+  const isV0 = !layout || layout.version === 0;
+  const base = layout ? layout.engineOff : 480; // V0=480, V1=640
+  const bitmapOff = layout ? layout.engineBitmapOff : ENGINE_BITMAP_OFF_V0;
+
+  const minLen = base + bitmapOff;
   if (data.length < minLen) {
     throw new Error(`Slab data too short for engine light parse: ${data.length} < ${minLen}`);
   }
 
   // Compute tier-dependent offsets for numUsedAccounts and nextAccountId
   const bitmapWords = Math.ceil(maxAccounts / 64);
-  const numUsedOff = ENGINE_BITMAP_OFF + bitmapWords * 8; // u16 right after bitmap
+  const numUsedOff = bitmapOff + bitmapWords * 8; // u16 right after bitmap
   const nextAccountIdOff = Math.ceil((numUsedOff + 2) / 8) * 8; // u64, 8-byte aligned
 
-  // Check if the partial slice is long enough to read these fields
   const canReadNumUsed = data.length >= base + numUsedOff + 2;
   const canReadNextId = data.length >= base + nextAccountIdOff + 8;
 
-  // Engine field offsets within engine struct (updated for PERC-120/121/122):
-  // vault(0) + insurance(16,32) + params(48,288) + currentSlot(336) + fundingIndex(344,16)
-  // + lastFundingSlot(360) + fundingRateBps(368) + markPrice(376) + fundingFrozen(384,8)
-  // + frozenRate(392) + lastCrankSlot(400) + maxCrankStaleness(408) + totalOI(416,16)
-  // + longOi(432,16) + shortOi(448,16) [PERC-298]
+  if (isV0) {
+    // V0 engine struct (deployed devnet): ENGINE_OFF=480
+    // vault(0,16) + insurance(16,32) + params(48,56) + currentSlot(104,8)
+    // + fundingIndex(112,16) + lastFundingSlot(128,8) + fundingRateBps(136,8)
+    // + lastCrankSlot(144,8) + maxCrankStaleness(152,8) + totalOI(160,16)
+    // + cTot(176,16) + pnlPosTot(192,16) + liqCursor(208,2) + gcCursor(210,2)
+    // + lastSweepStart(216,8) + lastSweepComplete(224,8) + crankCursor(232,2) + sweepStartIdx(234,2)
+    // + lifetimeLiquidations(240,8) + lifetimeForceCloses(248,8)
+    // + netLpPos(256,16) + lpSumAbs(272,16) + lpMaxAbs(288,16) + bitmap(320)
+    return {
+      vault: readU128LE(data, base + 0),
+      insuranceFund: {
+        balance: readU128LE(data, base + 16),
+        feeRevenue: readU128LE(data, base + 32),
+        isolatedBalance: 0n,
+        isolationBps: 0,
+      },
+      currentSlot: readU64LE(data, base + 104),
+      fundingIndexQpbE6: readI128LE(data, base + 112),
+      lastFundingSlot: readU64LE(data, base + 128),
+      fundingRateBpsPerSlotLast: readI64LE(data, base + 136),
+      lastCrankSlot: readU64LE(data, base + 144),
+      maxCrankStalenessSlots: readU64LE(data, base + 152),
+      totalOpenInterest: readU128LE(data, base + 160),
+      longOi: 0n,
+      shortOi: 0n,
+      cTot: readU128LE(data, base + 176),
+      pnlPosTot: readU128LE(data, base + 192),
+      liqCursor: readU16LE(data, base + 208),
+      gcCursor: readU16LE(data, base + 210),
+      lastSweepStartSlot: readU64LE(data, base + 216),
+      lastSweepCompleteSlot: readU64LE(data, base + 224),
+      crankCursor: readU16LE(data, base + 232),
+      sweepStartIdx: readU16LE(data, base + 234),
+      lifetimeLiquidations: readU64LE(data, base + 240),
+      lifetimeForceCloses: readU64LE(data, base + 248),
+      netLpPos: readI128LE(data, base + 256),
+      lpSumAbs: readU128LE(data, base + 272),
+      lpMaxAbs: readU128LE(data, base + 288),
+      lpMaxAbsSweep: 0n,
+      emergencyOiMode: false,
+      emergencyStartSlot: 0n,
+      lastBreakerSlot: 0n,
+      markPriceE6: 0n, // V0 engine has no mark_price field
+      numUsedAccounts: canReadNumUsed ? readU16LE(data, base + numUsedOff) : 0,
+      nextAccountId: canReadNextId ? readU64LE(data, base + nextAccountIdOff) : 0n,
+    };
+  }
+
+  // V1 engine struct (future upgrade / V1 slabs): ENGINE_OFF=640
+  // vault(0) + insurance(16,48) + params(64,288) + currentSlot(352) + fundingIndex(360,16)
+  // + lastFundingSlot(376) + fundingRateBps(384) + markPrice(392) + lastCrankSlot(400)
+  // + maxCrankStaleness(408) + totalOI(416,16) + longOi(432,16) + shortOi(448,16)
   // + cTot(464,16) + pnlPosTot(480,16) + liqCursor(496,2) + gcCursor(498,2)
   // + lastSweepStart(504) + lastSweepComplete(512) + crankCursor(520,2) + sweepStartIdx(522,2)
   // + lifetimeLiquidations(528) + lifetimeForceCloses(536)
   // + netLpPos(544,16) + lpSumAbs(560,16) + lpMaxAbs(576,16) + lpMaxAbsSweep(592,16)
-  // + emergencyOiMode(608,1+7pad) + emergencyStartSlot(616,8) + lastBreakerSlot(624,8)
-  // + bitmap(632)
+  // + emergencyOiMode(608,1+7pad) + emergencyStartSlot(616) + lastBreakerSlot(624) + bitmap(656)
   return {
     vault: readU128LE(data, base + 0),
     insuranceFund: {
@@ -193,37 +250,35 @@ function parseEngineLight(data: Uint8Array, maxAccounts: number = 4096): EngineS
       isolatedBalance: readU128LE(data, base + 48),
       isolationBps: readU16LE(data, base + 64),
     },
-    currentSlot: readU64LE(data, base + 384),
-    fundingIndexQpbE6: readI128LE(data, base + 392),
-    lastFundingSlot: readU64LE(data, base + 384),
-    fundingRateBpsPerSlotLast: readI64LE(data, base + 392),
-    lastCrankSlot: readU64LE(data, base + 424),
-    maxCrankStalenessSlots: readU64LE(data, base + 456),
-    totalOpenInterest: readU128LE(data, base + 440),
-    longOi: readU128LE(data, base + 456),
-    shortOi: readU128LE(data, base + 472),
-    cTot: readU128LE(data, base + 488),
-    pnlPosTot: readU128LE(data, base + 552),
-    liqCursor: readU16LE(data, base + 568),
-    gcCursor: readU16LE(data, base + 546),
-    lastSweepStartSlot: readU64LE(data, base + 552),
-    lastSweepCompleteSlot: readU64LE(data, base + 584),
-    crankCursor: readU16LE(data, base + 568),
-    sweepStartIdx: readU16LE(data, base + 546),
-    lifetimeLiquidations: readU64LE(data, base + 552),
-    lifetimeForceCloses: readU64LE(data, base + 584),
-    netLpPos: readI128LE(data, base + 568),
-    lpSumAbs: readU128LE(data, base + 584),
-    lpMaxAbs: readU128LE(data, base + 600),
-    lpMaxAbsSweep: readU128LE(data, base + 640),
-    emergencyOiMode: data[base + 632] !== 0,
-    emergencyStartSlot: readU64LE(data, base + 640),
-    lastBreakerSlot: readU64LE(data, base + 648),
+    currentSlot: readU64LE(data, base + 352),
+    fundingIndexQpbE6: readI128LE(data, base + 360),
+    lastFundingSlot: readU64LE(data, base + 376),
+    fundingRateBpsPerSlotLast: readI64LE(data, base + 384),
+    lastCrankSlot: readU64LE(data, base + 400),
+    maxCrankStalenessSlots: readU64LE(data, base + 408),
+    totalOpenInterest: readU128LE(data, base + 416),
+    longOi: readU128LE(data, base + 432),
+    shortOi: readU128LE(data, base + 448),
+    cTot: readU128LE(data, base + 464),
+    pnlPosTot: readU128LE(data, base + 480),
+    liqCursor: readU16LE(data, base + 496),
+    gcCursor: readU16LE(data, base + 498),
+    lastSweepStartSlot: readU64LE(data, base + 504),
+    lastSweepCompleteSlot: readU64LE(data, base + 512),
+    crankCursor: readU16LE(data, base + 520),
+    sweepStartIdx: readU16LE(data, base + 522),
+    lifetimeLiquidations: readU64LE(data, base + 528),
+    lifetimeForceCloses: readU64LE(data, base + 536),
+    netLpPos: readI128LE(data, base + 544),
+    lpSumAbs: readU128LE(data, base + 560),
+    lpMaxAbs: readU128LE(data, base + 576),
+    lpMaxAbsSweep: readU128LE(data, base + 592),
+    emergencyOiMode: data[base + 608] !== 0,
+    emergencyStartSlot: readU64LE(data, base + 616),
+    lastBreakerSlot: readU64LE(data, base + 624),
+    markPriceE6: readU64LE(data, base + 392),
     numUsedAccounts: canReadNumUsed ? readU16LE(data, base + numUsedOff) : 0,
     nextAccountId: canReadNextId ? readU64LE(data, base + nextAccountIdOff) : 0n,
-    markPriceE6: data.length >= base + ENGINE_MARK_PRICE_OFF + 8
-      ? readU64LE(data, base + ENGINE_MARK_PRICE_OFF)
-      : 0n,
   };
 }
 
@@ -235,23 +290,28 @@ export async function discoverMarkets(
   connection: Connection,
   programId: PublicKey,
 ): Promise<DiscoveredMarket[]> {
-  // Query all known slab sizes in parallel to discover markets of any tier
-  // Track which tier each account belongs to for correct offset computation
-  const ALL_TIERS = Object.values(SLAB_TIERS);
-  let rawAccounts: { pubkey: PublicKey; account: { data: Buffer | Uint8Array }; maxAccounts: number }[] = [];
+  // Query all known slab sizes in parallel — both V0 (deployed devnet) and V1 (upgraded) tiers.
+  // We track the actual dataSize per entry so detectSlabLayout can determine the correct layout,
+  // and pass that layout to all parse functions (avoids wrong-version offsets on partial slices).
+  const ALL_TIERS = [
+    ...Object.values(SLAB_TIERS),
+    ...Object.values(SLAB_TIERS_V1),
+  ];
+  type RawEntry = { pubkey: PublicKey; account: { data: Buffer | Uint8Array }; maxAccounts: number; dataSize: number };
+  let rawAccounts: RawEntry[] = [];
   try {
     const queries = ALL_TIERS.map(tier =>
       connection.getProgramAccounts(programId, {
         filters: [{ dataSize: tier.dataSize }],
         dataSlice: { offset: 0, length: HEADER_SLICE_LENGTH },
-      }).then(results => results.map(entry => ({ ...entry, maxAccounts: tier.maxAccounts })))
+      }).then(results => results.map(entry => ({ ...entry, maxAccounts: tier.maxAccounts, dataSize: tier.dataSize })))
     );
     const results = await Promise.allSettled(queries);
     let hadRejection = false;
     for (const result of results) {
       if (result.status === "fulfilled") {
         for (const entry of result.value) {
-          rawAccounts.push(entry as { pubkey: PublicKey; account: { data: Buffer | Uint8Array }; maxAccounts: number });
+          rawAccounts.push(entry as RawEntry);
         }
       } else {
         hadRejection = true;
@@ -275,7 +335,8 @@ export async function discoverMarkets(
         ],
         dataSlice: { offset: 0, length: HEADER_SLICE_LENGTH },
       });
-      rawAccounts = [...fallback].map(e => ({ ...e, maxAccounts: 4096 })) as { pubkey: PublicKey; account: { data: Buffer | Uint8Array }; maxAccounts: number }[];
+      // Unknown actual size — use large V0 as safe default (maxAccounts=4096)
+      rawAccounts = [...fallback].map(e => ({ ...e, maxAccounts: 4096, dataSize: SLAB_TIERS.large.dataSize })) as RawEntry[];
     }
   } catch (err) {
     console.warn(
@@ -293,13 +354,13 @@ export async function discoverMarkets(
       ],
       dataSlice: { offset: 0, length: HEADER_SLICE_LENGTH },
     });
-    rawAccounts = [...fallback].map(e => ({ ...e, maxAccounts: 4096 })) as { pubkey: PublicKey; account: { data: Buffer | Uint8Array }; maxAccounts: number }[];
+    rawAccounts = [...fallback].map(e => ({ ...e, maxAccounts: 4096, dataSize: SLAB_TIERS.large.dataSize })) as RawEntry[];
   }
   const accounts = rawAccounts;
 
   const markets: DiscoveredMarket[] = [];
 
-  for (const { pubkey, account, maxAccounts } of accounts) {
+  for (const { pubkey, account, maxAccounts, dataSize } of accounts) {
     const data = new Uint8Array(account.data);
 
     let valid = true;
@@ -311,11 +372,15 @@ export async function discoverMarkets(
     }
     if (!valid) continue;
 
+    // Detect layout from actual slab size — not slice length — so parse functions
+    // get correct V0/V1 offsets even when working on the partial HEADER_SLICE_LENGTH slice.
+    const layout = detectSlabLayout(dataSize);
+
     try {
       const header = parseHeader(data);
-      const config = parseConfig(data);
-      const engine = parseEngineLight(data, maxAccounts);
-      const params = parseParams(data);
+      const config = parseConfig(data, layout);
+      const engine = parseEngineLight(data, layout, maxAccounts);
+      const params = parseParams(data, layout);
 
       markets.push({ slabAddress: pubkey, programId, header, config, engine, params });
     } catch (err) {

--- a/packages/core/src/solana/slab.ts
+++ b/packages/core/src/solana/slab.ts
@@ -599,9 +599,12 @@ export function parseHeader(data: Uint8Array): SlabHeader {
  * Parse market config. Layout-version aware.
  * For V0 slabs, fields beyond the basic config are read if present in the data,
  * otherwise defaults are returned.
+ *
+ * @param data - Slab data (may be a partial slice for discovery; pass layoutHint in that case)
+ * @param layoutHint - Pre-detected layout to use; if omitted, detected from data.length.
  */
-export function parseConfig(data: Uint8Array): MarketConfig {
-  const layout = detectSlabLayout(data.length);
+export function parseConfig(data: Uint8Array, layoutHint?: SlabLayout | null): MarketConfig {
+  const layout = layoutHint !== undefined ? layoutHint : detectSlabLayout(data.length);
   const configOff = layout ? layout.configOffset : V0_HEADER_LEN;
   const configLen = layout ? layout.configLen : V0_CONFIG_LEN;
 
@@ -797,9 +800,12 @@ export function parseConfig(data: Uint8Array): MarketConfig {
  * Parse RiskParams from engine data. Layout-version aware.
  * For V0 slabs, extended params (risk_threshold, maintenance_fee, etc.) are
  * not present on-chain, so defaults (0) are returned.
+ *
+ * @param data - Slab data (may be a partial slice; pass layoutHint in that case)
+ * @param layoutHint - Pre-detected layout to use; if omitted, detected from data.length.
  */
-export function parseParams(data: Uint8Array): RiskParams {
-  const layout = detectSlabLayout(data.length);
+export function parseParams(data: Uint8Array, layoutHint?: SlabLayout | null): RiskParams {
+  const layout = layoutHint !== undefined ? layoutHint : detectSlabLayout(data.length);
   const engineOff = layout ? layout.engineOff : V0_ENGINE_OFF;
   const paramsOff = layout ? layout.engineParamsOff : V0_ENGINE_PARAMS_OFF;
   const paramsSize = layout ? layout.paramsSize : V0_PARAMS_SIZE;


### PR DESCRIPTION
## Problem

**CRITICAL (CodeRabbit flagged):** `parseEngineLight` in `discovery.ts` used hardcoded `ENGINE_OFF=640` (V1) for ALL slabs. V0 slabs (ENGINE_OFF=480) were parsed 160 bytes off — producing wrong mark prices, OI, funding rates, and vault balances.

Additionally, `discoverMarkets` only queried V0 tier sizes (`SLAB_TIERS`), so V1 slabs like HEY-PERP (257448 bytes) were completely invisible to the indexer/keeper.

`parseConfig` and `parseParams` called `detectSlabLayout(data.length)` on a 1940-byte slice — returns `null` → defaults to V0. Wrong for V1 slabs.

## Fix

1. **`discoverMarkets`** now queries both `SLAB_TIERS` (V0) and `SLAB_TIERS_V1` tier sizes in parallel, so V1 slabs are discovered
2. Stores `actualDataSize` per account; calls `detectSlabLayout(actualDataSize)` (not slice length) to get correct layout
3. Passes `layout` to all parse functions — no more wrong-version defaults
4. **`parseEngineLight`** has separate V0/V1 branches with correct field offsets:
   - V0: ENGINE_OFF=480, bitmap=320, no longOi/shortOi/markPrice/emergency fields
   - V1: ENGINE_OFF=640, bitmap=656, full fields
5. **`parseConfig` / `parseParams`** accept optional `layoutHint` param so slice callers can pass the pre-detected layout

## Tests
- `packages/core`: All tests pass ✅
- App suite: 833 passing (12 pre-existing failures, unchanged) ✅

## Impact
- V0 slabs: mark price, OI, funding now read from correct offsets
- V1 slabs: now discovered and parsed correctly
- Zero breaking changes (layoutHint is optional)