### PR TITLE
fix: retry guard + CI test stability — closes GH #1103 (partial) + #1102

### DIFF
--- a/app/__tests__/components/MarketCard.test.tsx
+++ b/app/__tests__/components/MarketCard.test.tsx
@@ -14,6 +14,11 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+// Import jest-dom matchers directly rather than relying on global setupFiles.
+// In parallel CI workers the setupFiles import can intermittently fail to
+// register custom matchers on the Chai expect object, causing
+// "Invalid Chai property: toBeInTheDocument / toHaveTextContent" errors.
+import "@testing-library/jest-dom/vitest";
 import { render, screen, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MarketBrowser } from "@/components/market/MarketBrowser";
@@ -239,13 +244,14 @@ describe("MarketBrowser Component Tests", () => {
 
   describe("MKT-004: Sort with null values (CRITICAL)", () => {
     it("should handle markets with null/zero values without crashing", () => {
-      const market1 = createMockMarket({});
+      // Use distinct slab addresses so React keys are unique and rows are not deduplicated.
+      const market1 = createMockMarket({ slabAddress: new PublicKey("3BdFUYmduSkFuuiKuHDfv5LFvXkSmjbuLGa9hDwkyekz") });
       market1.engine.vault = 0n; // Zero vault
       market1.engine.totalOpenInterest = 0n;
       market1.engine.insuranceFund = { balance: 0n, feeRevenue: 0n };
       market1.engine.numUsedAccounts = 0;
       
-      const market2 = createMockMarket({});
+      const market2 = createMockMarket({ slabAddress: new PublicKey("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM") });
       market2.engine.vault = 10000000n;
       market2.engine.totalOpenInterest = 5000000n;
       market2.engine.insuranceFund = { balance: 1000000n, feeRevenue: 0n };

--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -440,7 +440,12 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
 
   // Retry from failed step
   const handleRetry = () => {
-    if (!allValid || !publicKey || !createState.slabAddress) return;
+    if (!allValid || !publicKey) return;
+    // For step > 0, slab address must be known to resume the transaction chain.
+    // Step 0 generates a fresh keypair, so slabAddress is not required for step 0 retry.
+    // Without this guard, a blockhash-expiry error on step 0 would silently no-op when
+    // the user clicks "Retry Step 1" (slabAddress is null until sendTx succeeds).
+    if (createState.step > 0 && !createState.slabAddress) return;
     const { oracleFeed, priceE6 } = getOracleFeedAndPrice();
     const tier = SLAB_TIERS[wizard.slabTier];
     const effectiveMint = devnetMintAddress ?? wizard.mintAddress;


### PR DESCRIPTION
## Problem

### GH #1103 — `handleRetry` silently blocks step-0 blockhash-expiry retries

`handleRetry` in `CreateMarketWizard.tsx` had this guard:
```ts
if (!allValid || !publicKey || !createState.slabAddress) return;
```

When step 0 fails (blockhash expired during confirmation), `createState.slabAddress` is `null` — it's only set after `sendTx` returns a signature. So clicking "Retry Step 1" silently returned without calling `create()`, leaving the error on screen unchanged. User perceived this as "immediately fails again with the same error" with no Privy dialog.

PR #1104 fixed the SLAB_TIERS dataSize mismatch (the original simulation failure). This PR fixes the remaining retry path: blockhash-expiry on step 0 also needs to retry without slabAddress.

**Fix:** Relax the guard to only require `slabAddress` for step > 0. Step 0 generates a fresh keypair so no prior address is needed.

### GH #1102 — MarketCard.test.tsx: 5 tests flaky in CI (retry x3 failures)

CI logs showed: `Error: Invalid Chai property: toHaveTextContent` / `toBeInTheDocument`

Root cause: `@testing-library/jest-dom` matchers intermittently fail to register on the Chai `expect` object from the global `setupFiles` when tests run in parallel CI workers.

Also fixed: Both markets in `should handle markets with null/zero values without crashing` used the same `mockPublicKey` as `slabAddress`, triggering React duplicate-key warnings and making row counts unreliable.

**Fix:** 
1. Import `@testing-library/jest-dom/vitest` directly at the top of the test file (belt-and-suspenders)
2. Use distinct slab key addresses in the two-market test

## Testing
- `pnpm vitest run __tests__/components/MarketCard.test.tsx` → 15 passed, 4 skipped, 0 warnings
- No duplicate-key React warnings in test output

Closes #1102
Partially closes #1103 (GH#1103 was also addressed by PR #1104)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed market creation wizard retry mechanism to correctly validate transaction state. Retries now properly require established keypairs for later steps, preventing incomplete transactions from being retried inappropriately.

* **Tests**
  * Improved overall test stability with enhanced testing framework setup across CI environments and better test data isolation to prevent rendering inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->