### PR TITLE
Refactor authorityFresh condition for clarity

### DIFF
--- a/packages/keeper/src/services/liquidation.ts
+++ b/packages/keeper/src/services/liquidation.ts
@@ -110,9 +110,9 @@ function resolveMarketPrice(
     return { price: cfg.lastEffectivePriceE6, stale: false };
   }
   // Admin oracle: try authorityPriceE6 with off-chain staleness check
-  const now = BigInt(Math.floor(Date.now() / 1000));
-  const priceAge = cfg.authorityTimestamp > 0n ? now - cfg.authorityTimestamp : now;
-  const authorityFresh = cfg.authorityPriceE6 > 0n && priceAge <= 60n;
+ const authorityFresh = cfg.authorityTimestamp > 0n
+  && cfg.authorityPriceE6 > 0n
+  && (now - cfg.authorityTimestamp) <= 60n;
 
   if (authorityFresh) {
     return { price: cfg.authorityPriceE6, stale: false };


### PR DESCRIPTION
This pull request includes a minor update to the logic for checking the freshness of the admin oracle price in the `resolveMarketPrice` function. The change simplifies the staleness check by removing an intermediate variable and directly comparing the timestamp difference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the market price resolution logic in the liquidation service for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->