### PR TITLE
fix: reset wizard state on CLEAR & START FRESH (#946)

### DIFF
--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -561,6 +561,7 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
     <div className="space-y-6 p-4 sm:p-6">
       {/* Stuck slab recovery banner */}
       <RecoverSolBanner
+        onReset={handleReset}
         onResume={(_slabAddress, fromStep) => {
           // PERC-513 fix: DO NOT call resetCreate() here — that clears slabKpRef
           // and removes the localStorage keypair, making the Continue button a no-op.

--- a/app/components/create/RecoverSolBanner.tsx
+++ b/app/components/create/RecoverSolBanner.tsx
@@ -12,6 +12,8 @@ interface RecoverSolBannerProps {
    * or 0 when the slab exists but InitMarket didn't complete (retry from scratch).
    */
   onResume?: (slabPublicKey: string, fromStep: 0 | 1) => void;
+  /** Called when user clicks "Clear & Start Fresh" or "Discard & Start New" to reset the wizard. */
+  onReset?: () => void;
 }
 
 /**
@@ -25,7 +27,7 @@ interface RecoverSolBannerProps {
  * With the atomic createAccount + InitMarket flow, scenario 2 is extremely rare —
  * it would only happen if the tx landed on-chain but the client lost the confirmation.
  */
-export const RecoverSolBanner: FC<RecoverSolBannerProps> = ({ onResume }) => {
+export const RecoverSolBanner: FC<RecoverSolBannerProps> = ({ onResume, onReset }) => {
   const { stuckSlab, loading, clearStuck, refresh } = useStuckSlabs();
   const { closeSlab, loading: closeLoading, error: closeError } = useCloseMarket();
   const [dismissed, setDismissed] = useState(false);
@@ -72,6 +74,7 @@ export const RecoverSolBanner: FC<RecoverSolBannerProps> = ({ onResume }) => {
           type="button"
           onClick={() => {
             clearStuck();
+            onReset?.();
             setDismissed(true);
           }}
           className="mt-3 border border-[var(--border)] px-4 py-2 text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text-secondary)] hover:border-[var(--accent)]/30 hover:text-[var(--text)] transition-colors"
@@ -164,6 +167,7 @@ export const RecoverSolBanner: FC<RecoverSolBannerProps> = ({ onResume }) => {
             type="button"
             onClick={() => {
               clearStuck();
+              onReset?.();
               setDismissed(true);
             }}
             className="border border-[var(--border)] px-4 py-2 text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text-secondary)] hover:border-[var(--accent)]/30 hover:text-[var(--text)] transition-colors"
@@ -178,7 +182,7 @@ export const RecoverSolBanner: FC<RecoverSolBannerProps> = ({ onResume }) => {
   // Account exists but NOT initialized — slab is program-owned but uninitialised (magic = 0).
   // PERC-511: We can now reclaim the SOL via the ReclaimSlabRent instruction (tag 52).
   // The slab keypair signs the tx to prove ownership.
-  return <UninitialisedSlabBanner stuckSlab={stuckSlab} onResume={onResume} clearStuck={clearStuck} />;
+  return <UninitialisedSlabBanner stuckSlab={stuckSlab} onResume={onResume} clearStuck={clearStuck} onReset={onReset} />;
 };
 
 /** Sub-component: handles the uninitialised slab case with ReclaimSlabRent. */
@@ -186,7 +190,8 @@ const UninitialisedSlabBanner: FC<{
   stuckSlab: StuckSlab;
   onResume?: (slabPublicKey: string, fromStep: 0 | 1) => void;
   clearStuck: () => void;
-}> = ({ stuckSlab, onResume, clearStuck }) => {
+  onReset?: () => void;
+}> = ({ stuckSlab, onResume, clearStuck, onReset }) => {
   const { status, error: reclaimError, txSig, reclaim } = useReclaimSlabRent();
   const [dismissed, setDismissed] = useState(false);
 
@@ -226,6 +231,7 @@ const UninitialisedSlabBanner: FC<{
           type="button"
           onClick={() => {
             clearStuck();
+            onReset?.();
             setDismissed(true);
           }}
           className="border border-[var(--border)] px-4 py-2 text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text-secondary)] hover:text-[var(--text)] transition-colors"
@@ -300,6 +306,7 @@ const UninitialisedSlabBanner: FC<{
           disabled={isSending}
           onClick={() => {
             clearStuck();
+            onReset?.();
             setDismissed(true);
           }}
           className="border border-[var(--border)] px-4 py-2 text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text-secondary)] hover:border-[var(--accent)]/30 hover:text-[var(--text)] transition-colors disabled:opacity-50"


### PR DESCRIPTION
## Problem
After clicking **CLEAR & START FRESH** on /create, the LAUNCH button stays permanently disabled. The RecoverSolBanner clear buttons only dismissed the banner without resetting the wizard state, leaving stale `walletBalance: "0"` and the old step in localStorage.

## Root Cause
`RecoverSolBanner` had no way to reset the wizard — it only called `clearStuck()` (removes stuck slab from localStorage) and `setDismissed(true)` (hides banner). The wizard state (step, walletBalance, etc.) was never cleared, so the form stayed at the review step with a stale zero balance.

## Fix
- Add `onReset` prop to `RecoverSolBanner` and its sub-component `UninitialisedSlabBanner`
- Wire `handleReset` from `CreateMarketWizard` to all 4 clear/discard/start-new buttons
- On click: `clearStuck()` + `onReset()` + `setDismissed(true)` — fully resets wizard to step 1 with fresh state

## Testing
- `tsc --noEmit` ✅

Closes #946

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reset functionality to the market creation wizard during recovery scenarios. Users can now reset the wizard state when encountering account or initialization issues through dedicated reset actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->