### PR TITLE
fix: chunk portfolio slab batch fetch & fix LP pools 404 (#1098, #1099)

### DIFF
--- a/app/hooks/useLpPositions.ts
+++ b/app/hooks/useLpPositions.ts
@@ -5,7 +5,7 @@ import { PublicKey } from '@solana/web3.js';
 import { useWalletCompat, useConnectionCompat } from '@/hooks/useWalletCompat';
 import { getAssociatedTokenAddressSync, unpackAccount } from '@solana/spl-token';
 import { STAKE_PROGRAM_ID, deriveDepositPda } from '@percolator/sdk';
-import { getBackendUrl } from '@/lib/config';
+
 
 // ═══════════════════════════════════════════════════════════════
 // Types
@@ -107,9 +107,8 @@ export function useLpPositions(): LpPositionsState & { refresh: () => void } {
     setError(null);
 
     try {
-      // 1. Fetch all pools
-      const base = getBackendUrl();
-      const res = await fetch(`${base}/api/stake/pools`);
+      // 1. Fetch all pools (Next.js API route – use relative URL for same-origin)
+      const res = await fetch(`/api/stake/pools`);
       if (!res.ok) throw new Error(`Failed to fetch pools: ${res.status}`);
       const { pools } = (await res.json()) as { pools: ApiPool[] };
 

--- a/app/hooks/usePortfolio.ts
+++ b/app/hooks/usePortfolio.ts
@@ -115,11 +115,20 @@ export function usePortfolio(): PortfolioData {
         let riskCount = 0;
 
         // Batch fetch all slab accounts using getMultipleAccountsInfo
+        // RPC limit is 100 accounts per call, so chunk into batches
         const slabAddresses = markets.map((m) => m.slabAddress);
         let slabAccountsInfo: (import("@solana/web3.js").AccountInfo<Buffer> | null)[] = [];
         
         try {
-          slabAccountsInfo = await connection.getMultipleAccountsInfo(slabAddresses);
+          const BATCH_SIZE = 100;
+          const chunks: PublicKey[][] = [];
+          for (let i = 0; i < slabAddresses.length; i += BATCH_SIZE) {
+            chunks.push(slabAddresses.slice(i, i + BATCH_SIZE));
+          }
+          const results = await Promise.all(
+            chunks.map((chunk) => connection.getMultipleAccountsInfo(chunk))
+          );
+          slabAccountsInfo = results.flat();
         } catch (error) {
           console.error("[usePortfolio] Failed to batch fetch slabs:", error);
           slabAccountsInfo = [];


### PR DESCRIPTION
## What

**#1098 (P0):** `usePortfolio` calls `getMultipleAccountsInfo` with all slab addresses at once. When 87+ markets exist, this exceeds the Solana RPC 100-account limit, crashing the portfolio page with `SolanaJSONRPCError`.

**Fix:** Chunk into batches of 100, `Promise.all` each chunk, then flatten.

**#1099 (Medium):** `useLpPositions` fetches `${backendUrl}/api/stake/pools` — but `backendUrl` points to the percolator-api Express service, which doesn't serve Next.js API routes → 404.

**Fix:** Use relative URL `/api/stake/pools` since the hook runs client-side in the Next.js app.

## Testing
- Portfolio page loads with 100+ markets without RPC errors
- LP Positions section no longer shows 404 error

Fixes #1098, Fixes #1099

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability of portfolio data fetching for users with large account positions.
  * Optimized API communication for pool information retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->