### PR TITLE
fix(security): address issue #915 LOW findings in mm-bot

### DIFF
--- a/bots/devnet-mm/src/market.ts
+++ b/bots/devnet-mm/src/market.ts
@@ -19,6 +19,7 @@ import {
   getAssociatedTokenAddress,
   getAccount,
   createAssociatedTokenAccountInstruction,
+  TokenAccountNotFoundError,
 } from "@solana/spl-token";
 import {
   encodeInitUser,
@@ -282,7 +283,11 @@ async function ensureWalletAta(
   try {
     await getAccount(connection, ata);
     return ata; // already exists
-  } catch {
+  } catch (e) {
+    // Only proceed to create if the account genuinely doesn't exist.
+    // Rethrow transient RPC errors so callers can retry rather than
+    // spuriously creating a new ATA.
+    if (!(e instanceof TokenAccountNotFoundError)) throw e;
     // ATA does not exist — create it
     log("setup", `${label}: walletAta missing — creating ATA for mint ${mint.toBase58().slice(0, 12)}...`);
     if (dryRun) {

--- a/bots/devnet-mm/src/trader-fleet.ts
+++ b/bots/devnet-mm/src/trader-fleet.ts
@@ -250,6 +250,7 @@ async function ensureSol(
     if (bal / LAMPORTS_PER_SOL >= minSol) return;
 
     log("fleet", `${label}: low SOL (${(bal / LAMPORTS_PER_SOL).toFixed(3)}) — requesting airdrop...`);
+    if (connection.rpcEndpoint.includes("mainnet")) return; // never airdrop on mainnet
     const sig = await connection.requestAirdrop(wallet.publicKey, 2 * LAMPORTS_PER_SOL);
     await connection.confirmTransaction(sig, "confirmed");
     log("fleet", `${label}: ✅ airdrop +2 SOL`);


### PR DESCRIPTION
## Summary

Addresses two LOW-severity findings from security review of PRs #912 and #913 (issue #915).

### Finding 1 — ensureSol: no mainnet RPC guard before requestAirdrop (trader-fleet.ts)
- **Before:** `requestAirdrop` could be called on any RPC endpoint including mainnet
- **After:** Early return if `connection.rpcEndpoint.includes("mainnet")`

### Finding 2 — ensureWalletAta: empty catch{} swallows all errors (market.ts)
- **Before:** Bare `catch {}` catches everything — transient RPC errors would trigger spurious ATA creation
- **After:** Narrowed to `TokenAccountNotFoundError`; all other errors are rethrown so callers can handle/retry

## Testing
- Both files pass `tsc --noEmit` with no new errors
- Pre-existing `health.ts` error is unrelated and pre-dates this PR

Closes #915

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling for wallet account validation to distinguish between missing accounts and transient network errors, preventing unnecessary account creation during temporary connectivity issues.
  * Added network environment detection to prevent accidental SOL transfers on mainnet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->