### PR TITLE
fix(P0): force slab refetch after deposit/withdraw so balance updates immediately

### DIFF
--- a/app/__tests__/hooks/useDeposit.test.ts
+++ b/app/__tests__/hooks/useDeposit.test.ts
@@ -84,6 +84,7 @@ describe("useDeposit", () => {
         vaultPubkey: mockVault,
       },
       programId: mockProgramId,
+      refresh: vi.fn(),
     };
 
     ( useConnectionCompat as any).mockReturnValue({ connection: mockConnection });
@@ -312,7 +313,7 @@ describe("useDeposit", () => {
     });
 
     it("should throw error if market config not loaded", async () => {
-      (useSlabState as any).mockReturnValue({ config: null, programId: null });
+      (useSlabState as any).mockReturnValue({ config: null, programId: null, refresh: vi.fn() });
 
       const { result } = renderHook(() => useDeposit(mockSlabAddress));
 

--- a/app/__tests__/hooks/useWithdraw.test.ts
+++ b/app/__tests__/hooks/useWithdraw.test.ts
@@ -95,6 +95,7 @@ describe("useWithdraw", () => {
         authorityPriceE6: 1000000n,
       },
       programId: mockProgramId,
+      refresh: vi.fn(),
     };
 
     ( useConnectionCompat as any).mockReturnValue({ connection: mockConnection });
@@ -407,7 +408,7 @@ describe("useWithdraw", () => {
     });
 
     it("should throw error if market config not loaded", async () => {
-      (useSlabState as any).mockReturnValue({ config: null, programId: null });
+      (useSlabState as any).mockReturnValue({ config: null, programId: null, refresh: vi.fn() });
 
       const { result } = renderHook(() => useWithdraw(mockSlabAddress));
 

--- a/app/components/providers/SlabProvider.tsx
+++ b/app/components/providers/SlabProvider.tsx
@@ -42,7 +42,17 @@ export interface SlabState {
   programId: PublicKey | null;
 }
 
-const defaultState: SlabState = {
+/** Full context value exposed to consumers — includes stable callbacks on top of SlabState. */
+export interface SlabContextValue extends SlabState {
+  /**
+   * Force an immediate re-fetch of the slab account from the RPC.
+   * Call this after any tx that mutates the slab (deposit, withdraw, open/close position)
+   * so the UI reflects the confirmed on-chain state without waiting for the next poll cycle.
+   */
+  refresh: () => void;
+}
+
+const defaultSlabState: SlabState = {
   slabAddress: "",
   raw: null,
   header: null,
@@ -55,7 +65,9 @@ const defaultState: SlabState = {
   programId: null,
 };
 
-const SlabContext = createContext<SlabState>(defaultState);
+const defaultContextValue: SlabContextValue = { ...defaultSlabState, refresh: () => {} };
+
+const SlabContext = createContext<SlabContextValue>(defaultContextValue);
 
 export const useSlabState = () => useContext(SlabContext);
 
@@ -63,7 +75,7 @@ const POLL_INTERVAL_MS = 3000;
 
 export const SlabProvider: FC<{ children: ReactNode; slabAddress: string }> = ({ children, slabAddress }) => {
   const { connection } = useConnectionCompat();
-  const [state, setState] = useState<SlabState>({ ...defaultState, slabAddress });
+  const [state, setState] = useState<SlabState>({ ...defaultSlabState, slabAddress });
   const wsActive = useRef(false);
   const fetchRef = useRef<() => void>(() => {});
 
@@ -212,5 +224,11 @@ export const SlabProvider: FC<{ children: ReactNode; slabAddress: string }> = ({
     return () => document.removeEventListener("visibilitychange", handler);
   }, []);
 
-  return <SlabContext.Provider value={state}>{children}</SlabContext.Provider>;
+  const refresh = useCallback(() => { fetchRef.current(); }, []);
+
+  return (
+    <SlabContext.Provider value={{ ...state, refresh }}>
+      {children}
+    </SlabContext.Provider>
+  );
 };

--- a/app/hooks/useDeposit.ts
+++ b/app/hooks/useDeposit.ts
@@ -17,7 +17,7 @@ import { useSlabState } from "@/components/providers/SlabProvider";
 export function useDeposit(slabAddress: string) {
   const { connection } = useConnectionCompat();
   const wallet = useWalletCompat();
-  const { config: mktConfig, programId: slabProgramId } = useSlabState();
+  const { config: mktConfig, programId: slabProgramId, refresh: refreshSlab } = useSlabState();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inflightRef = useRef(false);
@@ -51,7 +51,13 @@ export function useDeposit(slabAddress: string) {
           ]),
           data: encodeDepositCollateral({ userIdx: params.userIdx, amount: params.amount.toString() }),
         });
-        return await sendTx({ connection, wallet, instructions: [ix] });
+        const sig = await sendTx({ connection, wallet, instructions: [ix] });
+        // P0 fix: force immediate slab re-read so balance updates without waiting
+        // for the next poll cycle (which can be up to 30s when WS is active).
+        refreshSlab();
+        // Re-read again after a short delay to catch any propagation lag on devnet RPCs.
+        setTimeout(() => refreshSlab(), 2000);
+        return sig;
       } catch (e) {
         setError(e instanceof Error ? e.message : String(e));
         throw e;
@@ -60,7 +66,7 @@ export function useDeposit(slabAddress: string) {
         setLoading(false);
       }
     },
-    [connection, wallet, mktConfig, slabAddress, slabProgramId]
+    [connection, wallet, mktConfig, slabAddress, slabProgramId, refreshSlab]
   );
 
   return { deposit, loading, error };

--- a/app/hooks/useWithdraw.ts
+++ b/app/hooks/useWithdraw.ts
@@ -23,7 +23,7 @@ import { useSlabState } from "@/components/providers/SlabProvider";
 export function useWithdraw(slabAddress: string) {
   const { connection } = useConnectionCompat();
   const wallet = useWalletCompat();
-  const { config: mktConfig, programId: slabProgramId } = useSlabState();
+  const { config: mktConfig, programId: slabProgramId, refresh: refreshSlab } = useSlabState();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inflightRef = useRef(false);
@@ -109,7 +109,11 @@ export function useWithdraw(slabAddress: string) {
           data: encodeWithdrawCollateral({ userIdx: params.userIdx, amount: params.amount.toString() }),
         }));
 
-        return await sendTx({ connection, wallet, instructions, computeUnits: 300_000 });
+        const sig = await sendTx({ connection, wallet, instructions, computeUnits: 300_000 });
+        // Force immediate slab re-read so balance updates without waiting for the next poll.
+        refreshSlab();
+        setTimeout(() => refreshSlab(), 2000);
+        return sig;
       } catch (e) {
         setError(e instanceof Error ? e.message : String(e));
         throw e;
@@ -118,7 +122,7 @@ export function useWithdraw(slabAddress: string) {
         setLoading(false);
       }
     },
