### PR TITLE
fix: Upgrade hono to 4.12.7 to fix prototype pollution CVE

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -20,7 +20,7 @@
     "@solana/web3.js": "^1.98.0",
     "@supabase/supabase-js": "^2.49.1",
     "dotenv": "^16.4.7",
-    "hono": "^4.12.2",
+    "hono": "^4.12.7",
     "ws": "^8.18.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- Update hono dependency from ^4.12.2 to ^4.12.7
- Addresses MODERATE severity CVE: Prototype Pollution in parseBody()
- Fixes HonoJS vulnerability that allows __proto__ injection
- Audit reference: Hono CVE (Prototype Pollution via __proto__ key)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend dependencies to latest patch versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->