### PR TITLE
fix(oracle-keeper): block PERCOLATOR-PERP slabs + skip on auth-check failure

### DIFF
--- a/bots/oracle-keeper/index.ts
+++ b/bots/oracle-keeper/index.ts
@@ -46,10 +46,21 @@ const PUSH_INTERVAL_MS = Number(process.env.PUSH_INTERVAL_MS ?? "3000");
 const HEALTH_PORT = Number(process.env.HEALTH_PORT ?? "18810");
 const MAX_PRICE_MOVE_PCT = Number(process.env.MAX_PRICE_MOVE_PCT ?? "10");
 const STALE_THRESHOLD_S = Number(process.env.STALE_THRESHOLD_S ?? "30");
+// Hardcoded slab addresses that can never be fixed (different slab_admin — not our keypair).
+// PERCOLATOR-PERP: user-created markets with slab_admin=3ee9...b55 (not FF7KFfU5...)
+// oracle_authority on-chain = DJKjmSbWjhx925kuk1fS1BENCBnqXCfwUJjb9EKwSEnV ≠ keeper key.
+// Confirmed 2026-03-10: SetOracleAuthority fails with 0xf (admin check).
+const HARDCODED_BLOCKED_MARKETS = new Set<string>([
+  "HjBePQZnoZVftg9B52gyeuHGjBvt2f8FNCVP4FeoP3YT", // PERCOLATOR-PERP-1 (Small)
+  "484DG6KQi5eVXuaXzWxaWMWeXDp9LFXyshNi33UnWfxV", // PERCOLATOR-PERP-2 (Small)
+  "GDyHCzpiuEsWDkLuji3NEFYJfqbDTzMCKn9ugUzTZqAW", // PERCOLATOR-PERP-3 (Large)
+]);
+
 // Comma-separated list of slab addresses to permanently skip (wrong oracle_authority, etc.)
-const ORACLE_KEEPER_BLOCKED_MARKETS = new Set<string>(
-  (process.env.ORACLE_KEEPER_BLOCKED_MARKETS ?? "").split(",").map(s => s.trim()).filter(Boolean)
-);
+const ORACLE_KEEPER_BLOCKED_MARKETS = new Set<string>([
+  ...HARDCODED_BLOCKED_MARKETS,
+  ...(process.env.ORACLE_KEEPER_BLOCKED_MARKETS ?? "").split(",").map(s => s.trim()).filter(Boolean),
+]);
 const ADMIN_KP_PATH = process.env.ADMIN_KEYPAIR_PATH ??
   `${process.env.HOME}/.config/solana/percolator-upgrade-authority.json`;
 const RPC_URL = process.env.RPC_URL ?? "https://api.devnet.solana.com";
@@ -343,8 +354,11 @@ async function pushAndCrank(market: MarketInfo, programId: PublicKey): Promise<v
       authorityVerified.add(market.slab);
       log(`✓ ${market.label}: oracle authority verified (${admin.publicKey.toBase58().slice(0, 12)}...)`);
     } catch (e) {
-      log(`⚠️ ${market.label}: failed to verify oracle authority (attempt ${s.totalErrors + 1}): ${(e as Error).message?.slice(0, 80)}`);
-      // Continue anyway — the tx will fail with a clear program error if authority is wrong
+      // fetchSlab/parseConfig failed — we cannot confirm we have authority.
+      // Skip this tick rather than pushing blindly and generating 'Provided owner is not allowed' spam.
+      log(`⚠️ ${market.label}: failed to verify oracle authority — skipping tick (attempt ${s.totalErrors + 1}): ${(e as Error).message?.slice(0, 80)}`);
+      s.totalErrors++;
+      return;
     }
   }
 

