### PR TITLE
fix(trade): pass newAccountFee in InitUser to prevent Custom(13) error

### DIFF
--- a/app/hooks/useDeposit.ts
+++ b/app/hooks/useDeposit.ts
@@ -25,7 +25,7 @@ import { useSlabState } from "@/components/providers/SlabProvider";
 export function useDeposit(slabAddress: string) {
   const { connection } = useConnectionCompat();
   const wallet = useWalletCompat();
-  const { config: mktConfig, programId: slabProgramId, refresh: refreshSlab } = useSlabState();
+  const { config: mktConfig, programId: slabProgramId, params: slabParams, refresh: refreshSlab } = useSlabState();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inflightRef = useRef(false);
@@ -104,7 +104,8 @@ export function useDeposit(slabAddress: string) {
                 );
               }
 
-              // InitUser (tag 1, feePayment=0 — just registers the slot)
+              // InitUser (tag 1) — must pay at least newAccountFee (PERC-1126)
+              const accountFee = slabParams?.newAccountFee ?? 0n;
               instructions.push(
                 buildIx({
                   programId,
@@ -115,7 +116,7 @@ export function useDeposit(slabAddress: string) {
                     mktConfig.vaultPubkey,
                     WELL_KNOWN.tokenProgram,
                   ]),
-                  data: encodeInitUser({ feePayment: "0" }),
+                  data: encodeInitUser({ feePayment: accountFee.toString() }),
                 }),
               );
             }

--- a/app/hooks/useInitUser.ts
+++ b/app/hooks/useInitUser.ts
@@ -24,16 +24,22 @@ import { useSlabState } from "@/components/providers/SlabProvider";
 export function useInitUser(slabAddress: string) {
   const { connection } = useConnectionCompat();
   const wallet = useWalletCompat();
-  const { config: mktConfig, programId: slabProgramId, raw: slabRaw, refresh: refreshSlab } = useSlabState();
+  const { config: mktConfig, programId: slabProgramId, raw: slabRaw, params, refresh: refreshSlab } = useSlabState();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const initUser = useCallback(
-    async (feePayment: bigint = 0n) => {
+    async (feePayment?: bigint) => {
       setLoading(true);
       setError(null);
       try {
         if (!wallet.publicKey || !mktConfig || !slabProgramId) throw new Error("Wallet not connected or market not loaded");
+
+        // PERC-1126: The on-chain program requires fee_payment >= new_account_fee.
+        // If the caller doesn't specify a fee (or passes 0), use the market's
+        // configured newAccountFee so the tx doesn't fail with Custom(13).
+        const minFee = params?.newAccountFee ?? 0n;
+        const effectiveFee = (feePayment != null && feePayment >= minFee) ? feePayment : minFee;
 
         // PERC-698 / bug bounty: Pre-flight V0/V1 slab version check.
         // If the slab is V0 size but the on-chain program now expects V1 layout,
@@ -73,7 +79,7 @@ export function useInitUser(slabAddress: string) {
           keys: buildAccountMetas(ACCOUNTS_INIT_USER, [
             wallet.publicKey, slabPk, userAta, mktConfig.vaultPubkey, WELL_KNOWN.tokenProgram,
           ]),
-          data: encodeInitUser({ feePayment: feePayment.toString() }),
+          data: encodeInitUser({ feePayment: effectiveFee.toString() }),
         });
         instructions.push(ix);
         const sig = await sendTx({ connection, wallet, instructions });
@@ -98,7 +104,7 @@ export function useInitUser(slabAddress: string) {
         setLoading(false);
       }
     },
-    [connection, wallet, mktConfig, slabAddress, slabProgramId, slabRaw, refreshSlab]
+    [connection, wallet, mktConfig, slabAddress, slabProgramId, slabRaw, params, refreshSlab]
   );
 
   return { initUser, loading, error };


### PR DESCRIPTION
## Fixes #1126

**Root cause**: The issue report hypothesized stale oracle, but the actual root cause is simpler — `useInitUser` and `useDeposit` both hardcoded `feePayment=0` when calling the on-chain `InitUser` instruction. The program requires `fee_payment >= new_account_fee` (set to 1,000,000 during market creation) and returns `RiskError::InsufficientBalance` (Custom:13) when underpaid.

**Fix**:
- `useInitUser.ts`: Read `params.newAccountFee` from slab state; use it as the minimum fee when caller passes 0 or omits fee
- `useDeposit.ts`: Same fix for the inline InitUser instruction in the deposit-with-auto-create flow

**Testing**:
- `tsc --noEmit` passes
- Full test suite passes (67/67)
- The e2e test script already documents the correct behavior: `feePayment must be >= newAccountFee (1_000_000)`

**Impact**: All newly created markets become immediately tradeable — no need to wait for keeper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account creation fee handling with dynamic parameter-based calculation and validation logic, replacing hardcoded fee values for more accurate fee computation.

* **Improvements**
  * Enhanced fee approval workflow during account initialization with flexible fee management and pre-flight validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->