### PR TITLE
fix(PERC-691,692,693): bug bounty — crank payer, webhook auth, health check

### DIFF
--- a/packages/api/src/routes/health.ts
+++ b/packages/api/src/routes/health.ts
@@ -22,8 +22,12 @@ export function healthRoutes(): Hono {
     }
     
     // Check Supabase connectivity
+    // PERC-693: Supabase client doesn't throw on query errors — check { error } explicitly
     try {
-      await getSupabase().from("markets").select("id", { count: "exact", head: true });
+      const { error: dbError } = await getSupabase().from("markets").select("id", { count: "exact", head: true });
+      if (dbError) {
+        throw new Error(dbError.message ?? "Supabase query failed");
+      }
       checks.db = true;
     } catch (err) {
       logger.error("DB check failed", { error: err instanceof Error ? err.message : err });

--- a/packages/indexer/src/routes/webhook.ts
+++ b/packages/indexer/src/routes/webhook.ts
@@ -12,13 +12,28 @@ const BASE58_PUBKEY = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
  * Helius Enhanced Transaction webhook receiver.
  * Parses trade instructions from enhanced tx data and stores them.
  */
+// PERC-692: Fail fast if webhook secret is not configured in production
+const IS_PRODUCTION = process.env.NODE_ENV === "production";
+if (!config.webhookSecret) {
+  if (IS_PRODUCTION) {
+    logger.error("FATAL: HELIUS_WEBHOOK_SECRET must be set in production — webhook auth would be bypassed");
+    process.exit(1);
+  } else {
+    logger.warn("HELIUS_WEBHOOK_SECRET not set — webhook auth disabled (dev only)");
+  }
+}
+
 export function webhookRoutes(): Hono {
   const app = new Hono();
 
   app.post("/webhook/trades", async (c) => {
-    // Validate auth header
+    // PERC-692: Always validate auth when secret is configured; reject if missing in production
     const authHeader = c.req.header("authorization");
-    if (config.webhookSecret && authHeader !== config.webhookSecret) {
+    if (!config.webhookSecret) {
+      // No secret configured — only allowed in non-production (checked at startup)
+      logger.warn("Webhook request accepted without auth (no secret configured)");
+    } else if (authHeader !== config.webhookSecret) {
+      logger.warn("Webhook auth failed", { hasHeader: !!authHeader });
       return c.json({ error: "Unauthorized" }, 401);
     }
 

--- a/scripts/auto-crank-service.ts
+++ b/scripts/auto-crank-service.ts
@@ -54,8 +54,9 @@ const PROGRAM_ID = new PublicKey(networkConfig.programIds[0]);
 const connection = new Connection(RPC_URL, "confirmed");
 
 // Load sealed signer (private key never exposed)
+// PERC-691: Use signer + crankPublicKey instead of undefined `payer`
 const signer = getSealedSigner();
-const crankPublicKey = getCrankPublicKey();
+const crankPublicKey = new PublicKey(getCrankPublicKey());
 
 console.log(`
 ✅ Crank Service Initialized
@@ -103,7 +104,7 @@ async function crankMarket(market: DiscoveredMarket): Promise<string> {
       priceE6: priceE6.toString(),
       timestamp: ts.toString(),
     });
-    const pushKeys = buildAccountMetas(ACCOUNTS_PUSH_ORACLE_PRICE, [payer.publicKey, slabPk]);
+    const pushKeys = buildAccountMetas(ACCOUNTS_PUSH_ORACLE_PRICE, [crankPublicKey, slabPk]);
     tx.add(buildIx({ programId: PROGRAM_ID, keys: pushKeys, data: pushData }));
 
     oracleAccount = slabPk;
@@ -115,14 +116,14 @@ async function crankMarket(market: DiscoveredMarket): Promise<string> {
 
   const crankData = encodeKeeperCrank({ callerIdx: 65535, allowPanic: false });
   const crankKeys = buildAccountMetas(ACCOUNTS_KEEPER_CRANK, [
-    payer.publicKey,
+    crankPublicKey,
     slabPk,
     SYSVAR_CLOCK_PUBKEY,
     oracleAccount,
   ]);
   tx.add(buildIx({ programId: PROGRAM_ID, keys: crankKeys, data: crankData }));
 
-  return sendAndConfirmTransaction(connection, tx, [payer], {
+  return sendAndConfirmTransaction(connection, tx, [signer], {
     commitment: "confirmed",
   });
 }
@@ -134,11 +135,11 @@ async function crankMarket(market: DiscoveredMarket): Promise<string> {
 async function main() {
   console.log("🔄 Percolator Auto-Crank Service");
   console.log(`   Program:  ${PROGRAM_ID.toBase58()}`);
-  console.log(`   Payer:    ${payer.publicKey.toBase58()}`);
+  console.log(`   Payer:    ${crankPublicKey.toBase58()}`);
   console.log(`   RPC:      ${RPC_URL.slice(0, 50)}…`);
   console.log(`   Interval: ${CRANK_INTERVAL_MS / 1000}s\n`);
 
-  const balance = await connection.getBalance(payer.publicKey);
+  const balance = await connection.getBalance(crankPublicKey);
   console.log(`   Balance:  ${(balance / 1e9).toFixed(4)} SOL\n`);
 
   let markets: DiscoveredMarket[] = [];


### PR DESCRIPTION
## Bug Bounty Fixes (3)

### PERC-692 (HIGH) — Helius webhook auth bypass
- **Before:** When `HELIUS_WEBHOOK_SECRET` not set, auth check was silently skipped (`config.webhookSecret && ...` evaluates to false)
- **After:** Fail fast with `process.exit(1)` in production if secret missing. Dev: warn-only.
- **Risk:** Fake trade injection via unauthenticated webhook POST

### PERC-691 (HIGH) — Auto-crank undefined payer crash
- **Before:** `payer` variable referenced throughout but never defined after sealedSigner refactor
- **After:** Use `signer` (from `getSealedSigner()`) for tx signing, `crankPublicKey` (wrapped as `PublicKey`) for account metas
- **Risk:** Crank service crashes on start, all markets stop updating

### PERC-693 (MEDIUM) — Health endpoint false positive
- **Before:** Supabase errors silently swallowed — `getSupabase().from(...).select()` returns `{ data, error }` without throwing
- **After:** Check `error` field explicitly, throw if present → health correctly reports degraded/down
- **Risk:** Monitoring reports healthy when DB is broken

## Tests
- API: 123 tests pass
- Indexer webhook: 13 tests pass