### PR TITLE
fix(mm): derive Pyth push oracle PDA for non-hyperp crank + executeTrade

### DIFF
--- a/bots/devnet-mm/src/market.ts
+++ b/bots/devnet-mm/src/market.ts
@@ -39,6 +39,7 @@ import {
   WELL_KNOWN,
   deriveVaultAuthority,
   deriveLpPda,
+  derivePythPushOraclePDA,
   discoverMarkets,
   parseAllAccounts,
   type DiscoveredMarket,
@@ -80,6 +81,8 @@ export interface ManagedMarket {
   matcherProgram: PublicKey;
   matcherContext: PublicKey;
   oracleMode: "authority" | "pyth";
+  /** Hex-encoded Pyth feed ID (64 chars). All-zeros for authority-mode markets. */
+  oracleFeedHex: string;
   // State tracking
   positionSize: bigint;
   collateral: bigint;
@@ -547,6 +550,7 @@ export async function setupMarketAccounts(
     matcherProgram: lpAccount.account.matcherProgram ?? config.matcherProgramId,
     matcherContext: lpAccount.account.matcherContext ?? PublicKey.default,
     oracleMode: isHyperp ? "authority" : "pyth",
+    oracleFeedHex: feedHex,
     positionSize: userAccount.account.positionSize ?? 0n,
     collateral: userAccount.account.capital ?? depositCollateral,
     lastOraclePriceE6: 0n,
@@ -570,7 +574,10 @@ export async function crankMarket(
   rpc?: ResilientRpc,
 ): Promise<boolean> {
   const crankData = encodeKeeperCrank({ callerIdx: 65535, allowPanic: false });
-  const oracleKey = market.oracleMode === "authority" ? market.slabAddress : market.slabAddress; // TODO: derive pyth PDA
+  const oracleKey =
+    market.oracleMode === "authority"
+      ? market.slabAddress
+      : derivePythPushOraclePDA(market.oracleFeedHex)[0];
   const crankKeys = buildAccountMetas(ACCOUNTS_KEEPER_CRANK, [
     wallet.publicKey,
     market.slabAddress,
@@ -625,7 +632,10 @@ export async function executeTrade(
 
   // Crank first to apply latest oracle
   const crankData = encodeKeeperCrank({ callerIdx: 65535, allowPanic: false });
-  const oracleKey = market.oracleMode === "authority" ? market.slabAddress : market.slabAddress;
+  const oracleKey =
+    market.oracleMode === "authority"
+      ? market.slabAddress
+      : derivePythPushOraclePDA(market.oracleFeedHex)[0];
   const crankKeys = buildAccountMetas(ACCOUNTS_KEEPER_CRANK, [
     wallet.publicKey, market.slabAddress, SYSVAR_CLOCK_PUBKEY, oracleKey,
   ]);


### PR DESCRIPTION
## What

Both `crankMarket()` and `executeTrade()` in `bots/devnet-mm/src/market.ts` were using `market.slabAddress` as the oracle key for **both** authority-mode and Pyth-mode markets (duplicate TODO with copy-paste bug).

For Pyth-mode markets the on-chain program expects the Pyth push oracle PDA derived from the feed ID hex — not the slab address.

## Changes

- Added `oracleFeedHex: string` to `ManagedMarket` interface (already computed at setup from `market.config.indexFeedId`, no extra RPC call)
- Imported `derivePythPushOraclePDA` from `@percolator/sdk`
- Both crank sites now compute: `oracleKey = authority ? slabAddress : derivePythPushOraclePDA(oracleFeedHex)[0]`

Matches the exact pattern already used in `packages/keeper/src/services/crank.ts` (line 249) and `liquidation.ts`.

## Why

On devnet all current markets are hyperp (authority mode) so the bug is silent. When Pyth-mode markets go live (mainnet), cranking and executing trades on those markets would silently pass the wrong account, likely causing a program error.

## Testing
- All 59 bot tests pass
- TypeScript: no errors in market.ts

## Reviewer note
This is a correctness fix for a pre-mainnet bug. Low risk — authority-mode markets are unaffected (slabAddress path unchanged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Markets now support per-market Pyth oracle feed identifiers for improved oracle account derivation during crank operations and trade execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->