### PR TITLE
fix(db): add migration 040 local file — seed admin_users

### DIFF
--- a/supabase/migrations/040_seed_admin_users.sql
+++ b/supabase/migrations/040_seed_admin_users.sql
@@ -1,0 +1,11 @@
+-- Seed admin_users table with project owner
+-- The admin dashboard requires a matching row in admin_users for login.
+-- Without this, the /admin page redirects to /admin/login after auth check fails.
+
+-- NOTE: The seed.sql file has placeholder emails (admin@percolator.com) that
+-- don't match any real Supabase auth user. This migration inserts the actual
+-- project owner email.
+
+INSERT INTO admin_users (email)
+VALUES ('khubair@dcccrypto.com')
+ON CONFLICT (email) DO NOTHING;


### PR DESCRIPTION
Migration 040 (040_seed_admin_users.sql) exists in remote Supabase but was missing from the repo. This adds the local file to keep migration history in sync.\n\nSchema drift reported by coder (message 11066).\n\nFile contents: seeds admin_users table with project owner email (khubair@dcccrypto.com), idempotent via ON CONFLICT DO NOTHING.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database initialization to configure admin user accounts for system administration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->