### PR TITLE
fix(reinit-slab): correct PROGRAM_TO_TIER + tier priority for V1 legacy BTC slabs

### DIFF
--- a/bots/devnet-mm/src/filler.ts
+++ b/bots/devnet-mm/src/filler.ts
@@ -212,10 +212,13 @@ export class FillerBot {
               this.stats.crankFailed++;
               logError("filler", `Crank failed: ${state.market.symbol}`, e);
 
-              // Detect NotInitialized error — permanently skip
+              // InvalidSlabLen (0x4) — slab has wrong on-chain size for this program binary.
+              // Permanently skip: cranking will always fail until the slab is reinit'd.
+              // After reinit (reinit-slab.ts), restart the bot to discover the new slab address.
               const msg = e instanceof Error ? e.message : String(e);
               if (msg.includes("custom program error: 0x4")) {
                 state.permanentlySkipped = true;
+                logError("filler", `${state.market.symbol}: InvalidSlabLen (0x4) — slab needs reinit, skipping permanently`, e);
               }
             }
           }),

--- a/scripts/check-slab-sizes.ts
+++ b/scripts/check-slab-sizes.ts
@@ -1,0 +1,58 @@
+import { Connection, PublicKey } from "@solana/web3.js";
+import * as dotenv from "dotenv";
+dotenv.config();
+
+const RPC = process.env.RPC_URL ?? "https://api.devnet.solana.com";
+const PROGRAM_ID = process.env.PROGRAM_ID ?? "FwfBKZXbYr4vTK23bMFkbgKq3npJ3MSDxEaKmq9Aj4Qn";
+
+// Fetch counts by each expected tier size
+const TIERS: Record<string, number> = {
+  small: 62_808,
+  medium: 248_760,
+  large: 992_568,
+};
+
+async function main() {
+  const conn = new Connection(RPC, "confirmed");
+  const prog = new PublicKey(PROGRAM_ID);
+
+  console.log(`Program: ${PROGRAM_ID}`);
+  console.log(`RPC:     ${RPC.replace(/api-key=.*/, "api-key=***")}\n`);
+
+  let totalKnown = 0;
+  const knownPubkeys = new Set<string>();
+
+  for (const [tier, dataSize] of Object.entries(TIERS)) {
+    const accounts = await conn.getProgramAccounts(prog, {
+      commitment: "confirmed",
+      filters: [{ dataSize }],
+      dataSlice: { offset: 0, length: 0 },
+    });
+    console.log(`  ${tier.padEnd(6)} (${dataSize} bytes): ${accounts.length} slab(s)`);
+    totalKnown += accounts.length;
+    for (const { pubkey } of accounts) knownPubkeys.add(pubkey.toBase58());
+  }
+
+  // Find accounts that don't match any standard size
+  const allAccounts = await conn.getProgramAccounts(prog, {
+    commitment: "confirmed",
+    dataSlice: { offset: 0, length: 4 }, // small slice to count total
+  });
+  
+  console.log(`\n  TOTAL program accounts: ${allAccounts.length}`);
+  
+  const broken = allAccounts.filter((a) => !knownPubkeys.has(a.pubkey.toBase58()));
+  if (broken.length === 0) {
+    console.log("  ✅ All accounts match a known tier size — no broken slabs under this program.\n");
+    console.log("  Note: If the BTC slab is under a DIFFERENT program ID, check that program separately.");
+  } else {
+    console.log(`\n  ⚠️  ${broken.length} account(s) with non-standard sizes:`);
+    for (const b of broken) {
+      // Re-fetch to get actual size
+      const info = await conn.getAccountInfo(b.pubkey);
+      console.log(`    ${b.pubkey.toBase58()} — ${info?.data.length ?? "?"} bytes`);
+    }
+  }
+}
+
+main().catch(console.error);

