### PR TITLE
fix: deduplicate markets (#1106) + guard auto-deposit trigger (#1107)

### DIFF
--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -147,6 +147,8 @@ function MarketsPageInner() {
         continue;
       }
       const addr = d.slabAddress.toBase58();
+      // GH#1106: deduplicate — same slab can appear from multiple program scans
+      if (seenSlabs.has(addr)) continue;
       const mint = d.config.collateralMint.toBase58();
       const maxLev = d.params.initialMarginBps > 0n ? Math.floor(10000 / Number(d.params.initialMarginBps)) : 0;
       const oracleMode = detectOracleMode(d.config);

--- a/app/hooks/useAutoDeposit.ts
+++ b/app/hooks/useAutoDeposit.ts
@@ -116,14 +116,15 @@ export function useAutoDeposit(slabAddress: string): AutoDepositState {
     // Don't auto-deposit if user already has an account
     if (userAccount) return;
 
-    // Trigger conditions:
-    // 1. Auto-fund just completed (freshly funded wallet)
-    // 2. User connected with existing wallet balance but no Percolator account
+    // GH#1107: only auto-deposit when auto-fund JUST completed.
+    // Without this guard any wallet navigation to a trade page with no Percolator
+    // account would immediately pop the Privy "Confirm transaction" modal.
+    if (!fundResult?.funded) return;
 
-    // Wait a short delay to let auto-fund complete and balances settle
+    // Wait a short delay to let auto-fund balances settle on-chain
     const timer = setTimeout(() => {
       attemptAutoDeposit();
-    }, fundResult?.funded ? 2000 : 3000);
+    }, 2000);
 
     return () => clearTimeout(timer);
   }, [connected, publicKey, userAccount, fundResult, isDevnet, attemptAutoDeposit]);


### PR DESCRIPTION
## Summary

Fixes two HIGH-priority bugs reported post-PR-#1105 deploy.

### GH#1106 — /markets renders each market twice

**Root cause:** `merged` useMemo Loop 1 in `app/markets/page.tsx` pushes every on-chain discovered market into `result` without first checking `seenSlabs`. `useMarketDiscovery` scans multiple program IDs and can return the same slab from more than one program — both copies got pushed, doubling the display count (60 unique → 120 rows).

**Fix:** One-line guard `if (seenSlabs.has(addr)) continue;` at the top of Loop 1, before the addr is added to the Set.

### GH#1107 — Trade page auto-triggers Privy 'Confirm transaction' on load

**Root cause:** `useAutoDeposit` ran `attemptAutoDeposit()` after a 3-second delay for *any* connected wallet that had no Percolator account — regardless of whether the auto-fund flow had run. Every trade-page navigation with a funded-but-unregistered wallet popped the Privy modal without user action.

**Fix:** Added `if (!fundResult?.funded) return;` guard so the hook only fires immediately after the auto-fund flow completes (PERC-372 intent). Manual-wallet users are unaffected.

## Testing
- 922 tests passing, 0 failures (`pnpm test --run`)
- Verified fix logic: same slab from 2 programs → merged to 1 row
- Auto-deposit now requires `fundResult.funded === true` to fire

Closes #1106
Closes #1107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed duplicate markets appearing in discovery results when markets are discovered across multiple program scans.
  * Improved auto-deposit behavior to prevent unwanted prompts when no account is available, with more consistent timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->