### PR TITLE
fix(#935): validate mint as base58 pubkey in /api/chart/[mint]

### DIFF
--- a/app/app/api/chart/[mint]/route.ts
+++ b/app/app/api/chart/[mint]/route.ts
@@ -98,7 +98,8 @@ export async function GET(
 ) {
   const { mint } = await params;
 
-  if (!mint || mint.length < 32) {
+  // Validate mint is a valid base58 Solana pubkey (32–44 chars, base58 alphabet only)
+  if (!mint || !/^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(mint)) {
     return NextResponse.json({ error: "Invalid mint address" }, { status: 400 });
   }
 
@@ -133,10 +134,14 @@ export async function GET(
   // Cache result
   cache.set(cacheKey, { candles, poolAddress, fetchedAt: Date.now() });
 
-  // Prune old cache entries (keep max 100)
+  // Prune old cache entries (keep max 100, evict 10 oldest to prevent gradual growth)
   if (cache.size > 100) {
-    const firstKey = cache.keys().next().value;
-    if (firstKey) cache.delete(firstKey);
+    const keys = cache.keys();
+    for (let i = 0; i < 10; i++) {
+      const k = keys.next();
+      if (k.done) break;
+      cache.delete(k.value);
+    }
   }
 
   return NextResponse.json(


### PR DESCRIPTION
## Fixes #935

**Security:** LOW — mint param was only length-checked, allowing path traversal chars into GeckoTerminal API URLs.

### Changes
- Replace `mint.length < 32` with base58 regex: `/^[1-9A-HJ-NP-Za-km-z]{32,44}$/`
- Cache prune: evict 10 oldest entries when >100 (was 1, allowing unbounded growth under unique-mint spam)

### Testing
- 863 tests passing (34 skipped, pre-existing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for chart data requests to properly reject invalid input with error responses.

* **Performance**
  * Improved cache management to prevent gradual memory growth during extended usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->