### PR TITLE
fix(health): use getBackendUrl() for consistent backend URL resolution

### DIFF
--- a/app/app/api/health/route.ts
+++ b/app/app/api/health/route.ts
@@ -2,10 +2,6 @@ import { NextResponse } from "next/server";
 import { getBackendUrl, getRpcEndpoint } from "@/lib/config";
 export const dynamic = "force-dynamic";
 
-const API_URL = getBackendUrl();
-
-const RPC_URL = getRpcEndpoint();
-
 async function checkWithTimeout(
   url: string,
   init: RequestInit,
@@ -24,6 +20,19 @@ async function checkWithTimeout(
 }
 
 export async function GET() {
+  let API_URL: string;
+  try {
+    API_URL = getBackendUrl();
+  } catch {
+    // getBackendUrl() throws in non-production when env vars are missing.
+    // Return a degraded response instead of crashing the route at import time.
+    return NextResponse.json(
+      { status: "offline", api: false, rpc: false, ts: Date.now(), error: "Backend URL not configured" },
+      { headers: { "Cache-Control": "no-store, max-age=0" } }
+    );
+  }
+  const RPC_URL = getRpcEndpoint();
+
   const [apiOk, rpcOk] = await Promise.all([
     checkWithTimeout(`${API_URL}/health`, {}, 3000),
     checkWithTimeout(


### PR DESCRIPTION
## What
Replaces the inline hardcoded fallback in `app/api/health/route.ts` with `getBackendUrl()` from `@/lib/config`.

## Why
- Keeps backend URL resolution centralised (same pattern as `prices/*` routes)
- Fixes a latent bug: the old hardcoded fallback pointed to `percolator-api1-production.up.railway.app` — `getBackendUrl()` correctly defaults to `percolator-api-production.up.railway.app`
- Picks up both `NEXT_PUBLIC_API_URL` and `NEXT_PUBLIC_BACKEND_URL` env vars automatically

## How to test
Deploy to preview; `/api/health` should still return `{ status, api, rpc, ts }`. Confirm `api: true` in devnet env.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved how the app determines backend connectivity for its health check.
* **Bug Fixes**
  * Health endpoint now returns a graceful "degraded/offline" response when the backend URL cannot be resolved, avoiding startup failures and improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->