### PR TITLE
fix: resolve all TypeScript errors across monorepo

### DIFF
--- a/bots/devnet-mm/src/trader-fleet.ts
+++ b/bots/devnet-mm/src/trader-fleet.ts
@@ -651,6 +651,7 @@ export class TraderFleetBot {
 
   getStatus() {
     return {
+      running: this.running,
       stats: { ...this.stats },
       traders: this.traders.map((t) => ({
         id: t.id,


### PR DESCRIPTION
## Summary
Fixes all TypeScript compilation errors across percolator-launch monorepo.

### Root Cause
- `@percolator/shared` wasn't built, causing 48 'Cannot find module' errors in packages/api, packages/keeper, packages/indexer
- `TraderFleet.getStatus()` was missing the `running` field that `health.ts` relied on (2 errors in bots/devnet-mm)

### Changes
- **bots/devnet-mm/src/trader-fleet.ts**: Add `running: this.running` to `getStatus()` return (Filler + Maker already had it)

### Verification
After building `@percolator/shared`:
- app: 0 errors ✅
- packages/core: 0 errors ✅  
- packages/shared: 0 errors ✅
- packages/keeper: 0 errors ✅
- packages/api: 0 errors ✅
- packages/indexer: 0 errors ✅
- bots/devnet-mm: 0 errors ✅
- percolator-api (separate repo): 0 errors ✅

**Note:** CI should ensure `@percolator/shared` is built before other packages to avoid the 48 module-not-found errors.

Task: PERC-745

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced status monitoring for better visibility into bot operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->