### PR TITLE
refactor(api): proxy /api/bugs + /api/chart to percolator-api

### DIFF
--- a/app/__tests__/api/bugs-proxy.test.ts
+++ b/app/__tests__/api/bugs-proxy.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for /api/bugs proxy route.
+ *
+ * GET  /api/bugs — auth-gated proxy (x-api-key required)
+ * POST /api/bugs — public proxy (IP forwarding for per-IP rate limiting)
+ *
+ * Business logic (rate limiting, sanitisation, DB writes) lives in
+ * percolator-api. These tests verify the proxy wrapper behaves correctly.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+// Mock api-proxy so no real network calls are made
+vi.mock("@/lib/api-proxy", () => ({
+  proxyToApi: vi.fn(),
+}));
+
+// Mock api-auth to control auth check results
+vi.mock("@/lib/api-auth", () => ({
+  requireAuth: vi.fn(),
+  UNAUTHORIZED: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+}));
+
+import { proxyToApi } from "@/lib/api-proxy";
+import { requireAuth } from "@/lib/api-auth";
+import { GET, POST } from "../../app/api/bugs/route";
+
+function makeGetReq(apiKey?: string): NextRequest {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (apiKey) headers["x-api-key"] = apiKey;
+  return new NextRequest("http://localhost/api/bugs", { headers });
+}
+
+function makePostReq(body: object, ip = "1.2.3.4"): NextRequest {
+  return new NextRequest("http://localhost/api/bugs", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-forwarded-for": ip,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("GET /api/bugs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when auth check fails (no proxy call)", async () => {
+    vi.mocked(requireAuth).mockReturnValue(false);
+
+    const res = await GET(makeGetReq());
+    expect(res.status).toBe(401);
+    expect(vi.mocked(proxyToApi)).not.toHaveBeenCalled();
+  });
+
+  it("proxies to /bugs when auth passes, forwarding x-api-key", async () => {
+    vi.mocked(requireAuth).mockReturnValue(true);
+    const mockBugs = [{ id: 1, title: "test bug", severity: "medium" }];
+    vi.mocked(proxyToApi).mockResolvedValue(
+      NextResponse.json(mockBugs, { status: 200 })
+    );
+
+    const res = await GET(makeGetReq("my-api-key"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(vi.mocked(proxyToApi)).toHaveBeenCalledOnce();
+    expect(vi.mocked(proxyToApi)).toHaveBeenCalledWith(
+      expect.any(Object), // req
+      "/bugs",
+      { "x-api-key": "my-api-key" }
+    );
+  });
+
+  it("forwards empty x-api-key when header is absent", async () => {
+    vi.mocked(requireAuth).mockReturnValue(true);
+    vi.mocked(proxyToApi).mockResolvedValue(
+      NextResponse.json([], { status: 200 })
+    );
+
+    await GET(makeGetReq()); // no key in headers
+    expect(vi.mocked(proxyToApi)).toHaveBeenCalledWith(
+      expect.any(Object),
+      "/bugs",
+      { "x-api-key": "" }
+    );
+  });
+
+  it("forwards 502 when backend is unreachable", async () => {
+    vi.mocked(requireAuth).mockReturnValue(true);
+    vi.mocked(proxyToApi).mockResolvedValue(
+      NextResponse.json({ error: "Backend unavailable" }, { status: 502 })
+    );
+
+    const res = await GET(makeGetReq("key"));
+    expect(res.status).toBe(502);
+  });
+});
+
+describe("POST /api/bugs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("proxies to /bugs with body and x-real-ip from x-forwarded-for", async () => {
+    vi.mocked(proxyToApi).mockResolvedValue(
+      NextResponse.json({ ok: true }, { status: 201 })
+    );
+
+    const req = makePostReq(
+      { twitter_handle: "alice", title: "bug", description: "details", severity: "low" },
+      "203.0.113.1"
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+    expect(vi.mocked(proxyToApi)).toHaveBeenCalledOnce();
+    expect(vi.mocked(proxyToApi)).toHaveBeenCalledWith(
+      expect.any(Object),
+      "/bugs",
+      { "x-real-ip": "203.0.113.1" },
+      { includeBody: true }
+    );
+  });
+
+  it("uses x-real-ip header directly when x-forwarded-for is absent", async () => {
+    vi.mocked(proxyToApi).mockResolvedValue(
+      NextResponse.json({ ok: true }, { status: 201 })
+    );
+
+    const req = new NextRequest("http://localhost/api/bugs", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-real-ip": "198.51.100.5",
+      },
+      body: JSON.stringify({ twitter_handle: "bob", title: "b", description: "d", severity: "high" }),
+    });
+
+    await POST(req);
+    expect(vi.mocked(proxyToApi)).toHaveBeenCalledWith(
+      expect.any(Object),
+      "/bugs",
+      { "x-real-ip": "198.51.100.5" },
+      { includeBody: true }
+    );
+  });
+
+  it("uses 'unknown' as IP when neither forwarding header is present", async () => {
+    vi.mocked(proxyToApi).mockResolvedValue(
+      NextResponse.json({ ok: true }, { status: 201 })
+    );
+
+    const req = new NextRequest("http://localhost/api/bugs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ twitter_handle: "t", title: "t", description: "d", severity: "low" }),
+    });
+
+    await POST(req);
+    expect(vi.mocked(proxyToApi)).toHaveBeenCalledWith(
+      expect.any(Object),
+      "/bugs",
+      { "x-real-ip": "unknown" },
+      { includeBody: true }
+    );
+  });
+
+  it("forwards 429 from backend when IP is rate-limited", async () => {
+    vi.mocked(proxyToApi).mockResolvedValue(
+      NextResponse.json(
+        { error: "Rate limited — max 3 bug reports per hour" },
+        { status: 429 }
+      )
+    );
+
+    const req = makePostReq({ twitter_handle: "t", title: "t", description: "d", severity: "low" });
+    const res = await POST(req);
+    expect(res.status).toBe(429);
+  });
+
+  it("forwards 400 validation errors from backend", async () => {
+    vi.mocked(proxyToApi).mockResolvedValue(
+      NextResponse.json({ error: "Title required (max 120 chars)" }, { status: 400 })
+    );
+
+    const req = makePostReq({ twitter_handle: "t" }); // missing required fields
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/__tests__/api/chart-mint-validation.test.ts
+++ b/app/__tests__/api/chart-mint-validation.test.ts
@@ -1,18 +1,28 @@
 /**
- * Tests for /api/chart/[mint] input validation.
- * Ensures that the mint path segment is validated as a properly decodable
- * Solana PublicKey, not just a base58-alphabet string.
+ * Tests for /api/chart/[mint] input validation + proxy behaviour.
  *
- * Covers regression for GitHub issue #942.
+ * Since the route was converted to a thin proxy (GH feat/proxy-bugs-chart-to-api),
+ * business logic (GeckoTerminal fetch, caching) lives in percolator-api.
+ * These tests verify:
+ *   1. The mint path segment is validated as a properly-decodable Solana PublicKey
+ *      before the request is forwarded upstream (covers regression for GH issue #942).
+ *   2. Valid mints are proxied and the upstream response is forwarded correctly.
  */
 
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+// Mock the shared proxy utility — no real network calls in unit tests
+vi.mock("@/lib/api-proxy", () => ({
+  proxyToApi: vi.fn(),
+}));
+
+import { proxyToApi } from "@/lib/api-proxy";
 import { GET } from "../../app/api/chart/[mint]/route";
 
-// Minimal mock for NextRequest with nextUrl
 function makeReq(mint: string): NextRequest {
-  const url = `http://localhost/api/chart/${mint}`;
-  return new NextRequest(url);
+  return new NextRequest(`http://localhost/api/chart/${mint}`);
 }
 
 async function callRoute(mint: string) {
@@ -22,33 +32,62 @@ async function callRoute(mint: string) {
 }
 
 describe("GET /api/chart/[mint] — input validation", () => {
-  it("returns 400 for an empty mint", async () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 for an empty mint (no proxy call)", async () => {
     const res = await callRoute("");
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error).toMatch(/invalid mint/i);
+    expect(vi.mocked(proxyToApi)).not.toHaveBeenCalled();
   });
 
-  it("returns 400 for a non-base58 string", async () => {
+  it("returns 400 for a non-base58 string (no proxy call)", async () => {
     const res = await callRoute("not-a-pubkey!!");
     expect(res.status).toBe(400);
+    expect(vi.mocked(proxyToApi)).not.toHaveBeenCalled();
   });
 
-  it("returns 400 for a base58-alphabet string that is not a valid pubkey", async () => {
-    // 44-char base58 string that passes the old regex but fails PublicKey decode
-    const res = await callRoute("11111111111111111111111111111111111111111111");
-    // This is actually the system program (valid) — use a string of wrong length
-    const res2 = await callRoute("1111111111111111111111111111111"); // 31 chars
-    expect(res2.status).toBe(400);
+  it("returns 400 for a base58-alphabet string that is not a valid pubkey (no proxy call)", async () => {
+    const res = await callRoute("1111111111111111111111111111111"); // 31 chars — too short
+    expect(res.status).toBe(400);
+    expect(vi.mocked(proxyToApi)).not.toHaveBeenCalled();
   });
 
-  it("accepts a valid Solana pubkey (system program)", async () => {
-    // System program: 11111111111111111111111111111111 — 32 chars, valid
-    // Route will try to fetch GeckoTerminal data; with no pool it returns 200 with empty candles
-    const res = await callRoute("11111111111111111111111111111111");
-    // Accepts the pubkey (200) — external fetch returns no pool → { candles: [], poolAddress: null }
+  it("accepts a valid Solana pubkey and proxies to percolator-api", async () => {
+    const mockPayload = { candles: [], poolAddress: null, cached: false };
+    vi.mocked(proxyToApi).mockResolvedValue(
+      NextResponse.json(mockPayload, { status: 200 })
+    );
+
+    const res = await callRoute("11111111111111111111111111111111"); // system program
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toHaveProperty("candles");
+    expect(vi.mocked(proxyToApi)).toHaveBeenCalledOnce();
+    expect(vi.mocked(proxyToApi)).toHaveBeenCalledWith(
+      expect.any(Object), // req
+      "/chart/11111111111111111111111111111111"
+    );
+  });
+
+  it("forwards OHLCV candles from upstream when a pool exists", async () => {
+    const candles = [
+      { timestamp: 1_700_000_000_000, open: 1.0, high: 1.1, low: 0.9, close: 1.05, volume: 500 },
+    ];
+    vi.mocked(proxyToApi).mockResolvedValue(
+      NextResponse.json(
+        { candles, poolAddress: "somePool123", cached: false },
+        { status: 200 }
+      )
+    );
+
+    const res = await callRoute("So11111111111111111111111111111111111111112"); // wSOL
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.candles).toHaveLength(1);
+    expect(body.poolAddress).toBe("somePool123");
   });
 });

--- a/app/app/api/bugs/route.ts
+++ b/app/app/api/bugs/route.ts
@@ -1,132 +1,37 @@
-import { NextRequest, NextResponse } from "next/server";
-import { getServiceClient } from "@/lib/supabase";
+/**
+ * GET  /api/bugs  — proxy to percolator-api GET /bugs
+ * POST /api/bugs  — proxy to percolator-api POST /bugs
+ *
+ * Business logic (rate limiting, sanitisation, DB writes) lives in
+ * percolator-api and is tested there. This file is a thin auth-aware proxy.
+ *
+ * GET:  Protected by x-api-key (used by Discord bot poller + admin dashboard).
+ *       Forwards the key to percolator-api which re-checks it.
+ *
+ * POST: Public endpoint. Forwards the real client IP so percolator-api can
+ *       apply per-IP rate limiting (3 req/hr).
+ */
+
+import { NextRequest } from "next/server";
 import { requireAuth, UNAUTHORIZED } from "@/lib/api-auth";
+import { proxyToApi } from "@/lib/api-proxy";
 
-export const dynamic = 'force-dynamic';
-
-const rateMap = new Map<string, { count: number; resetAt: number }>();
-
-function isRateLimited(ip: string): boolean {
-  const now = Date.now();
-  const entry = rateMap.get(ip);
-  if (!entry || now > entry.resetAt) {
-    rateMap.set(ip, { count: 1, resetAt: now + 3600_000 });
-    return false;
-  }
-  if (entry.count >= 3) return true;
-  entry.count++;
-  return false;
-}
-
-function sanitize(str: string): string {
-  return str.replace(/[<>]/g, "").trim();
-}
-
-const TABLE = "bug_reports";
+export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest) {
   if (!requireAuth(req)) return UNAUTHORIZED;
 
-  try {
-    const sb = getServiceClient();
-    const { data, error } = await (sb.from as any)(TABLE)
-      .select(
-        "id, twitter_handle, title, description, severity, page, bounty_wallet, transaction_wallet, page_url, status, created_at"
-      )
-      .order("created_at", { ascending: false })
-      .limit(50);
-
-    if (error) {
-      if (error.code === "42P01") return NextResponse.json([]);
-      throw error;
-    }
-
-    return NextResponse.json(data ?? []);
-  } catch (err) {
-    console.error("GET /api/bugs error:", err);
-    return NextResponse.json([], { status: 200 });
-  }
+  const apiKey = req.headers.get("x-api-key") ?? "";
+  return proxyToApi(req, "/bugs", { "x-api-key": apiKey });
 }
 
 export async function POST(req: NextRequest) {
-  try {
-    const ip =
-      req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
-      req.headers.get("x-real-ip") ??
-      "unknown";
+  // Extract real client IP from Vercel/proxy forwarded headers and pass it to
+  // percolator-api so that the per-IP rate limiter operates on the actual client.
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    req.headers.get("x-real-ip") ??
+    "unknown";
 
-    if (isRateLimited(ip)) {
-      return NextResponse.json(
-        { error: "Rate limited — max 3 bug reports per hour" },
-        { status: 429 }
-      );
-    }
-
-    const body = await req.json();
-    const twitter_handle = sanitize(String(body.twitter_handle ?? ""));
-    const title = sanitize(String(body.title ?? ""));
-    const description = sanitize(String(body.description ?? ""));
-    const severity = sanitize(String(body.severity ?? "medium"));
-    const page = sanitize(String(body.page ?? ""));
-    const steps_to_reproduce = sanitize(String(body.steps_to_reproduce ?? ""));
-    const expected_behavior = sanitize(String(body.expected_behavior ?? ""));
-    const actual_behavior = sanitize(String(body.actual_behavior ?? ""));
-    const bounty_wallet = body.bounty_wallet ? sanitize(String(body.bounty_wallet)) : null;
-    const transaction_wallet = body.transaction_wallet ? sanitize(String(body.transaction_wallet)) : null;
-    const page_url = body.page_url ? sanitize(String(body.page_url)) : null;
-    const browser = body.browser ? sanitize(String(body.browser)) : null;
-
-    if (!twitter_handle || twitter_handle.length > 30) {
-      return NextResponse.json(
-        { error: "Twitter handle required (max 30 chars)" },
-        { status: 400 }
-      );
-    }
-    if (!title || title.length > 120) {
-      return NextResponse.json(
-        { error: "Title required (max 120 chars)" },
-        { status: 400 }
-      );
-    }
-    if (!description || description.length > 2000) {
-      return NextResponse.json(
-        { error: "Description required (max 2000 chars)" },
-        { status: 400 }
-      );
-    }
-    if (!["low", "medium", "high", "critical"].includes(severity)) {
-      return NextResponse.json(
-        { error: "Invalid severity" },
-        { status: 400 }
-      );
-    }
-
-    const sb = getServiceClient();
-    const { error } = await (sb.from as any)(TABLE).insert({
-      twitter_handle,
-      title,
-      description,
-      severity,
-      page,
-      steps_to_reproduce: steps_to_reproduce || null,
-      expected_behavior: expected_behavior || null,
-      actual_behavior: actual_behavior || null,
-      bounty_wallet,
-      transaction_wallet,
-      page_url: page_url || null,
-      browser,
-      ip,
-    });
-
-    if (error) throw error;
-
-    // Discord notification handled by bot poller (polls /api/bugs every 30s)
-    return NextResponse.json({ ok: true }, { status: 201 });
-  } catch (err) {
-    console.error("POST /api/bugs error:", err);
-    return NextResponse.json(
-      { error: "Failed to submit bug report" },
-      { status: 500 }
-    );
-  }
+  return proxyToApi(req, "/bugs", { "x-real-ip": ip }, { includeBody: true });
 }

--- a/app/app/api/chart/[mint]/route.ts
+++ b/app/app/api/chart/[mint]/route.ts
@@ -1,27 +1,25 @@
-import { PublicKey } from "@solana/web3.js";
-import { NextRequest, NextResponse } from "next/server";
-
-export const dynamic = "force-dynamic";
-
 /**
  * GET /api/chart/[mint]?timeframe=1h&limit=168
  *
- * Returns OHLCV candle data for a Solana SPL token by mint address.
+ * Proxy to percolator-api GET /chart/:mint.
  *
- * Data source: GeckoTerminal (free, no API key required)
- *   Step 1: /api/v2/networks/solana/tokens/{mint}/pools?limit=1 → top pool address
- *   Step 2: /api/v2/networks/solana/pools/{pool}/ohlcv/{timeframe}?aggregate=1&limit={limit}
+ * Mint validation is kept here so Vercel can reject malformed requests at the
+ * edge before they hit Railway.
  *
- * Query params:
- *   timeframe — "minute" | "hour" | "day"  (default: "hour")
- *   aggregate — candle aggregation (default: 1 for hour, 5 for minute)
- *   limit     — number of candles (default: 168 = 7 days of hourly)
+ * Business logic (GeckoTerminal fetch, in-memory cache, candle parsing) now
+ * lives in percolator-api and is tested there.
  *
  * Response: { candles: CandleData[], poolAddress: string | null, cached: boolean }
- *
- * In-memory cache: 60s TTL for most recent candle, 5min for older data.
  */
 
+import { type NextRequest, NextResponse } from "next/server";
+import { PublicKey } from "@solana/web3.js";
+import { proxyToApi } from "@/lib/api-proxy";
+
+export const dynamic = "force-dynamic";
+
+// Re-export the CandleData type so consumers can import it from the route module
+// without importing from percolator-api directly.
 export interface CandleData {
   timestamp: number; // Unix ms
   open: number;
@@ -31,77 +29,15 @@ export interface CandleData {
   volume: number;
 }
 
-interface CacheEntry {
-  candles: CandleData[];
-  poolAddress: string | null;
-  fetchedAt: number;
-}
-
-// In-memory cache: mint → CacheEntry
-const cache = new Map<string, CacheEntry>();
-const CACHE_TTL_MS = 60 * 1000; // 60 seconds
-
-const GECKO_BASE = "https://api.geckoterminal.com/api/v2";
-const GECKO_HEADERS = {
-  Accept: "application/json;version=20230302",
-};
-
-async function getTopPool(mint: string): Promise<string | null> {
-  try {
-    const url = `${GECKO_BASE}/networks/solana/tokens/${mint}/pools?limit=1&sort=h24_volume_usd_liquidity_desc`;
-    const res = await fetch(url, { headers: GECKO_HEADERS, next: { revalidate: 300 } });
-    if (!res.ok) return null;
-    const json = await res.json();
-    const pools = json?.data;
-    if (!Array.isArray(pools) || pools.length === 0) return null;
-    return pools[0]?.id?.replace("solana_", "") ?? null;
-  } catch {
-    return null;
-  }
-}
-
-async function fetchOhlcv(
-  poolAddress: string,
-  timeframe: string,
-  aggregate: number,
-  limit: number
-): Promise<CandleData[]> {
-  try {
-    const url = `${GECKO_BASE}/networks/solana/pools/${poolAddress}/ohlcv/${timeframe}?aggregate=${aggregate}&limit=${limit}&currency=usd&include_empty_intervals=false`;
-    const res = await fetch(url, { headers: GECKO_HEADERS });
-    if (!res.ok) return [];
-    const json = await res.json();
-
-    // GeckoTerminal response shape:
-    // { data: { attributes: { ohlcv_list: [[timestamp_sec, open, high, low, close, volume], ...] } } }
-    const ohlcvList = json?.data?.attributes?.ohlcv_list;
-    if (!Array.isArray(ohlcvList)) return [];
-
-    return ohlcvList
-      .map(([ts, o, h, l, c, v]: [number, number, number, number, number, number]) => ({
-        timestamp: ts * 1000, // convert to ms
-        open: o,
-        high: h,
-        low: l,
-        close: c,
-        volume: v,
-      }))
-      .filter((candle) => candle.close > 0)
-      .sort((a, b) => a.timestamp - b.timestamp);
-  } catch {
-    return [];
-  }
-}
-
 export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ mint: string }> }
 ) {
   const { mint } = await params;
 
-  // Validate mint is a properly decodable Solana public key.
+  // Validate mint at the edge before forwarding to Railway.
   // PublicKey constructor ensures the bytes decode to a valid 32-byte point,
-  // not just a base58-alphabet string. Matches /api/markets/[slab]/route.ts.
+  // not just a base58-alphabet string. Matches the upstream validation.
   try {
     if (!mint) throw new Error("missing");
     new PublicKey(mint);
@@ -109,53 +45,7 @@ export async function GET(
     return NextResponse.json({ error: "Invalid mint address" }, { status: 400 });
   }
 
-  // Parse query params
-  const { searchParams } = req.nextUrl;
-  const timeframe = (searchParams.get("timeframe") ?? "hour") as "minute" | "hour" | "day";
-  const aggregate = parseInt(searchParams.get("aggregate") ?? (timeframe === "minute" ? "5" : "1"), 10);
-  const limit = Math.min(parseInt(searchParams.get("limit") ?? "168", 10), 500);
-
-  // Cache key includes query params
-  const cacheKey = `${mint}:${timeframe}:${aggregate}:${limit}`;
-  const cached = cache.get(cacheKey);
-  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
-    return NextResponse.json({
-      candles: cached.candles,
-      poolAddress: cached.poolAddress,
-      cached: true,
-    });
-  }
-
-  // Step 1: Resolve top pool
-  const poolAddress = await getTopPool(mint);
-
-  if (!poolAddress) {
-    // No pool found — return empty, TradingChart will fall back to oracle prices
-    return NextResponse.json({ candles: [], poolAddress: null, cached: false });
-  }
-
-  // Step 2: Fetch OHLCV
-  const candles = await fetchOhlcv(poolAddress, timeframe, aggregate, limit);
-
-  // Cache result
-  cache.set(cacheKey, { candles, poolAddress, fetchedAt: Date.now() });
-
-  // Prune old cache entries (keep max 100, evict 10 oldest to prevent gradual growth)
-  if (cache.size > 100) {
-    const keys = cache.keys();
-    for (let i = 0; i < 10; i++) {
-      const k = keys.next();
-      if (k.done) break;
-      cache.delete(k.value);
-    }
-  }
-
-  return NextResponse.json(
-    { candles, poolAddress, cached: false },
-    {
-      headers: {
-        "Cache-Control": "public, max-age=60, stale-while-revalidate=120",
-      },
-    }
-  );
+  // Proxy to percolator-api, forwarding timeframe/aggregate/limit query params.
+  // Cache-Control is passed through from the upstream (60s public cache).
+  return proxyToApi(req, `/chart/${mint}`);
 }

--- a/app/lib/api-proxy.ts
+++ b/app/lib/api-proxy.ts
@@ -7,6 +7,8 @@
  * Usage:
  *   return proxyToApi(req, "/markets");
  *   return proxyToApi(req, `/markets/${slab}/trades`);
+ *   return proxyToApi(req, "/bugs", { "x-api-key": key });
+ *   return proxyToApi(req, "/bugs", { "x-real-ip": ip }, { includeBody: true });
  */
 
 import { type NextRequest, NextResponse } from "next/server";
@@ -14,17 +16,33 @@ import { getBackendUrl } from "@/lib/config";
 
 const PROXY_TIMEOUT_MS = 8_000;
 
+export interface ProxyOptions {
+  /**
+   * When true, the raw request body is forwarded to the upstream.
+   * Useful for POST/PUT/PATCH proxy routes.
+   * Ignored for GET and HEAD requests.
+   */
+  includeBody?: boolean;
+  /**
+   * Override the upstream Cache-Control header instead of using the backend's value.
+   * When omitted, the upstream Cache-Control is forwarded (or "no-store" as default).
+   */
+  cacheControl?: string;
+}
+
 /**
  * Proxy a Next.js route handler request to the percolator-api backend.
  *
  * @param req          The incoming NextRequest (query params are forwarded automatically).
  * @param apiPath      The backend path to call (e.g. "/markets", "/funding/global").
- * @param extraHeaders Optional headers to forward to the backend.
+ * @param extraHeaders Optional headers to forward to the backend (e.g. x-api-key, x-real-ip).
+ * @param options      Optional proxy behaviour overrides.
  */
 export async function proxyToApi(
   req: NextRequest,
   apiPath: string,
-  extraHeaders?: Record<string, string>
+  extraHeaders?: Record<string, string>,
+  options?: ProxyOptions
 ): Promise<NextResponse> {
   let backendUrl: string;
   try {
@@ -42,6 +60,16 @@ export async function proxyToApi(
     ? `${backendUrl}${apiPath}?${searchParams}`
     : `${backendUrl}${apiPath}`;
 
+  // Optionally read and forward the request body for mutation methods
+  let requestBody: string | undefined;
+  if (
+    options?.includeBody &&
+    req.method !== "GET" &&
+    req.method !== "HEAD"
+  ) {
+    requestBody = await req.text();
+  }
+
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), PROXY_TIMEOUT_MS);
 
@@ -52,16 +80,21 @@ export async function proxyToApi(
         "Content-Type": "application/json",
         ...extraHeaders,
       },
+      body: requestBody,
       signal: controller.signal,
     });
 
     const body = await upstream.text();
 
+    const upstreamCacheControl =
+      upstream.headers.get("Cache-Control") ?? "no-store, max-age=0";
+
     return new NextResponse(body, {
       status: upstream.status,
       headers: {
-        "Content-Type": upstream.headers.get("Content-Type") ?? "application/json",
-        "Cache-Control": "no-store, max-age=0",
+        "Content-Type":
+          upstream.headers.get("Content-Type") ?? "application/json",
+        "Cache-Control": options?.cacheControl ?? upstreamCacheControl,
       },
     });
   } catch (err) {


### PR DESCRIPTION
## What

Now that PR #14 shipped `/bugs` and `/chart` endpoints to percolator-api, this converts the duplicate Next.js route handlers into thin auth-aware proxies.

## Changes

### `lib/api-proxy.ts`
- New `ProxyOptions` interface: `includeBody` (forward request body for POST) + `cacheControl` (override upstream cache header)
- Body forwarded for non-GET/HEAD methods when `includeBody: true`
- Upstream `Cache-Control` now threaded through to response

### `/api/bugs` (GET + POST)
- **GET**: auth check kept at Vercel edge, then proxy with `x-api-key` forwarded
- **POST**: public proxy; real client IP from `x-forwarded-for` → `x-real-ip` so percolator-api per-IP rate limiter operates on actual client

### `/api/chart/[mint]`
- Mint validation kept at Vercel edge (400 before hitting Railway)
- Valid requests proxied to `GET /chart/:mint` with query params forwarded
- Duplicate GeckoTerminal fetch + in-memory cache logic removed

## Tests
- **New**: `bugs-proxy.test.ts` — 9 tests (GET auth gate, x-api-key forwarding, POST IP extraction, 429/400 passthrough)
- **Updated**: `chart-mint-validation.test.ts` — mocks proxyToApi (no live network in CI), 4 tests
- **922 tests passing, tsc clean**

Closes #13 follow-up (proxy the duplicate routes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for bugs and chart mint endpoints, covering proxy behavior, authentication, error handling, and IP extraction.

* **Refactor**
  * Migrated bugs and chart endpoints to proxy-based architecture for improved maintainability.
  * Enhanced proxy utility to support request body forwarding and configurable cache control headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->