### PR TITLE
fix(P0): PERC-1094 stale slab retry — regenerate keypair when existing account has wrong size

### DIFF
--- a/app/hooks/useCreateMarket.ts
+++ b/app/hooks/useCreateMarket.ts
@@ -293,7 +293,7 @@ export function useCreateMarket() {
         return;
       }
 
-      const [vaultPda] = deriveVaultAuthority(programId, slabPk);
+      let [vaultPda] = deriveVaultAuthority(programId, slabPk);
 
       try {
         // Step 0: Create slab + vault ATA + InitMarket (ATOMIC — all-or-nothing)
@@ -305,7 +305,31 @@ export function useCreateMarket() {
           vaultAta = await getAssociatedTokenAddress(params.mint, vaultPda, true);
 
           // Check if slab account already exists (previous attempt may have landed)
-          const existingAccount = await connection.getAccountInfo(slabKp.publicKey);
+          // PERC-1094 fix: also regenerate if the existing slab has the wrong size (stale
+          // orphan from old SDK — e.g. 65352-byte account created before ENGINE_OFF fix).
+          // Without this check, retries always call InitMarket on the wrong-sized slab and
+          // fail with InvalidSlabLen (error 0x4) even after the SDK size was corrected.
+          const expectedSlabSize = params.slabDataSize ?? DEFAULT_SLAB_SIZE;
+          let existingAccount = await connection.getAccountInfo(slabKp.publicKey);
+          if (existingAccount && existingAccount.data.length !== expectedSlabSize) {
+            console.warn(
+              `[useCreateMarket] PERC-1094: stale slab ${slabKp.publicKey.toBase58()} ` +
+              `(${existingAccount.data.length}B, expected ${expectedSlabSize}B). ` +
+              `Abandoning orphan and generating fresh keypair.`,
+            );
+            localStorage.removeItem("percolator-pending-slab-keypair");
+            slabKp = Keypair.generate();
+            slabKpRef.current = slabKp;
+            slabPk = slabKp.publicKey;
+            localStorage.setItem(
+              "percolator-pending-slab-keypair",
+              JSON.stringify(Array.from(slabKp.secretKey)),
+            );
+            // Recompute PDA and ATA for new slab keypair
+            [vaultPda] = deriveVaultAuthority(programId, slabPk);
+            vaultAta = await getAssociatedTokenAddress(params.mint, vaultPda, true);
+            existingAccount = null; // treat as fresh creation
+          }
           if (existingAccount) {
             // Slab already created — check if market is initialized
             const headerMagic = existingAccount.data.length >= 8


### PR DESCRIPTION
## Problem

`useCreateMarket` persists the slab keypair in localStorage across retries. PR #1096 fixed the SDK slab size (65352 → 65312 for Small tier), but users who had already triggered market creation with the OLD SDK had a **65352-byte orphaned slab account** stored in their browser's localStorage keypair.

On retry after the PR #1096 fix:
1. Wizard loads stored keypair → slab account exists at 65352 bytes
2. Slab exists but NOT initialized → wizard calls `InitMarket` on it
3. Program's `slab_guard` rejects: `data.len() == 65352` ≠ `SLAB_LEN == 65312` → **InvalidSlabLen (error 0x4)**

Result: Khubair still gets Invalid slab length on BOTH flows (test mint token + mainnet mirror) even after PR #1096 was deployed.

## Root Cause Confirmed On-Chain

```
FwfBKZXbYr4vTK23bMFkbgKq3npJ3MSDxEaKmq9Aj4Qn (Small program):
  3  accounts at 65312 bytes  ← valid, initialized
  32 accounts at 65352 bytes  ← orphaned, old SDK, uninitialized
```

## Fix

Before processing an existing slab account, compare `existingAccount.data.length` against `expectedSlabSize` (`params.slabDataSize ?? DEFAULT_SLAB_SIZE`).

If mismatched → **stale orphan from old SDK**:
1. Remove stored keypair from localStorage
2. Generate fresh `Keypair`
3. Recompute `vaultPda` + `vaultAta` for new keypair
4. Set `existingAccount = null` → falls through to normal fresh-creation path

The orphaned 65352-byte accounts on devnet are abandoned in place (they hold no user funds — they're empty system accounts owned by the program that never ran InitMarket).

## Testing

- All 74 test files pass (912 tests, 0 failures)
- TypeScript: no new errors
- Matches on-chain reality: 3 valid 65312-byte slabs already exist and work

## Related

- Fixes: #1094 (root cause of remaining failure after PR #1096)
- Parent fix: #1096 (SDK size 65352 → 65312)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved market creation robustness by adding validation for account sizes during initialization.
  * Fixed handling of stale or incorrectly-sized accounts that may have been created by previous SDK versions, enabling automatic recovery and proper market creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->