--- a/scripts/fix-oracle-authority-percolator-perp.ts
+++ b/scripts/fix-oracle-authority-percolator-perp.ts
@@ -1,0 +1,166 @@
+/**
+ * Fix oracle_authority mismatch for PERCOLATOR-PERP slabs
+ *
+ * DevOps reported: oracle-keeper failing with 'Provided owner is not allowed'
+ * every 3-4 seconds on PERCOLATOR-PERP (dynamic). BTC-PERP-1/2 healthy.
+ *
+ * Slabs (3 total — 2 Small, 1 Large):
+ *   HjBePQZnoZVftg9B52gyeuHGjBvt2f8FNCVP4FeoP3YT  → Small  (FwfBKZX...)
+ *   484DG6KQi5eVXuaXzWxaWMWeXDp9LFXyshNi33UnWfxV  → Small  (FwfBKZX...)
+ *   GDyHCzpiuEsWDkLuji3NEFYJfqbDTzMCKn9ugUzTZqAW  → Large  (FxfD37s...)
+ *
+ * Admin: percolator-upgrade-authority.json (FF7KFfU5...)
+ * Sets oracle_authority = admin pubkey so the keeper can push prices.
+ *
+ * Usage:
+ *   npx tsx scripts/fix-oracle-authority-percolator-perp.ts [--dry-run]
+ *   ADMIN_KEYPAIR_PATH=/path/to/key.json npx tsx scripts/fix-oracle-authority-percolator-perp.ts
+ */
+
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  Transaction,
+  ComputeBudgetProgram,
+  sendAndConfirmTransaction,
+} from "@solana/web3.js";
+import fs from "fs";
+import path from "path";
+import {
+  encodeSetOracleAuthority,
+  buildAccountMetas,
+  ACCOUNTS_SET_ORACLE_AUTHORITY,
+  buildIx,
+} from "../packages/core/src/index.js";
+
+const SMALL_PROGRAM = new PublicKey("FwfBKZXbYr4vTK23bMFkbgKq3npJ3MSDxEaKmq9Aj4Qn");
+const LARGE_PROGRAM = new PublicKey("FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD");
+const RPC_URL = process.env.RPC_URL || "https://api.devnet.solana.com";
+
+// V0 layout: HEADER_LEN=72, oracle_authority at offset 72+32=104
+const HEADER_LEN = 72;
+const ORACLE_AUTH_OFFSET = HEADER_LEN + 32; // 104
+
+const SLABS: { name: string; address: string; program: PublicKey }[] = [
+  {
+    name: "PERCOLATOR-PERP-1",
+    address: "HjBePQZnoZVftg9B52gyeuHGjBvt2f8FNCVP4FeoP3YT",
+    program: SMALL_PROGRAM,
+  },
+  {
+    name: "PERCOLATOR-PERP-2",
+    address: "484DG6KQi5eVXuaXzWxaWMWeXDp9LFXyshNi33UnWfxV",
+    program: SMALL_PROGRAM,
+  },
+  {
+    name: "PERCOLATOR-PERP-3",
+    address: "GDyHCzpiuEsWDkLuji3NEFYJfqbDTzMCKn9ugUzTZqAW",
+    program: LARGE_PROGRAM,
+  },
+];
+
+async function main() {
+  const adminPath =
+    process.env.ADMIN_KEYPAIR_PATH ??
+    path.join(process.env.HOME!, ".config/solana/percolator-upgrade-authority.json");
+
+  const adminKp = Keypair.fromSecretKey(
+    Uint8Array.from(JSON.parse(fs.readFileSync(adminPath, "utf8")))
+  );
+
+  const conn = new Connection(RPC_URL, "confirmed");
+  const dryRun = process.argv.includes("--dry-run");
+
+  console.log("=".repeat(60));
+  console.log("Fix oracle_authority — PERCOLATOR-PERP (all 3 slabs)");
+  console.log("=".repeat(60));
+  console.log("Admin:             ", adminKp.publicKey.toBase58());
+  console.log("New oracle_auth:   ", adminKp.publicKey.toBase58());
+  console.log("Dry run:           ", dryRun);
+  console.log();
+
+  let successCount = 0;
+  let failCount = 0;
+
+  for (const slab of SLABS) {
+    const slabPubkey = new PublicKey(slab.address);
+    console.log(`--- ${slab.name} (${slab.address}) ---`);
+    console.log(`    Program: ${slab.program.toBase58()}`);
+
+    const accountInfo = await conn.getAccountInfo(slabPubkey);
+    if (!accountInfo) {
+      console.log("  ❌ Slab not found on-chain — skipping");
+      failCount++;
+      console.log();
+      continue;
+    }
+
+    console.log(`  Size: ${accountInfo.data.length} bytes`);
+    console.log(`  On-chain owner: ${accountInfo.owner.toBase58()}`);
+
+    // Read current oracle_authority from raw slab data
+    if (accountInfo.data.length > ORACLE_AUTH_OFFSET + 32) {
+      const currentOracleAuth = new PublicKey(
+        accountInfo.data.slice(ORACLE_AUTH_OFFSET, ORACLE_AUTH_OFFSET + 32)
+      );
+      console.log(`  Current oracle_authority: ${currentOracleAuth.toBase58()}`);
+      if (currentOracleAuth.equals(adminKp.publicKey)) {
+        console.log("  ✅ oracle_authority already correct — skipping");
+        successCount++;
+        console.log();
+        continue;
+      }
+    }
+
+    if (dryRun) {
+      console.log(
+        `  🔍 DRY RUN — would call SetOracleAuthority(newAuthority=${adminKp.publicKey.toBase58()})`
+      );
+      console.log();
+      continue;
+    }
+
+    const data = encodeSetOracleAuthority({ newAuthority: adminKp.publicKey });
+    const keys = buildAccountMetas(ACCOUNTS_SET_ORACLE_AUTHORITY, [
+      adminKp.publicKey,
+      slabPubkey,
+    ]);
+
+    const tx = new Transaction().add(
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 50_000 }),
+      ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 50_000 }),
+      buildIx({ programId: slab.program, keys, data })
+    );
+
+    try {
+      const sig = await sendAndConfirmTransaction(conn, tx, [adminKp], {
+        commitment: "confirmed",
+      });
+      console.log("  ✅ SetOracleAuthority success:", sig);
+      console.log(
+        "  Explorer: https://explorer.solana.com/tx/" + sig + "?cluster=devnet"
+      );
+      successCount++;
+    } catch (err) {
+      const e = err as Error & { logs?: string[] };
+      console.log("  ❌ SetOracleAuthority failed:", e.message);
+      if (e.logs) {
+        console.log("  Program logs:", e.logs.slice(-8).join("\n    "));
+      }
+      failCount++;
+    }
+    console.log();
+  }
+
+  console.log("=".repeat(60));
+  console.log(`Done. ${successCount} fixed, ${failCount} failed.`);
+  if (failCount > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});


