### PR TITLE
fix: Remove hardcoded Railway hostname fallbacks — require NEXT_PUBLI…

### DIFF
--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -203,13 +203,12 @@ export function setNetwork(network: Network) {
 export function getBackendUrl(): string {
   const url = process.env.NEXT_PUBLIC_API_URL ?? process.env.NEXT_PUBLIC_BACKEND_URL;
   if (!url) {
-    // On non-production, require explicit backend URL to prevent silent proxy to production
-    if (process.env.NODE_ENV !== "production") {
-      throw new Error(
-        "NEXT_PUBLIC_API_URL or NEXT_PUBLIC_BACKEND_URL must be set in non-production environments"
-      );
-    }
-    return "https://percolator-api-production.up.railway.app";
+    // Backend URL is required in all environments — no hardcoded fallback
+    // This prevents misconfigured deployments from silently routing to production
+    throw new Error(
+      "NEXT_PUBLIC_API_URL or NEXT_PUBLIC_BACKEND_URL must be explicitly set. " +
+      "No hardcoded fallback is provided — ensure your environment configuration is correct."
+    );
   }
   return url;
 }

--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://percolator-api1-production.up.railway.app";
+// NEXT_PUBLIC_API_URL must be explicitly set — no hardcoded fallback
+// This ensures misconfigured deployments fail loudly, not silently to production
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+if (!API_URL && process.env.NODE_ENV === "production") {
+  throw new Error(
+    "NEXT_PUBLIC_API_URL environment variable is required in production. " +
+    "Please configure this before deploying."
+  );
+}
 
 const nextConfig: NextConfig = {
   // @solana/kit must be transpiled: its browser export resolves to an ESM .mjs file


### PR DESCRIPTION
…C_API_URL

- Remove hardcoded 'percolator-api-production.up.railway.app' fallback from getBackendUrl()
- Remove hardcoded 'percolator-api1-production.up.railway.app' fallback from next.config.ts
- Throw descriptive error if NEXT_PUBLIC_API_URL is not set
- Prevents misconfigured deployments from silently proxying to production
- Audit reference: F9 - Hardcoded Railway hostname in health route

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed hardcoded API URL fallbacks; all environments now require explicit configuration.
  * Enhanced error handling with clearer messages when API URLs are not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->