### PR TITLE
fix(airdrop): guard against undefined tokens in success state (PERC-520)

### DIFF
--- a/app/components/trade/AirdropButton.tsx
+++ b/app/components/trade/AirdropButton.tsx
@@ -79,7 +79,7 @@ export function AirdropButton({ mintAddress, symbol, isUserCreated = true }: Air
       } else if (!resp.ok) {
         setError(data.error ?? "Airdrop failed");
       } else {
-        setResult({ tokens: data.amount, nextClaimAt: data.nextClaimAt });
+        setResult({ tokens: data.amount ?? data.tokens ?? 0, nextClaimAt: data.nextClaimAt });
         setError(null);
       }
     } catch (e: any) {
@@ -108,7 +108,7 @@ export function AirdropButton({ mintAddress, symbol, isUserCreated = true }: Air
     return (
       <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-[var(--long)]/10 border border-[var(--long)]/20 text-[11px]">
         <span className="text-[var(--long)] font-medium">
-          ✓ {result.tokens.toLocaleString(undefined, { maximumFractionDigits: 2 })} {symbol} airdropped
+          ✓ {(result.tokens ?? 0).toLocaleString(undefined, { maximumFractionDigits: 2 })} {symbol} airdropped
         </span>
       </div>
     );


### PR DESCRIPTION
## What
AirdropButton success state could crash with `undefined.toLocaleString()` if the API response didn't include `amount`.

## Fix
- Accept `data.amount ?? data.tokens ?? 0` when setting result state
- Add nullish coalescing guard in the render path: `(result.tokens ?? 0).toLocaleString()`

## Testing
- Trigger airdrop on a devnet user-created market → success message shows amount
- If API returns neither `amount` nor `tokens`, displays `0` instead of crashing

Closes PERC-520

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved token amount handling in airdrop confirmations to prevent display errors when token data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->