### PR TITLE
fix: remove duplicate PublicKey import breaking build

### DIFF
--- a/app/app/api/chart/[mint]/route.ts
+++ b/app/app/api/chart/[mint]/route.ts
@@ -1,6 +1,5 @@
 import { PublicKey } from "@solana/web3.js";
 import { NextRequest, NextResponse } from "next/server";
-import { PublicKey } from "@solana/web3.js";
 
 export const dynamic = "force-dynamic";
 


### PR DESCRIPTION
## BLOCKER fix

PR #948 introduced a duplicate `import { PublicKey } from "@solana/web3.js"` on lines 1 and 3 of `app/app/api/chart/[mint]/route.ts`. Turbopack fails with "name PublicKey defined multiple times", breaking all CI.

**Fix:** Delete the duplicate import line.

Fixes #951