### PR TITLE
fix(P0): force slab refetch after deposit/withdraw so balance updates immediately

### DIFF
--- a/app/__tests__/hooks/useDeposit.test.ts
+++ b/app/__tests__/hooks/useDeposit.test.ts
@@ -84,6 +84,7 @@ describe("useDeposit", () => {
         vaultPubkey: mockVault,
       },
       programId: mockProgramId,
+      refresh: vi.fn(),
     };
 
     ( useConnectionCompat as any).mockReturnValue({ connection: mockConnection });
@@ -312,7 +313,7 @@ describe("useDeposit", () => {
     });
 
     it("should throw error if market config not loaded", async () => {
-      (useSlabState as any).mockReturnValue({ config: null, programId: null });
+      (useSlabState as any).mockReturnValue({ config: null, programId: null, refresh: vi.fn() });
 
       const { result } = renderHook(() => useDeposit(mockSlabAddress));
 

--- a/app/__tests__/hooks/useWithdraw.test.ts
+++ b/app/__tests__/hooks/useWithdraw.test.ts
@@ -95,6 +95,7 @@ describe("useWithdraw", () => {
         authorityPriceE6: 1000000n,
       },
       programId: mockProgramId,
+      refresh: vi.fn(),
     };
 
     ( useConnectionCompat as any).mockReturnValue({ connection: mockConnection });
@@ -407,7 +408,7 @@ describe("useWithdraw", () => {
     });
 
     it("should throw error if market config not loaded", async () => {
-      (useSlabState as any).mockReturnValue({ config: null, programId: null });
+      (useSlabState as any).mockReturnValue({ config: null, programId: null, refresh: vi.fn() });
 
       const { result } = renderHook(() => useWithdraw(mockSlabAddress));
 

--- a/app/components/providers/SlabProvider.tsx
+++ b/app/components/providers/SlabProvider.tsx
@@ -42,7 +42,17 @@ export interface SlabState {
   programId: PublicKey | null;
 }
 
-const defaultState: SlabState = {
+/** Full context value exposed to consumers — includes stable callbacks on top of SlabState. */
+export interface SlabContextValue extends SlabState {
+  /**
+   * Force an immediate re-fetch of the slab account from the RPC.
+   * Call this after any tx that mutates the slab (deposit, withdraw, open/close position)
+   * so the UI reflects the confirmed on-chain state without waiting for the next poll cycle.
+   */
+  refresh: () => void;
+}
+
+const defaultSlabState: SlabState = {
   slabAddress: "",
   raw: null,
   header: null,
@@ -55,7 +65,9 @@ const defaultState: SlabState = {
   programId: null,
 };
 
-const SlabContext = createContext<SlabState>(defaultState);
+const defaultContextValue: SlabContextValue = { ...defaultSlabState, refresh: () => {} };
+
+const SlabContext = createContext<SlabContextValue>(defaultContextValue);
 
 export const useSlabState = () => useContext(SlabContext);
 
@@ -63,7 +75,7 @@ const POLL_INTERVAL_MS = 3000;
 
 export const SlabProvider: FC<{ children: ReactNode; slabAddress: string }> = ({ children, slabAddress }) => {
   const { connection } = useConnectionCompat();
-  const [state, setState] = useState<SlabState>({ ...defaultState, slabAddress });
+  const [state, setState] = useState<SlabState>({ ...defaultSlabState, slabAddress });
   const wsActive = useRef(false);
   const fetchRef = useRef<() => void>(() => {});
 
@@ -212,5 +224,11 @@ export const SlabProvider: FC<{ children: ReactNode; slabAddress: string }> = ({
     return () => document.removeEventListener("visibilitychange", handler);
   }, []);
 
-  return <SlabContext.Provider value={state}>{children}</SlabContext.Provider>;
+  const refresh = useCallback(() => { fetchRef.current(); }, []);
+
+  return (
+    <SlabContext.Provider value={{ ...state, refresh }}>
+      {children}
+    </SlabContext.Provider>
+  );
 };

--- a/app/hooks/useDeposit.ts
+++ b/app/hooks/useDeposit.ts
@@ -17,7 +17,7 @@ import { useSlabState } from "@/components/providers/SlabProvider";
 export function useDeposit(slabAddress: string) {
   const { connection } = useConnectionCompat();
   const wallet = useWalletCompat();
-  const { config: mktConfig, programId: slabProgramId } = useSlabState();
+  const { config: mktConfig, programId: slabProgramId, refresh: refreshSlab } = useSlabState();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inflightRef = useRef(false);
@@ -51,7 +51,13 @@ export function useDeposit(slabAddress: string) {
           ]),
           data: encodeDepositCollateral({ userIdx: params.userIdx, amount: params.amount.toString() }),
         });
-        return await sendTx({ connection, wallet, instructions: [ix] });
+        const sig = await sendTx({ connection, wallet, instructions: [ix] });
+        // P0 fix: force immediate slab re-read so balance updates without waiting
+        // for the next poll cycle (which can be up to 30s when WS is active).
+        refreshSlab();
+        // Re-read again after a short delay to catch any propagation lag on devnet RPCs.
+        setTimeout(() => refreshSlab(), 2000);
+        return sig;
       } catch (e) {
         setError(e instanceof Error ? e.message : String(e));
         throw e;
@@ -60,7 +66,7 @@ export function useDeposit(slabAddress: string) {
         setLoading(false);
       }
     },
-    [connection, wallet, mktConfig, slabAddress, slabProgramId]
+    [connection, wallet, mktConfig, slabAddress, slabProgramId, refreshSlab]
   );
 
   return { deposit, loading, error };

--- a/app/hooks/useWithdraw.ts
+++ b/app/hooks/useWithdraw.ts
@@ -23,7 +23,7 @@ import { useSlabState } from "@/components/providers/SlabProvider";
 export function useWithdraw(slabAddress: string) {
   const { connection } = useConnectionCompat();
   const wallet = useWalletCompat();
-  const { config: mktConfig, programId: slabProgramId } = useSlabState();
+  const { config: mktConfig, programId: slabProgramId, refresh: refreshSlab } = useSlabState();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inflightRef = useRef(false);
@@ -109,7 +109,11 @@ export function useWithdraw(slabAddress: string) {
           data: encodeWithdrawCollateral({ userIdx: params.userIdx, amount: params.amount.toString() }),
         }));
 
-        return await sendTx({ connection, wallet, instructions, computeUnits: 300_000 });
+        const sig = await sendTx({ connection, wallet, instructions, computeUnits: 300_000 });
+        // Force immediate slab re-read so balance updates without waiting for the next poll.
+        refreshSlab();
+        setTimeout(() => refreshSlab(), 2000);
+        return sig;
       } catch (e) {
         setError(e instanceof Error ? e.message : String(e));
         throw e;
@@ -118,7 +122,7 @@ export function useWithdraw(slabAddress: string) {
         setLoading(false);
       }
     },
