### PR TITLE
fix(PERC-515): check confirmTransaction result.value.err in all hooks

### DIFF
--- a/app/__tests__/hooks/useReclaimSlabRent.test.ts
+++ b/app/__tests__/hooks/useReclaimSlabRent.test.ts
@@ -1,0 +1,280 @@
+/**
+ * useReclaimSlabRent Hook Tests — PERC-515
+ *
+ * Verifies that confirmTransaction result.value.err is checked and surfaces
+ * on-chain rejections as errors instead of false "success" states.
+ *
+ * Test Cases:
+ * - Happy path: confirmed tx with no error → status = "success"
+ * - On-chain rejection: confirmTransaction returns value.err → status = "error"
+ * - Wallet not connected → early error
+ * - Wallet cannot sign → early error
+ * - Slab not found on-chain → early error
+ * - Slab already initialised (magic = MAGIC) → early error
+ * - Slab not owned by program → early error
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { act } from "react";
+import { Keypair, PublicKey } from "@solana/web3.js";
+
+// ─── Mock @solana/web3.js Transaction (avoids real serialization in unit tests) ─
+
+vi.mock("@solana/web3.js", async () => {
+  const actual = await vi.importActual<typeof import("@solana/web3.js")>("@solana/web3.js");
+  // Must use regular function expressions (not arrow functions) for constructors
+  /* eslint-disable prefer-arrow-callback */
+  function MockTransaction(this: Record<string, unknown>) {
+    this.add = vi.fn().mockReturnThis();
+    this.partialSign = vi.fn();
+    this.serialize = vi.fn().mockReturnValue(Buffer.from([1, 2, 3]));
+    this.feePayer = null;
+  }
+  function MockTransactionInstruction(this: Record<string, unknown>, args: unknown) {
+    Object.assign(this, args);
+  }
+  /* eslint-enable prefer-arrow-callback */
+  return {
+    ...actual,
+    Transaction: MockTransaction,
+    TransactionInstruction: MockTransactionInstruction,
+  };
+});
+
+// ─── Mock wallet/connection hooks ─────────────────────────────────────────────
+
+vi.mock("@/hooks/useWalletCompat", () => ({
+  useWalletCompat: vi.fn(),
+  useConnectionCompat: vi.fn(),
+}));
+
+import { useWalletCompat, useConnectionCompat } from "@/hooks/useWalletCompat";
+import { useReclaimSlabRent } from "../../hooks/useReclaimSlabRent";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+// Must match NEXT_PUBLIC_PROGRAM_ID in vitest.config.ts (module-level const captured at load time)
+const PROGRAM_ID = new PublicKey("5BZWY6XWPxuWFxs2nPCLLsVaKRWZVnzZh3FkJDLJBkJf");
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Build an uninitialised slab account info (magic = 0). */
+function makeUninitialisedSlabData(): Buffer {
+  return Buffer.alloc(32, 0);
+}
+
+/** Build an initialised slab account info (magic = PERCOLA T). */
+function makeInitialisedSlabData(): Buffer {
+  const buf = Buffer.alloc(32, 0);
+  buf.writeBigUInt64LE(0x504552434f4c4154n, 0);
+  return buf;
+}
+
+interface ConnectionOverrides {
+  /** What getAccountInfo resolves to (undefined = uninitialised slab; null = not found). */
+  accountInfoResult?: ReturnType<typeof makeDefaultAccountInfo> | null;
+  /** If set, confirmTransaction returns value.err = this object. */
+  confirmError?: object | null;
+}
+
+function makeDefaultAccountInfo() {
+  return {
+    data: makeUninitialisedSlabData(),
+    lamports: 2_000_000_000,
+    owner: PROGRAM_ID,
+    executable: false,
+  };
+}
+
+function makeMockConnection(overrides: ConnectionOverrides = {}) {
+  const accountInfoResult =
+    "accountInfoResult" in overrides
+      ? overrides.accountInfoResult
+      : makeDefaultAccountInfo();
+
+  const confirmError = overrides.confirmError ?? null;
+
+  return {
+    getAccountInfo: vi.fn().mockResolvedValue(accountInfoResult),
+    getLatestBlockhash: vi.fn().mockResolvedValue({
+      blockhash: "4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi",
+      lastValidBlockHeight: 999999,
+    }),
+    sendRawTransaction: vi.fn().mockResolvedValue("test-tx-sig"),
+    confirmTransaction: vi.fn().mockResolvedValue({
+      value: { err: confirmError },
+      context: { slot: 1 },
+    }),
+  };
+}
+
+function makeMockWallet(overrides: {
+  publicKey?: PublicKey | null;
+  signTransaction?: ((tx: object) => Promise<object>) | null;
+} = {}) {
+  const walletPubkey = new PublicKey("7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU");
+  return {
+    publicKey: "publicKey" in overrides ? overrides.publicKey : walletPubkey,
+    signTransaction:
+      "signTransaction" in overrides
+        ? overrides.signTransaction
+        : vi.fn().mockImplementation(async (tx: object) => tx),
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("useReclaimSlabRent", () => {
+  let mockConnection: ReturnType<typeof makeMockConnection>;
+  let mockWallet: ReturnType<typeof makeMockWallet>;
+  let slabKeypair: Keypair;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    slabKeypair = Keypair.generate();
+    mockConnection = makeMockConnection();
+    mockWallet = makeMockWallet();
+
+    vi.mocked(useWalletCompat).mockReturnValue(mockWallet as ReturnType<typeof useWalletCompat>);
+    vi.mocked(useConnectionCompat).mockReturnValue({
+      connection: mockConnection,
+    } as ReturnType<typeof useConnectionCompat>);
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────────────
+
+  it("sets status to success when confirmTransaction returns no error", async () => {
+    const { result } = renderHook(() => useReclaimSlabRent());
+    expect(result.current.status).toBe("idle");
+
+    await act(async () => {
+      await result.current.reclaim(slabKeypair);
+    });
+
+    expect(result.current.status).toBe("success");
+    expect(result.current.txSig).toBe("test-tx-sig");
+    expect(result.current.error).toBeNull();
+    expect(mockConnection.confirmTransaction).toHaveBeenCalledOnce();
+  });
+
+  // ── PERC-515: on-chain rejection check ───────────────────────────────────
+
+  it("sets status to error when confirmTransaction returns value.err (on-chain rejection)", async () => {
+    const onChainError = { InstructionError: [0, { Custom: 42 }] };
+    mockConnection = makeMockConnection({ confirmError: onChainError });
+    vi.mocked(useConnectionCompat).mockReturnValue({
+      connection: mockConnection,
+    } as ReturnType<typeof useConnectionCompat>);
+
+    const { result } = renderHook(() => useReclaimSlabRent());
+
+    await act(async () => {
+      await result.current.reclaim(slabKeypair);
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toMatch(/Transaction landed on-chain but was rejected/i);
+    expect(result.current.error).toContain("InstructionError");
+    // txSig must NOT be set — caller should not treat this as success
+    expect(result.current.txSig).toBeNull();
+  });
+
+  // ── Preflight guards ─────────────────────────────────────────────────────
+
+  it("errors early when wallet is not connected", async () => {
+    mockWallet = makeMockWallet({ publicKey: null });
+    vi.mocked(useWalletCompat).mockReturnValue(mockWallet as ReturnType<typeof useWalletCompat>);
+
+    const { result } = renderHook(() => useReclaimSlabRent());
+
+    await act(async () => {
+      await result.current.reclaim(slabKeypair);
+    });
+
+    expect(result.current.status).toBe("idle");
+    expect(result.current.error).toMatch(/Wallet not connected/i);
+    expect(mockConnection.sendRawTransaction).not.toHaveBeenCalled();
+  });
+
+  it("errors early when wallet cannot sign", async () => {
+    mockWallet = makeMockWallet({ signTransaction: null });
+    vi.mocked(useWalletCompat).mockReturnValue(mockWallet as ReturnType<typeof useWalletCompat>);
+
+    const { result } = renderHook(() => useReclaimSlabRent());
+
+    await act(async () => {
+      await result.current.reclaim(slabKeypair);
+    });
+
+    expect(result.current.status).toBe("idle");
+    expect(result.current.error).toMatch(/does not support signing/i);
+    expect(mockConnection.sendRawTransaction).not.toHaveBeenCalled();
+  });
+
+  it("errors when slab account not found on-chain", async () => {
+    mockConnection = makeMockConnection({ accountInfoResult: null });
+    vi.mocked(useConnectionCompat).mockReturnValue({
+      connection: mockConnection,
+    } as ReturnType<typeof useConnectionCompat>);
+
+    const { result } = renderHook(() => useReclaimSlabRent());
+
+    await act(async () => {
+      await result.current.reclaim(slabKeypair);
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toMatch(/not found on-chain/i);
+    expect(mockConnection.sendRawTransaction).not.toHaveBeenCalled();
+  });
+
+  it("errors when slab is already initialised (magic = MAGIC)", async () => {
+    mockConnection = makeMockConnection({
+      accountInfoResult: {
+        data: makeInitialisedSlabData(),
+        lamports: 2_000_000_000,
+        owner: PROGRAM_ID,
+        executable: false,
+      },
+    });
+    vi.mocked(useConnectionCompat).mockReturnValue({
+      connection: mockConnection,
+    } as ReturnType<typeof useConnectionCompat>);
+
+    const { result } = renderHook(() => useReclaimSlabRent());
+
+    await act(async () => {
+      await result.current.reclaim(slabKeypair);
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toMatch(/already initialised/i);
+    expect(mockConnection.sendRawTransaction).not.toHaveBeenCalled();
+  });
+
+  it("errors when slab is not owned by the Percolator program", async () => {
+    const foreignOwner = Keypair.generate().publicKey;
+    mockConnection = makeMockConnection({
+      accountInfoResult: {
+        data: makeUninitialisedSlabData(),
+        lamports: 2_000_000_000,
+        owner: foreignOwner,
+        executable: false,
+      },
+    });
+    vi.mocked(useConnectionCompat).mockReturnValue({
+      connection: mockConnection,
+    } as ReturnType<typeof useConnectionCompat>);
+
+    const { result } = renderHook(() => useReclaimSlabRent());
+
+    await act(async () => {
+      await result.current.reclaim(slabKeypair);
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toMatch(/not owned by the Percolator program/i);
+    expect(mockConnection.sendRawTransaction).not.toHaveBeenCalled();
+  });
+});

--- a/app/app/api/auto-fund/route.ts
+++ b/app/app/api/auto-fund/route.ts
@@ -96,7 +96,10 @@ export async function POST(req: NextRequest) {
     if (balance < MIN_SOL_BALANCE) {
       try {
         const sig = await publicConnection.requestAirdrop(walletPk, AIRDROP_AMOUNT);
-        await publicConnection.confirmTransaction(sig, "confirmed");
+        const airdropResult = await publicConnection.confirmTransaction(sig, "confirmed");
+        if (airdropResult.value.err) {
+          throw new Error(`Airdrop confirmed but failed on-chain: ${JSON.stringify(airdropResult.value.err)}`);
+        }
         results.sol_airdropped = true;
         results.sol_amount = AIRDROP_AMOUNT / LAMPORTS_PER_SOL;
       } catch (e: any) {

--- a/app/hooks/useCreateMarket.ts
+++ b/app/hooks/useCreateMarket.ts
@@ -478,7 +478,10 @@ export function useCreateMarket() {
                     wallet.publicKey,
                     Math.max(2_000_000_000, minSolRequired - solBalance + 500_000_000),
                   );
-                  await connection.confirmTransaction(airdropSig, "confirmed");
+                  const airdropConfirm = await connection.confirmTransaction(airdropSig, "confirmed");
+                  if (airdropConfirm.value.err) {
+                    throw new Error(`Airdrop transaction failed on-chain: ${JSON.stringify(airdropConfirm.value.err)}`);
+                  }
                   setState((s) => ({ ...s, stepLabel: STEP_LABELS[0] }));
                 } catch (airdropErr) {
                   throw new Error(

--- a/app/hooks/useReclaimSlabRent.ts
+++ b/app/hooks/useReclaimSlabRent.ts
@@ -127,10 +127,16 @@ export function useReclaimSlabRent(): UseReclaimSlabRentResult {
           skipPreflight: false,
         });
 
-        await connection.confirmTransaction(
+        const confirmation = await connection.confirmTransaction(
           { signature: sig, blockhash, lastValidBlockHeight },
           "confirmed"
         );
+
+        if (confirmation.value.err) {
+          throw new Error(
+            `Transaction landed on-chain but was rejected by the program: ${JSON.stringify(confirmation.value.err)}`
+          );
+        }
 
         setTxSig(sig);
         setStatus("success");

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -16,6 +16,8 @@ export default defineConfig({
       // Test environment is always devnet; prevents getConfig() mainnet validation errors
       // when NEXT_PUBLIC_DEFAULT_NETWORK is not set in the test process env.
       NEXT_PUBLIC_DEFAULT_NETWORK: 'devnet',
+      // Valid program ID for tests (module-level consts evaluated at load time need a real pubkey)
+      NEXT_PUBLIC_PROGRAM_ID: '5BZWY6XWPxuWFxs2nPCLLsVaKRWZVnzZh3FkJDLJBkJf',
     },
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## PERC-515: confirmTransaction on-chain error check

### Problem
QA filed LOW finding against PR #932 (PERC-511): `useReclaimSlabRent` hook calls `confirmTransaction` but does not inspect the returned `result.value.err`. A transaction can broadcast, be confirmed by the network, and still be rejected by the program on-chain. The old code silently set `status='success'` in that case.

### Fix
Capture the return value of `confirmTransaction` and throw immediately if `value.err` is non-null — putting us in the `catch` block which sets `status='error'` and `error=<message>`.

The same unchecked pattern existed in two other sites:
- `useCreateMarket.ts` — devnet airdrop confirm
- `auto-fund/route.ts` — server-side airdrop confirm

All three fixed.

### Changes
| File | Change |
|------|--------|
| `app/hooks/useReclaimSlabRent.ts` | Capture `confirmTransaction` result, throw if `value.err` |
| `app/hooks/useCreateMarket.ts` | Same fix for devnet airdrop `confirmTransaction` |
| `app/app/api/auto-fund/route.ts` | Same fix for server-side airdrop `confirmTransaction` |
| `app/__tests__/hooks/useReclaimSlabRent.test.ts` | New: 7 unit tests covering happy path + on-chain rejection + all preflight guards |
| `app/vitest.config.ts` | Added `NEXT_PUBLIC_PROGRAM_ID` test env var (module-level `PublicKey` const needs a valid key at load time) |

### Before / After (useReclaimSlabRent.ts)
```diff
-await connection.confirmTransaction(
-  { signature: sig, blockhash, lastValidBlockHeight },
-  "confirmed"
-);
+const confirmation = await connection.confirmTransaction(
+  { signature: sig, blockhash, lastValidBlockHeight },
+  "confirmed"
+);
+if (confirmation.value.err) {
+  throw new Error(
+    `Transaction landed on-chain but was rejected by the program: ${JSON.stringify(confirmation.value.err)}`
+  );
+}
```

### Tests
871 tests passing ✅ (was 864 before this PR — 7 new tests added)

@qa — test the reclaim flow: start market creation → kill tab mid-tx → reopen /create → see banner → click Reclaim SOL. If the program rejects, you should see an inline error instead of a false success state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for devnet airdrop operations with clearer failure messages
  * Enhanced transaction confirmation validation to detect and report on-chain errors, preventing silent failures

* **Tests**
  * Added comprehensive test suite for reclaim operations, covering successful transactions, on-chain rejections, validation guards, and error handling across multiple scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->