### PR TITLE
fix(PERC-513): Continue button broken after page refresh mid-market-creation

### DIFF
--- a/app/__tests__/components/RecoverSolBanner.test.tsx
+++ b/app/__tests__/components/RecoverSolBanner.test.tsx
@@ -89,14 +89,24 @@ describe("RecoverSolBanner", () => {
     expect(screen.getByText(/VIEW ON EXPLORER/i)).toBeDefined();
   });
 
-  it("calls onResume with slab address when resume clicked", () => {
+  it("calls onResume with slab address and fromStep=1 when resume clicked on initialized slab", () => {
     const kp = Keypair.generate();
     mockStuckSlab = makeStuckSlab({ isInitialized: true, exists: true, publicKey: kp.publicKey });
     const onResume = vi.fn();
     render(<RecoverSolBanner onResume={onResume} />);
 
     fireEvent.click(screen.getByRole("button", { name: /RESUME/i }));
-    expect(onResume).toHaveBeenCalledWith(kp.publicKey.toBase58());
+    expect(onResume).toHaveBeenCalledWith(kp.publicKey.toBase58(), 1);
+  });
+
+  it("calls onResume with slab address and fromStep=0 when retry clicked on uninitialized slab", () => {
+    const kp = Keypair.generate();
+    mockStuckSlab = makeStuckSlab({ isInitialized: false, exists: true, publicKey: kp.publicKey });
+    const onResume = vi.fn();
+    render(<RecoverSolBanner onResume={onResume} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /RETRY/i }));
+    expect(onResume).toHaveBeenCalledWith(kp.publicKey.toBase58(), 0);
   });
 
   it("calls clearStuck when discard clicked", () => {

--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -81,6 +81,12 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
     mintAddress: initialMint ?? "",
   }));
   const [completedSteps, setCompletedSteps] = useState<Set<number>>(new Set());
+  /**
+   * PERC-513: Track which step to resume from when recovering a stuck slab.
+   * Set by onResume from RecoverSolBanner; null = fresh creation (step 0).
+   * When non-null, handleLaunch skips slab creation and resumes from this step.
+   */
+  const [resumeFromStep, setResumeFromStep] = useState<number | null>(null);
 
   // Quick launch auto-detection for parameters
   const quickMintForHook = wizard.mode === "quick" && wizard.mintAddress.length >= 32 ? wizard.mintAddress : null;
@@ -343,7 +349,7 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
     return { oracleFeed: "0".repeat(64), priceE6 };
   };
 
-  // Launch market
+  // Launch market (or resume from a stuck slab when resumeFromStep is set)
   const handleLaunch = () => {
     if (!allValid || !publicKey) return;
     const { oracleFeed, priceE6 } = getOracleFeedAndPrice();
@@ -387,7 +393,9 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
           (isValidBase58Pubkey(wizard.oracleFeed) ? wizard.oracleFeed : undefined),
       } : {}),
     };
-    create(params);
+    // PERC-513: If resuming from a stuck slab, skip slab creation (step 0).
+    // The existing slab keypair is already in slabKpRef (loaded from localStorage).
+    create(params, resumeFromStep ?? undefined);
   };
 
   // Retry from failed step
@@ -435,6 +443,7 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
     setWizard({ ...DEFAULT_STATE });
     setCompletedSteps(new Set());
     setDevnetMintAddress(null);
+    setResumeFromStep(null);
   };
 
   // --- Render ---
@@ -500,13 +509,40 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
     <div className="space-y-6 p-4 sm:p-6">
       {/* Stuck slab recovery banner */}
       <RecoverSolBanner
-        onResume={(slabAddress) => {
-          // The stuck slab's keypair is already in localStorage —
-          // useCreateMarket will pick it up. Just trigger a retry from step 1.
-          resetCreate();
-          // Start the wizard at step 1 so user can fill in parameters
+        onResume={(_slabAddress, fromStep) => {
+          // PERC-513 fix: DO NOT call resetCreate() here — that clears slabKpRef
+          // and removes the localStorage keypair, making the Continue button a no-op.
+          // The keypair is already loaded into slabKpRef by useCreateMarket's useEffect.
+          // Set resumeFromStep so handleLaunch skips slab creation and resumes correctly.
+          setResumeFromStep(fromStep);
         }}
       />
+
+      {/* PERC-513: Resume mode indicator — shown when user clicked "Resume Creation" from the banner */}
+      {resumeFromStep !== null && (
+        <div className="border border-[var(--accent)]/40 bg-[var(--accent)]/[0.06] px-4 py-3 flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <span className="text-[var(--accent)] text-[12px]">⚡</span>
+            <span className="text-[11px] text-[var(--text-secondary)]">
+              <span className="font-semibold text-[var(--accent)]">Resume mode</span>
+              {" — "}
+              {resumeFromStep === 1
+                ? "Slab is initialized. Re-enter your parameters to complete oracle setup, LP, and insurance."
+                : "Re-enter your parameters to retry market initialization."}
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              setResumeFromStep(null);
+              resetCreate();
+            }}
+            className="flex-shrink-0 text-[10px] text-[var(--text-dim)] hover:text-[var(--text)] transition-colors px-2 py-1 border border-[var(--border)]"
+          >
+            CANCEL
+          </button>
+        </div>
+      )}
 
       {/* Mode Selector */}
       <ModeSelector mode={wizard.mode} onModeChange={handleModeChange} />

