### PR TITLE
fix(#1081): suppress OS media transport overlay in MusicPlayer

### DIFF
--- a/app/components/ui/MusicPlayer.tsx
+++ b/app/components/ui/MusicPlayer.tsx
@@ -56,6 +56,39 @@ export function MusicPlayer() {
   const prefersReduced = usePrefersReducedMotion();
   const pathname = usePathname();
 
+  /* Suppress OS-level media transport overlay.
+   * The hidden <audio> element triggers the browser/OS media session API which
+   * surfaces native play/pause/skip controls independently of DOM controls.
+   * (1) disableRemotePlayback prevents AirPlay/Chromecast picker triggering OS controls.
+   * (2) Clearing mediaSession.metadata + nulling all action handlers suppresses the OS overlay. */
+  useEffect(() => {
+    // disableRemotePlayback is a standard HTMLMediaElement property but is not in
+    // React's JSX types, so we set it imperatively.
+    if (audioRef.current) {
+      (audioRef.current as HTMLAudioElement & { disableRemotePlayback?: boolean }).disableRemotePlayback = true;
+    }
+
+    if (!("mediaSession" in navigator)) return;
+    navigator.mediaSession.metadata = null;
+    (
+      [
+        "play",
+        "pause",
+        "stop",
+        "seekbackward",
+        "seekforward",
+        "previoustrack",
+        "nexttrack",
+      ] as MediaSessionAction[]
+    ).forEach((action) => {
+      try {
+        navigator.mediaSession.setActionHandler(action, null);
+      } catch {
+        // Older browsers may not support all actions — ignore
+      }
+    });
+  }, []);
+
   /* Determine if the player should be hidden on mobile for this route */
   const hideOnMobile = HIDE_ON_MOBILE_ROUTES.some((r) => pathname?.startsWith(r));
 


### PR DESCRIPTION
## What
Fixes #1081 — OS-level media transport controls (play/pause/skip) appearing as a system overlay triggered by the hidden `<audio>` element.

## Root Cause
Browser/OS detects the `<audio>` element and surfaces native media session controls independently of DOM `controls` attribute.

## Fix
- Set `disableRemotePlayback = true` imperatively on the audio element (suppresses AirPlay/Chromecast picker that triggers OS controls)
- Clear `navigator.mediaSession.metadata` and null all action handlers on mount to suppress the OS media overlay

## Testing
- Verify no OS media controls overlay appears on macOS/iOS/Android when audio is playing
- Verify play/pause/volume still work in the in-app widget

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed OS and browser media transport controls that previously appeared during audio playback, ensuring a seamless experience with the application's dedicated player controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->