### PR TITLE
Fix URL parameter for ref in buildSolflareBrowseUrl

### DIFF
--- a/app/lib/solflare.ts
+++ b/app/lib/solflare.ts
@@ -1,5 +1,5 @@
 export function buildSolflareBrowseUrl(currentUrl: string, ref?: string): string {
   const encodedUrl = encodeURIComponent(currentUrl);
-  const encodedRef = ref ? `?ref=${encodeURIComponent(ref)}` : "";
+  const encodedRef = ref ? `&ref=${encodeURIComponent(ref)}` : "";
   return `https://solflare.com/ul/v1/browse/${encodedUrl}${encodedRef}`;
 }


### PR DESCRIPTION
CHANGE FROM:
  const encodedRef = ref ? `?ref=${encodeURIComponent(ref)}` : "";

CHANGE TO:
  const encodedRef = ref ? `&ref=${encodeURIComponent(ref)}` : "";


Problem: When currentUrl is already encoded and might have ? in it, adding another ? breaks the URL.

Solution: Use & for the second parameter (ref), not ?.