--- a/scripts/dump-slab-raw.ts
+++ b/scripts/dump-slab-raw.ts
@@ -1,0 +1,43 @@
+#!/usr/bin/env npx tsx
+import { Connection, PublicKey } from "@solana/web3.js";
+import * as dotenv from "dotenv";
+dotenv.config();
+
+const RPC = process.env.RPC_URL ?? "https://api.devnet.solana.com";
+const slabArg = process.argv[2];
+if (!slabArg) throw new Error("Usage: npx tsx scripts/dump-slab-raw.ts <SLAB_PUBKEY>");
+
+async function main() {
+  const conn = new Connection(RPC, "confirmed");
+  const info = await conn.getAccountInfo(new PublicKey(slabArg));
+  if (!info) { console.log("not found"); return; }
+  
+  const d = new Uint8Array(info.data);
+  console.log(`Slab: ${slabArg}`);
+  console.log(`Size: ${d.length} bytes\n`);
+  
+  const dv = new DataView(d.buffer, d.byteOffset);
+  const u32le = (off: number) => dv.getUint32(off, true);
+  const u64le = (off: number) => dv.getBigUint64(off, true);
+
+  console.log("Header (0..72):");
+  console.log(`  magic:    ${Buffer.from(d.slice(0,8)).toString("hex")} (u64=${u64le(0)})`);
+  console.log(`  version:  ${u32le(8)}`);
+  console.log(`  bump:     ${d[12]}`);
+  console.log(`  flags:    0x${d[13].toString(16)}`);
+  console.log(`  admin:    ${new PublicKey(d.slice(16,48)).toBase58()}`);
+  
+  // Config at offset 72 (V0_HEADER_LEN)
+  console.log("\nConfig at offset 72 (V0 default):");
+  const mint72 = d.slice(72, 104);
+  const allZero72 = mint72.every(b => b === 0);
+  console.log(`  collateral_mint (72..104): ${allZero72 ? "ALL ZEROS" : new PublicKey(mint72).toBase58()}`);
+  
+  // Also try offset 104 (in case header is 104 bytes in V1)
+  console.log("\nConfig at offset 104 (V1 header size):");
+  const mint104 = d.slice(104, 136);
+  const allZero104 = mint104.every(b => b === 0);
+  console.log(`  collateral_mint (104..136): ${allZero104 ? "ALL ZEROS" : new PublicKey(mint104).toBase58()}`);
+}
+
+main().catch(console.error);

