### PR TITLE
fix(sentry): correct org/project defaults + enable source map upload on build

### DIFF
--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -78,16 +78,27 @@ const nextConfig: NextConfig = {
 
 export default withSentryConfig(nextConfig, {
   // Sentry webpack plugin options
-  silent: true, // Suppresses all logs
-  
-  // Source maps: enabled when SENTRY_AUTH_TOKEN is set (CI/CD only)
-  // Set SENTRY_AUTH_TOKEN, SENTRY_ORG, and SENTRY_PROJECT in your CI environment
+  silent: true, // Suppress verbose upload logs in CI
+
+  // Source maps: enabled when SENTRY_AUTH_TOKEN is set (CI/Vercel only).
+  // To enable: add SENTRY_AUTH_TOKEN + SENTRY_ORG + SENTRY_PROJECT to Vercel env vars.
+  //   SENTRY_ORG=dcc-pz
+  //   SENTRY_PROJECT=percolator-frontend
+  //   SENTRY_AUTH_TOKEN=<token from https://sentry.io/settings/auth-tokens/>
   sourcemaps: {
     disable: !process.env.SENTRY_AUTH_TOKEN,
+    deleteSourcemapsAfterUpload: true, // do not ship source maps to browsers
   },
 
-  // Upload source maps during build when auth token is available
-  org: process.env.SENTRY_ORG || "percolator",
-  project: process.env.SENTRY_PROJECT || "percolator-app",
+  // Sentry org/project — must match your Sentry workspace.
+  // Defaults are the production values; override via env vars if needed.
+  org: process.env.SENTRY_ORG || "dcc-pz",
+  project: process.env.SENTRY_PROJECT || "percolator-frontend",
   authToken: process.env.SENTRY_AUTH_TOKEN,
+
+  // Automatically instrument server components and route handlers
+  autoInstrumentServerFunctions: true,
+
+  // Disable the Sentry telemetry/privacy popup in the Next.js dev overlay
+  disableLogger: true,
 });


### PR DESCRIPTION
## Problem
Sentry is receiving minified errors with unreadable variable names (`b`, `w`) because source maps are never uploaded during Vercel builds.

## Root Cause
`app/next.config.ts` had wrong `org`/`project` defaults:
- `org` was `"percolator"` → should be `"dcc-pz"`
- `project` was `"percolator-app"` → should be `"percolator-frontend"`
- `sourcemaps.disable = !SENTRY_AUTH_TOKEN` → correct, but SENTRY_AUTH_TOKEN was never added to Vercel

## Code Change
```diff
- org: process.env.SENTRY_ORG || "percolator",
- project: process.env.SENTRY_PROJECT || "percolator-app",
+ org: process.env.SENTRY_ORG || "dcc-pz",
+ project: process.env.SENTRY_PROJECT || "percolator-frontend",
+ deleteSourcemapsAfterUpload: true,  // don't ship source maps to browsers
+ autoInstrumentServerFunctions: true,
+ disableLogger: true,
```

## DevOps: Required Vercel Env Vars (unblocks this)
Add these three in Vercel dashboard → percolator-frontend → Settings → Environment Variables:
| Variable | Value |
|---|---|
| `SENTRY_AUTH_TOKEN` | `<token from https://sentry.io/settings/auth-tokens/>` |
| `SENTRY_ORG` | `dcc-pz` |
| `SENTRY_PROJECT` | `percolator-frontend` |

Once set, every Vercel build will upload source maps and errors will show readable stack frames.