### PR TITLE
fix: truncate excess decimals in parseHumanAmount instead of throwing

### DIFF
--- a/app/__tests__/lib/parseAmount.test.ts
+++ b/app/__tests__/lib/parseAmount.test.ts
@@ -42,8 +42,11 @@ describe("parseHumanAmount", () => {
     expect(parseHumanAmount("1.2.3", 6)).toBe(0n);
   });
 
-  it("throws if too many decimal places", () => {
-    expect(() => parseHumanAmount("1.1234567", 6)).toThrow(/Input has 7 decimals/);
+  it("truncates excess decimal places instead of throwing", () => {
+    // "1.1234567" with 6 decimals → truncates to "1.123456" → 1_123_456n
+    expect(parseHumanAmount("1.1234567", 6)).toBe(1_123456n);
+    // "0.0000001" with 6 decimals → truncates to "0.000000" → 0n
+    expect(parseHumanAmount("0.0000001", 6)).toBe(0n);
   });
 
   it("handles 9-decimal tokens (SOL)", () => {

--- a/app/lib/parseAmount.ts
+++ b/app/lib/parseAmount.ts
@@ -15,12 +15,11 @@ export function parseHumanAmount(input: string, decimals: number): bigint {
   const whole = parts[0] || "0";
   const fracPart = parts[1] || "";
   
-  // M1: Throw error if decimals exceed token precision
-  if (fracPart.length > decimals) {
-    throw new Error(`Input has ${fracPart.length} decimals, but token only supports ${decimals}`);
-  }
+  // Truncate excess decimals instead of throwing — this is called during render
+  // and unhandled throws crash the component tree (issue #1046)
+  const truncatedFrac = fracPart.length > decimals ? fracPart.slice(0, decimals) : fracPart;
   
-  const frac = fracPart.padEnd(decimals, "0");
+  const frac = truncatedFrac.padEnd(decimals, "0");
   const result = BigInt(whole) * (10n ** BigInt(decimals)) + BigInt(frac);
   return negative ? -result : result;
 }


### PR DESCRIPTION
## Problem
`parseHumanAmount` throws when input has more decimal places than the token supports (e.g. `0.0000001` on a 6-decimal token). This crashes the `DepositWithdrawCard` and `CreateMarketWizard` component trees during render.

## Fix
Truncate excess decimals silently (round down to token precision) instead of throwing. Updated tests to match.

## Testing
- `pnpm vitest run __tests__/lib/parseAmount.test.ts` — 26/26 pass

Closes #1046

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decimal amount handling to gracefully truncate excess decimal places rather than rejecting input, providing a smoother experience when entering precise values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->