### PR TITLE
fix(#941): add deploy-artifacts/*.so and *.so to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,10 @@ config/sim-bot-wallets.json
 # Slab reinit — ephemeral new keypairs (devnet only, never commit)
 new-slab-keypair-*.json
 
+# Compiled Solana program binaries — build from source, never deploy from these
+deploy-artifacts/*.so
+*.so
+
 Percolator-Deck-Final.pdf
 Percolator-Deck-v2.pdf
 Percolator-Pitch-Deck.pdf


### PR DESCRIPTION
## Summary

Closes #941 — [SECURITY] LOW: Binary artifacts (.so) committed to percolator-prog deploy-artifacts/

## What Changed

Added two `.gitignore` rules to prevent precompiled Solana program binaries from being re-committed:
- `deploy-artifacts/*.so` — covers the specific directory flagged in the issue
- `*.so` — broad repo-wide catch-all

## Why

Security issue flagged a supply chain risk: if `.so` binaries get back into the repo, a future operator or CI script could deploy from `deploy-artifacts/` directly, bypassing the source build step. The deploy script (`scripts/rebuild-deploy-devnet.sh`) already correctly builds from `target/deploy/` — no script changes needed.

## Impact

- No functional change — binaries are already absent from the working tree
- Pure hygiene: closes the door so they can't be re-committed
- Devnet-only scope (LOW severity as scoped in the issue)

## How to Test

```bash
# Verify .so files are now ignored
echo 'test' > test.so
git status  # should NOT show test.so as untracked
rm test.so
```