### PR TITLE
Enhance crankAll with detailed skipped market tracking

### DIFF
--- a/packages/keeper/src/services/crank.ts
+++ b/packages/keeper/src/services/crank.ts
@@ -332,36 +332,49 @@ export class CrankService {
   }
 
   async crankAll(): Promise<{ success: number; failed: number; skipped: number }> {
-    let success = 0;
-    let failed = 0;
-    let skipped = 0;
+  let success = 0;
+  let failed = 0;
 
-    const MAX_CONSECUTIVE_FAILURES = 10;
+  // NEW: split skipped into categories
+  let skippedPermanent = 0;
+  let skippedFailures = 0;
+  let skippedNotDue = 0;
 
-    const toCrank: string[] = [];
+  const MAX_CONSECUTIVE_FAILURES = 10;
 
-    // H5: Crank all discovered markets, not just admin-oracle ones
-    for (const [slabAddress, state] of this.markets) {
-      if (state.permanentlySkipped) {
-        skipped++;
-        continue;
-      }
-      if (state.consecutiveFailures > MAX_CONSECUTIVE_FAILURES) {
-        skipped++;
-        continue;
-      }
+  const toCrank: string[] = [];
 
-      if (!this.isDue(state)) {
-        skipped++;
-        continue;
-      }
-
-      toCrank.push(slabAddress);
+  for (const [slabAddress, state] of this.markets) {
+    if (state.permanentlySkipped) {
+      skippedPermanent++;
+      continue;
     }
-
-    if (toCrank.length !== this.markets.size - skipped) {
-      logger.warn("Crank mismatch", { totalMarkets: this.markets.size, toCrank: toCrank.length, skipped });
+    if (state.consecutiveFailures > MAX_CONSECUTIVE_FAILURES) {
+      skippedFailures++;
+      continue;
     }
+    if (!this.isDue(state)) {
+      skippedNotDue++;
+      continue;
+    }
+    toCrank.push(slabAddress);
+  }
+
+  // NEW: meaningful accounting check
+  const skipped = skippedPermanent + skippedFailures + skippedNotDue;
+  const total = this.markets.size;
+  const accounted = toCrank.length + skipped;
+
+  if (accounted !== total) {
+    logger.warn("Crank accounting mismatch", {
+      totalMarkets: total,
+      toCrank: toCrank.length,
+      skipped,
+      skippedPermanent,
+      skippedFailures,
+      skippedNotDue,
+    });
+  }
 
     // PERC-204: Full parallel fan-out — all market cranks are independent transactions,
     // submit them all simultaneously instead of in sequential batches.


### PR DESCRIPTION
This pull request refines the tracking and reporting of skipped markets in the `CrankService` by categorizing skipped reasons and improving accounting checks. The changes help clarify why markets are skipped and ensure the crank process accounts for all markets.

Improvements to skipped market tracking:

* Split the `skipped` count into three categories: `skippedPermanent`, `skippedFailures`, and `skippedNotDue`, allowing for more granular tracking of why markets are skipped.

Enhancements to crank accounting:

* Added a more meaningful accounting check that verifies all markets are properly accounted for by summing cranked and skipped markets, and logs detailed information if there is a mismatch.Added categories for skipped markets and improved accounting checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved market processing pipeline with enhanced state categorization and refined selection logic.

* **Bug Fixes**
  * Added validation to detect and warn of accounting discrepancies in market processing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->