### PR TITLE
fix(PERC-687): catch parseHumanAmount throw in DepositWithdrawCard

### DIFF
--- a/app/components/trade/DepositWithdrawCard.tsx
+++ b/app/components/trade/DepositWithdrawCard.tsx
@@ -146,10 +146,22 @@ export const DepositWithdrawCard: FC<DepositWithdrawCardProps> = ({ slabAddress,
   const loading = mode === "deposit" ? depositLoading : withdrawLoading;
   const error = mode === "deposit" ? depositError : withdrawError;
 
-  const parsedAmount = maxRawRef.current ?? (amount ? parseHumanAmount(amount, decimals) : 0n);
-  const isOverWithdraw = mode === "withdraw" && parsedAmount > 0n && parsedAmount > capital;
-  const isOverDeposit = mode === "deposit" && parsedAmount > 0n && walletBalance !== null && parsedAmount > walletBalance;
-  const validationError = isOverWithdraw
+  let parsedAmount: bigint = 0n;
+  let parseError: string | null = null;
+  if (maxRawRef.current !== null) {
+    parsedAmount = maxRawRef.current;
+  } else if (amount) {
+    try {
+      parsedAmount = parseHumanAmount(amount, decimals);
+    } catch {
+      parseError = `Too many decimal places (max ${decimals})`;
+    }
+  }
+  const isOverWithdraw = !parseError && mode === "withdraw" && parsedAmount > 0n && parsedAmount > capital;
+  const isOverDeposit = !parseError && mode === "deposit" && parsedAmount > 0n && walletBalance !== null && parsedAmount > walletBalance;
+  const validationError = parseError
+    ? parseError
+    : isOverWithdraw
     ? "Insufficient capital"
     : isOverDeposit
     ? "Insufficient wallet balance"


### PR DESCRIPTION
## Problem
`parseHumanAmount` throws when the input has more decimal places than the token supports (e.g. typing `1.1234567` on a 6-decimal token). This call happens **at render time** in `DepositWithdrawCard`, so the exception propagates unhandled and crashes the entire component.

Ref: https://github.com/dcccrypto/percolator-launch/issues/1046

## Fix
Wrap the render-time `parseHumanAmount` call in a `try/catch` block:

- On error → set a local `parseError` flag with a user-friendly message: _"Too many decimal places (max N)"_
- `parseError` feeds into `validationError`, so the submit button is disabled and the error is shown inline
- `isOverWithdraw`/`isOverDeposit` checks are skipped when `parseError` is set (avoid redundant logic on a 0n fallback)

`parseHumanAmount` itself keeps its throwing contract — the fix is entirely in the component layer.

## Testing
- 912 unit tests pass (`pnpm test`)
- Manual: type `1.1234567` in the deposit input on a 6-decimal market → see inline validation error, no crash
- Max button (pre-formatted) is unaffected (`maxRawRef.current` path bypasses parse entirely)