### PR TITLE
feat(oracle): oracle_markets table + keeper HYPERP discovery override

### DIFF
--- a/bots/oracle-keeper/index.ts
+++ b/bots/oracle-keeper/index.ts
@@ -625,6 +625,65 @@ function startHealthServer() {
 const knownSlabs = new Set<string>();
 
 /**
+ * Poll Supabase `oracle_markets` table for explicitly-registered oracle configs.
+ *
+ * This table is an override layer: rows here take precedence over
+ * markets.oracle_mode. Useful for registering HYPERP markets on devnet where
+ * all markets are forced to oracle_mode='admin' because devnet-mirrored tokens
+ * don't have real DEX pools (isDevnetMirror path in useCreateMarket).
+ *
+ * Any market listed here with oracle_type='hyperp' will be cranked via
+ * UpdateHyperpMark regardless of what markets.oracle_mode says.
+ * If the slab is already tracked with a different mode, this function
+ * updates it in-place and clears the pool cache so the new pool is resolved.
+ */
+async function discoverHyperpFromOracleTable(): Promise<MarketInfo[]> {
+  if (!supabaseEnabled) return [];
+  try {
+    const data = await supabaseQuery(
+      "oracle_markets",
+      "select=slab_address,oracle_type,dex_pool_address&oracle_type=eq.hyperp&enabled=eq.true",
+    );
+    if (!data) return [];
+
+    const newMarkets: MarketInfo[] = [];
+    for (const row of data) {
+      if (!row.slab_address || !row.dex_pool_address) continue;
+
+      if (knownSlabs.has(row.slab_address)) {
+        // Upgrade an already-tracked market from admin/pyth → hyperp
+        const existing = markets.find(m => m.slab === row.slab_address);
+        if (existing && existing.oracleMode !== "hyperp") {
+          log(`🔄 ${existing.label}: oracle_markets override → hyperp (pool=${row.dex_pool_address.slice(0, 12)}...)`);
+          existing.oracleMode = "hyperp";
+          existing.dexPoolAddress = row.dex_pool_address;
+          hyperpPoolCache.delete(row.slab_address); // force re-fetch with new pool
+        }
+        continue;
+      }
+
+      knownSlabs.add(row.slab_address);
+      newMarkets.push({
+        symbol: "HYPERP",
+        label: `${row.slab_address.slice(0, 8)}... (oracle_markets)`,
+        slab: row.slab_address,
+        oracleMode: "hyperp",
+        dexPoolAddress: row.dex_pool_address ?? undefined,
+      });
+    }
+
+    if (newMarkets.length > 0) {
+      log(`🗂 oracle_markets: ${newMarkets.length} new HYPERP slab(s) registered for cranking`);
+    }
+
+    return newMarkets;
+  } catch (e) {
+    log(`⚠️ oracle_markets discovery error: ${(e as Error).message?.slice(0, 80)}`);
+    return [];
+  }
+}
+
+/**
  * Poll Supabase `markets` table for newly created markets with a mainnet_ca.
  * Returns new MarketInfo entries that aren't already tracked.
  */
@@ -835,7 +894,10 @@ async function main() {
           }
         }
 