-    [connection, wallet, mktConfig, slabAddress, slabProgramId]
+    [connection, wallet, mktConfig, slabAddress, slabProgramId, refreshSlab]
   );
 
   return { withdraw, loading, error };


### PR DESCRIPTION
## Problem
After a `depositCollateral` tx confirms on-chain, the UI balance was not updating. The slab account was only refreshed on the next poll cycle — up to **30 seconds** when WebSocket subscription is active.

## Root Cause
`SlabProvider` uses an adaptive polling strategy:
- WS active → 30s poll interval
- No WS → 3s poll interval

`useDeposit` and `useWithdraw` send the tx and return the signature, but never triggered a forced re-read of the slab account. UI balance stayed stale until the next scheduled poll.

## Fix

**`SlabProvider.tsx`**
- Added `SlabContextValue` interface extending `SlabState` with a stable `refresh: () => void` callback
- `refresh` maps to `fetchRef.current` — triggers an immediate RPC poll of the slab account without disturbing the poll loop

**`useDeposit.ts` / `useWithdraw.ts`**
- Pull `refresh` from `useSlabState()`
- After `sendTx` confirms: call `refresh()` immediately, then again after 2 seconds to catch any devnet RPC propagation lag

**Tests**
- Added `refresh: vi.fn()` to mock slab state in `useDeposit.test.ts` and `useWithdraw.test.ts` to prevent `TypeError: refreshSlab is not a function`

## Test Results
```
Test Files  73 passed | 2 skipped (75)
Tests      904 passed | 34 skipped (938)
```

## How to Test
1. Connect wallet on devnet
2. Deposit any amount → balance should update within 1-2 seconds of tx confirmation (not 30s)
3. Withdraw → same

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Account balances now automatically refresh immediately after deposits and withdrawals are completed, ensuring you see the most current state
* Implemented manual refresh capability in the state management system to allow on-demand updates of account information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->