### PR TITLE
fix(db): ensure devnet_airdrop_claims table + reload PostgREST schema (PERC-749)

### DIFF
--- a/supabase/migrations/039_ensure_devnet_airdrop_claims_reload.sql
+++ b/supabase/migrations/039_ensure_devnet_airdrop_claims_reload.sql
@@ -1,0 +1,34 @@
+-- Migration 039: Ensure devnet_airdrop_claims table exists + reload PostgREST schema
+--
+-- Context: Migration 038 added devnet_airdrop_claims but was never applied to
+-- production Supabase, causing Sentry FE errors:
+--   "Could not find table public.devnet_airdrop_claims in schema cache"
+-- (9 events, last seen 2026-03-11, PERC-749)
+--
+-- This migration is idempotent (IF NOT EXISTS guards) so it is safe to run
+-- even if 038 was previously applied. The trailing NOTIFY forces PostgREST
+-- to reload its schema cache, resolving the "not in schema cache" error.
+
+-- Create table (no-op if 038 was already applied)
+CREATE TABLE IF NOT EXISTS devnet_airdrop_claims (
+  id          BIGSERIAL     PRIMARY KEY,
+  wallet      TEXT          NOT NULL,
+  mint        TEXT          NOT NULL,
+  claimed_at  TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+-- Unique index: enforces 1-claim-per-wallet-per-mint (INSERT-as-gate)
+CREATE UNIQUE INDEX IF NOT EXISTS devnet_airdrop_claims_wallet_mint_idx
+  ON devnet_airdrop_claims(wallet, mint);
+
+-- Lookup index for the 24h window check
+CREATE INDEX IF NOT EXISTS devnet_airdrop_claims_claimed_at_idx
+  ON devnet_airdrop_claims(claimed_at);
+
+-- No public access — service_role bypasses RLS; anon/authenticated have zero grants
+ALTER TABLE devnet_airdrop_claims ENABLE ROW LEVEL SECURITY;
+
+-- Force PostgREST to reload its schema cache so the table becomes visible immediately.
+-- Without this, the new table may not appear in PostgREST's schema cache until the
+-- next scheduled reload (up to 24h), causing the "not in schema cache" Sentry error.
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Problem

Sentry is logging 9 FE errors (last seen 2026-03-11):
```
[devnet-airdrop] gate INSERT failed — Could not find table public.devnet_airdrop_claims in schema cache
```

**Root cause:** Migration `038_devnet_airdrop_claims.sql` was merged in PR #899 (2026-03-07) but was **never applied to the production Supabase project**. The table simply doesn't exist in the DB, so PostgREST can't find it in its schema cache.

## Fix

New migration `039_ensure_devnet_airdrop_claims_reload.sql`:
- Re-creates the table and indexes with `IF NOT EXISTS` guards (idempotent — safe whether migration 038 was already applied or not)  
- `NOTIFY pgrst, 'reload schema'` forces PostgREST cache reload immediately after apply

## Testing

1. Apply migration via `supabase db push` (or SQL editor in Supabase dashboard)
2. Confirm `devnet_airdrop_claims` table is visible in Supabase Table Editor
3. Confirm `/api/devnet-airdrop` no longer throws the schema-cache error on devnet
4. Sentry error count should stop incrementing after deploy

## Notes for Devops

After this PR is merged, **`supabase db push` must be run** to apply migration 039 to the production Supabase project. The code path in `/api/devnet-airdrop/route.ts` that does the INSERT-as-gate (`tryClaimGate`) will fail-open on DB errors (per the existing fail-open design), so users are not blocked — but the rate-limit is bypassed until the migration is applied.

Closes PERC-749.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced devnet airdrop claims system infrastructure to ensure reliable operation and immediate availability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->