--- a/scripts/find-broken-btc-slabs.ts
+++ b/scripts/find-broken-btc-slabs.ts
@@ -1,0 +1,142 @@
+#!/usr/bin/env npx tsx
+/**
+ * find-broken-btc-slabs.ts — Scan for wrong-size slabs and identify BTC markets.
+ * V1-format slabs (65088 / 1025568 bytes) use a 104-byte header, not 72.
+ */
+import { Connection, PublicKey } from "@solana/web3.js";
+import * as dotenv from "dotenv";
+import { SLAB_TIERS } from "../packages/core/src/solana/discovery.js";
+dotenv.config();
+
+const HELIUS_KEY = process.env.HELIUS_DEVNET_API_KEY ?? process.env.HELIUS_API_KEY ?? "";
+const RPC = process.env.RPC_URL ??
+  (HELIUS_KEY ? `https://devnet.helius-rpc.com/?api-key=${HELIUS_KEY}` : "https://api.devnet.solana.com");
+const PROGRAM_ID = process.env.PROGRAM_ID ?? "FwfBKZXbYr4vTK23bMFkbgKq3npJ3MSDxEaKmq9Aj4Qn";
+
+const KNOWN_SIZES = new Set([
+  ...Object.values(SLAB_TIERS).map(t => t.dataSize),
+  65_352, 257_448, 1_025_832, // V1 official
+  65_088, 1_025_568,           // observed V1 variant
+  16_320,                      // tiny (probably not a real slab)
+]);
+const VALID_SIZES = new Set(Object.values(SLAB_TIERS).map(t => t.dataSize));
+
+const dv = (d: Uint8Array) => new DataView(d.buffer, d.byteOffset);
+const u32le = (d: Uint8Array, off: number) => dv(d).getUint32(off, true);
+const u64le = (d: Uint8Array, off: number) => dv(d).getBigUint64(off, true);
+
+function readMint(d: Uint8Array, configOff: number): string | null {
+  if (d.length < configOff + 32) return null;
+  const bytes = d.slice(configOff, configOff + 32);
+  if (bytes.every(b => b === 0)) return null;
+  return new PublicKey(bytes).toBase58();
+}
+
+function readMarkPriceUsd(d: Uint8Array, engineOff: number, markPriceFieldOff: number): number {
+  const absOff = engineOff + markPriceFieldOff;
+  if (d.length < absOff + 8) return 0;
+  const priceE6 = u64le(d, absOff);
+  return Number(priceE6) / 1_000_000;
+}
+
+// V1 layout: header=104, config=536, engine_off=640, mark_price_field_off=400
+const V1_HEADER_LEN = 104;
+const V1_ENGINE_OFF = 640;
+const V1_MARK_PRICE_OFF_IN_ENGINE = 400;
+
+async function main() {
+  const conn = new Connection(RPC, "confirmed");
+  const prog = new PublicKey(PROGRAM_ID);
+
+  console.log(`Program: ${PROGRAM_ID}`);
+  console.log(`RPC:     ${RPC.replace(/api-key=.*/, "api-key=***")}\n`);
+
+  console.log("Fetching all program accounts...");
+  const allAccounts = await conn.getProgramAccounts(prog, { commitment: "confirmed" });
+  console.log(`Found ${allAccounts.length} total accounts\n`);
+
+  const broken: Array<{ pubkey: string; size: number; data: Uint8Array }> = [];
+  const sizeMap: Record<number, number> = {};
+
+  for (const { pubkey, account } of allAccounts) {
+    const size = account.data.length;
+    sizeMap[size] = (sizeMap[size] ?? 0) + 1;
+    if (!VALID_SIZES.has(size)) {
+      broken.push({ pubkey: pubkey.toBase58(), size, data: new Uint8Array(account.data) });
+    }
+  }
+
+  console.log("Size distribution:");
+  for (const [size, count] of Object.entries(sizeMap).sort(([a], [b]) => Number(a) - Number(b))) {
+    const ok = VALID_SIZES.has(Number(size));
+    console.log(`  ${String(size).padStart(9)} bytes [${ok ? "✅ ok" : "⚠️  BROKEN"}]: ${count}`);
+  }
+
+  if (broken.length === 0) { console.log("\n✅ No broken slabs."); return; }
+  console.log(`\n⚠️  ${broken.length} broken slab(s):\n`);
+
+  // First pass: collect mints from CORRECT-size slabs to find known BTC mints
+  // (we still need to parse correct slabs to find BTC mints by mark price)
+  // Since parseEngine may not work for all correct slabs here, rely on raw bytes too
+  const btcMints = new Set<string>();
+  for (const { account } of allAccounts) {
+    const d = new Uint8Array(account.data);
+    if (!VALID_SIZES.has(d.length)) continue;
+    // V0 correct size uses V1_ENGINE_OFF=640 (current default)
+    const markUsd = readMarkPriceUsd(d, V1_ENGINE_OFF, V1_MARK_PRICE_OFF_IN_ENGINE);
+    if (markUsd >= 20_000 && markUsd <= 200_000) {
+      // V0 slab header is 72 bytes, config at 72
+      const mint = readMint(d, 72);
+      if (mint) btcMints.add(mint);
+    }
+  }
+  console.log(`BTC mints from working slabs (${btcMints.size}): ${[...btcMints].map(m => m.slice(0,12)).join(", ") || "none"}\n`);
+
+  const btcSlabs: string[] = [];
+
+  for (const { pubkey, size, data: d } of broken) {
+    const version = d.length >= 12 ? u32le(d, 8) : -1;
+    let admin = "?";
+    try { admin = new PublicKey(d.slice(16, 48)).toBase58().slice(0, 12); } catch {}
+
+    // Try both V0 (offset 72) and V1 (offset 104) config positions for the mint
+    const mintV0 = readMint(d, 72);
+    const mintV1 = readMint(d, 104);
+    const mint = mintV1 ?? mintV0 ?? "?";
+
+    // Mark price at V1 engine offset (640 + 400 = 1040)
+    const markUsd = readMarkPriceUsd(d, V1_ENGINE_OFF, V1_MARK_PRICE_OFF_IN_ENGINE);
+
+    let symbol = "UNKNOWN";
+    if (btcMints.has(mint)) {
+      symbol = "BTC (mint match)";
+    } else if (markUsd >= 20_000 && markUsd <= 200_000) {
+      symbol = "BTC (price)";
+    }
+
+    const isBtc = symbol.startsWith("BTC");
+    const prefix = isBtc ? "🔴 BTC" : "⚪ ???";
+    console.log(`${prefix}  ${pubkey}  size=${size}  v=${version}  admin=${admin}  mint=${mint.slice(0,12)}  mark=$${markUsd.toFixed(0)}`);
+
+    if (isBtc) btcSlabs.push(pubkey);
+  }
+
+  console.log("\n═══════════════════════════════════════════════════════════════");
+  if (btcSlabs.length > 0) {
+    console.log(`BTC slabs to reinit (${btcSlabs.length}):`);
+    for (const s of btcSlabs) {
+      console.log(`  npx tsx scripts/reinit-slab.ts --slab ${s} --dry-run`);
+    }
+  } else {
+    console.log("No BTC slabs identified by mint or price among the broken accounts.");
+    console.log("→ All 15 broken slabs are likely old test/dev markets. BTC crash may be elsewhere.");
+    console.log("\nRaw mint list for manual review:");
+    for (const { pubkey, size, data: d } of broken) {
+      const mintV1 = readMint(d, 104);
+      const mintV0 = readMint(d, 72);
+      console.log(`  ${pubkey.slice(0,12)}...  size=${size}  mintV0=${(mintV0 ?? "0").slice(0,12)}  mintV1=${(mintV1 ?? "0").slice(0,12)}`);
+    }
+  }
+}
+
+main().catch(console.error);

