### PR TITLE
fix: MM bot RPC 429 crash — throttle setup, handle UserExists, global error handlers

### DIFF
--- a/bots/devnet-mm/src/filler.ts
+++ b/bots/devnet-mm/src/filler.ts
@@ -133,6 +133,8 @@ export class FillerBot {
       } catch (e) {
         logError("filler", `Failed to setup ${key.slice(0, 12)}`, e);
       }
+      // Throttle setup: 500ms between markets to avoid RPC 429 floods
+      await new Promise((r) => setTimeout(r, 500));
     }
 
     this.stats.marketsActive = this.markets.size;

--- a/bots/devnet-mm/src/index.ts
+++ b/bots/devnet-mm/src/index.ts
@@ -159,6 +159,26 @@ async function checkPrograms(connection: Connection, config: BotConfig): Promise
 // Main
 // ═══════════════════════════════════════════════════════════════
 
+// ═══════════════════════════════════════════════════════════════
+// Global Error Handlers — prevent Railway restart loops
+// ═══════════════════════════════════════════════════════════════
+
+process.on("unhandledRejection", (reason) => {
+  const msg = reason instanceof Error ? reason.message : String(reason);
+  // 429s during setup are expected under load — log and continue
+  if (msg.includes("429") || msg.includes("Too Many Requests")) {
+    logError("global", `Unhandled 429 (suppressed): ${msg.slice(0, 200)}`);
+    return;
+  }
+  logError("global", `Unhandled rejection: ${msg.slice(0, 300)}`);
+});
+
+process.on("uncaughtException", (err) => {
+  logError("global", `Uncaught exception: ${err.message.slice(0, 300)}`);
+  // Give logger time to flush, then exit
+  setTimeout(() => process.exit(1), 2000);
+});
+
 async function main() {
   const config = loadConfig();
   printBanner(config);

--- a/bots/devnet-mm/src/maker.ts
+++ b/bots/devnet-mm/src/maker.ts
@@ -196,6 +196,8 @@ export class MakerBot {
       } catch (e) {
         logError("maker", `Failed to setup ${key.slice(0, 12)}`, e);
       }
+      // Throttle setup: 500ms between markets to avoid RPC 429 floods
+      await new Promise((r) => setTimeout(r, 500));
     }
 
     this.stats.marketsActive = this.markets.length;

--- a/bots/devnet-mm/src/market.ts
+++ b/bots/devnet-mm/src/market.ts
@@ -233,11 +233,21 @@ async function sendTx(
     // Extract custom program error code if present
     const customMatch = msg.match(/custom program error:\s*0x([0-9a-fA-F]+)/);
     const instrMatch = msg.match(/InstructionError.*?Custom\((\d+)\)/);
-    const errorDetail = customMatch
-      ? `Custom error 0x${customMatch[1]} (${parseInt(customMatch[1], 16)})`
+    const errorCode = customMatch
+      ? parseInt(customMatch[1], 16)
       : instrMatch
-        ? `Custom error ${instrMatch[1]} (0x${Number(instrMatch[1]).toString(16)})`
+        ? Number(instrMatch[1])
         : null;
+    const errorDetail = errorCode !== null
+      ? `Custom error ${errorCode} (0x${errorCode.toString(16)})`
+      : null;
+
+    // Custom:1 = UserExists / LPExists — account already created, treat as success
+    if (errorCode === 1 && (label.includes("InitUser") || label.includes("InitLP"))) {
+      log("tx", `⚠️ ${label} → already exists (Custom:1), skipping`);
+      return "(already-exists)";
+    }
+
     logError("tx", label, errorDetail ? `${errorDetail} — ${msg.slice(0, 200)}` : msg.slice(0, 300));
     return null;
   }


### PR DESCRIPTION
## Problem
devnet-mm-bots DOWN — Railway exhausted 10 restarts. Unhandled 429 exceptions during setup phase.

## Changes
1. Global unhandledRejection/uncaughtException handlers
2. Custom:1 (UserExists/LPExists) treated as success in sendTx
3. 500ms throttle between market setups in discover()

Refs: PERC-562