### PR TITLE
Refactor API_URL to use getBackendUrl function

### DIFF
--- a/app/app/api/health/route.ts
+++ b/app/app/api/health/route.ts
@@ -2,10 +2,12 @@ import { NextResponse } from "next/server";
 import { getRpcEndpoint } from "@/lib/config";
 export const dynamic = "force-dynamic";
 
-const API_URL =
-  process.env.NEXT_PUBLIC_API_URL ||
-  "https://percolator-api1-production.up.railway.app";
+import { NextResponse } from "next/server";
+import { getBackendUrl, getRpcEndpoint } from "@/lib/config";
 
+export const dynamic = "force-dynamic";
+
+const API_URL = getBackendUrl();
 const RPC_URL = getRpcEndpoint();
 
 async function checkWithTimeout(


### PR DESCRIPTION
This pull request refactors the way the backend API URL is determined in the `app/app/api/health/route.ts` file. Instead of directly accessing environment variables or hardcoding the URL, it now uses the `getBackendUrl` utility function for improved consistency and maintainability.

Configuration improvements:

* Replaced manual construction of `API_URL` with the `getBackendUrl` function, ensuring centralized and consistent backend URL configuration.
* Added import for `getBackendUrl` from `@/lib/config` to support the new approach.