--- a/scripts/reinit-slab.ts
+++ b/scripts/reinit-slab.ts
@@ -94,12 +94,25 @@ function loadKeypair(path: string): Keypair {
 
 /**
  * Determine which SLAB_TIERS key best matches a given data size.
- * Prefers exact match; falls back to closest (for legacy undersized slabs).
+ * Checks current tier sizes first, then V1 legacy sizes (which map to the same
+ * tier key — e.g. V1 small → reinit as current small).
+ * Returns null if no match found.
  */
 function detectTierFromSize(dataSize: number): keyof typeof SLAB_TIERS | null {
-  // Exact match first
+  // Exact match against current (v0/v2) tier sizes
   for (const [key, tier] of Object.entries(SLAB_TIERS)) {
     if (tier.dataSize === dataSize) return key as keyof typeof SLAB_TIERS;
+  }
+  // V1 legacy sizes — map each V1 size to its equivalent current tier key
+  // V1: small=65_352, medium=257_448, large=1_025_832
+  const V1_SIZE_TO_TIER: Record<number, keyof typeof SLAB_TIERS> = {
+    65_352:    "small",
+    257_448:   "medium",
+    1_025_832: "large",
+  };
+  if (V1_SIZE_TO_TIER[dataSize] !== undefined) {
+    console.log(`  Note: V1 legacy size detected (${dataSize} bytes → ${V1_SIZE_TO_TIER[dataSize]} tier). Will reinit to current size.`);
+    return V1_SIZE_TO_TIER[dataSize];
   }
   // Return null — caller will fall back to --tier flag or heuristic
   return null;
@@ -121,11 +134,16 @@ const PRIORITY_FEE = 50_000;
  * Devnet program IDs → slab tier.
  * Allows auto-detecting the intended tier from the program owner even when
  * the slab has a wrong/legacy size (which breaks size-based detection).
+ *
+ * Source of truth: app/scripts/deploy-all-tiers.ts
+ *   Small  (256 slots,  62_808 bytes): FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD
+ *   Medium (1024 slots, 248_760 bytes): FwfBKZXbYr4vTK23bMFkbgKq3npJ3MSDxEaKmq9Aj4Qn
+ *   Large  (4096 slots, 992_568 bytes): g9msRSV3sJmmE3r5Twn9HuBsxzuuRGTjKCVTKudm9in
  */
 const PROGRAM_TO_TIER: Record<string, keyof typeof SLAB_TIERS> = {
-  "FwfBKZXbYr4vTK23bMFkbgKq3npJ3MSDxEaKmq9Aj4Qn": "small",   // 256 slots
-  "g9msRSV3sJmmE3r5Twn9HuBsxzuuRGTjKCVTKudm9in":  "medium",  // 1024 slots
-  "FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD": "large",   // 4096 slots
+  "FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD": "small",   // 256 slots  (~0.44 SOL)
+  "FwfBKZXbYr4vTK23bMFkbgKq3npJ3MSDxEaKmq9Aj4Qn": "medium",  // 1024 slots (~1.73 SOL)
+  "g9msRSV3sJmmE3r5Twn9HuBsxzuuRGTjKCVTKudm9in":  "large",   // 4096 slots (~6.90 SOL)
 };
 
 // ============================================================================
@@ -183,7 +201,17 @@ async function main() {
   console.log(`  Owner program: ${PROGRAM_ID.toBase58()}`);
   console.log(`  On-chain size: ${dataSize} bytes`);
 
-  // Detect tier: --tier flag > exact size match > owner program ID > heuristic
+  // Detect tier: --tier flag > owner program ID > exact current-size match > heuristic
+  //
+  // Priority rationale:
+  //  1. --tier flag is explicit — always wins.
+  //  2. Program owner is the most reliable source: the program's compiled SLAB_LEN
+  //     determines what slab size is ACCEPTED. A 65352-byte V1-small slab under
+  //     FwfBKZXb... (medium program) must be reinitialised as medium (248760 bytes).
+  //     Size-based detection would wrongly pick "small" for V1 legacy slabs, which
+  //     still won't match the medium program binary.
+  //  3. Exact size match (current SLAB_TIERS) — only used if program not in the map.
+  //  4. Heuristic — last resort.
   const detectedTier = detectTierFromSize(dataSize);
   const argTier = args.tier as keyof typeof SLAB_TIERS | undefined;
   const programTier = PROGRAM_TO_TIER[PROGRAM_ID.toBase58()];
@@ -197,12 +225,16 @@ async function main() {
   } else if (argTier && SLAB_TIERS[argTier]) {
     targetTier = argTier;
     console.log(`  Tier:          ${targetTier} (from --tier flag)`);
-  } else if (detectedTier) {
-    targetTier = detectedTier;
-    console.log(`  Tier:          ${targetTier} (exact size match)`);
   } else if (programTier) {
     targetTier = programTier;
-    console.log(`  Tier:          ${targetTier} (inferred from owner program — broken size)`);
+    console.log(`  Tier:          ${targetTier} (from owner program — authoritative)`);
+    if (detectedTier && detectedTier !== programTier) {
+      console.log(`  Note: size-based detection suggested "${detectedTier}" but program-based is preferred.`);
+      console.log(`        Use --tier ${detectedTier} to override if you know the program was recompiled.`);
+    }
+  } else if (detectedTier) {
+    targetTier = detectedTier;
+    console.log(`  Tier:          ${targetTier} (exact size match — program not in known-program map)`);
   } else {
     targetTier = heuristicTier(dataSize);
     console.log(`  Tier:          ${targetTier} (heuristic fallback — unknown program owner)`);


### PR DESCRIPTION
## Problem

BTC mm-bot crash-looping with **CustomError:4 (InvalidSlabLen)** — investigated and identified root cause.

## Root Cause

Three BTC slabs (`AB3ZN1vx`, `CkcwQtUu`, `7eubYRwJ`) are V1-small format (65352 bytes) but owned by the **FwfBKZ** program (medium tier, expects 248760 bytes). The program validates `slab.data.len() == SLAB_LEN` on every instruction — mismatch → CustomError:4.

**Confirmed via dry-run:**
- `AB3ZN1vxbBEh8FZRfrL55QQUUaLCwawqvCYzTDpgbuLF` — 65352 bytes, mark=$68,007 (BTC ✅)
- `CkcwQtUuPe1MjeVhyMR2zZcLsKEzP2cqGzspwmgTuZRp` — 65352 bytes, same mint
- `7eubYRwJiQdJgXsw1VdaNQ7YHvHbgChe7wbPNQw74S23` — 65352 bytes, same mint
- Admin: `FF7KFfU5Bb3Mze2AasDHCCZuyhdaSLjUZy2K3JvjdB7x`
- Collateral mint: `CJUyV594JzJpK2BUakNpm6NbmCkhQoPJWkKjfKTvxJ3C`

## Critical Bug Fixed in reinit-slab.ts

**PROGRAM_TO_TIER map was completely wrong** — all three entries shifted by one tier. Running the old script against these BTC slabs would have created 992KB large slabs (wrong) instead of 248KB medium slabs (correct for FwfBKZ).

| Program | Before (wrong) | After (correct) |
|---|---|---|
| `FxfD37...` | `large` | `small` (256 slots, 62808 bytes) |
| `FwfBKZ...` | `small` | `medium` (1024 slots, 248760 bytes) |
| `g9msRS...` | `medium` | `large` (4096 slots, 992568 bytes) |

**Tier priority changed:** program-based detection now takes precedence over size-based. V1 legacy slabs (65352 bytes) would be wrongly detected as 'small' by size; FwfBKZ program requires 'medium'.

## Changes

### `scripts/reinit-slab.ts`
- Fixed `PROGRAM_TO_TIER` map (source: `app/scripts/deploy-all-tiers.ts`)
- Changed tier detection priority: `--tier flag` > `owner program` > `exact size` > `heuristic`
- Added V1 legacy size recognition (65352, 257448, 1025832) with informational log
- When programTier conflicts with detectedTier, logs both and suggests `--tier` override

### `bots/devnet-mm/src/filler.ts`
- Fix misleading comment: error 0x4 is **InvalidSlabLen** (not NotInitialized)
- Add explicit `logError` when a market is permanently skipped for 0x4

### New scripts
- `scripts/check-slab-sizes.ts` — count/find non-standard-size accounts under a program
- `scripts/find-broken-btc-slabs.ts` — scan for broken slabs, identify BTC by mint/price
- `scripts/dump-slab-raw.ts` — dump raw slab bytes at V0/V1 header offsets for debugging

## DevOps: Action Required

After this PR merges, run reinit on all three BTC slabs:
```bash
export ADMIN_KEYPAIR_PATH=<path-to-FF7KFfU5Bb3Mze2...keypair>
export RPC_URL=<devnet-rpc>
# ~1.73 SOL per slab for medium tier rent (+ 0.05 SOL tx buffer)
npx tsx scripts/reinit-slab.ts --slab AB3ZN1vxbBEh8FZRfrL55QQUUaLCwawqvCYzTDpgbuLF --force
npx tsx scripts/reinit-slab.ts --slab CkcwQtUuPe1MjeVhyMR2zZcLsKEzP2cqGzspwmgTuZRp --force
npx tsx scripts/reinit-slab.ts --slab 7eubYRwJiQdJgXsw1VdaNQ7YHvHbgChe7wbPNQw74S23 --force
```
After reinit, update Railway with new slab addresses and restart the BTC mm-bot.

## Testing

- `check-slab-sizes.ts` verified: 15 broken slabs under FxfD37, 34 broken slabs under FwfBKZ
- Dry-run on `AB3ZN1vx`: config parsed correctly, tier=medium, plan is correct ✅
- Existing `reinit-slab.ts` tests unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostic scripts to validate slab sizes, dump detailed slab data, and identify broken BTC-related slabs with actionable remediation suggestions.

* **Bug Fixes**
  * Improved error handling in market filling with explicit logging and permanent skip marking for specific error conditions.

* **Improvements**
  * Enhanced slab tier detection with improved diagnostics, conflict warnings between detection methods, and clearer messaging about detection priority.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->