### PR TITLE
fix(api): P0 — check mint authority before airdrop, return 400 not 500

### DIFF
--- a/app/app/api/devnet-airdrop/route.ts
+++ b/app/app/api/devnet-airdrop/route.ts
@@ -316,6 +316,45 @@ export async function POST(req: NextRequest) {
       const cfg = getConfig();
       const connection = new Connection(cfg.rpcUrl, "confirmed");
 
+      // Verify we are the mint authority — if not, we cannot mint tokens.
+      // This happens for devnet-native tokens (e.g. user pasted a token address
+      // that exists on devnet but was created by someone else).
+      try {
+        const mintInfo = await connection.getAccountInfo(mintPk);
+        if (!mintInfo) {
+          return NextResponse.json(
+            { error: `Mint ${mintAddress} does not exist on devnet. The token may need to be mirrored first.` },
+            { status: 400 },
+          );
+        }
+        // SPL Token mint layout: bytes 0-3 = coption(u32), bytes 4-35 = mint_authority (32 bytes)
+        // If coption == 0, no mint authority (fixed supply). If coption == 1, authority is at offset 4.
+        const mintData = new Uint8Array(mintInfo.data);
+        if (mintData.length >= 36) {
+          const hasAuthority = new DataView(mintData.buffer, mintData.byteOffset).getUint32(0, true) === 1;
+          if (hasAuthority) {
+            const onChainAuthority = new PublicKey(mintData.slice(4, 36));
+            if (!onChainAuthority.equals(mintAuthority.publicKey)) {
+              return NextResponse.json(
+                {
+                  error: `Cannot mint tokens: this mint's authority is ${onChainAuthority.toBase58().slice(0, 8)}…, not our devnet mint authority. This token was not created by the Percolator mirror system. You need to obtain tokens from the original source.`,
+                  mintAuthority: onChainAuthority.toBase58(),
+                },
+                { status: 400 },
+              );
+            }
+          } else {
+            return NextResponse.json(
+              { error: "This mint has no mint authority (fixed supply). Cannot airdrop new tokens." },
+              { status: 400 },
+            );
+          }
+        }
+      } catch (authCheckErr) {
+        console.warn("[devnet-airdrop] mint authority check failed:", authCheckErr);
+        // Continue anyway — the mintTo will fail with a clear Solana error if authority is wrong
+      }
+
       // Derive user's ATA
       const ata = await getAssociatedTokenAddress(mintPk, walletPk);
       let ataExists = false;


### PR DESCRIPTION
## P0 Bug Fix

### Problem
Market creation for non-mirrored devnet tokens (like `5Sx2...`) throws 'Internal server error' (500) during the token airdrop step. The `MINT & TRADE` button also returns the same 500.

**Root cause**: `/api/devnet-airdrop` calls `createMintToInstruction` with our `DEVNET_MINT_AUTHORITY_KEYPAIR`, but for tokens we didn't create (devnet-native tokens, or mainnet tokens that happen to exist on devnet), we're not the mint authority. Solana rejects the tx, and the generic catch returns 500.

### Fix
Before attempting to mint, verify on-chain that the mint's authority matches our keypair:
- **No mint on-chain** → 400 with 'Mint does not exist on devnet'
- **Wrong authority** → 400 with clear message showing whose authority it is
- **No authority (fixed supply)** → 400 with 'fixed supply, cannot airdrop'
- **Our authority** → proceed with mint (existing behavior)

The frontend already handles 400 responses gracefully — `DevnetTokenFaucetButton` and `LaunchSuccess` both display the error message.

### How to test
1. Create a market using a devnet-native token address (not mirrored)
2. Post-creation airdrop should show a clear error instead of 'Internal server error'
3. Mirror-minted tokens (our authority) should still airdrop normally