### PR DESCRIPTION
## Problem

DevOps reported oracle-keeper spamming `Provided owner is not allowed` on **PERCOLATOR-PERP (dynamic)** every 3-4 seconds.

**Root cause investigation:**
1. Ran `fix-oracle-authority-percolator-perp.ts --dry-run` → confirmed 3 slabs have `oracle_authority=DJKjmSbWjhx925kuk1fS1BENCBnqXCfwUJjb9EKwSEnV` (not our keeper key FF7KFfU5...)
2. Ran `fix-oracle-authority-percolator-perp.ts` → all 3 fail with `0x0f` (admin check) — these slabs have `slab_admin=3ee9...b55`, created by a user, not us
3. We cannot call `SetOracleAuthority` without the market creator's keypair

**Two bugs fixed:**
- The keeper was trying to push prices to markets it doesn't control
- When the on-chain authority check throws (fetchSlab/parseConfig failure), the old code fell through and pushed anyway — generating the error spam

## Changes

### `bots/oracle-keeper/index.ts`
- Added `HARDCODED_BLOCKED_MARKETS` set with 3 PERCOLATOR-PERP slabs
- Merged with `ORACLE_KEEPER_BLOCKED_MARKETS` env var (both remain functional)
- Fixed authority-check catch block: now skips the tick instead of continuing blindly

### `scripts/fix-oracle-authority-percolator-perp.ts`
- Investigation script (documents the 3 slabs, their programs, the mismatch)

## Slabs blocked

| Slab | Program | Size |
|------|---------|------|
| HjBePQZnoZVftg9B52gyeuHGjBvt2f8FNCVP4FeoP3YT | Small (FwfBKZX...) | 65352 |
| 484DG6KQi5eVXuaXzWxaWMWeXDp9LFXyshNi33UnWfxV | Small (FwfBKZX...) | 65352 |
| GDyHCzpiuEsWDkLuji3NEFYJfqbDTzMCKn9ugUzTZqAW | Large (FxfD37s...) | 1025832 |

## Testing
- `npx tsx --check bots/oracle-keeper/index.ts` ✅ clean
- Dry-run confirmed all 3 slabs found on-chain, authority mismatch confirmed
- After deploy: keeper error spam should stop; blocked markets log `⛔` at startup

## Deploy
Railway oracle-keeper service needs redeploy after merge. No env var changes needed (hardcoded).