### PR TITLE
fix(PERC-520): rename result.tokens → result.amount in AirdropButton

### DIFF
--- a/app/components/trade/AirdropButton.tsx
+++ b/app/components/trade/AirdropButton.tsx
@@ -26,7 +26,7 @@ interface AirdropButtonProps {
 export function AirdropButton({ mintAddress, symbol, isUserCreated = true }: AirdropButtonProps) {
   const { publicKey, connected } = useWalletCompat();
   const [loading, setLoading] = useState(false);
-  const [result, setResult] = useState<{ tokens: number; nextClaimAt: string } | null>(null);
+  const [result, setResult] = useState<{ amount: number; nextClaimAt: string } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [countdown, setCountdown] = useState<string | null>(null);
   const [nextClaimAt, setNextClaimAt] = useState<string | null>(null);
@@ -79,7 +79,7 @@ export function AirdropButton({ mintAddress, symbol, isUserCreated = true }: Air
       } else if (!resp.ok) {
         setError(data.error ?? "Airdrop failed");
       } else {
-        setResult({ tokens: data.amount, nextClaimAt: data.nextClaimAt });
+        setResult({ amount: data.amount, nextClaimAt: data.nextClaimAt });
         setError(null);
       }
     } catch (e: any) {
@@ -108,7 +108,7 @@ export function AirdropButton({ mintAddress, symbol, isUserCreated = true }: Air
     return (
       <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-[var(--long)]/10 border border-[var(--long)]/20 text-[11px]">
         <span className="text-[var(--long)] font-medium">
-          ✓ {result.tokens.toLocaleString(undefined, { maximumFractionDigits: 2 })} {symbol} airdropped
+          ✓ {result.amount.toLocaleString(undefined, { maximumFractionDigits: 2 })} {symbol} airdropped
         </span>
       </div>
     );


### PR DESCRIPTION
## Summary

Security flagged (in PR #948 retroactive review) that AirdropButton success state referenced `result.tokens` while the API returns `amount`, causing the displayed value to be `undefined`.

A previous partial fix mapped `data.amount → result.tokens` so the render worked, but left a misleading naming inconsistency in the state type. This PR cleans it up fully.

## Changes
- `app/components/trade/AirdropButton.tsx`
  - State type: `{ tokens: number }` → `{ amount: number }`
  - Setter: `{ tokens: data.amount }` → `{ amount: data.amount }`
  - Render: `result.tokens.toLocaleString()` → `result.amount.toLocaleString()`

## Testing
All 875 tests pass. AirdropButton: 9/9.

Closes: PERC-520

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal naming conventions for consistency in the airdrop feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->