### PR TITLE
fix(PERC-688): catch parseHumanAmount throw in DepositWithdrawCard

### DIFF
--- a/app/components/trade/DepositWithdrawCard.tsx
+++ b/app/components/trade/DepositWithdrawCard.tsx
@@ -146,14 +146,21 @@ export const DepositWithdrawCard: FC<DepositWithdrawCardProps> = ({ slabAddress,
   const loading = mode === "deposit" ? depositLoading : withdrawLoading;
   const error = mode === "deposit" ? depositError : withdrawError;
 
-  const parsedAmount = maxRawRef.current ?? (amount ? parseHumanAmount(amount, decimals) : 0n);
+  let parsedAmount = 0n;
+  let decimalError: string | null = null;
+  try {
+    parsedAmount = maxRawRef.current ?? (amount ? parseHumanAmount(amount, decimals) : 0n);
+  } catch {
+    decimalError = `Too many decimals (max ${decimals})`;
+  }
   const isOverWithdraw = mode === "withdraw" && parsedAmount > 0n && parsedAmount > capital;
   const isOverDeposit = mode === "deposit" && parsedAmount > 0n && walletBalance !== null && parsedAmount > walletBalance;
-  const validationError = isOverWithdraw
-    ? "Insufficient capital"
-    : isOverDeposit
-    ? "Insufficient wallet balance"
-    : null;
+  const validationError = decimalError
+    ?? (isOverWithdraw
+      ? "Insufficient capital"
+      : isOverDeposit
+      ? "Insufficient wallet balance"
+      : null);
   const hasOpenPosition = positionSize !== 0n;
 
   async function handleSubmit() {


### PR DESCRIPTION
## Problem
`parseHumanAmount` throws when user types more decimal places than the token supports (e.g. typing `1.1234567890` for a 6-decimal token). This throw was unhandled in the render path of `DepositWithdrawCard`, crashing the component.

## Fix
Wrap the render-path `parseHumanAmount` call in try/catch. On error, sets a `decimalError` that flows into the existing `validationError` system — disabling submit, showing inline error text.

The `handleSubmit` path was already wrapped in try/catch.

## Testing
- Type `1.1234567890` in deposit/withdraw input with a 6-decimal token
- Should show 'Too many decimals (max 6)' error, button disabled
- No crash

Fixes: #1046