### PR TITLE
fix(api): funding 500 resilience + add migration 20260312161900 local file

### DIFF
--- a/packages/api/src/routes/funding.ts
+++ b/packages/api/src/routes/funding.ts
@@ -135,9 +135,15 @@ export function fundingRoutes(): Hono {
       const dailyRatePercent = (rateBps / 10000.0) * SLOTS_PER_DAY;
       const annualizedPercent = (rateBps / 10000.0) * SLOTS_PER_YEAR;
 
-      // Fetch 24h funding history
+      // Fetch 24h funding history — gracefully degrade if table is unavailable
       const since24h = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-      const history = await getFundingHistorySince(slab, since24h);
+      let history: Awaited<ReturnType<typeof getFundingHistorySince>>;
+      try {
+        history = await getFundingHistorySince(slab, since24h);
+      } catch (histErr) {
+        logger.warn("funding_history unavailable, returning empty history", { slab, error: histErr });
+        history = [];
+      }
 
       // Format history for response
       const last24hHistory = history.map((h) => ({

--- a/supabase/migrations/20260312161900_funding_history_table.sql
+++ b/supabase/migrations/20260312161900_funding_history_table.sql
@@ -1,0 +1,53 @@
+-- Migration 20260312161900: Create funding_history table
+--
+-- Context: The funding_rates migration (20260214190000_funding_rates.sql.skip)
+-- was intentionally skipped in the automated migration pipeline because some
+-- of its view DDL conflicted with migration 037. This migration was applied
+-- directly to production Supabase on 2026-03-12 to resolve API 500 errors
+-- on GET /funding/:slab (missing funding_history table).
+--
+-- Supabase recorded the remote application with timestamp 20260312161900.
+-- This local file aligns the local migration history so supabase db push/pull
+-- work again. It is idempotent — safe to run even if applied previously.
+--
+-- The market_stats columns (funding_rate, net_lp_pos etc.) were already
+-- present from migration 037 and do not need re-adding here.
+
+-- ============================================================================
+-- funding_history table for time-series funding rate data
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS funding_history (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  market_slab TEXT NOT NULL REFERENCES markets(slab_address) ON DELETE CASCADE,
+  slot BIGINT NOT NULL,
+  timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  rate_bps_per_slot BIGINT NOT NULL,
+  net_lp_pos TEXT NOT NULL,
+  price_e6 BIGINT NOT NULL,
+  funding_index_qpb_e6 TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Efficient time-series queries by market + time
+CREATE INDEX IF NOT EXISTS idx_funding_history_market_time
+  ON funding_history(market_slab, timestamp DESC);
+
+CREATE INDEX IF NOT EXISTS idx_funding_history_slot
+  ON funding_history(market_slab, slot DESC);
+
+-- Public read (consistent with market_stats access pattern)
+ALTER TABLE funding_history ENABLE ROW LEVEL SECURITY;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'funding_history'
+      AND policyname = 'Public read access'
+  ) THEN
+    CREATE POLICY "Public read access" ON funding_history FOR SELECT USING (true);
+  END IF;
+END $$;
+
+-- Notify PostgREST to reload schema cache
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary

Two fixes in one PR — both stem from the devops report about missing migration + Sentry 500s on the funding endpoint.

## Changes

### 1. `supabase/migrations/20260312161900_funding_history_table.sql`
- Creates the local migration file that matches what was applied directly to remote Supabase on 2026-03-12 (the `funding_history` table creation).
- Without this local file, `supabase db push` and `supabase db pull` both fail: "remote has migration 20260312161900 with no local equivalent".
- Migration is **idempotent** (`IF NOT EXISTS`, `DO$$...IF NOT EXISTS$$` for the policy) — safe to apply against any state.
- Aligns with migration 037 (no view DDL conflicts — the view is already handled there).

### 2. `packages/api/src/routes/funding.ts`
- Wraps `getFundingHistorySince()` in a dedicated `try/catch` so that if `funding_history` table is missing or inaccessible, the endpoint returns a **200 with empty history array** instead of 500.
- The 3 Sentry events on `GET /funding/:slab` were caused by the table not existing before the migration was applied.
- Fixes root cause (migration) + adds defensive fallback so it never 500s again.

## Testing

- `pnpm --filter @percolator/api build` ✅
- App test suite: **912 passing, 34 skipped** ✅

## Notes

- The old `20260214190000_funding_rates.sql.skip` file can be deleted in a follow-up cleanup PR — it's no longer needed now that the proper timestamped migration exists.
- DevOps: after this PR merges, `supabase db push` should work again.
