### PR TITLE
fix(ui): 3 P0 rendering bugs — leverage 0x display, chart duplicate mount, CONTINUE button invisible

### DIFF
--- a/app/app/trade/[slab]/page.tsx
+++ b/app/app/trade/[slab]/page.tsx
@@ -15,6 +15,7 @@ import { EngineHealthCard } from "@/components/trade/EngineHealthCard";
 import { MarketStatsCard } from "@/components/trade/MarketStatsCard";
 import { MarketBookCard } from "@/components/trade/MarketBookCard";
 import { TradingChart } from "@/components/trade/TradingChart";
+import { useIsLargeScreen } from "@/hooks/useIsLargeScreen";
 import { TradeHistory } from "@/components/trade/TradeHistory";
 import { LiquidationAnalytics } from "@/components/trade/LiquidationAnalytics";
 import { CrankHealthCard } from "@/components/trade/CrankHealthCard";
@@ -145,6 +146,11 @@ function CopyButton({ text }: { text: string }) {
 /* ── Main inner page ──────────────────────────────────────── */
 
 function TradePageInner({ slab }: { slab: string }) {
+  // Render TradingChart exactly once by tracking breakpoint in JS.
+  // CSS-only hidden/shown dual-mount caused two ChartEmptyState instances to stack
+  // during SSR/hydration before the responsive classes were applied (P0 render bug).
+  const isLargeScreen = useIsLargeScreen();
+
   const { engine, config, header, accounts, loading: slabLoading, error: slabError } = useSlabState();
   const tokenMeta = useTokenMeta(config?.collateralMint ?? null);
   const { priceUsd } = useLivePrice();
@@ -397,12 +403,14 @@ function TradePageInner({ slab }: { slab: string }) {
           Single column, everything stacked
           ════════════════════════════════════════════════════════ */}
       <div className="flex flex-col gap-1.5 px-2 pt-2 pb-4 lg:hidden min-w-0 w-full">
-        {/* Chart */}
-        <ErrorBoundary label="TradingChart">
-          <div className="w-full overflow-hidden">
-            <TradingChart slabAddress={slab} mintAddress={mintAddress || undefined} />
-          </div>
-        </ErrorBoundary>
+        {/* Chart — only mount on mobile to prevent dual ChartEmptyState stacking */}
+        {!isLargeScreen && (
+          <ErrorBoundary label="TradingChart">
+            <div className="w-full overflow-hidden">
+              <TradingChart slabAddress={slab} mintAddress={mintAddress || undefined} />
+            </div>
+          </ErrorBoundary>
+        )}
 
         {/* Deposit trigger */}
         <ErrorBoundary label="DepositTrigger">
@@ -453,10 +461,12 @@ function TradePageInner({ slab }: { slab: string }) {
       <div className="hidden lg:grid grid-cols-[1fr_380px] gap-4 px-4 lg:px-6 pb-3 pt-2">
         {/* ── Left column ── */}
         <div className="min-w-0 space-y-1.5">
-          {/* Chart */}
-          <ErrorBoundary label="TradingChart">
-            <TradingChart slabAddress={slab} mintAddress={mintAddress || undefined} />
-          </ErrorBoundary>
+          {/* Chart — only mount on desktop to prevent dual ChartEmptyState stacking */}
+          {isLargeScreen && (
+            <ErrorBoundary label="TradingChart">
+              <TradingChart slabAddress={slab} mintAddress={mintAddress || undefined} />
+            </ErrorBoundary>
+          )}
 
           {/* My Positions / Account — tabbed */}
           <Tabs tabs={["My Positions", "Positions & Liqs"]}>

--- a/app/components/create/StepOracleSelect.tsx
+++ b/app/components/create/StepOracleSelect.tsx
@@ -347,7 +347,7 @@ export const StepOracleSelect: FC<StepOracleSelectProps> = ({
           type="button"
           onClick={onContinue}
           disabled={!canContinue}
-          className="flex-1 border border-[var(--accent)]/50 bg-[var(--accent)]/[0.08] py-3 text-[13px] font-bold uppercase tracking-[0.1em] text-[var(--accent)] transition-all duration-200 hud-btn-corners hover:border-[var(--accent)] hover:bg-[var(--accent)]/[0.15] disabled:cursor-not-allowed disabled:border-[var(--border)] disabled:bg-transparent disabled:text-[var(--text-dim)] disabled:opacity-50"
+          className="flex-1 border border-[var(--accent)]/50 bg-[var(--accent)]/[0.08] py-3 text-[13px] font-bold uppercase tracking-[0.1em] text-[var(--accent)] transition-all duration-200 hud-btn-corners hover:border-[var(--accent)] hover:bg-[var(--accent)]/[0.15] disabled:cursor-not-allowed disabled:border-[var(--border)] disabled:bg-transparent disabled:text-[var(--text-secondary)] disabled:opacity-50"
         >
           CONTINUE →
         </button>

--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -100,7 +100,9 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
   const initialMarginBps = params?.initialMarginBps ?? 1000n;
   const maintenanceMarginBps = params?.maintenanceMarginBps ?? 500n;
   const tradingFeeBps = params?.tradingFeeBps ?? 30n;
-  const maxLeverage = initialMarginBps > 0n ? Number(10000n / initialMarginBps) : 1;
+  // Clamp to minimum 1 — if initialMarginBps > 10000 (>100% margin), integer division yields
+  // 0 which breaks the slider (min=1 > max=0) and causes the "1x and 0x simultaneously" bug.
+  const maxLeverage = initialMarginBps > 0n ? Math.max(1, Number(10000n / initialMarginBps)) : 1;
 
   const availableLeverage = useMemo(() => {
     const arr = LEVERAGE_PRESETS.filter((l) => l <= maxLeverage);

--- a/app/hooks/useIsLargeScreen.ts
+++ b/app/hooks/useIsLargeScreen.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+/**
+ * Returns true when the viewport is >= 1024px (Tailwind `lg` breakpoint).
+ * Defaults to `false` on SSR/initial render to match the mobile-first approach
+ * (`hidden lg:grid`). This prevents the chart from being double-mounted during
+ * server rendering, which caused the "two ChartEmptyState stacking" bug.
+ */
+export function useIsLargeScreen(): boolean {
+  const [isLarge, setIsLarge] = useState(false);
+
+  useEffect(() => {
+    const mql = window.matchMedia("(min-width: 1024px)");
+    setIsLarge(mql.matches);
+    const handler = (e: MediaQueryListEvent) => setIsLarge(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
+  return isLarge;
+}


### PR DESCRIPTION
## Summary

Fixes 3 P0 rendering bugs flagged by designer during latest build review.

---

### Bug 1 — Leverage shows "1x" and "0x" simultaneously (TradeForm)

**Root cause:** When `initialMarginBps > 10000n` (>100% margin), integer division `10000n / initialMarginBps` yields `0n`. This made `maxLeverage = 0`, causing:
- Slider: `min=1, max=0` (invalid range)
- Preset button array: empty after filter, so `0` was pushed as the only option → shows "0x" button
- Header: state still shows `leverage=1` → "1x"
- Result: "1x" in header + "0x" in button simultaneously

**Fix:** Clamp `maxLeverage` to minimum 1:
```ts
const maxLeverage = initialMarginBps > 0n ? Math.max(1, Number(10000n / initialMarginBps)) : 1;
```

---

### Bug 2 — Two ChartEmptyState components stacking on trade page

**Root cause:** The trade page renders `TradingChart` in BOTH the mobile layout (`lg:hidden`) and desktop layout (`hidden lg:grid`). Before client-side CSS resolves after SSR/hydration, both instances briefly render — causing two `ChartEmptyState` components to stack visually.

**Fix:** Added `useIsLargeScreen` hook (mirrors `usePrefersReducedMotion` pattern using `matchMedia`) and conditionally mount exactly one `TradingChart`:
- Mobile section: renders only when `!isLargeScreen`
- Desktop section: renders only when `isLargeScreen`

---

### Bug 3 — CONTINUE button invisible when disabled on /create

**Root cause:** `StepOracleSelect` CONTINUE button used `disabled:text-[var(--text-dim)]` which is `#2a2e3d` — nearly identical to the `--bg: #0a0a0f` background. At 50% opacity (`disabled:opacity-50`) the label becomes effectively invisible.

**Fix:** Changed to `disabled:text-[var(--text-secondary)]` (`#7a7f96`) which has adequate contrast at 50% opacity.

---

## Testing

- `pnpm test` — 53 tests pass ✓
- `tsc --noEmit` — no TypeScript errors ✓

## Files Changed
- `app/components/trade/TradeForm.tsx` — leverage clamp fix
- `app/components/create/StepOracleSelect.tsx` — disabled button contrast fix
- `app/app/trade/[slab]/page.tsx` — conditional TradingChart mount
- `app/hooks/useIsLargeScreen.ts` — new hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed leverage slider calculation to prevent invalid minimum values and ensure proper functionality
  * Resolved trading chart display issues during initial page load

* **Style**
  * Updated visual styling of the continue button in the oracle selection interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->