### PR TITLE
fix(indexer): fail-closed on missing webhookSecret (PERC-1063)

### DIFF
--- a/packages/indexer/src/routes/webhook.ts
+++ b/packages/indexer/src/routes/webhook.ts
@@ -27,12 +27,14 @@ export function webhookRoutes(): Hono {
   const app = new Hono();
 
   app.post("/webhook/trades", async (c) => {
-    // PERC-692: Always validate auth when secret is configured; reject if missing in production
+    // PERC-1063: Fail-closed — 503 if secret not configured, 401 if header mismatch.
+    // No unauthenticated requests accepted regardless of environment.
     const authHeader = c.req.header("authorization");
     if (!config.webhookSecret) {
-      // No secret configured — only allowed in non-production (checked at startup)
-      logger.warn("Webhook request accepted without auth (no secret configured)");
-    } else if (authHeader !== config.webhookSecret) {
+      logger.error("Webhook request rejected: HELIUS_WEBHOOK_SECRET not configured");
+      return c.json({ error: "Webhook auth not configured" }, 503);
+    }
+    if (authHeader !== config.webhookSecret) {
       logger.warn("Webhook auth failed", { hasHeader: !!authHeader });
       return c.json({ error: "Unauthorized" }, 401);
     }

--- a/packages/indexer/tests/routes/webhook.test.ts
+++ b/packages/indexer/tests/routes/webhook.test.ts
@@ -10,10 +10,14 @@ vi.mock('@percolator/sdk', () => ({
   }),
 }));
 
+// NOTE: This constant must be a literal string used inside vi.mock (which is hoisted before const declarations).
+// The string 'test-secret-token' is duplicated intentionally — do not replace with a variable reference.
+const TEST_WEBHOOK_SECRET = 'test-secret-token';
+
 vi.mock('@percolator/shared', () => ({
   config: {
     allProgramIds: ['FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD'],
-    webhookSecret: null,
+    webhookSecret: 'test-secret-token', // must be a literal — vi.mock is hoisted
   },
   insertTrade: vi.fn(),
   eventBus: { publish: vi.fn() },
@@ -47,10 +51,12 @@ const SLAB = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
 const SIG = '5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW';
 const SIG2 = '4VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW';
 
-function makeRequest(body: any): Request {
+function makeRequest(body: any, secret: string | null = TEST_WEBHOOK_SECRET): Request {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (secret !== null) headers['authorization'] = secret;
   return new Request('http://localhost/webhook/trades', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers,
     body: JSON.stringify(body),
   });
 }
@@ -280,22 +286,29 @@ describe('POST /webhook/trades — price extraction', () => {
   it('returns 400 for invalid JSON body', async () => {
     const req = new Request('http://localhost/webhook/trades', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'authorization': TEST_WEBHOOK_SECRET },
       body: 'not-json',
     });
     const res = await app.fetch(req);
     expect(res.status).toBe(400);
   });
 
-  it('returns 401 when auth header is missing and webhookSecret is set', async () => {
+  it('returns 503 when webhookSecret is not configured', async () => {
     const origSecret = (shared.config as any).webhookSecret;
-    (shared.config as any).webhookSecret = 'secret-token';
+    (shared.config as any).webhookSecret = null;
     try {
       const req = makeRequest([]);
       const res = await app.fetch(req);
-      expect(res.status).toBe(401);
+      expect(res.status).toBe(503);
     } finally {
       (shared.config as any).webhookSecret = origSecret;
     }
+  });
+
+  it('returns 401 when auth header is missing and webhookSecret is set', async () => {
+    // Pass null as secret to omit the authorization header
+    const req = makeRequest([], null);
+    const res = await app.fetch(req);
+    expect(res.status).toBe(401);
   });
 });


### PR DESCRIPTION
## Problem

Security issue #1063: Helius webhook auth guard short-circuited when `HELIUS_WEBHOOK_SECRET` was not configured — all requests accepted without auth. An attacker could inject fake trade data leading to corrupted leaderboard and misleading UI price/history.

**Affected code (before):**
```ts
if (config.webhookSecret && authHeader !== config.webhookSecret) { ... }
// ^ if webhookSecret is null, guard is skipped — all requests accepted
```

## Fix

Fail-closed at the handler level:
```ts
if (!config.webhookSecret) return c.json({ error: 'Webhook auth not configured' }, 503);
if (authHeader !== config.webhookSecret) return c.json({ error: 'Unauthorized' }, 401);
```

- No secret configured → **503** (misconfiguration, not a silent pass-through)
- Header mismatch → **401**
- Valid header → request processed

Existing PERC-692 startup guard (process.exit in production) is retained as defense-in-depth.

## Tests

- Updated mock: default `webhookSecret` set to `'test-secret-token'`
- `makeRequest()` now sends auth header by default
- Added: test for 503 when secret is null
- All 55 tests pass

Closes #1063

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook authentication enforcement with distinct status codes: 503 when webhook configuration is missing, 401 for mismatched credentials.
  * Webhooks now properly reject unauthenticated requests across all environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->