### PR TITLE
fix(airdrop): wrap releaseClaim() in try/catch+Sentry inside finally

### DIFF
--- a/app/app/api/devnet-airdrop/route.ts
+++ b/app/app/api/devnet-airdrop/route.ts
@@ -336,8 +336,16 @@ export async function POST(req: NextRequest) {
       mintSucceeded = true;
     } finally {
       // Release the claim slot on ANY failure so user isn't locked out 24h.
+      // Wrapped in try/catch so a releaseClaim() throw doesn't mask the original
+      // mint error and lose its stack trace from Sentry.
       if (!mintSucceeded && claimId !== undefined) {
-        await releaseClaim(supabase, claimId);
+        try {
+          await releaseClaim(supabase, claimId);
+        } catch (releaseErr) {
+          Sentry.captureException(releaseErr, {
+            tags: { endpoint: "/api/devnet-airdrop", step: "release_claim_finally" },
+          });
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to PR #903 — addresses security's non-blocking review note.

## Problem

If `releaseClaim()` throws inside the `finally` block, the original mint error is silently swallowed and its stack trace is lost from Sentry. The user gets an unrelated 500 instead of the actual failure reason being captured.

## Fix

Wrap the `releaseClaim()` call in a dedicated `try/catch` that:
- Captures any unexpected throw to Sentry under `step: release_claim_finally`  
- Does **not** re-throw, so the original error propagates cleanly to the outer `catch` block

## Testing

- All 846 unit tests pass
- No behaviour change for the happy path or normal DB-error path (those are already handled inside `releaseClaim` itself)

## Related
- PR #903 (original fix)
- Security review comment: msg 7607

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error monitoring and reporting for the airdrop API endpoint to ensure errors are properly tracked and logged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->