### PR TITLE
fix(P0): resolve 4 critical bugs from 0xSquid live testing (#PERC-BUG1/2/5/6)

### DIFF
--- a/app/app/api/devnet-mint-token/route.ts
+++ b/app/app/api/devnet-mint-token/route.ts
@@ -137,16 +137,16 @@ export async function POST(req: NextRequest) {
       .eq("mainnet_ca", mainnetCA)
       .maybeSingle();
 
-    if (existing?.devnet_mint) {
-      return NextResponse.json({
-        status: "already_exists",
-        devnetMint: existing.devnet_mint,
-      });
-    }
-
-    // Load mint authority
+    // Load mint authority (needed for both already_exists airdrop and new mint creation)
     const mintAuthKeyJson = process.env.DEVNET_MINT_AUTHORITY_KEYPAIR;
     if (!mintAuthKeyJson) {
+      // If mint authority not configured and an existing mint is found, return it without airdrop
+      if (existing?.devnet_mint) {
+        return NextResponse.json({
+          status: "already_exists",
+          devnetMint: existing.devnet_mint,
+        });
+      }
       return NextResponse.json(
         { error: "Server not configured for minting (DEVNET_MINT_AUTHORITY_KEYPAIR missing)" },
         { status: 500 },
@@ -159,6 +159,13 @@ export async function POST(req: NextRequest) {
     // Fetch token info from DexScreener
     const tokenInfo = await fetchTokenInfo(mainnetCA);
     if (!tokenInfo) {
+      // If we have an existing devnet mint, return it even if token info fetch fails
+      if (existing?.devnet_mint) {
+        return NextResponse.json({
+          status: "already_exists",
+          devnetMint: existing.devnet_mint,
+        });
+      }
       return NextResponse.json(
         { error: "Cannot fetch token info. Token may not have liquidity on any DEX." },
         { status: 400 },
@@ -167,6 +174,65 @@ export async function POST(req: NextRequest) {
 
     const cfg = getConfig();
     const connection = new Connection(cfg.rpcUrl, "confirmed");
+
+    // BUG-1 FIX: If devnet mint already exists, airdrop tokens to creator instead of
+    // creating a new mint. devnet-mirror-mint creates the mint during wizard Step 1, so
+    // by the time this endpoint is called (post-market-creation), the mint already exists.
+    if (existing?.devnet_mint) {
+      try {
+        const existingMintPk = new PublicKey(existing.devnet_mint);
+        const decimals = tokenInfo.decimals;
+        const tokensFloat = AIRDROP_USD_VALUE / tokenInfo.priceUsd;
+        const airdropAmount = BigInt(Math.floor(tokensFloat * 10 ** decimals));
+
+        const creatorAta = await getAssociatedTokenAddress(existingMintPk, creatorPk);
+        const airdropTx = new Transaction();
+
+        // Create creator ATA if it doesn't exist
+        const ataInfo = await connection.getAccountInfo(creatorAta);
+        if (!ataInfo) {
+          airdropTx.add(
+            createAssociatedTokenAccountInstruction(
+              mintAuthority.publicKey,
+              creatorAta,
+              creatorPk,
+              existingMintPk,
+            ),
+          );
+        }
+
+        airdropTx.add(
+          createMintToInstruction(
+            existingMintPk,
+            creatorAta,
+            mintAuthority.publicKey,
+            airdropAmount,
+          ),
+        );
+
+        await sendAndConfirmTransaction(connection, airdropTx, [mintAuthority], {
+          commitment: "confirmed",
+        });
+
+        return NextResponse.json({
+          status: "already_exists",
+          devnetMint: existing.devnet_mint,
+          symbol: tokenInfo.symbol,
+          name: tokenInfo.name,
+          decimals,
+          priceUsd: tokenInfo.priceUsd,
+          airdropTokens: tokensFloat,
+          airdropUsd: AIRDROP_USD_VALUE,
+        });
+      } catch (airdropErr) {
+        // Non-fatal — return existing mint even if airdrop fails
+        console.warn("devnet-mint-token: airdrop to existing mint failed:", airdropErr);
+        return NextResponse.json({
+          status: "already_exists",
+          devnetMint: existing.devnet_mint,
+        });
+      }
+    }
 
     // Create new devnet mint
     const mintKeypair = Keypair.generate();

--- a/app/app/earn/[slab]/page.tsx
+++ b/app/app/earn/[slab]/page.tsx
@@ -4,12 +4,13 @@ import { useEffect, useState, useCallback, useMemo } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import dynamic from 'next/dynamic';
-import { SlabProvider } from '@/components/providers/SlabProvider';
+import { SlabProvider, useSlabState } from '@/components/providers/SlabProvider';
 import { useStakePool } from '@/hooks/useStakePool';
 import { useStakeDeposit } from '@/hooks/useStakeDeposit';
 import { useStakeWithdraw } from '@/hooks/useStakeWithdraw';
 import { useEngineState } from '@/hooks/useEngineState';
 import { useEarnStats, type MarketVaultInfo } from '@/hooks/useEarnStats';
+import { useTokenMeta } from '@/hooks/useTokenMeta';
 import { getSupabase } from '@/lib/supabase';
 import { OiCapMeter } from '@/components/earn/OiCapMeter';
 import { ScrollReveal } from '@/components/ui/ScrollReveal';
@@ -65,6 +66,13 @@ function VaultDetailInner({ slabAddress }: { slabAddress: string }) {
   const { withdraw: stakeWithdraw, loading: withdrawLoading } = useStakeWithdraw();
   const { engine, totalOI, vault: engineVault } = useEngineState();
 
+  // BUG-5 FIX: resolve actual collateral mint from on-chain slab data.
+  // Previously hardcoded to USDC — wrong for coin-margined markets.
+  const { config: slabConfig } = useSlabState();
+  const collateralTokenMeta = useTokenMeta(slabConfig?.collateralMint ?? null);
+  const collateralSymbol = collateralTokenMeta?.symbol ?? 'Token';
+  const collateralDecimals = collateralTokenMeta?.decimals ?? 6;
+
   // Get market info from earn stats
   const { stats: earnStats, loading: earnLoading } = useEarnStats();
   const marketInfo = useMemo<MarketVaultInfo | null>(() => {
@@ -113,7 +121,8 @@ function VaultDetailInner({ slabAddress }: { slabAddress: string }) {
   const maxOI = marketInfo?.maxOI ?? 0;
   const currentOI = marketInfo?.totalOI ?? (totalOI ? Number(totalOI) / 1e6 : 0);
   const estimatedApy = marketInfo?.estimatedApyPct ?? 0;
-  const vaultUsd = Number(poolState.vaultBalance) / 1e6;
+  const collateralScale = Math.pow(10, collateralDecimals);
+  const vaultUsd = Number(poolState.vaultBalance) / collateralScale;
   const insuranceFund = marketInfo?.insuranceFund ?? 0;
 
   return (
@@ -235,8 +244,8 @@ function VaultDetailInner({ slabAddress }: { slabAddress: string }) {
               userLpBalance={poolState.userLpBalance}
               lpSupply={poolState.lpSupply}
               vaultBalance={poolState.vaultBalance}
-              decimals={6}
-              collateralSymbol="USDC"
+              decimals={collateralDecimals}
+              collateralSymbol={collateralSymbol}
               estimatedApyPct={estimatedApy}
               redemptionRateE6={poolState.redemptionRateE6}
               loading={loading}
@@ -250,8 +259,8 @@ function VaultDetailInner({ slabAddress }: { slabAddress: string }) {
               userLpBalance={poolState.userLpBalance}
               vaultBalance={poolState.vaultBalance}
               lpSupply={poolState.lpSupply}
-              decimals={6}
-              collateralSymbol="USDC"
+              decimals={collateralDecimals}
+              collateralSymbol={collateralSymbol}
               loading={loading || depositLoading || withdrawLoading}
               cooldownElapsed={poolState.cooldownElapsed}
               onDeposit={handleDeposit}
@@ -291,7 +300,7 @@ function VaultDetailInner({ slabAddress }: { slabAddress: string }) {
                 label="Deposit Cap"
                 value={
                   poolState.depositCap > 0n
-                    ? `${formatCompact(Number(poolState.depositCap) / 1e6)} USDC`
+                    ? `${formatCompact(Number(poolState.depositCap) / collateralScale)} ${collateralSymbol}`
                     : 'Unlimited'
                 }
               />

--- a/app/app/stake/page.tsx
+++ b/app/app/stake/page.tsx
@@ -426,7 +426,7 @@ function DepositWidget({
                 style={{ fontFamily: "var(--font-mono)" }}
                 title="Click to use max balance"
               >
-                Balance: {walletBalance.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} USDC
+                Balance: {walletBalance.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} {pool?.symbol ?? 'Token'}
               </button>
             )}
           </div>

--- a/app/components/create/StepTokenSelect.tsx
+++ b/app/components/create/StepTokenSelect.tsx
@@ -90,11 +90,38 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
     setMirrorMeta(null);
 
     if (isDevnet) {
-      // DEVNET: Always call mirror-mint to get/create the canonical devnet mint address.
-      // Do NOT early-return — devnetMintAddress must be resolved before the wizard can proceed.
-      setMintNetworkStatus("mirroring");
+      // DEVNET: First check if the mint already exists on devnet.
+      // - If it does (owned by Token Program): it's a devnet-native token — use directly.
+      // - If it doesn't: treat as mainnet CA → call devnet-mirror-mint to create a devnet copy.
+      // BUG-2 FIX: previously always called mirror-mint, which fails for devnet-created tokens
+      // because DexScreener/Jupiter cannot resolve devnet-only addresses on mainnet.
+      setMintNetworkStatus("loading");
       (async () => {
         try {
+          // Step 1: Check if this mint exists on devnet
+          const accountInfo = await connection.getAccountInfo(mintPk);
+          if (cancelled) return;
+
+          const isDevnetNative =
+            accountInfo !== null &&
+            (accountInfo.owner.equals(TOKEN_PROGRAM_ID) ||
+              accountInfo.owner.equals(TOKEN_2022_PROGRAM_ID));
+
+          if (isDevnetNative) {
+            // Mint already exists on devnet — use it directly, no mirror needed.
+            const nativeMeta = tokenMeta
+              ? { name: tokenMeta.name ?? debounced.slice(0, 8), symbol: tokenMeta.symbol ?? debounced.slice(0, 4).toUpperCase(), decimals: tokenMeta.decimals ?? 6 }
+              : { name: `Token ${debounced.slice(0, 6)}`, symbol: debounced.slice(0, 4).toUpperCase(), decimals: 6 };
+            setMirrorMeta(nativeMeta);
+            onDevnetMintResolved?.(debounced, nativeMeta);
+            onTokenResolved(nativeMeta);
+            setMintNetworkStatus("valid");
+            onMintNetworkValidChange?.(true);
+            return;
+          }
+
+          // Step 2: Mint not on devnet → try to mirror from mainnet
+          setMintNetworkStatus("mirroring");
           const resp = await fetch("/api/devnet-mirror-mint", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
@@ -124,7 +151,7 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
         } catch {
           if (!cancelled) {
             setMintNetworkStatus("mirror-failed");
-            setMirrorError("Network error — could not reach mirror-mint endpoint");
+            setMirrorError("Network error — could not validate token");
             onMintNetworkValidChange?.(false);
           }
         }

--- a/app/hooks/useCreateMarket.ts
+++ b/app/hooks/useCreateMarket.ts
@@ -941,11 +941,16 @@ export function useCreateMarket() {
           // Mint devnet token + airdrop $500 to creator
           setState((s) => ({ ...s, stepLabel: "Minting devnet tokens..." }));
           try {
+            // BUG-1 FIX: pass the original mainnet CA (params.mainnetCA), not the
+            // devnet mirror mint address (mintAddr). devnet-mint-token looks up by
+            // mainnet_ca; passing the devnet mirror address causes a DB miss → API
+            // tries to fetch it from DexScreener → fails → creator never gets tokens.
+            const mintTokenCA = params.mainnetCA ?? mintAddr;
             const mintResp = await fetch("/api/devnet-mint-token", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({
-                mainnetCA: mintAddr,
+                mainnetCA: mintTokenCA,
                 marketAddress: slabAddr,
                 creatorWallet: wallet.publicKey.toBase58(),
               }),


### PR DESCRIPTION
## Summary

Fixes 4 of the 6 P0 bugs reported by 0xSquid from live devnet testing at percolatorlaunch.com.

## Bug Fixes

### BUG 1 — Create Market → trading broken (no tokens for InitUser)

**Root cause:** `useCreateMarket.ts` was passing `params.mint.toBase58()` (the devnet mirror address) as `mainnetCA` to `/api/devnet-mint-token`. That endpoint looks up `devnet_mints` by `mainnet_ca`; passing the devnet mirror address caused a DB miss → DexScreener fetch → 400 error → `createState.devnetMint = null` → LaunchSuccess showed "TRADE THIS MARKET" (no airdrop) → creator had no tokens → `DepositWithdrawCard` showed disabled "Create Account" button.

**Fix:**
- `useCreateMarket.ts`: use `params.mainnetCA ?? mintAddr` so the original mainnet CA is passed
- `devnet-mint-token/route.ts`: when `already_exists`, airdrop $500 worth of tokens to creator instead of returning early with no tokens

### BUG 2 — Failed to mirror mainnet token (devnet-native tokens)

**Root cause:** `StepTokenSelect.tsx` always called `/api/devnet-mirror-mint` for any address on devnet, including devnet-created tokens. Mirror-mint calls DexScreener/Jupiter which can't find devnet-only addresses on mainnet → "Cannot fetch token info from mainnet" error → wizard blocked.

**Fix:** On devnet, first check `connection.getAccountInfo` to see if the mint exists on devnet (owned by Token Program). If yes: use it directly as a devnet-native token. Only fall through to mirror-mint if the address doesn't exist on devnet.

### BUG 5 — Earn section: deposit value shown in USDC, deposit fails

**Root cause:** `earn/[slab]/page.tsx` hardcoded `collateralSymbol="USDC"` and `decimals={6}` for the deposit panels, wrong for coin-margined markets where collateral is the token itself (e.g. SOL, BTC).

**Fix:** Import `useSlabState` + `useTokenMeta`, derive actual symbol and decimals from on-chain collateral mint. Pass to `LpPositionDashboard`, `DepositWithdrawPanel`, and deposit cap display.

### BUG 6 — Stake section: hardcoded USDC balance label

**Fix:** `stake/page.tsx` balance label changed from hardcoded `USDC` to `pool.symbol` (already resolved from collateral mint via `useStakePool`).

## Not Fixed Here

- **BUG 3** — Admin stats all zero: `markets_with_stats` view returns no data. Root cause is indexer not writing to `trades`/`positions` tables. PR #1018 (indexer resilience) should help. No frontend code fix applicable.
- **BUG 4** — Trader dashboard zero transactions: Same indexer data issue as BUG 3.

## Tests

```
Test Files  73 passed (75)
Tests       904 passed (938)
```

## How to Test

1. Go to Create Market, paste a mainnet token CA (e.g. JUP, BONK)
2. Complete wizard → market should launch, click "MINT & TRADE" → should receive airdrop, navigate to trade, "Create Account" button should be active
3. Go to Create Market, paste a devnet-native token address → wizard should accept it without mirror-mint error
4. Go to Earn page for any market → token symbol should match the market's collateral (not USDC)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed devnet token creation to properly handle existing tokens and enable airdrop functionality.
* Corrected hardcoded token symbol display to dynamically show actual collateral tokens across staking and earning interfaces.
* Improved token selection flow with enhanced devnet-native token detection, reducing unnecessary mirroring operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->