### PR TITLE
fix(app): P0 — auto-InitUser before deposit, eliminate silent failures

### DIFF
--- a/app/components/trade/DepositWithdrawCard.tsx
+++ b/app/components/trade/DepositWithdrawCard.tsx
@@ -68,76 +68,33 @@ export const DepositWithdrawCard: FC<DepositWithdrawCardProps> = ({ slabAddress 
     );
   }
 
-  if (!userAccount) {
-    const hasTokens = walletBalance !== null && walletBalance > 0n;
-    const suggestedDeposit = walletBalance !== null && walletBalance > 0n
-      ? walletBalance > 10_000_000n ? 10_000_000n : walletBalance
-      : 0n;
+  // P0 FIX: No separate "Create Account" gate. When userAccount is null,
+  // we fall through to the normal deposit form. The useDeposit hook auto-
+  // bundles InitUser + Deposit in one tx, so users just click "Deposit".
+  // The faucet warning still shows when wallet has no tokens.
+  if (!userAccount && walletBalance !== null && walletBalance === 0n) {
     return (
       <div className="relative rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 p-3">
-        <p className="mb-1 text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Create Account</p>
-        {walletBalance !== null && (
-          <p className="mb-2 text-[10px] text-[var(--text-dim)]" style={{ fontFamily: "var(--font-mono)" }}>
-            Wallet: {formatTokenAmount(walletBalance, decimals)} {symbol}
+        <p className="mb-1 text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Deposit</p>
+        <div className="mb-2 border border-[var(--warning)]/20 bg-[var(--warning)]/[0.04] p-2 space-y-2">
+          <p className="text-[10px] text-[var(--warning)]">
+            You need {symbol} tokens to trade this market.
           </p>
-        )}
-        {!hasTokens && (
-          <div className="mb-2 border border-[var(--warning)]/20 bg-[var(--warning)]/[0.04] p-2 space-y-2">
-            <p className="text-[10px] text-[var(--warning)]">
-              You need {symbol} tokens to trade this market.
-            </p>
-            {/* Show devnet faucet button for all devnet markets */}
-            {mktConfig?.collateralMint ? (
-              <DevnetTokenFaucetButton
-                mintAddress={mktConfig.collateralMint.toBase58()}
-                symbol={symbol}
-              />
-            ) : null}
-          </div>
-        )}
-        {hasTokens ? (
-          <>
-            <p className="mb-2 text-[10px] text-[var(--text-secondary)]">
-              Create an account with an initial deposit to start trading.
-            </p>
-            <button
-              onClick={async () => { 
-                try { 
-                  const sig = await initUser(suggestedDeposit); 
-                  setLastSig(sig ?? null); 
-                } catch (err) {
-                  if (process.env.NODE_ENV === 'development') {
-                    console.error('initUser failed:', err);
-                  }
-                }
-              }}
-              disabled={initLoading}
-              className="w-full rounded-none bg-[var(--accent)] py-2 text-[10px] font-medium uppercase tracking-[0.1em] text-white hover:bg-[var(--accent-muted)] hover:scale-[1.01] active:scale-[0.99] transition-transform disabled:opacity-50"
-            >
-              {initLoading ? "Creating..." : `Create Account (deposit ${formatTokenAmount(suggestedDeposit, decimals)} ${symbol})`}
-            </button>
-          </>
-        ) : (
-          <>
-            <p className="mb-2 text-[10px] text-[var(--text-secondary)]">
-              Get tokens first, then create your account.
-            </p>
-            <button
-              disabled
-              className="w-full rounded-none bg-[var(--bg-surface)] py-2 text-[10px] font-medium text-[var(--text-muted)] cursor-not-allowed opacity-50"
-            >
-              Create Account
-            </button>
-          </>
-        )}
+          {mktConfig?.collateralMint ? (
+            <DevnetTokenFaucetButton
+              mintAddress={mktConfig.collateralMint.toBase58()}
+              symbol={symbol}
+            />
+          ) : null}
+        </div>
         {initError && <p className="mt-2 text-[10px] text-[var(--short)]">{initError}</p>}
-        {lastSig && <p className="mt-2 text-[10px] text-[var(--text-dim)]" style={{ fontFamily: "var(--font-mono)" }}>Tx: {lastSig.slice(0, 12)}...</p>}
+        {depositError && <p className="mt-2 text-[10px] text-[var(--short)]">{depositError}</p>}
       </div>
     );
   }
 
-  const capital = userAccount.account.capital;
-  const positionSize = userAccount.account.positionSize ?? 0n;
+  const capital = userAccount?.account.capital ?? 0n;
+  const positionSize = userAccount?.account.positionSize ?? 0n;
   const loading = mode === "deposit" ? depositLoading : withdrawLoading;
   const error = mode === "deposit" ? depositError : withdrawError;
 
@@ -152,23 +109,27 @@ export const DepositWithdrawCard: FC<DepositWithdrawCardProps> = ({ slabAddress 
   const hasOpenPosition = positionSize !== 0n;
 
   async function handleSubmit() {
-    if (!amount || !userAccount || validationError) return;
+    // Allow deposits without userAccount — useDeposit auto-calls InitUser.
+    // Withdrawals still require an existing account.
+    if (!amount || validationError) return;
+    if (mode === "withdraw" && !userAccount) return;
     if (mockMode) { setAmount(""); return; }
     try {
       const amtNative = maxRawRef.current ?? parseHumanAmount(amount, decimals);
       if (amtNative <= 0n) return;
       let sig: string | undefined;
       if (mode === "deposit") {
-        sig = await deposit({ userIdx: userAccount.idx, amount: amtNative });
+        // userIdx=0 is a placeholder when no account exists;
+        // useDeposit will auto-detect and override with the correct idx.
+        sig = await deposit({ userIdx: userAccount?.idx ?? 0, amount: amtNative });
       } else {
-        sig = await withdraw({ userIdx: userAccount.idx, amount: amtNative });
+        sig = await withdraw({ userIdx: userAccount!.idx, amount: amtNative });
       }
       setLastSig(sig ?? null);
       setAmount("");
     } catch (err) {
-      if (process.env.NODE_ENV === 'development') {
-        console.error(`${mode} failed:`, err);
-      }
+      // Show errors in all environments (was production-silent before)
+      console.error(`${mode} failed:`, err);
       // Error state is already handled by deposit/withdraw hooks
     }
   }

--- a/app/hooks/useDeposit.ts
+++ b/app/hooks/useDeposit.ts
@@ -2,14 +2,21 @@
 
 import { useCallback, useRef, useState } from "react";
 import { PublicKey } from "@solana/web3.js";
+import {
+  createAssociatedTokenAccountInstruction,
+  getAccount,
+} from "@solana/spl-token";
 import { useWalletCompat, useConnectionCompat } from "@/hooks/useWalletCompat";
 import {
   encodeDepositCollateral,
+  encodeInitUser,
   ACCOUNTS_DEPOSIT_COLLATERAL,
+  ACCOUNTS_INIT_USER,
   buildAccountMetas,
   WELL_KNOWN,
   buildIx,
   getAta,
+  AccountKind,
 } from "@percolator/sdk";
 import { sendTx } from "@/lib/tx";
 import { useSlabState } from "@/components/providers/SlabProvider";
@@ -17,7 +24,7 @@ import { useSlabState } from "@/components/providers/SlabProvider";
 export function useDeposit(slabAddress: string) {
   const { connection } = useConnectionCompat();
   const wallet = useWalletCompat();
-  const { config: mktConfig, programId: slabProgramId, refresh: refreshSlab } = useSlabState();
+  const { config: mktConfig, accounts: slabAccounts, programId: slabProgramId, refresh: refreshSlab } = useSlabState();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inflightRef = useRef(false);
@@ -44,14 +51,62 @@ export function useDeposit(slabAddress: string) {
         const slabPk = new PublicKey(slabAddress);
         const userAta = await getAta(wallet.publicKey, mktConfig.collateralMint);
 
-        const ix = buildIx({
+        const instructions = [];
+
+        // Auto-create ATA if needed
+        try {
+          await getAccount(connection, userAta);
+        } catch {
+          instructions.push(
+            createAssociatedTokenAccountInstruction(
+              wallet.publicKey, userAta, wallet.publicKey, mktConfig.collateralMint,
+            ),
+          );
+        }
+
+        // P0 FIX: Auto-InitUser if user has no account on this slab.
+        // Previously, deposit required the user to manually click "Create Account"
+        // first. Now we bundle InitUser + Deposit in a single tx, making the
+        // experience seamless — user just clicks "Deposit" and it works.
+        const pkStr = wallet.publicKey.toBase58();
+        const hasAccount = slabAccounts.some(
+          ({ account }) => account.kind === AccountKind.User && account.owner.toBase58() === pkStr
+        );
+
+        if (!hasAccount) {
+          // InitUser with feePayment=0 (deposit will follow as separate ix)
+          const initIx = buildIx({
+            programId,
+            keys: buildAccountMetas(ACCOUNTS_INIT_USER, [
+              wallet.publicKey, slabPk, userAta, mktConfig.vaultPubkey, WELL_KNOWN.tokenProgram,
+            ]),
+            data: encodeInitUser({ feePayment: "0" }),
+          });
+          instructions.push(initIx);
+
+          // After InitUser, the user's idx will be the next available slot.
+          // We need to re-read the slab to find the new idx, but since we're
+          // bundling in one tx, we can't do that. Instead, use the total
+          // account count (InitUser assigns the next sequential idx).
+          // The userIdx param won't be used for InitUser, but we need it for
+          // the deposit ix that follows. Count existing accounts to predict idx.
+          const userCount = slabAccounts.filter(
+            ({ account }) => account.kind === AccountKind.User
+          ).length;
+          // Override the userIdx for deposit to use the newly created account
+          params = { ...params, userIdx: userCount };
+        }
+
+        const depositIx = buildIx({
           programId,
           keys: buildAccountMetas(ACCOUNTS_DEPOSIT_COLLATERAL, [
             wallet.publicKey, slabPk, userAta, mktConfig.vaultPubkey, WELL_KNOWN.tokenProgram, WELL_KNOWN.clock,
           ]),
           data: encodeDepositCollateral({ userIdx: params.userIdx, amount: params.amount.toString() }),
         });
-        const sig = await sendTx({ connection, wallet, instructions: [ix] });
+        instructions.push(depositIx);
+
+        const sig = await sendTx({ connection, wallet, instructions, computeUnits: 400_000 });
         // P0 fix: force immediate slab re-read so balance updates without waiting
         // for the next poll cycle (which can be up to 30s when WS is active).
         refreshSlab();
@@ -66,7 +121,7 @@ export function useDeposit(slabAddress: string) {
         setLoading(false);
       }
     },
-    [connection, wallet, mktConfig, slabAddress, slabProgramId, refreshSlab]
+    [connection, wallet, mktConfig, slabAccounts, slabAddress, slabProgramId, refreshSlab]
   );
 
   return { deposit, loading, error };


### PR DESCRIPTION
## P0: Deposit fails silently on new markets

### Root Cause
Three compounding issues:
1. `useDeposit` required a pre-existing user account (`userIdx`) — impossible on brand new markets
2. `DepositWithdrawCard` returned early (`return;`) when `userAccount` was null, showing a separate 'Create Account' flow
3. The 'Create Account' button's `catch` block only logged errors in `development` — production users saw nothing

### Fix
**`useDeposit`** now auto-bundles `InitUser` (tag 1) + `DepositCollateral` (tag 3) in a single atomic transaction:
- Checks if connected wallet has an account on the slab
- If not: prepends InitUser ix with feePayment=0, then adds Deposit ix
- Also auto-creates ATA if missing (prevents SPL token error 24)
- Single wallet popup → both execute atomically

**`DepositWithdrawCard`** simplified:
- Removed separate 'Create Account' gate — users just see the normal Deposit form
- Only blocks when wallet has 0 token balance (shows faucet button)
- Error logging now works in all environments

### User Experience (Before → After)
**Before**: User → sees 'Create Account' → clicks → maybe works, maybe fails silently → then must deposit separately
**After**: User → sees 'Deposit' → enters amount → clicks → wallet prompts once → account created + funded atomically

### How to test
1. Connect fresh wallet to any market (no existing account)
2. Click Deposit → enter amount → approve
3. Should see balance update immediately (no separate account creation step)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now deposit funds without explicitly creating an account first; account setup is handled automatically
  * Automatic token account creation for users when needed

* **Improvements**
  * Streamlined deposit flow and onboarding experience
  * More efficient transaction processing through bundled deposits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->