--- a/app/components/create/RecoverSolBanner.tsx
+++ b/app/components/create/RecoverSolBanner.tsx
@@ -4,8 +4,12 @@ import { FC, useState } from "react";
 import { useStuckSlabs, type StuckSlab } from "@/hooks/useStuckSlabs";
 
 interface RecoverSolBannerProps {
-  /** Called when user wants to resume market creation with the stuck slab */
-  onResume?: (slabPublicKey: string) => void;
+  /**
+   * Called when user wants to resume market creation with the stuck slab.
+   * `fromStep` is 1 when the market is initialized (need oracle/LP/insurance),
+   * or 0 when the slab exists but InitMarket didn't complete (retry from scratch).
+   */
+  onResume?: (slabPublicKey: string, fromStep: 0 | 1) => void;
 }
 
 /**
@@ -113,7 +117,7 @@ export const RecoverSolBanner: FC<RecoverSolBannerProps> = ({ onResume }) => {
           {onResume && (
             <button
               type="button"
-              onClick={() => onResume(stuckSlab.publicKey.toBase58())}
+              onClick={() => onResume(stuckSlab.publicKey.toBase58(), 1)}
               className="border border-[var(--accent)]/50 bg-[var(--accent)]/[0.08] px-4 py-2 text-[11px] font-bold uppercase tracking-[0.1em] text-[var(--accent)] hover:bg-[var(--accent)]/[0.15] transition-colors"
             >
               RESUME CREATION →
@@ -175,7 +179,7 @@ export const RecoverSolBanner: FC<RecoverSolBannerProps> = ({ onResume }) => {
         {onResume && (
           <button
             type="button"
-            onClick={() => onResume(stuckSlab.publicKey.toBase58())}
+            onClick={() => onResume(stuckSlab.publicKey.toBase58(), 0)}
             className="border border-[var(--warning)]/50 bg-[var(--warning)]/[0.08] px-4 py-2 text-[11px] font-bold uppercase tracking-[0.1em] text-[var(--warning)] hover:bg-[var(--warning)]/[0.15] transition-colors"
           >
             RETRY INITIALIZATION →


### PR DESCRIPTION
## Problem
When market creation fails mid-flow and the user refreshes, the wizard shows a **Continue / Resume Creation** button but clicking it does nothing — silent failure.

## Root Cause
The `onResume` callback in `CreateMarketWizard` called `resetCreate()`, which:
1. Cleared `slabKpRef.current` (the slab keypair loaded from localStorage)
2. Removed the keypair from localStorage
3. Reset state to step 0

Net effect: the button erased the recovery data and left the wizard in an empty initial state — indistinguishable from doing nothing.

## Fix
**`RecoverSolBanner`**: extended `onResume` prop signature to include `fromStep: 0 | 1`:
- Initialized slab (oracle/LP/insurance missing) → `fromStep = 1`
- Slab exists but not initialized → `fromStep = 0`

**`CreateMarketWizard`**:
- `onResume` now sets `resumeFromStep` state instead of calling `resetCreate()` — keypair stays in `slabKpRef` (already loaded from localStorage by `useCreateMarket`'s `useEffect` on mount)
- `handleLaunch` passes `resumeFromStep` to `create()`, skipping slab creation when resuming
- Visual **resume mode banner** shown with a CANCEL button that clears state if user wants to start fresh
- `handleReset` clears `resumeFromStep`

## Testing
- 860 tests passing
- Scenario 1: Refresh with initialized stuck slab → click Resume → fill params → Launch calls `create(params, 1)` — skips Step 0, uses persisted keypair ✓
- Scenario 2: Refresh with uninitialized stuck slab → click Retry → fill params → Launch calls `create(params, 0)` — generates new keypair, checks for existing account ✓  
- Scenario 3: Cancel resume mode → calls `resetCreate()`, clears keypair, wizard resets ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Market creation can now resume from the specific step where it was interrupted, eliminating the need to restart from the beginning and improving recovery efficiency.
  * Added a status indicator showing resume mode with an option to cancel and reset the operation completely if needed.

* **Tests**
  * Updated test coverage to ensure proper step tracking during recovery operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->