### PR TITLE
fix(sentry): isOnCurve guard in devnet-mint-token — closes TokenOwnerOffCurveError (PERC-751)

### DIFF
--- a/app/app/api/devnet-mint-token/route.ts
+++ b/app/app/api/devnet-mint-token/route.ts
@@ -128,6 +128,17 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Invalid creatorWallet" }, { status: 400 });
     }
 
+    // Guard: SPL token accounts require an on-curve (Ed25519) owner.
+    // Passing a PDA (off-curve) as the creator wallet causes
+    // TokenOwnerOffCurveError during getAssociatedTokenAddress.
+    // Reject early with a clear 400 before touching the DB or chain.
+    if (!PublicKey.isOnCurve(creatorPk.toBytes())) {
+      return NextResponse.json(
+        { error: "creatorWallet must be a regular wallet, not a program-derived address (PDA)" },
+        { status: 400 },
+      );
+    }
+
     // Check if we already have a devnet mint for this CA
     const supabase = getServiceClient();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary
Mirrors the fix from PR #910 (devnet-airdrop) to devnet-mint-token.

## Root cause
`getAssociatedTokenAddress` from `@solana/spl-token` throws `TokenOwnerOffCurveError` when the owner pubkey is off-curve (a PDA). The `devnet-airdrop/route.ts` already had an `isOnCurve` guard added in #910, but `devnet-mint-token/route.ts` was missing the same guard — causing the 1 Sentry event.

## Fix
Added `PublicKey.isOnCurve(creatorPk.toBytes())` check immediately after pubkey validation in `devnet-mint-token/route.ts`, returning a clear 400 error before any DB or chain interaction.

## Risk
- **Mainnet impact**: None — both APIs are devnet-only (gated by `if (NETWORK !== 'devnet')`)
- **Behaviour change**: Previously threw an unhandled `TokenOwnerOffCurveError` (Sentry 500-level noise); now returns a clear 400 with a descriptive message

## Testing
Passing a PDA address as `creatorWallet` to `POST /api/devnet-mint-token` now returns:
```json
{"error": "creatorWallet must be a regular wallet, not a program-derived address (PDA)"}
```
Status: 400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input validation for creator wallet addresses in token minting to ensure addresses are valid and reject invalid formats with clear error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->