### PR TITLE
fix(tests): add missing Sentry.captureMessage mock + next/navigation mock

### DIFF
--- a/app/__tests__/api/markets-price-sanitize.test.ts
+++ b/app/__tests__/api/markets-price-sanitize.test.ts
@@ -6,8 +6,8 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// Mock Sentry
-vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn() }));
+// Mock Sentry (must include all methods called in route — captureMessage is used by sanitizePrice)
+vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn(), captureMessage: vi.fn() }));
 
 // Mock config
 vi.mock("@/lib/config", () => ({

--- a/app/__tests__/components/CreateMarketWizard.test.tsx
+++ b/app/__tests__/components/CreateMarketWizard.test.tsx
@@ -16,6 +16,13 @@ vi.mock("next/link", () => ({
   ),
 }));
 
+// Mock next/navigation — LaunchSuccess calls useRouter() for post-mint navigation
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn(), back: vi.fn() }),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
 // Mock LogoUpload
 vi.mock("@/components/create/LogoUpload", () => ({
   LogoUpload: () => <div data-testid="logo-upload" />,


### PR DESCRIPTION
## Problem

Two test suites were **silently failing** — not caught by CI since `@percolator/app` tests are not yet in the GitHub Actions `test.yml`.

Running `pnpm --filter @percolator/app test` locally: **12 failed, 834 passed**.

---

### 1. `markets-price-sanitize.test.ts` — 4 failures

**Root cause:** `sanitizePrice()` calls `Sentry.captureMessage()` when a price is nulled out (added in #883). The Sentry mock only mocked `captureException` — `captureMessage` was `undefined`, so calling it threw a TypeError. The route's try/catch caught it and returned `{ error: 'Internal server error' }` instead of `{ markets: [...] }`.

**Symptom:** `body.markets is not iterable` — tests that expected corrupted prices to be nulled got an error response instead.

**Fix:** Add `captureMessage: vi.fn()` to the Sentry mock.

---

### 2. `CreateMarketWizard.test.tsx` — 8 failures

**Root cause:** `LaunchSuccess` component calls `useRouter()` from `next/navigation` (added in PR #826, PERC-475). Tests had no mock for `next/navigation`, triggering `invariant expected app router to be mounted` on every render.

**Fix:** Add `vi.mock('next/navigation', ...)` with a `useRouter` stub.

---

## After fix

```
Test Files  67 passed | 2 skipped (69)
Tests      846 passed | 34 skipped (880)
```

**0 failures.**

## Follow-up

Consider adding `pnpm --filter @percolator/app test` to the CI `test.yml` so these regressions are caught automatically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated error tracking test mocks to align with actual route implementation
  * Enhanced component test suite with navigation mocks to better simulate post-action behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->