### PR TITLE
Update API route to fetch trades instead of markets

### DIFF
--- a/app/app/api/markets/[slab]/route.ts
+++ b/app/app/api/markets/[slab]/route.ts
@@ -31,11 +31,13 @@ export async function GET(
 
     if (isValidPublicKey(slab)) {
       // Standard lookup by slab address
-      const { data: row, error } = await supabase
-        .from("markets_with_stats")
-        .select("*")
-        .eq("slab_address", slab)
-        .maybeSingle();
+      const { data, error } = await supabase
+       .from("trades")
+       .select("id, trader, side, size, price, fee, tx_signature, created_at")
+       .eq("slab_address", slab)
+       .order("created_at", { ascending: false })
+       .limit(limit);
+      //If the frontend needs additional fields (e.g. liquidation flag, order_id, etc.), add them explicitly.
 
       if (error) {
         Sentry.captureException(error, {


### PR DESCRIPTION
This pull request updates the market lookup endpoint to return recent trade data instead of full market stats, streamlining the response and making it more relevant for frontend consumption.

Trade data retrieval changes:

* Changed the database query in `route.ts` to fetch recent trades from the `trades` table, selecting only essential fields (`id, trader, side, size, price, fee, tx_signature, created_at`), and ordering by `created_at` descending with a limit. This replaces the previous query to `markets_with_stats` and improves efficiency and clarity for frontend use. ([app/app/api/markets/[slab]/route.tsL34-R40](diffhunk://#diff-c705850c4b2b1357b7cd67a7e91b322b0031aad6b49d55636712812219e9df86L34-R40))Changed data source from 'markets_with_stats' to 'trades' and updated selected fields.