### PR TITLE
fix(bots): add Pyth Hermes as 3rd price fallback in MM maker

### DIFF
--- a/bots/devnet-mm/src/maker.ts
+++ b/bots/devnet-mm/src/maker.ts
@@ -222,7 +222,7 @@ export class MakerBot {
     // Fetch price
     const priceData = await fetchPrice(market.symbol);
     if (!priceData) {
-      log("maker", `⚠️ ${market.symbol}: no price from Binance/CoinGecko, skipping`);
+      log("maker", `⚠️ ${market.symbol}: no price from Binance/CoinGecko/Pyth, skipping`);
       return;
     }
 

--- a/bots/devnet-mm/src/prices.ts
+++ b/bots/devnet-mm/src/prices.ts
@@ -1,7 +1,8 @@
 /**
  * PERC-377: Multi-source price feeds with caching.
  *
- * Fetches oracle prices from Binance (primary) and CoinGecko (fallback).
+ * Fetches oracle prices from Binance (primary), CoinGecko (secondary),
+ * and Pyth Hermes REST API (tertiary fallback, free + no key required).
  * Includes a TTL cache to avoid hammering external APIs.
  */
 
@@ -39,10 +40,32 @@ const COINGECKO_MAP: Record<string, string> = {
   RNDR: "render-token",
 };
 
+/**
+ * Pyth Hermes feed IDs (mainnet) — free REST API, no key required.
+ * https://hermes.pyth.network/v2/updates/price/latest?ids[]=<id>
+ */
+const PYTH_FEED_IDS: Record<string, string> = {
+  SOL:  "0xef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d",
+  BTC:  "0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
+  ETH:  "0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
+  BONK: "0x72b021217ca3fe68922a19aaf990109cb9d84e9ad004b4d2025ad6f529314419",
+  WIF:  "0x4ca4beeca86f0d164160323817a4e42b10010a724c2217c6ee41b54cd4cc61fc",
+  JUP:  "0x0a0408d619e9380abad35060f9192039ed5042fa6f82301d0e48bb52be830996",
+  PYTH: "0x0bbf28e9a841a1cc788f6a361b17ca072d0ea3098a1e5df1c3922d06719579ff",
+  RAY:  "0x91568baa8beb53db23eb3fb7f22c6e8bd303d103919e19733f2bb642d3e7987a",
+  JTO:  "0xb43660a5f790c69354b0729a5ef9d50d68f1df92107540210b9cccba1f947cc2",
+  RNDR: "0xab7347771135fc733f8f38db462ba085ed3309955f42554a14a982b67b8f781a",
+};
+
 // ── Cache ───────────────────────────────────────────────
 
 const cache = new Map<string, PriceData>();
 const CACHE_TTL_MS = 2_000;
+
+/** Clear the in-memory price cache. Exposed for unit testing only. */
+export function clearCacheForTesting(): void {
+  cache.clear();
+}
 
 function normalizeSymbol(symbol: string): string {
   return symbol.trim().toUpperCase();
@@ -96,6 +119,31 @@ async function fetchCoinGecko(symbol: string): Promise<number | null> {
   }
 }
 
+/**
+ * Pyth Hermes REST fallback (free, no API key).
+ * Returns the USD price or null on any failure.
+ */
+async function fetchPyth(symbol: string): Promise<number | null> {
+  const feedId = PYTH_FEED_IDS[symbol.toUpperCase()];
+  if (!feedId) return null;
+  try {
+    const resp = await fetch(
+      `https://hermes.pyth.network/v2/updates/price/latest?ids[]=${feedId}`,
+      { signal: AbortSignal.timeout(5000) },
+    );
+    if (!resp.ok) return null;
+    const json = (await resp.json()) as {
+      parsed?: Array<{ price?: { price: string; expo: number } }>;
+    };
+    const parsed = json.parsed?.[0]?.price;
+    if (!parsed) return null;
+    const price = Number(parsed.price) * Math.pow(10, parsed.expo);
+    return Number.isFinite(price) && price > 0 ? price : null;
+  } catch {
+    return null;
+  }
+}
+
 // ── Public API ──────────────────────────────────────────
 
 /**
@@ -119,6 +167,14 @@ export async function fetchPrice(symbol: string): Promise<PriceData | null> {
   const cgPrice = await fetchCoinGecko(symbol);
   if (cgPrice !== null) {
     const data: PriceData = { priceUsd: cgPrice, source: "coingecko", timestamp: Date.now() };
+    setCache(symbol, data);
+    return data;
+  }
+
+  // Final fallback: Pyth Hermes REST (free, no key, mainnet prices)
+  const pythPrice = await fetchPyth(symbol);
+  if (pythPrice !== null) {
+    const data: PriceData = { priceUsd: pythPrice, source: "pyth-hermes", timestamp: Date.now() };
     setCache(symbol, data);
     return data;
   }

--- a/bots/devnet-mm/tests/prices.test.ts
+++ b/bots/devnet-mm/tests/prices.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for multi-source price feeds (Binance → CoinGecko → Pyth Hermes).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fetchPrice, fetchPrices, clearCacheForTesting } from "../src/prices.js";
+
+// ── Helpers ─────────────────────────────────────────────
+
+function makeFetchResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+// Pyth response shape for BTC
+const PYTH_BTC_RESPONSE = {
+  parsed: [
+    {
+      price: {
+        price: "6800000000000", // 68000 * 10^8
+        expo: -8,
+      },
+    },
+  ],
+};
+
+// Binance response shape
+const BINANCE_BTC_RESPONSE = { price: "68000.12" };
+
+// CoinGecko response shape
+const CG_BTC_RESPONSE = { bitcoin: { usd: 68001.5 } };
+
+describe("fetchPrice", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    clearCacheForTesting();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    clearCacheForTesting();
+  });
+
+  it("returns Binance price when available", async () => {
+    fetchMock.mockResolvedValueOnce(makeFetchResponse(BINANCE_BTC_RESPONSE));
+
+    const result = await fetchPrice("BTC");
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe("binance");
+    expect(result!.priceUsd).toBeCloseTo(68000.12, 1);
+  });
+
+  it("falls back to CoinGecko when Binance fails", async () => {
+    // Binance fails
+    fetchMock.mockResolvedValueOnce(makeFetchResponse(null, false, 429));
+    // CoinGecko succeeds
+    fetchMock.mockResolvedValueOnce(makeFetchResponse(CG_BTC_RESPONSE));
+
+    const result = await fetchPrice("BTC");
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe("coingecko");
+    expect(result!.priceUsd).toBeCloseTo(68001.5, 1);
+  });
+
+  it("falls back to Pyth Hermes when Binance and CoinGecko both fail", async () => {
+    // Binance 429
+    fetchMock.mockResolvedValueOnce(makeFetchResponse(null, false, 429));
+    // CoinGecko 429
+    fetchMock.mockResolvedValueOnce(makeFetchResponse(null, false, 429));
+    // Pyth succeeds
+    fetchMock.mockResolvedValueOnce(makeFetchResponse(PYTH_BTC_RESPONSE));
+
+    const result = await fetchPrice("BTC");
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe("pyth-hermes");
+    // 6800000000000 * 10^-8 = 68000
+    expect(result!.priceUsd).toBeCloseTo(68000, 0);
+  });
+
+  it("falls back to Pyth when Binance throws and CoinGecko returns non-ok", async () => {
+    // Binance network error
+    fetchMock.mockRejectedValueOnce(new Error("ECONNRESET"));
+    // CoinGecko 503
+    fetchMock.mockResolvedValueOnce(makeFetchResponse(null, false, 503));
+    // Pyth
+    fetchMock.mockResolvedValueOnce(makeFetchResponse(PYTH_BTC_RESPONSE));
+
+    const result = await fetchPrice("BTC");
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe("pyth-hermes");
+  });
+
+  it("returns null when all three sources fail", async () => {
+    fetchMock.mockResolvedValueOnce(makeFetchResponse(null, false, 429));
+    fetchMock.mockResolvedValueOnce(makeFetchResponse(null, false, 429));
+    fetchMock.mockResolvedValueOnce(makeFetchResponse(null, false, 503));
+
+    const result = await fetchPrice("BTC");
+    expect(result).toBeNull();
+  });
+
+  it("returns null for unknown symbols (no mapping in any source)", async () => {
+    // Binance: no mapping (returns null early), CoinGecko: no mapping, Pyth: no mapping
+    const result = await fetchPrice("UNKNOWN_TOKEN");
+    expect(result).toBeNull();
+    // fetch should not have been called since all maps return early
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("handles Pyth response with invalid expo gracefully", async () => {
+    fetchMock.mockResolvedValueOnce(makeFetchResponse(null, false, 429));
+    fetchMock.mockResolvedValueOnce(makeFetchResponse(null, false, 429));
+    fetchMock.mockResolvedValueOnce(
+      makeFetchResponse({ parsed: [{ price: { price: "abc", expo: -8 } }] }),
+    );
+
+    // NaN price — should return null
+    const result = await fetchPrice("SOL");
+    expect(result).toBeNull();
+  });
+
+  it("handles Pyth empty parsed array gracefully", async () => {
+    fetchMock.mockResolvedValueOnce(makeFetchResponse(null, false, 429));
+    fetchMock.mockResolvedValueOnce(makeFetchResponse(null, false, 429));
+    fetchMock.mockResolvedValueOnce(makeFetchResponse({ parsed: [] }));
+
+    const result = await fetchPrice("SOL");
+    expect(result).toBeNull();
+  });
+});
+
+describe("fetchPrices (batch)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    clearCacheForTesting();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    clearCacheForTesting();
+  });
+
+  it("returns prices for all successfully fetched symbols", async () => {
+    // SOL: Binance ok
+    fetchMock.mockResolvedValueOnce(makeFetchResponse({ price: "150.00" }));
+    // BTC: Binance ok
+    fetchMock.mockResolvedValueOnce(makeFetchResponse({ price: "68000.00" }));
+
+    const results = await fetchPrices(["SOL", "BTC"]);
+    expect(results.size).toBe(2);
+    expect(results.get("SOL")!.priceUsd).toBeCloseTo(150, 1);
+    expect(results.get("BTC")!.priceUsd).toBeCloseTo(68000, 1);
+  });
+
+  it("returns partial results when one symbol fails all sources", async () => {
+    // SOL: Binance ok
+    fetchMock.mockResolvedValueOnce(makeFetchResponse({ price: "150.00" }));
+    // ETH: all fail
+    fetchMock.mockResolvedValueOnce(makeFetchResponse(null, false, 429));
+    fetchMock.mockResolvedValueOnce(makeFetchResponse(null, false, 429));
+    fetchMock.mockResolvedValueOnce(makeFetchResponse(null, false, 503));
+
+    const results = await fetchPrices(["SOL", "ETH"]);
+    expect(results.has("SOL")).toBe(true);
+    expect(results.has("ETH")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem
The MM maker bot logs `⚠️ BTC: no price from Binance/CoinGecko, skipping` continuously.
Binance and CoinGecko public (unauthenticated) endpoints are being rate-limited, so quotes=439 but trades=0.

## Fix
Add Pyth Hermes REST API as a 3rd fallback (free, no API key required).

Priority chain: **Binance → CoinGecko → Pyth Hermes**

Pyth Hermes endpoint:
```
https://hermes.pyth.network/v2/updates/price/latest?ids[]=<feed_id>
```

Symbols with Pyth feed IDs: SOL, BTC, ETH, BONK, WIF, JUP, PYTH, RAY, JTO, RNDR.

## Tests
10 new unit tests covering all fallback paths (65 total, all passing):
- Binance ok → returns binance
- Binance 429 → CoinGecko ok → returns coingecko
- Binance 429 → CoinGecko 429 → Pyth ok → returns pyth-hermes
- All fail → null
- Unknown symbol → null, no fetch called
- Pyth invalid/empty response → null

## How to test
Deploy to Railway and verify the maker no longer logs `skipping` for BTC/SOL when exchange feeds are rate-limited.