### PR TITLE
feat(PERC-690): block IPs on WebSocket + tighten unauth per-IP limit to 3

### DIFF
--- a/packages/api/src/middleware/ip-blocklist.ts
+++ b/packages/api/src/middleware/ip-blocklist.ts
@@ -65,7 +65,7 @@ const PARSED_BLOCKLIST: ParsedEntry[] = RAW_BLOCKLIST.map(parseEntry).filter(
   (e): e is ParsedEntry => e !== null
 );
 
-function isBlocked(clientIp: string): boolean {
+export function isBlocked(clientIp: string): boolean {
   if (PARSED_BLOCKLIST.length === 0) return false;
 
   const clientInt = ipToInt(clientIp);

--- a/packages/api/src/routes/ws.ts
+++ b/packages/api/src/routes/ws.ts
@@ -3,6 +3,7 @@ import type { Server } from "node:http";
 import type { IncomingMessage } from "node:http";
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { eventBus, getSupabase, createLogger, sanitizeSlabAddress } from "@percolator/shared";
+import { isBlocked } from "../middleware/ip-blocklist.js";
 
 const logger = createLogger("api:ws");
 
@@ -12,7 +13,8 @@ const MAX_CONNECTIONS_PER_SLAB = 100; // New: per-slab connection limit
 const MAX_BUFFER_BYTES = 64 * 1024; // 64KB
 const MAX_SUBSCRIPTIONS_PER_CLIENT = 50; // Prevent Helius WS subscription exhaustion
 const MAX_GLOBAL_SUBSCRIPTIONS = 1000; // Global subscription cap to prevent DoS
-const MAX_CONNECTIONS_PER_IP = 5; // Max concurrent connections per IP
+const MAX_CONNECTIONS_PER_IP = 5; // Max concurrent connections per IP (authenticated)
+const MAX_UNAUTH_CONNECTIONS_PER_IP = 3; // Max concurrent connections per IP (unauthenticated)
 
 // Authentication settings
 // In production, WS_AUTH_REQUIRED must be explicitly set. Defaults to true unless NODE_ENV=development.
@@ -365,6 +367,7 @@ export function getWebSocketMetrics(): any {
       maxGlobalConnections: MAX_WS_CONNECTIONS,
       maxConnectionsPerSlab: MAX_CONNECTIONS_PER_SLAB,
       maxConnectionsPerIp: MAX_CONNECTIONS_PER_IP,
+      maxUnauthConnectionsPerIp: MAX_UNAUTH_CONNECTIONS_PER_IP,
     },
   };
 }
@@ -474,6 +477,13 @@ export function setupWebSocket(server: Server): WebSocketServer {
       return;
     }
     
+    // Reject blocklisted IPs before any other processing (PERC-690)
+    if (isBlocked(clientIp)) {
+      logger.warn("Rejected WS connection from blocklisted IP", { ip: clientIp });
+      ws.close(1008, "Forbidden");
+      return;
+    }
+
     // Reject IPs temporarily banned for repeated auth failures (issue #839)
     if (isAuthBanned(clientIp)) {
       logger.warn("Rejected connection from auth-banned IP", { ip: clientIp });
@@ -481,11 +491,16 @@ export function setupWebSocket(server: Server): WebSocketServer {
       return;
     }
 
-    // Check connections per IP
+    // Check connections per IP — use stricter limit for unauthenticated (PERC-690)
+    // At connection time we only have the query-param token; if absent, apply unauth limit.
+    const url = new URL(req.url || "", `http://${req.headers.host}`);
+    const connectToken = url.searchParams.get("token");
+    const hasValidToken = connectToken ? verifyWsToken(connectToken).isValid : false;
+    const ipLimit = hasValidToken ? MAX_CONNECTIONS_PER_IP : MAX_UNAUTH_CONNECTIONS_PER_IP;
     const ipConnections = connectionsPerIp.get(clientIp) || 0;
-    if (ipConnections >= MAX_CONNECTIONS_PER_IP) {
-      logger.warn("Max connections per IP reached", { ip: clientIp, count: ipConnections });
-      ws.close(1008, `Max ${MAX_CONNECTIONS_PER_IP} connections per IP`);
+    if (ipConnections >= ipLimit) {
+      logger.warn("Max connections per IP reached", { ip: clientIp, count: ipConnections, limit: ipLimit, authenticated: hasValidToken });
+      ws.close(1008, `Max ${ipLimit} connections per IP`);
       return;
     }
     
@@ -493,8 +508,8 @@ export function setupWebSocket(server: Server): WebSocketServer {
     connectionsPerIp.set(clientIp, ipConnections + 1);
     
     // Check for auth token in query params (optional)
-    const url = new URL(req.url || "", `http://${req.headers.host}`);
-    const token = url.searchParams.get("token");
+    // (url + connectToken already parsed above for per-IP limit check)
+    const token = connectToken;
     
     // Determine if authenticated
     let authenticated = !WS_AUTH_REQUIRED; // If auth not required, auto-authenticate

--- a/packages/api/tests/middleware/ip-blocklist.test.ts
+++ b/packages/api/tests/middleware/ip-blocklist.test.ts
@@ -117,4 +117,14 @@ describe("ipBlocklist middleware", () => {
     const res = await app.request(req);
     expect(res.status).toBe(200);
   });
+
+  it("exports isBlocked for use by WebSocket handler (PERC-690)", async () => {
+    vi.resetModules();
+    process.env.IP_BLOCKLIST = "88.97.223.158,10.0.0.0/24";
+    const mod = await import("../../src/middleware/ip-blocklist.js");
+    expect(mod.isBlocked).toBeDefined();
+    expect(mod.isBlocked("88.97.223.158")).toBe(true);
+    expect(mod.isBlocked("10.0.0.42")).toBe(true);
+    expect(mod.isBlocked("1.2.3.4")).toBe(false);
+  });
 });


### PR DESCRIPTION
## What
- Export `isBlocked()` from ip-blocklist middleware so WS handler can reuse it
- Add IP blocklist check at WebSocket connection time (before any processing) — blocked IPs now get 1008 close immediately
- Split per-IP WS connection limit: **3 for unauthenticated**, 5 for authenticated (was 5 for all)
- Update `/ws/stats` metrics endpoint to expose new `maxUnauthConnectionsPerIp` limit

## Why
Security flagged IP 88.97.223.158 DoS-probing via WebSocket hammering. The HTTP blocklist was in place but WS connections bypassed it. Unauthenticated connections also had the same generous limit as authenticated ones.

## How to Test
1. Set `IP_BLOCKLIST=88.97.223.158` and try WS connect from that IP → should get 1008 Forbidden
2. Without auth token, open 4 WS connections from same IP → 4th should be rejected
3. With valid auth token, can open up to 5 connections per IP
4. All 115 existing tests pass

## Task
PERC-690

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * IP blocklist enforcement added to WebSocket connections
  * Separate connection limits for authenticated and unauthenticated connections
  * Metrics endpoint now exposes unauthenticated connection limit information

* **Tests**
  * Added tests for IP blocklist functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->