### PR TITLE
refactor: Remove unused ORACLE_BRIDGE_URL constant from airdrop endpoint

### DIFF
--- a/app/app/api/airdrop/route.ts
+++ b/app/app/api/airdrop/route.ts
@@ -29,7 +29,6 @@ export const dynamic = "force-dynamic";
 const NETWORK = process.env.NEXT_PUBLIC_SOLANA_NETWORK;
 const AIRDROP_USD_VALUE = 500;
 const RATE_LIMIT_HOURS = 24;
-const ORACLE_BRIDGE_URL = process.env.ORACLE_BRIDGE_URL ?? "http://127.0.0.1:18802";
 
 export async function POST(req: NextRequest) {
   try {


### PR DESCRIPTION
- Remove dead code: const ORACLE_BRIDGE_URL = process.env.ORACLE_BRIDGE_URL ?? ...
- Constant was declared but never used in the endpoint
- Code comment indicates this was removed in favor of markets_with_stats Supabase view
- Audit reference: I1 - Unused ORACLE_BRIDGE_URL constant