### PR TITLE
fix(seed): remove nonexistent role column from admin_users INSERT

### DIFF
--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -6,10 +6,12 @@
 -- 1. Admin Users (Example - replace with real emails)
 -- ============================================================================
 
-INSERT INTO admin_users (email, role)
+-- NOTE: admin_users table only has (id, email, created_at) — no role column.
+-- Replace these placeholder emails with real Supabase auth emails.
+INSERT INTO admin_users (email)
 VALUES 
-  ('admin@percolator.com', 'admin'),
-  ('dev@percolator.com', 'developer')
+  ('admin@percolator.com'),
+  ('dev@percolator.com')
 ON CONFLICT (email) DO NOTHING;
 
 -- ============================================================================


### PR DESCRIPTION
## Problem
`supabase/seed.sql` was inserting into `admin_users (email, role)` but migration 016 only created columns `(id, email, created_at)`. The `role` column doesn't exist, causing the seed INSERT to fail.

## Fix
Removed `role` column from the INSERT statement. Added a comment noting the correct schema.

## Related
- PM investigation into admin dashboard login failures
- Migration 016 (`admin_users` table)
- Separate migration needed to seed Khubair's actual email (pending email confirmation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved database seed data schema inconsistency to ensure proper admin user initialization during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->