### PR TITLE
fix(app): PERC-672 — leaderboard 429 graceful msg, faucet wallet gate, create market back nav

### DIFF
--- a/app/app/create/page.tsx
+++ b/app/app/create/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Suspense } from "react";
+import Link from "next/link";
 import { useWalletCompat } from "@/hooks/useWalletCompat";
 import { useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
@@ -39,6 +40,16 @@ function CreatePageInner() {
       <div className="absolute inset-x-0 top-0 h-16 bg-grid pointer-events-none opacity-50" />
 
       <div className="relative mx-auto max-w-4xl px-4 pt-4 pb-10">
+        {/* Back nav */}
+        <div className="mb-4">
+          <Link
+            href="/markets"
+            className="inline-flex items-center gap-1.5 text-[11px] font-mono text-[var(--text-muted)] transition-colors hover:text-[var(--text)] uppercase tracking-[0.1em]"
+          >
+            ← Markets
+          </Link>
+        </div>
+
         {/* Page header */}
         <ScrollReveal>
           <div className="mb-8">

--- a/app/app/devnet-mint/devnet-mint-content.tsx
+++ b/app/app/devnet-mint/devnet-mint-content.tsx
@@ -489,6 +489,23 @@ const DevnetMintContent: FC = () => {
           </div>
         </ScrollReveal>
 
+        {/* ── Wallet gate — show connect prompt if no wallet connected ─────── */}
+        {!walletReady && (
+          <div className="max-w-xl mx-auto mb-6 border border-[var(--warning)]/30 bg-[var(--warning)]/[0.04] px-5 py-5 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <div className="flex h-6 w-6 items-center justify-center border border-[var(--warning)]/40 shrink-0">
+                <span className="text-[11px] text-[var(--warning)]">!</span>
+              </div>
+              <div>
+                <p className="text-[13px] font-medium text-[var(--warning)]">Wallet required</p>
+                <p className="text-[11px] text-[var(--text-muted)] mt-0.5">
+                  Connect your wallet using the button in the header to use the Token Factory.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
         <div className="max-w-xl mx-auto space-y-6">
 
           {/* ── Get Market Test Tokens ─────────────────────────────────────────── */}

--- a/app/app/leaderboard/page.tsx
+++ b/app/app/leaderboard/page.tsx
@@ -435,12 +435,20 @@ export default function LeaderboardPage() {
     setError(null);
     try {
       const res = await fetch(`/api/leaderboard?period=${p}&limit=100`);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      if (!res.ok) {
+        if (res.status === 429) {
+          throw new Error("Leaderboard is temporarily unavailable — too many requests. Try again in a moment.");
+        }
+        if (res.status >= 500) {
+          throw new Error("Leaderboard service is temporarily down. Please try again shortly.");
+        }
+        throw new Error("Failed to load leaderboard. Please try again.");
+      }
       const json = await res.json();
       setEntries(json.leaderboard ?? []);
       setGeneratedAt(json.generatedAt ?? null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load leaderboard");
+      setError(err instanceof Error ? err.message : "Failed to load leaderboard. Please try again.");
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## PERC-672 — Fix 3 mobile UX bugs from QA regression

### Changes

**GH#102 — Leaderboard raw 429 error**
- `app/app/leaderboard/page.tsx`: `fetchLeaderboard` now maps HTTP 429 → "Leaderboard is temporarily unavailable — too many requests. Try again in a moment." and 5xx → "Leaderboard service is temporarily down." Raw HTTP status codes no longer shown to users.

**GH#103 — Faucet accessible without wallet**
- `app/app/devnet-mint/devnet-mint-content.tsx`: Added a hard wallet gate banner at the top of the page when no wallet is connected. Users now see a clear "Wallet required" warning with instructions before scrolling into the form. Existing per-step dimming logic retained as secondary guard.

**GH#104 — Create Market no back button**
- `app/app/create/page.tsx`: Added `← Markets` nav link above the page header. Persistent across all wizard steps. Allows users to exit the wizard without relying on browser history.

### Testing
- `pnpm test`: 904 passed, 0 failed
- `pnpm tsc --noEmit`: clean

### How to test
1. Leaderboard: Throttle network to trigger 429 — should show friendly message not "HTTP 429"
2. Devnet Mint: Visit `/devnet-mint` without wallet connected — should see yellow warning banner immediately
3. Create Market: Visit `/create` — should see "← Markets" link above page title on all steps