### PR TITLE
Refactor PnL calculation by removing overflow checks

### DIFF
--- a/packages/keeper/src/services/liquidation.ts
+++ b/packages/keeper/src/services/liquidation.ts
@@ -237,21 +237,16 @@ export class LiquidationService {
               ? price - entryPrice    // long: profit when price goes up
               : entryPrice - price;   // short: profit when price goes down
             
-            // BH5: Overflow protection - check bounds before multiplication
-            const MAX_SAFE_BIGINT = 9007199254740991n; // Number.MAX_SAFE_INTEGER
-            const absPosSize = absBI(account.positionSize);
-            
-            // Check if multiplication would overflow
-            if (diff > 0n && absPosSize > MAX_SAFE_BIGINT / diff) {
-              logger.warn("PnL calculation overflow", { accountIndex: i, slabAddress });
-              markPnl = diff > 0n ? MAX_SAFE_BIGINT : -MAX_SAFE_BIGINT;
-            } else if (diff < 0n && absPosSize > MAX_SAFE_BIGINT / -diff) {
-              logger.warn("PnL calculation overflow", { accountIndex: i, slabAddress });
-              markPnl = -MAX_SAFE_BIGINT;
-            } else {
-              markPnl = (diff * absPosSize) / price;
+            const entryPrice = account.entryPrice;
+            let markPnl = 0n;
+            if (entryPrice > 0n && price > 0n) {
+               const diff = account.positionSize > 0n
+                 ? price - entryPrice
+                 : entryPrice - price;
+
+             // BigInt does not overflow—compute exactly.
+             markPnl = (diff * absBI(account.positionSize)) / price;
             }
-          }
           const equity = account.capital + markPnl;
 
           // H4: If equity <= 0, definitely liquidatable (skip ratio calc)


### PR DESCRIPTION
This pull request simplifies the profit and loss (PnL) calculation logic in the `LiquidationService` by removing overflow protection checks and clarifying the BigInt arithmetic. The changes focus on ensuring the calculation is both accurate and easier to maintain.

PnL calculation improvements:

* Removed overflow protection and related warnings, relying on BigInt's exact arithmetic for PnL calculations in `LiquidationService`.
* Refactored PnL calculation to only compute when both `entryPrice` and `price` are positive, and clarified the logic for determining profit based on position direction.Removed overflow protection checks for PnL calculation and simplified the logic to compute markPnl directly using BigInt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved price validation and profit/loss calculation accuracy in liquidation decisions to enhance system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->