### PR TITLE
docs(env): document missing internal service URLs in .env.example — PERC-746

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -53,3 +53,12 @@ SENTRY_AUTH_TOKEN=
 # Sentry org and project slugs
 SENTRY_ORG=percolator
 SENTRY_PROJECT=percolator-app
+
+# ── Internal Service URLs (server-side only) ──
+# Oracle Keeper service URL — used by /api/oracle-keeper/register to forward keeper registrations
+# Default: http://localhost:8081 (dev). MUST be set in production to point to the keeper container.
+KEEPER_INTERNAL_URL=
+
+# Oracle Bridge service URL — used by /api/oracle/publishers to read publisher list
+# Default: http://127.0.0.1:18802 (dev). MUST be set in production to point to the bridge service.
+ORACLE_BRIDGE_URL=


### PR DESCRIPTION
## Summary
Secrets/localhost URL scan (PERC-746) found two internal service env vars with localhost defaults that were undocumented in `.env.example`.

### Findings
| File | Env Var | Default | Risk |
|------|---------|---------|------|
| `app/app/api/oracle-keeper/register/route.ts:22` | `KEEPER_INTERNAL_URL` | `http://localhost:8081` | Silent localhost in prod |
| `app/app/api/oracle/publishers/route.ts:6` | `ORACLE_BRIDGE_URL` | `http://127.0.0.1:18802` | Silent localhost in prod |

### Changes
- Added both vars to `app/.env.example` with production guidance

### Clean scan results
- No hardcoded secrets or private keys in source
- TODO:FIX hits are in `.next` build artifacts only (third-party deps)
- CORS localhost fallback (`packages/api/src/index.ts`) is safe — guarded by `process.exit(1)` in production if `CORS_ORIGINS` is not set

Task: PERC-746

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added two new required environment variables to the application configuration that must be set in production deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->