### PR TITLE
fix(mm-bot): better InitUser error logging + auto-airdrop on low SOL

### DIFF
--- a/bots/devnet-mm/src/market.ts
+++ b/bots/devnet-mm/src/market.ts
@@ -13,6 +13,7 @@ import {
   ComputeBudgetProgram,
   sendAndConfirmTransaction,
   SYSVAR_CLOCK_PUBKEY,
+  LAMPORTS_PER_SOL,
 } from "@solana/web3.js";
 import {
   getAssociatedTokenAddress,
@@ -130,8 +131,46 @@ async function sendTx(
     return sig;
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);
-    logError("tx", label, msg.slice(0, 150));
+    // Extract custom program error code if present
+    const customMatch = msg.match(/custom program error:\s*0x([0-9a-fA-F]+)/);
+    const instrMatch = msg.match(/InstructionError.*?Custom\((\d+)\)/);
+    const errorDetail = customMatch
+      ? `Custom error 0x${customMatch[1]} (${parseInt(customMatch[1], 16)})`
+      : instrMatch
+        ? `Custom error ${instrMatch[1]} (0x${Number(instrMatch[1]).toString(16)})`
+        : null;
+    logError("tx", label, errorDetail ? `${errorDetail} — ${msg.slice(0, 200)}` : msg.slice(0, 300));
     return null;
+  }
+}
+
+/**
+ * Ensure wallet has enough SOL for transactions. On devnet, attempt airdrop if low.
+ * Returns true if balance is sufficient, false if critically low and airdrop failed.
+ */
+const MIN_SOL_FOR_TX = 0.01;
+const AIRDROP_SOL = 1;
+
+async function ensureSolBalance(
+  connection: Connection,
+  wallet: Keypair,
+  label: string,
+): Promise<boolean> {
+  const balance = await connection.getBalance(wallet.publicKey);
+  const balSol = balance / LAMPORTS_PER_SOL;
+  if (balSol >= MIN_SOL_FOR_TX) return true;
+
+  log("setup", `${label}: wallet ${wallet.publicKey.toBase58().slice(0, 12)}... has ${balSol.toFixed(4)} SOL — attempting devnet airdrop`);
+  try {
+    const sig = await connection.requestAirdrop(wallet.publicKey, AIRDROP_SOL * LAMPORTS_PER_SOL);
+    await connection.confirmTransaction(sig, "confirmed");
+    const newBal = await connection.getBalance(wallet.publicKey);
+    log("setup", `${label}: airdrop OK — now ${(newBal / LAMPORTS_PER_SOL).toFixed(4)} SOL`);
+    return true;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    logError("setup", `${label}: airdrop failed (${msg.slice(0, 100)}) — wallet has ${balSol.toFixed(4)} SOL, InitUser/InitLP will likely fail`);
+    return false;
   }
 }
 
@@ -206,6 +245,7 @@ export async function setupMarketAccounts(
 
   // Create LP if needed and requested
   if (!lpAccount && createLp) {
+    await ensureSolBalance(connection, wallet, symbol);
     log("setup", `${symbol}: creating LP account...`);
     const initLpData = encodeInitLP({
       matcherProgram: config.matcherProgramId,
@@ -241,6 +281,7 @@ export async function setupMarketAccounts(
 
   // Create user if needed
   if (!userAccount) {
+    await ensureSolBalance(connection, wallet, symbol);
     log("setup", `${symbol}: creating user account...`);
     const initUserData = encodeInitUser({ feePayment: "1000000" });
     const initUserKeys = buildAccountMetas(ACCOUNTS_INIT_USER, [


### PR DESCRIPTION
## Problem
devnet-mm-bots BTC market failing on InitUser with InstructionError. Root cause likely: wallet ran out of SOL.

## Changes
- **Better error parsing** in `sendTx`: extracts custom program error codes from InstructionError messages, increases logged message length from 150→300 chars
- **SOL balance check** before InitUser/InitLP: calls `ensureSolBalance()` which checks wallet balance and auto-requests devnet airdrop if < 0.01 SOL
- Airdrop is 1 SOL — enough for many transactions on devnet

## Testing
- TypeScript compiles clean (no new errors in market.ts)
- Logic is devnet-safe: `requestAirdrop` only works on devnet/testnet, will gracefully fail and log on mainnet