-    [connection, wallet, mktConfig, slabAddress, slabProgramId]
+    [connection, wallet, mktConfig, slabAddress, slabProgramId, refreshSlab]
   );
 
   return { withdraw, loading, error };


### PR DESCRIPTION
## Summary

**P0 bug**: deposit/withdraw collateral tx succeeds on-chain but the portfolio balance stays stale until `SlabProvider`'s next poll cycle (up to 30s).

## Root Cause

`SlabProvider` fetches slab account data on mount and via a polling interval + WebSocket subscription. After `depositCollateral`/`withdrawCollateral` confirms, neither `useDeposit` nor `useWithdraw` signalled the provider to re-read — the balance only updated when the next poll fired.

## Fix

- **`SlabProvider.tsx`**: Add `SlabContextValue` interface exposing a stable `refresh()` callback alongside `SlabState`. Internally exposes `fetchRef.current` (the imperative fetch function) so consumers can force an immediate re-read without unmounting.
- **`useDeposit.ts`**: After tx confirmation, call `refresh()` immediately + once more after 2s (covers any finality lag on slow validators).
- **`useWithdraw.ts`**: Same pattern as `useDeposit`.
- **Tests**: Update `useDeposit.test.ts` and `useWithdraw.test.ts` mock contexts to include `refresh: vi.fn()` (prevents TypeError in test suite).

## How to Test

1. Open Portfolio screen → deposit any amount of USDC  
2. Observe balance updates within ~1s (previously could take up to 30s)
3. Same for withdraw  

## Checklist

- [x] Tests pass (all packages green)
- [x] No new ESLint warnings
- [x] Fixes: P0 deposit collateral balance not updating in UI

Closes #PERC-WEB-P0-BALANCE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added automatic state refresh after deposit and withdrawal operations to ensure the interface reflects the latest data, with immediate and delayed refresh cycles to account for network propagation.

## Tests
* Updated test mocks to align with new state management structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->