### PR TITLE
fix(admin): PERC-694 — admin dashboard bugs shows empty (migration 034 column restriction)

### DIFF
--- a/app/app/admin/page.tsx
+++ b/app/app/admin/page.tsx
@@ -389,11 +389,16 @@ export default function AdminDashboard() {
 
   const updateStatus = async (bugId: string, newStatus: string) => {
     setSaving(true);
-    await fetch("/api/admin/bugs", {
+    const res = await fetch("/api/admin/bugs", {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ id: bugId, status: newStatus }),
-    });
+    }).catch(() => null);
+    if (!res?.ok) {
+      console.error("Failed to update bug status");
+      setSaving(false);
+      return;
+    }
     await fetchBugs();
     if (selectedBug?.id === bugId) {
       setSelectedBug((prev) => (prev ? { ...prev, status: newStatus } : null));
@@ -404,11 +409,16 @@ export default function AdminDashboard() {
   const saveNotes = async () => {
     if (!selectedBug) return;
     setSaving(true);
-    await fetch("/api/admin/bugs", {
+    const res = await fetch("/api/admin/bugs", {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ id: selectedBug.id, admin_notes: adminNotes }),
-    });
+    }).catch(() => null);
+    if (!res?.ok) {
+      console.error("Failed to save admin notes");
+      setSaving(false);
+      return;
+    }
     await fetchBugs();
     setSelectedBug((prev) =>
       prev ? { ...prev, admin_notes: adminNotes } : null

--- a/app/app/api/admin/bugs/route.ts
+++ b/app/app/api/admin/bugs/route.ts
@@ -58,11 +58,14 @@ export async function GET(req: NextRequest) {
   }
 
   // 2. Verify admin
+  if (!user.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const sb = getServiceClient();
   const { data: adminRow } = await (sb as any)
     .from("admin_users")
     .select("id")
-    .eq("email", user.email!)
+    .eq("email", user.email)
     .maybeSingle();
 
   if (!adminRow) {
@@ -92,11 +95,14 @@ export async function PATCH(req: NextRequest) {
   }
 
   // 2. Verify admin
+  if (!user.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const sb = getServiceClient();
   const { data: adminRow } = await (sb as any)
     .from("admin_users")
     .select("id")
-    .eq("email", user.email!)
+    .eq("email", user.email)
     .maybeSingle();
 
   if (!adminRow) {
@@ -109,7 +115,20 @@ export async function PATCH(req: NextRequest) {
     return NextResponse.json({ error: "Missing bug id" }, { status: 400 });
   }
 
-  const { id, ...updates } = body;
+  const { id } = body;
+
+  // Whitelist allowed fields — prevent arbitrary column writes
+  const ALLOWED_FIELDS = ["status", "admin_notes"] as const;
+  type AllowedField = typeof ALLOWED_FIELDS[number];
+  const updates: Partial<Record<AllowedField, string>> & { updated_at?: string } = {};
+  for (const field of ALLOWED_FIELDS) {
+    if (field in body && body[field] !== undefined) {
+      updates[field] = body[field] as string;
+    }
+  }
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: "No updatable fields provided" }, { status: 400 });
+  }
   // Ensure updated_at is refreshed
   updates.updated_at = new Date().toISOString();
 


### PR DESCRIPTION
## Problem

Admin dashboard bug bounty section shows empty/zeros — all analytics are 0, bug list is empty.

**Root cause:** Migration `034` (security audit fix N7) restricted the `authenticated` Supabase role to only 7 columns on `bug_reports`:
```sql
GRANT SELECT (id, title, description, status, severity, created_at, updated_at)
  ON bug_reports TO authenticated;
```

The admin page was calling Supabase **directly from the browser** using `getAuthClient()`, which uses the `authenticated` role. Fields like `twitter_handle`, `admin_notes`, `bounty_wallet`, `steps_to_reproduce`, etc. all returned undefined.

## Fix

- **New route:** `/api/admin/bugs` (GET + PATCH)
  - GET: Verifies Supabase session cookie → checks `admin_users` → fetches with `service_role` (bypasses column restriction)
  - PATCH: Same auth check → updates with `service_role`
- **Admin page:** `fetchBugs` now calls `/api/admin/bugs` instead of Supabase directly
- `updateStatus` and `saveNotes` mutations updated to call `PATCH /api/admin/bugs`

Same pattern already used for `/api/stats` and `/api/health` in the platform stats section.

## Test

1. Log in to `/admin`
2. Bug reports section should now show all reports with full data (twitter handle, severity, status bars, top reporters, etc.)
3. Status updates and admin notes should still save correctly

Resolves: PERC-694 (P0 — admin dashboard bug bounty section broken)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Admin Features**
  * Bug report management now operates via secure server-side APIs with admin-only access.
  * Admins can fetch reports, update statuses, and save notes through hardened endpoints.
  * Existing UI and workflows remain unchanged for admins.

* **Reliability & Error Handling**
  * Improved resilience with defensive fetch handling and clearer failure responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->