### PR TITLE
fix: Bug 5+6 — Admin stats zero + Dashboard trade history uses real data

### DIFF
--- a/app/app/admin/page.tsx
+++ b/app/app/admin/page.tsx
@@ -346,27 +346,26 @@ export default function AdminDashboard() {
   const fetchPlatformStats = useCallback(async () => {
     setStatsLoading(true);
     try {
-      const [marketsRes, healthRes] = await Promise.all([
-        getAuthClient()
-          .from("markets_with_stats")
-          .select(
-            "slab_address, total_open_interest, open_interest_long, open_interest_short, volume_24h, trade_count_24h"
-          ),
+      // Use the server-side /api/stats endpoint which:
+      // 1. Uses service role client (bypasses RLS)
+      // 2. Applies activeMarketFilter + isSaneMarketValue (filters sentinel u64::MAX values)
+      // 3. Queries trades table for real trade counts
+      // Previously this queried Supabase directly from the browser client, which
+      // returned empty results due to RLS policy on markets_with_stats.
+      const [statsRes, healthRes] = await Promise.all([
+        fetch("/api/stats")
+          .then((r) => r.json())
+          .catch(() => null),
         fetch("/api/health")
           .then((r) => r.json())
           .catch(() => ({ status: "unknown", checks: {} })),
       ]);
 
-      const markets = (marketsRes.data ?? []) as MarketStat[];
       setPlatformStats({
-        totalMarkets: markets.length,
-        totalVolume24h: markets.reduce((s, m) => s + (m.volume_24h ?? 0), 0),
-        totalOpenInterest: markets.reduce(
-          (s, m) =>
-            s + ((m.open_interest_long ?? 0) + (m.open_interest_short ?? 0)),
-          0
-        ),
-        trades24h: markets.reduce((s, m) => s + (m.trade_count_24h ?? 0), 0),
+        totalMarkets: statsRes?.totalMarkets ?? 0,
+        totalVolume24h: statsRes?.totalVolume24h ?? 0,
+        totalOpenInterest: statsRes?.totalOpenInterest ?? 0,
+        trades24h: statsRes?.trades24h ?? 0,
         health: {
           status: healthRes.status ?? "unknown",
           checks: healthRes.checks ?? {},

--- a/app/components/dashboard/TradeHistory.tsx
+++ b/app/components/dashboard/TradeHistory.tsx
@@ -1,54 +1,99 @@
 "use client";
 
-import { useState, useMemo } from "react";
-import { getMockTradeHistory, type TradeRecord } from "@/lib/mock-dashboard-data";
+/**
+ * Dashboard Trade History — wired to real on-chain data via /api/trader/:wallet/trades.
+ *
+ * Previously used mock data (getMockTradeHistory). Now uses the same API
+ * as the portfolio page's TradeHistoryTable but with dashboard-specific layout.
+ *
+ * Bug 6 fix: "Trader dashboard showing stats but zero transactions"
+ */
 
-type TradeType = "all" | "open" | "close" | "liquidation" | "partial-close";
-type MarketFilter = "all" | string;
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { useWalletCompat } from "@/hooks/useWalletCompat";
+import type { TraderTradeEntry } from "@/app/api/trader/[wallet]/trades/route";
 
-function formatTime(ts: number): string {
+type TradeType = "all" | "long" | "short";
+
+function formatTime(ts: string): string {
   const d = new Date(ts);
-  return d.toLocaleDateString([], { month: "short", day: "numeric" }) + ", " +
-    d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  return (
+    d.toLocaleDateString([], { month: "short", day: "numeric" }) +
+    ", " +
+    d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+  );
 }
 
 function formatUsd(val: number, showSign = false): string {
   const sign = showSign ? (val >= 0 ? "+" : "") : "";
-  return `${sign}$${Math.abs(val).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  return `${sign}$${Math.abs(val).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function shortAddr(addr: string): string {
+  return addr.length > 8 ? `${addr.slice(0, 4)}…${addr.slice(-4)}` : addr;
 }
 
 const PAGE_SIZE = 25;
 
 export function TradeHistory() {
-  const allTrades = useMemo(() => getMockTradeHistory(), []);
-  const [marketFilter, setMarketFilter] = useState<MarketFilter>("all");
-  const [typeFilter, setTypeFilter] = useState<TradeType>("all");
-  const [search, setSearch] = useState("");
-  const [page, setPage] = useState(1);
+  const { publicKey } = useWalletCompat();
+  const wallet = publicKey?.toBase58() ?? null;
 
-  const markets = useMemo(() => {
-    const unique = new Set(allTrades.map((t) => t.market));
-    return ["all", ...Array.from(unique).sort()];
-  }, [allTrades]);
+  const [trades, setTrades] = useState<TraderTradeEntry[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+  const [sideFilter, setSideFilter] = useState<TradeType>("all");
+
+  const offset = (page - 1) * PAGE_SIZE;
+
+  const fetchTrades = useCallback(async () => {
+    if (!wallet) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/trader/${wallet}/trades?limit=${PAGE_SIZE}&offset=${offset}`
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      const data = await res.json();
+      setTrades(data.trades ?? []);
+      setTotal(data.total ?? 0);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load trades");
+    } finally {
+      setLoading(false);
+    }
+  }, [wallet, offset]);
+
+  useEffect(() => {
+    fetchTrades();
+  }, [fetchTrades]);
 
   const filtered = useMemo(() => {
-    return allTrades.filter((t) => {
-      if (marketFilter !== "all" && t.market !== marketFilter) return false;
-      if (typeFilter !== "all" && t.type !== typeFilter) return false;
-      if (search && !t.market.toLowerCase().includes(search.toLowerCase()) && !t.txHash.toLowerCase().includes(search.toLowerCase())) return false;
-      return true;
-    });
-  }, [allTrades, marketFilter, typeFilter, search]);
+    if (sideFilter === "all") return trades;
+    return trades.filter((t) => t.side === sideFilter);
+  }, [trades, sideFilter]);
 
-  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
-  const paginated = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
   const handleExportCsv = () => {
-    const headers = ["Time", "Market", "Side", "Size", "Size USD", "Entry", "Exit", "PnL", "Fees", "Type", "Tx"];
+    const headers = ["Time", "Market", "Side", "Size", "Price", "Fee", "Tx"];
     const rows = filtered.map((t) => [
-      new Date(t.timestamp).toISOString(),
-      t.market, t.side, t.size, t.sizeUsd, t.entryPrice,
-      t.exitPrice ?? "", t.pnl, t.fees, t.type, t.txHash,
+      t.created_at,
+      t.slab_address,
+      t.side,
+      t.size,
+      t.price,
+      t.fee,
+      t.tx_signature ?? "",
     ]);
     const csv = [headers, ...rows].map((r) => r.join(",")).join("\n");
     const blob = new Blob([csv], { type: "text/csv" });
@@ -60,6 +105,21 @@ export function TradeHistory() {
     URL.revokeObjectURL(url);
   };
 
+  if (!wallet) {
+    return (
+      <div className="flex flex-col border border-[var(--border)] bg-[var(--panel-bg)]">
+        <div className="px-5 py-4 border-b border-[var(--border)]">
+          <p className="text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-dim)]">
+            Trade History
+          </p>
+        </div>
+        <div className="flex flex-col items-center justify-center py-12">
+          <p className="text-[13px] text-[var(--text-dim)]">Connect wallet to view trades</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col border border-[var(--border)] bg-[var(--panel-bg)]">
       {/* Header */}
@@ -69,145 +129,137 @@ export function TradeHistory() {
         </p>
         <button
           onClick={handleExportCsv}
-          className="rounded-sm border border-[var(--border)] px-3 py-1 text-[10px] text-[var(--text-muted)] transition-all hover:border-[var(--accent)]/30 hover:text-[var(--text-secondary)]"
+          disabled={filtered.length === 0}
+          className="rounded-sm border border-[var(--border)] px-3 py-1 text-[10px] text-[var(--text-muted)] transition-all hover:border-[var(--accent)]/30 hover:text-[var(--text-secondary)] disabled:opacity-30"
         >
           Export CSV
         </button>
       </div>
 
       {/* Filters */}
-      <div className="flex flex-wrap items-center gap-2 border-b border-[var(--border)] px-5 py-3">
+      <div className="flex items-center gap-2 border-b border-[var(--border)] px-5 py-3">
         <select
-          value={marketFilter}
-          onChange={(e) => { setMarketFilter(e.target.value); setPage(1); }}
+          value={sideFilter}
+          onChange={(e) => {
+            setSideFilter(e.target.value as TradeType);
+          }}
           className="rounded-sm border border-[var(--border)] bg-[var(--bg)] px-3 py-1.5 text-[11px] text-[var(--text-secondary)] outline-none focus:border-[var(--accent)]/30"
         >
-          {markets.map((m) => (
-            <option key={m} value={m}>{m === "all" ? "All Markets" : m}</option>
-          ))}
+          <option value="all">All Sides</option>
+          <option value="long">Long</option>
+          <option value="short">Short</option>
         </select>
-        <select
-          value={typeFilter}
-          onChange={(e) => { setTypeFilter(e.target.value as TradeType); setPage(1); }}
-          className="rounded-sm border border-[var(--border)] bg-[var(--bg)] px-3 py-1.5 text-[11px] text-[var(--text-secondary)] outline-none focus:border-[var(--accent)]/30"
-        >
-          <option value="all">All Types</option>
-          <option value="open">Open</option>
-          <option value="close">Close</option>
-          <option value="liquidation">Liquidation</option>
-          <option value="partial-close">Partial Close</option>
-        </select>
-        <input
-          type="text"
-          placeholder="Search market or tx..."
-          value={search}
-          onChange={(e) => { setSearch(e.target.value); setPage(1); }}
-          className="flex-1 rounded-sm border border-[var(--border)] bg-[var(--bg)] px-3 py-1.5 text-[11px] text-[var(--text)] placeholder-[var(--text-dim)] outline-none focus:border-[var(--accent)]/30 min-w-[140px]"
-        />
       </div>
 
       {/* Table */}
       <div className="overflow-x-auto">
-        <table className="w-full min-w-[700px]">
-          <thead>
-            <tr className="border-b border-[var(--border)] text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">
-              <th className="px-4 py-3 text-left">Time</th>
-              <th className="px-3 py-3 text-left">Market</th>
-              <th className="px-3 py-3 text-left">Side</th>
-              <th className="px-3 py-3 text-right">Size</th>
-              <th className="px-3 py-3 text-right">Entry</th>
-              <th className="px-3 py-3 text-right">Exit</th>
-              <th className="px-3 py-3 text-right">PnL</th>
-              <th className="px-3 py-3 text-right">Fees</th>
-              <th className="px-3 py-3 text-left">Type</th>
-              <th className="px-3 py-3 text-center">Tx</th>
-            </tr>
-          </thead>
-          <tbody>
-            {paginated.length === 0 ? (
-              <tr>
-                <td colSpan={10} className="px-4 py-8 text-center text-[12px] text-[var(--text-dim)]">
-                  No trades match your filters.
-                </td>
+        {loading ? (
+          <div className="flex items-center justify-center py-12">
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-[var(--accent)]/30 border-t-[var(--accent)]" />
+          </div>
+        ) : error ? (
+          <div className="flex flex-col items-center justify-center py-12 gap-2">
+            <p className="text-[12px] text-[var(--short)]">{error}</p>
+            <button
+              onClick={fetchTrades}
+              className="text-[11px] text-[var(--accent)] hover:underline"
+            >
+              Retry
+            </button>
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-12">
+            <p className="text-[13px] text-[var(--text-dim)]">No trades yet</p>
+            <p className="mt-1 text-[10px] text-[var(--text-dim)]/60">
+              Your executed trades will appear here once the trade indexer has processed them.
+            </p>
+            {process.env.NEXT_PUBLIC_SOLANA_NETWORK === "devnet" && (
+              <p className="mt-2 text-[10px] text-[var(--warning)]/60">
+                ⚠ Devnet: trade indexer may not be running. Trades are on-chain but not yet indexed.
+              </p>
+            )}
+          </div>
+        ) : (
+          <table className="w-full min-w-[600px]">
+            <thead>
+              <tr className="border-b border-[var(--border)] text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">
+                <th className="px-4 py-3 text-left">Time</th>
+                <th className="px-3 py-3 text-left">Market</th>
+                <th className="px-3 py-3 text-left">Side</th>
+                <th className="px-3 py-3 text-right">Size</th>
+                <th className="px-3 py-3 text-right">Price</th>
+                <th className="px-3 py-3 text-right">Fee</th>
+                <th className="px-3 py-3 text-center">Tx</th>
               </tr>
-            ) : (
-              paginated.map((trade) => (
+            </thead>
+            <tbody>
+              {filtered.map((trade) => (
                 <tr
                   key={trade.id}
-                  className={[
-                    "border-b border-[rgba(255,255,255,0.04)] text-[11px] transition-colors hover:bg-[rgba(255,255,255,0.02)]",
-                    trade.type === "liquidation" ? "bg-[var(--short)]/[0.04]" : "",
-                    trade.pnl >= 0 ? "border-l-2 border-l-[var(--long)]/30" : "border-l-2 border-l-[var(--short)]/30",
-                  ].join(" ")}
+                  className="border-b border-[rgba(255,255,255,0.04)] text-[11px] transition-colors hover:bg-[rgba(255,255,255,0.02)]"
                 >
-                  <td className="px-4 py-2.5 text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
-                    {formatTime(trade.timestamp)}
+                  <td
+                    className="px-4 py-2.5 text-[var(--text-secondary)]"
+                    style={{ fontFamily: "var(--font-jetbrains-mono)" }}
+                  >
+                    {formatTime(trade.created_at)}
                   </td>
                   <td className="px-3 py-2.5">
                     <span className="rounded border border-[var(--accent)]/20 bg-[var(--accent)]/5 px-1.5 py-0.5 text-[10px] font-bold text-[var(--accent)]">
-                      {trade.market}
+                      {shortAddr(trade.slab_address)}
                     </span>
                   </td>
                   <td className="px-3 py-2.5">
                     <span
                       className={`text-[10px] font-bold ${
-                        trade.side === "long" ? "text-[var(--long)]" : "text-[var(--short)]"
+                        trade.side === "long"
+                          ? "text-[var(--long)]"
+                          : "text-[var(--short)]"
                       }`}
                     >
                       {trade.side.toUpperCase()}
                     </span>
                   </td>
-                  <td className="px-3 py-2.5 text-right text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
-                    {trade.size}
-                    <span className="ml-1 text-[var(--text-dim)]">({formatUsd(trade.sizeUsd)})</span>
-                  </td>
-                  <td className="px-3 py-2.5 text-right text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
-                    ${trade.entryPrice.toLocaleString()}
-                  </td>
-                  <td className="px-3 py-2.5 text-right text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
-                    {trade.exitPrice ? `$${trade.exitPrice.toLocaleString()}` : "—"}
-                  </td>
                   <td
-                    className={`px-3 py-2.5 text-right font-bold ${
-                      trade.pnl >= 0 ? "text-[var(--long)]" : "text-[var(--short)]"
-                    }`}
+                    className="px-3 py-2.5 text-right text-[var(--text-secondary)]"
                     style={{ fontFamily: "var(--font-jetbrains-mono)" }}
                   >
-                    {formatUsd(trade.pnl, true)}
+                    {(Number(trade.size) / 1e6).toLocaleString(undefined, {
+                      maximumFractionDigits: 4,
+                    })}
                   </td>
-                  <td className="px-3 py-2.5 text-right text-[var(--text-muted)]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
-                    ${trade.fees.toFixed(2)}
+                  <td
+                    className="px-3 py-2.5 text-right text-[var(--text-secondary)]"
+                    style={{ fontFamily: "var(--font-jetbrains-mono)" }}
+                  >
+                    {formatUsd(trade.price)}
                   </td>
-                  <td className="px-3 py-2.5">
-                    <span
-                      className={[
-                        "rounded px-1.5 py-0.5 text-[9px] font-bold uppercase",
-                        trade.type === "open" ? "bg-[var(--accent)]/10 text-[var(--accent)]" :
-                        trade.type === "close" ? "bg-[var(--text-muted)]/20 text-[var(--text-secondary)]" :
-                        trade.type === "liquidation" ? "bg-[var(--short)]/10 text-[var(--short)]" :
-                        "bg-[var(--warning)]/10 text-[var(--warning)]",
-                      ].join(" ")}
-                    >
-                      {trade.type === "partial-close" ? "Partial" : trade.type}
-                      {trade.type === "liquidation" && " ⚠"}
-                    </span>
+                  <td
+                    className="px-3 py-2.5 text-right text-[var(--text-muted)]"
+                    style={{ fontFamily: "var(--font-jetbrains-mono)" }}
+                  >
+                    {formatUsd(trade.fee)}
                   </td>
                   <td className="px-3 py-2.5 text-center">
-                    <a
-                      href={`https://explorer.solana.com/tx/${trade.txHash}?cluster=devnet`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-[var(--text-dim)] transition-colors hover:text-[var(--accent)]"
-                      title="View on Solana Explorer"
-                    >
-                      ↗
-                    </a>
+                    {trade.tx_signature ? (
+                      <a
+                        href={`https://explorer.solana.com/tx/${trade.tx_signature}?cluster=devnet`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-[var(--text-dim)] transition-colors hover:text-[var(--accent)]"
+                        title="View on Solana Explorer"
+                      >
+                        ↗
+                      </a>
+                    ) : (
+                      "—"
+                    )}
                   </td>
                 </tr>
-              ))
-            )}
-          </tbody>
-        </table>
+              ))}
+            </tbody>
+          </table>
+        )}
       </div>
 
       {/* Pagination */}
@@ -220,7 +272,10 @@ export function TradeHistory() {
           >
             ← Prev
           </button>
-          <span className="text-[10px] text-[var(--text-muted)]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
+          <span
+            className="text-[10px] text-[var(--text-muted)]"
+            style={{ fontFamily: "var(--font-jetbrains-mono)" }}
+          >
             Page {page} of {totalPages}
           </span>
           <button

--- a/app/components/trade/TradeHistoryTable.tsx
+++ b/app/components/trade/TradeHistoryTable.tsx
@@ -108,8 +108,13 @@ export function TradeHistoryTable({
       <div className="border border-dashed border-[var(--border)] bg-[var(--panel-bg)]/50 p-8 text-center">
         <p className="text-[13px] text-[var(--text-dim)]">No trades yet</p>
         <p className="mt-1 text-[10px] text-[var(--text-dim)]/60">
-          Your executed trades will appear here
+          Your executed trades will appear here once the trade indexer has processed them.
         </p>
+        {process.env.NEXT_PUBLIC_SOLANA_NETWORK === "devnet" && (
+          <p className="mt-2 text-[10px] text-[var(--warning)]/60">
+            ⚠ Devnet: trade indexer may not be running. Trades are on-chain but not yet indexed.
+          </p>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## What

### Bug 5: Admin page all stats zero
**Root cause**: Admin page queried `markets_with_stats` directly from the browser Supabase client using the anon key. RLS policy blocks this → query returns empty → all stats show 0.

**Fix**: Use the existing `/api/stats` endpoint which uses the service role client, applies `isActiveMarket()` / `isSaneMarketValue()` filters, and queries the `trades` table for real trade counts.

### Bug 6: Dashboard trade history showing zero transactions
**Root cause**: The Dashboard's `TradeHistory` component used `getMockTradeHistory()` — hardcoded mock data that was never wired to real on-chain trades. The user saw fake mock stats from other dashboard components but the trade history didn't reflect their actual wallet activity.

**Fix**: Rewired `TradeHistory` to use `/api/trader/:wallet/trades` (the same API the portfolio page uses). Added devnet warning when the trades table is empty explaining the indexer may not be running.

### Note
Trade history on devnet requires the trade indexer to be deployed and running. Will message devops about this.

## Testing
1. Admin page: stats should show real market counts, volume, and OI
2. Dashboard: trade history shows real trades (if indexer is running) or clear empty state
3. Portfolio page: unchanged (already uses real API)
