### PR TITLE
fix(trade): stop Privy modal firing on every trade page load (#1120)

### DIFF
--- a/app/__tests__/hooks/useAutoDeposit.test.ts
+++ b/app/__tests__/hooks/useAutoDeposit.test.ts
@@ -38,11 +38,10 @@ vi.mock("@/components/providers/SlabProvider", () => ({
   })),
 }));
 
-vi.mock("@/hooks/useAutoFund", () => ({
-  useAutoFund: vi.fn(() => ({
+vi.mock("@/components/providers/AutoFundProvider", () => ({
+  useAutoFundResult: vi.fn(() => ({
     funding: false,
     result: null,
-    error: null,
   })),
 }));
 

--- a/app/__tests__/providers/AutoFundProvider.test.tsx
+++ b/app/__tests__/providers/AutoFundProvider.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * GH#1120: Tests for AutoFundProvider windowed result behavior
+ *
+ * Ensures that `fundResult.funded` expires after FUNDED_WINDOW_MS (30s)
+ * so navigating to a second trade page does NOT trigger auto-deposit.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { FC, ReactNode } from "react";
+
+// Track the mock return value so we can change it mid-test
+let mockAutoFundReturn = { funding: false, result: null as any, error: null };
+
+vi.mock("@/hooks/useAutoFund", () => ({
+  useAutoFund: () => mockAutoFundReturn,
+}));
+
+vi.mock("@/hooks/useWalletCompat", () => ({
+  useWalletCompat: vi.fn(() => ({
+    publicKey: null,
+    connected: false,
+  })),
+  useConnectionCompat: vi.fn(() => ({
+    connection: {},
+  })),
+}));
+
+describe("AutoFundProvider", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockAutoFundReturn = { funding: false, result: null, error: null };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should expose null result initially", async () => {
+    const { AutoFundProvider, useAutoFundResult } = await import(
+      "@/components/providers/AutoFundProvider"
+    );
+
+    const wrapper: FC<{ children: ReactNode }> = ({ children }) => (
+      <AutoFundProvider>{children}</AutoFundProvider>
+    );
+
+    const { result } = renderHook(() => useAutoFundResult(), { wrapper });
+    expect(result.current.result).toBeNull();
+    expect(result.current.funding).toBe(false);
+  });
+
+  it("should expose funded result when auto-fund succeeds", async () => {
+    mockAutoFundReturn = {
+      funding: false,
+      result: { funded: true, sol_airdropped: true, usdc_minted: true, sol_amount: 2, usdc_amount: 1000 },
+      error: null,
+    };
+
+    const { AutoFundProvider, useAutoFundResult } = await import(
+      "@/components/providers/AutoFundProvider"
+    );
+
+    const wrapper: FC<{ children: ReactNode }> = ({ children }) => (
+      <AutoFundProvider>{children}</AutoFundProvider>
+    );
+
+    const { result } = renderHook(() => useAutoFundResult(), { wrapper });
+    expect(result.current.result?.funded).toBe(true);
+  });
+
+  it("should clear funded result after 30 seconds (GH#1120)", async () => {
+    mockAutoFundReturn = {
+      funding: false,
+      result: { funded: true, sol_airdropped: true, usdc_minted: true, sol_amount: 2, usdc_amount: 1000 },
+      error: null,
+    };
+
+    const { AutoFundProvider, useAutoFundResult } = await import(
+      "@/components/providers/AutoFundProvider"
+    );
+
+    const wrapper: FC<{ children: ReactNode }> = ({ children }) => (
+      <AutoFundProvider>{children}</AutoFundProvider>
+    );
+
+    const { result } = renderHook(() => useAutoFundResult(), { wrapper });
+    expect(result.current.result?.funded).toBe(true);
+
+    // Advance past the 30s window
+    await act(async () => {
+      vi.advanceTimersByTime(31_000);
+    });
+
+    expect(result.current.result).toBeNull();
+  });
+
+  it("should NOT clear non-funded result", async () => {
+    mockAutoFundReturn = {
+      funding: false,
+      result: { funded: false, sol_airdropped: false, usdc_minted: false },
+      error: null,
+    };
+
+    const { AutoFundProvider, useAutoFundResult } = await import(
+      "@/components/providers/AutoFundProvider"
+    );
+
+    const wrapper: FC<{ children: ReactNode }> = ({ children }) => (
+      <AutoFundProvider>{children}</AutoFundProvider>
+    );
+
+    const { result } = renderHook(() => useAutoFundResult(), { wrapper });
+    expect(result.current.result?.funded).toBe(false);
+
+    // Advance time — should NOT clear since it wasn't funded
+    await act(async () => {
+      vi.advanceTimersByTime(31_000);
+    });
+
+    // Non-funded result persists (no timer set)
+    expect(result.current.result?.funded).toBe(false);
+  });
+});

--- a/app/components/providers/AutoFundProvider.tsx
+++ b/app/components/providers/AutoFundProvider.tsx
@@ -1,27 +1,79 @@
 /**
  * PERC-356: Auto-fund provider
  *
- * Renders nothing visible — just triggers the auto-fund hook when a wallet
- * connects on devnet. Shows a toast notification when funding completes.
+ * Triggers the auto-fund hook when a wallet connects on devnet, and shares the
+ * result via React Context so `useAutoDeposit` can react to it without creating
+ * a second `useAutoFund` instance (which caused race conditions — GH #1120).
  */
 
 "use client";
 
-import { FC, useEffect } from "react";
-import { useAutoFund } from "@/hooks/useAutoFund";
+import { createContext, FC, ReactNode, useContext, useEffect, useRef, useState } from "react";
+import { useAutoFund, type AutoFundResult } from "@/hooks/useAutoFund";
 
-export const AutoFundProvider: FC = () => {
-  const { result } = useAutoFund();
+interface AutoFundContextValue {
+  /**
+   * Auto-fund result. `funded` is true only within a 30-second window after the
+   * auto-fund API call succeeds. After the window closes, `result` resets to null
+   * to prevent stale `funded: true` from triggering auto-deposit on subsequent
+   * trade page navigations (GH #1120).
+   */
+  result: AutoFundResult | null;
+  funding: boolean;
+}
+
+const AutoFundContext = createContext<AutoFundContextValue>({
+  result: null,
+  funding: false,
+});
+
+/**
+ * Read the auto-fund result from the nearest `AutoFundProvider`.
+ * Returns `{ result, funding }` — result is null until the auto-fund API resolves,
+ * and resets to null 30s after funding completes.
+ */
+export function useAutoFundResult(): AutoFundContextValue {
+  return useContext(AutoFundContext);
+}
+
+/** How long (ms) after funding completes that the result stays available */
+const FUNDED_WINDOW_MS = 30_000;
+
+export const AutoFundProvider: FC<{ children?: ReactNode }> = ({ children }) => {
+  const { result: rawResult, funding } = useAutoFund();
+  const [windowedResult, setWindowedResult] = useState<AutoFundResult | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    if (!result?.funded) return;
+    if (!rawResult?.funded) {
+      setWindowedResult(rawResult);
+      return;
+    }
+
+    // Fund just completed — expose result and start expiry timer
+    setWindowedResult(rawResult);
+
     const parts: string[] = [];
-    if (result.sol_airdropped) parts.push(`${result.sol_amount} SOL`);
-    if (result.usdc_minted) parts.push(`${result.usdc_amount} USDC`);
+    if (rawResult.sol_airdropped) parts.push(`${rawResult.sol_amount} SOL`);
+    if (rawResult.usdc_minted) parts.push(`${rawResult.usdc_amount} USDC`);
     if (parts.length > 0) {
       console.log(`[AutoFund] ✅ Funded: ${parts.join(" + ")}`);
     }
-  }, [result]);
 
-  return null; // Renders nothing
+    // After the window, clear the result so late-mounting useAutoDeposit instances
+    // (e.g. navigating to a second trade page) do NOT trigger the Privy modal.
+    timerRef.current = setTimeout(() => {
+      setWindowedResult(null);
+    }, FUNDED_WINDOW_MS);
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [rawResult]);
+
+  return (
+    <AutoFundContext.Provider value={{ result: windowedResult, funding }}>
+      {children ?? null}
+    </AutoFundContext.Provider>
+  );
 };

--- a/app/components/providers/WalletProvider.tsx
+++ b/app/components/providers/WalletProvider.tsx
@@ -75,8 +75,9 @@ export const WalletProvider: FC<{ children: ReactNode }> = ({ children }) => {
       <PrivyAvailableContext.Provider value={true}>
         <PreferredWalletContext.Provider value={preferredWallet}>
           <PrivyProviderClient appId={appId}>
-            <AutoFundProvider />
-            {children}
+            <AutoFundProvider>
+              {children}
+            </AutoFundProvider>
           </PrivyProviderClient>
         </PreferredWalletContext.Provider>
       </PrivyAvailableContext.Provider>

--- a/app/hooks/useAutoDeposit.ts
+++ b/app/hooks/useAutoDeposit.ts
@@ -44,7 +44,7 @@ import { useWalletCompat, useConnectionCompat } from "@/hooks/useWalletCompat";
 import { useUserAccount } from "@/hooks/useUserAccount";
 import { useInitUser } from "@/hooks/useInitUser";
 import { useSlabState } from "@/components/providers/SlabProvider";
-import { useAutoFund } from "@/hooks/useAutoFund";
+import { useAutoFundResult } from "@/components/providers/AutoFundProvider";
 
 const AUTO_DEPOSIT_AMOUNT = 500_000_000n; // 500 USDC (6 decimals) — reasonable starter
 const MIN_WALLET_BALANCE = 10_000_000n; // 10 USDC minimum to bother depositing
@@ -68,7 +68,7 @@ export function useAutoDeposit(slabAddress: string): AutoDepositState {
   const userAccount = useUserAccount();
   const { initUser } = useInitUser(slabAddress);
   const { config: mktConfig } = useSlabState();
-  const { result: fundResult } = useAutoFund();
+  const { result: fundResult } = useAutoFundResult();
 
   const [depositing, setDepositing] = useState(false);
   const [deposited, setDeposited] = useState(false);

--- a/app/hooks/useAutoFund.ts
+++ b/app/hooks/useAutoFund.ts
@@ -33,7 +33,7 @@ function markAutoFundAttempted(wallet: string): void {
   }
 }
 
-interface AutoFundResult {
+export interface AutoFundResult {
   funded: boolean;
   sol_airdropped: boolean;
   usdc_minted: boolean;


### PR DESCRIPTION
## Summary
Fixes #1120 — Privy "Confirm transaction" modal appeared on every `/trade/[slab]` page load without user interaction.

## Root Cause
`useAutoDeposit` created its own `useAutoFund()` hook instance, separate from the root `AutoFundProvider`. Two problems:

1. **Race condition**: Both instances checked sessionStorage nearly simultaneously on first mount — the child's `useEffect` fires before the parent's in React 18, so both could call the auto-fund API before either marked the wallet in sessionStorage.

2. **Stale funded state**: Once auto-fund succeeded, the `funded: true` result persisted in state for the entire session. Any navigation to a new trade page (where the user had no Percolator account) would see `fundResult.funded === true` and trigger `initUser` → Privy signing modal.

## Fix
- **Share auto-fund result via React Context**: `AutoFundProvider` now wraps children and exposes the fund result through `useAutoFundResult()` context hook. `useAutoDeposit` reads from context instead of creating its own `useAutoFund` instance — single source of truth, no race.

- **30-second expiry window**: After auto-fund succeeds, the `funded: true` result is only available for 30 seconds. This is long enough for the initial auto-deposit to fire on the first trade page, but prevents stale `funded: true` from triggering on subsequent navigations.

## Changes
- `AutoFundProvider.tsx`: Wraps children, provides context, adds 30s windowed expiry
- `useAutoDeposit.ts`: Uses `useAutoFundResult()` context instead of `useAutoFund()`
- `useAutoFund.ts`: Export `AutoFundResult` type
- `WalletProvider.tsx`: `AutoFundProvider` now wraps children instead of rendering as sibling

## Tests
926 passing (+4 new tests for windowed result behavior):
- Exposes null initially
- Exposes funded result on success
- **Clears funded result after 30s** (core GH#1120 fix)
- Does NOT clear non-funded results

## How to Test
1. Log in with Privy wallet on devnet
2. Navigate to any trade page → modal should appear at most ONCE (if auto-fund fires)
3. Navigate to a second trade page → **NO modal** (the fix)
4. Wait 30+ seconds, navigate to another trade page → still no modal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-fund results now expire after a 30-second window, preventing stale triggers during navigation.
  * Enhanced tracking for fund amounts (SOL and USDC).

* **Refactor**
  * Improved auto-fund integration across the application using a context-based approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->