-        const newMarkets = await discoverNewMarkets();
+        // Also check the oracle_markets override table (HYPERP explicit registrations)
+        const oracleTableMarkets = await discoverHyperpFromOracleTable();
+
+        const newMarkets = [...(await discoverNewMarkets()), ...oracleTableMarkets];
         if (newMarkets.length > 0) {
           log(`🔍 Discovered ${newMarkets.length} new market(s): ${newMarkets.map(m => m.label).join(", ")}`);
           for (const m of newMarkets) {

--- a/supabase/migrations/041_oracle_markets.sql
+++ b/supabase/migrations/041_oracle_markets.sql
@@ -1,0 +1,85 @@
+-- #HYPERP: Create oracle_markets table for explicit oracle config registration.
+--
+-- Problem: All markets created via Quick Launch on devnet have oracle_mode='admin'
+-- because the Create Market wizard forces admin mode for devnet-mirrored mainnet
+-- tokens (isDevnetMirror=true). This means the oracle-keeper's Supabase discovery
+-- finds zero HYPERP markets even though oracle_keeper PR #1123 added UpdateHyperpMark
+-- support.
+--
+-- Solution: A standalone oracle_markets table that the oracle-keeper checks as an
+-- explicit override/supplement. DevOps can INSERT rows here to register known HYPERP
+-- markets (or any oracle config) without touching the markets table directly.
+-- oracle_markets rows take precedence over markets.oracle_mode for the keeper.
+--
+-- Usage:
+--   INSERT INTO oracle_markets (slab_address, oracle_type, dex_pool_address)
+--   VALUES ('<slab_pubkey>', 'hyperp', '<dex_pool_pubkey>');
+--
+-- The oracle-keeper reads this table every DISCOVERY_INTERVAL_MS (30s) and will
+-- immediately start cranking UpdateHyperpMark for any hyperp entries.
+
+CREATE TABLE IF NOT EXISTS oracle_markets (
+  slab_address TEXT PRIMARY KEY REFERENCES markets(slab_address) ON DELETE CASCADE,
+  oracle_type TEXT NOT NULL CHECK (oracle_type IN ('pyth', 'hyperp', 'admin')),
+  dex_pool_address TEXT,
+  pyth_feed_id TEXT,
+  enabled BOOLEAN NOT NULL DEFAULT true,
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  -- Ensure hyperp entries always have a pool address
+  CONSTRAINT oracle_markets_hyperp_needs_pool
+    CHECK (oracle_type != 'hyperp' OR dex_pool_address IS NOT NULL)
+);
+
+-- Index for keeper queries (hyperp, enabled-only)
+CREATE INDEX IF NOT EXISTS idx_oracle_markets_type_enabled
+  ON oracle_markets (oracle_type)
+  WHERE enabled = true;
+
+-- Trigger: keep updated_at current
+CREATE OR REPLACE FUNCTION oracle_markets_set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER oracle_markets_updated_at
+  BEFORE UPDATE ON oracle_markets
+  FOR EACH ROW EXECUTE FUNCTION oracle_markets_set_updated_at();
+
+-- RLS
+ALTER TABLE oracle_markets ENABLE ROW LEVEL SECURITY;
+
+-- Public read (oracle-keeper uses service role but expose for admin UI)
+CREATE POLICY "oracle_markets_public_read"
+  ON oracle_markets FOR SELECT USING (true);
+
+-- Only service role can mutate
+CREATE POLICY "oracle_markets_service_write"
+  ON oracle_markets FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Reload PostgREST schema cache so the new table is immediately queryable
+NOTIFY pgrst, 'reload schema';
+
+-- ── Seed ──────────────────────────────────────────────────────────────────────
+-- Insert known HYPERP devnet markets below.
+-- Obtain slab_address + dex_pool_address from the markets table or Quick Launch logs.
+-- Example (uncomment + replace with real addresses):
+--
+-- INSERT INTO oracle_markets (slab_address, oracle_type, dex_pool_address, notes)
+-- VALUES
+--   ('SLAB_PUBKEY_1', 'hyperp', 'DEX_POOL_PUBKEY_1', 'BONK-PERP PumpSwap pool'),
+--   ('SLAB_PUBKEY_2', 'hyperp', 'DEX_POOL_PUBKEY_2', 'WIF-PERP Raydium CLMM pool')
+-- ON CONFLICT (slab_address) DO UPDATE
+--   SET oracle_type      = EXCLUDED.oracle_type,
+--       dex_pool_address = EXCLUDED.dex_pool_address,
+--       notes            = EXCLUDED.notes,
+--       enabled          = EXCLUDED.enabled,
+--       updated_at       = NOW();


### PR DESCRIPTION
## Problem

All 194 devnet markets have `oracle_mode='admin'` because Quick Launch forces admin mode for devnet-mirrored tokens (`isDevnetMirror=true` in `useCreateMarket.ts`, line 225). PR #1123 (merged 2026-03-13 12:37 UTC) added `UpdateHyperpMark` cranking to the oracle-keeper, but `discoverNewMarkets()` queries `markets.oracle_mode` and finds zero `hyperp` rows. HYPERP auto-discovery is broken.

Additionally, `oracle_prices` is stale >23h — this is a **separate issue** (StatsCollector/indexer not writing to DB, not an oracle-keeper code issue — oracle-keeper writes on-chain only).

## Fix

### Migration 041 — `oracle_markets` table
An explicit oracle config override layer. The oracle-keeper checks this table on every discovery tick and cranks any `oracle_type='hyperp'` + `enabled=true` row via `UpdateHyperpMark`, regardless of what `markets.oracle_mode` says.

Schema:
```sql
oracle_markets (
  slab_address TEXT PK → markets.slab_address,
  oracle_type  TEXT CHECK (pyth|hyperp|admin),
  dex_pool_address TEXT,  -- required for hyperp
  pyth_feed_id TEXT,
  enabled BOOLEAN DEFAULT true,
  notes TEXT
)
```
Constraint: `hyperp` rows must have `dex_pool_address`. RLS: public read, service-role write. PostgREST schema reload on apply.

### oracle-keeper: `discoverHyperpFromOracleTable()`
New discovery function runs alongside `discoverNewMarkets()` every 30s:
- **New slab**: added to `markets` array, authority verified, starts cranking
- **Already-tracked slab** with wrong mode: upgraded in-place to `hyperp`, `hyperpPoolCache` cleared so new pool resolves on next tick

## DevOps action required
To activate HYPERP cranking, INSERT known slab+pool pairs:
```sql
INSERT INTO oracle_markets (slab_address, oracle_type, dex_pool_address, notes)
VALUES
  ('<SLAB_PUBKEY>', 'hyperp', '<DEX_POOL_PUBKEY>', 'description')
ON CONFLICT (slab_address) DO UPDATE
  SET oracle_type=EXCLUDED.oracle_type, dex_pool_address=EXCLUDED.dex_pool_address,
      enabled=EXCLUDED.enabled, updated_at=NOW();
```
Then run `supabase db push` or apply migration 041 manually. Oracle-keeper picks up new rows within 30s (no restart needed).

## oracle_prices staleness (separate issue)
Oracle-keeper has always written prices **on-chain only**. `oracle_prices` table is populated by the indexer's `StatsCollector`. If it's stale >23h, the Railway indexer service is likely down or stuck. DevOps should check Railway indexer logs.

## Testing
- `npx tsx --check bots/oracle-keeper/index.ts` → exit 0
- tsc clean (no new errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added oracle-backed market discovery and registration system supporting multiple oracle types (HYPERP, Pyth, Admin)
  * Enabled dynamic market registration through oracle configuration with automatic pool resolution for HYPERP markets
  * Markets registered via oracle system now override existing discovery mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->