### PR TITLE
fix(GH#1117): hide airdrop promise for custom tokens in /create wizard

### DIFF
--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -199,6 +199,10 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
   const hasSufficientSol = solBalance !== null && solBalance >= requiredSol;
   // On devnet, tokens are auto-airdropped after market creation — skip token balance checks
   const isDevnet = getNetwork() === "devnet";
+  // GH#1117: True only when the selected token is a Percolator mirror mint
+  // (devnetMintAddress differs from the user's input = mirror flow ran).
+  // False for custom tokens entered directly (user = mint authority; no auto-airdrop).
+  const isPercolatorMirror = devnetMintAddress !== null && devnetMintAddress !== wizard.mintAddress;
   const allValid = step1Valid && step2Valid && step3Valid && (isDevnet || (hasTokens && hasSufficientTokensForSeed)) && hasSufficientSol;
 
   // Quick Launch auto-advance: step 1 → step 2 when token is resolved and params ready
@@ -751,6 +755,7 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
             hasTokens={hasTokens}
             hasSufficientTokensForSeed={hasSufficientTokensForSeed}
             feeConflict={feeConflict}
+            isPercolatorMirror={isPercolatorMirror}
             onBack={goBack}
             onLaunch={handleLaunch}
             canLaunch={allValid && !!publicKey}

--- a/app/components/create/StepReview.tsx
+++ b/app/components/create/StepReview.tsx
@@ -32,6 +32,12 @@ interface StepReviewProps {
   hasTokens: boolean;
   hasSufficientTokensForSeed: boolean;
   feeConflict: boolean;
+  /**
+   * GH#1117: True only when the token is a Percolator-managed devnet mirror
+   * (Percolator = mint authority). False for custom tokens (user = mint authority).
+   * Controls whether the "tokens auto-airdropped" promise is shown at Review.
+   */
+  isPercolatorMirror?: boolean;
   // Actions
   onBack: () => void;
   onLaunch: () => void;
@@ -72,6 +78,7 @@ export const StepReview: FC<StepReviewProps> = ({
   hasTokens,
   hasSufficientTokensForSeed,
   feeConflict,
+  isPercolatorMirror = false,
   onBack,
   onLaunch,
   canLaunch,
@@ -96,9 +103,9 @@ export const StepReview: FC<StepReviewProps> = ({
     if (!isDevnet && !hasSufficientTokensForSeed) return "Insufficient Tokens for Vault Seed (500)";
     if (feeConflict) return "Fix Parameters to Continue";
     if (!hasSufficientBalance) return "Insufficient SOL";
-    if (isDevnet) return "LAUNCH & MINT TOKENS →";
+    if (isDevnet) return isPercolatorMirror ? "LAUNCH & MINT TOKENS →" : "LAUNCH MARKET →";
     return "LAUNCH MARKET →";
-  }, [walletConnected, mintValid, mintExistsOnNetwork, hasTokens, hasSufficientTokensForSeed, feeConflict, hasSufficientBalance, isDevnet]);
+  }, [walletConnected, mintValid, mintExistsOnNetwork, hasTokens, hasSufficientTokensForSeed, feeConflict, hasSufficientBalance, isDevnet, isPercolatorMirror]);
 
   return (
     <div className="space-y-5">
@@ -193,8 +200,8 @@ export const StepReview: FC<StepReviewProps> = ({
         </div>
       )}
 
-      {/* Devnet: tokens are auto-minted after market creation */}
-      {walletConnected && isDevnet && (
+      {/* Devnet: token funding info — differs by mint authority (GH#1117) */}
+      {walletConnected && isDevnet && isPercolatorMirror && (
         <div className="border border-[var(--long)]/20 bg-[var(--long)]/[0.04] px-4 py-3 space-y-1">
           <p className="text-[11px] text-[var(--text)]">
             <span className="text-[var(--long)] font-medium">✓ Devnet mode.</span>{" "}
@@ -202,6 +209,17 @@ export const StepReview: FC<StepReviewProps> = ({
           </p>
           <p className="text-[9px] text-[var(--text-dim)]">
             No tokens needed upfront — tokens are airdropped post-launch for testing.
+          </p>
+        </div>
+      )}
+      {walletConnected && isDevnet && !isPercolatorMirror && (
+        <div className="border border-[var(--accent)]/20 bg-[var(--accent)]/[0.04] px-4 py-3 space-y-1">
+          <p className="text-[11px] text-[var(--text)]">
+            <span className="text-[var(--accent)] font-medium">ℹ Custom token.</span>{" "}
+            You are the mint authority — tokens will not be auto-airdropped.
+          </p>
+          <p className="text-[9px] text-[var(--text-dim)]">
+            After launch, mint tokens from your wallet and deposit them into the vault to enable trading.
           </p>
         </div>
       )}


### PR DESCRIPTION
## Problem

GH#1117 — /create wizard Step 4 (Review) falsely promised `Your wallet will receive devnet {TOKEN} tokens automatically after the market is created` for **all** devnet tokens, including custom user-authority mints. Error was only revealed after all 5 transactions completed and ~0.46 SOL was spent.

Root cause: the airdrop info block checked only `isDevnet`, not whether the token's mint authority is Percolator vs the user's wallet.

## Fix

**`StepReview.tsx`** — add `isPercolatorMirror?: boolean` prop (default `false`):
- Show airdrop banner only when `isPercolatorMirror === true`
- Show custom-token notice ("You are the mint authority — tokens will not be auto-airdropped") when `false`
- `launchButtonLabel`: use `LAUNCH & MINT TOKENS →` only for mirror tokens; `LAUNCH MARKET →` for custom

**`CreateMarketWizard.tsx`** — derive `isPercolatorMirror`:
```ts
const isPercolatorMirror = devnetMintAddress !== null && devnetMintAddress !== wizard.mintAddress;
```
This is `true` only when the devnet mirror flow ran (different address returned), `false` for direct devnet tokens (user-authority).

## Test

- Paste a custom devnet token (user = mint authority) → Review shows "Custom token. You are the mint authority — tokens will not be auto-airdropped"
- Paste a mainnet CA → mirror runs → Review shows "tokens auto-airdropped" (unchanged)
- 917/917 existing tests pass (5 baseline failures are pre-existing `@upstash/redis` missing dep, unrelated)

Closes GH#1117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced market creation for devnet with clearer distinction between Percolator-managed and custom tokens
  * Dynamic launch button labels that reflect token minting behavior
  * Improved notifications explaining auto-airdrop availability for different token types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->