### PR TITLE
fix(markets): fingerprint Sentry price-sanitization warnings to collapse poll noise (PERC-801)

### DIFF
--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -30,14 +30,32 @@ const MAX_SANE_PRICE_USD = 1_000_000; // $1M
 /**
  * Sanitize a price field from the DB (USD float). Returns null for corrupt/garbage values.
  * Logs a Sentry warning when sanitization fires so we can track data quality. (#882)
+ *
+ * Fingerprinted per (field, slab) so repeated sanitizations from the same bad market
+ * collapse into ONE Sentry issue rather than one event per API poll cycle (#PERC-801).
+ *
+ * Known causes of sanitization:
+ *  - Admin-mode markets with on-chain authorityPriceE6 set to garbage/test values
+ *    (e.g. value > MAX_SANE_PRICE_USD × 1e6 on-chain, e.g. GYpukkn94, 2Zta2EPRR)
+ *  - HYPERP markets without oracle_markets entries — oracle-keeper can't crank them,
+ *    stale/uninitialised lastEffectivePriceE6 leaks through StatsCollector
+ *  Fix: seed oracle_markets table (migration 041) for HYPERP markets, or correct the
+ *  admin oracle price via the admin UI (pushPrice action with correct price_e6).
  */
 function sanitizePrice(v: number | null | undefined, field?: string, slabAddress?: string): number | null {
   if (v == null) return null;
   if (!Number.isFinite(v) || v <= 0 || v > MAX_SANE_PRICE_USD) {
-    Sentry.captureMessage(`Price sanitization: ${field ?? "price"} = ${v} nulled for slab ${slabAddress ?? "unknown"}`, {
-      level: "warning",
-      tags: { endpoint: "/api/markets", sanitization: "price" },
-    });
+    Sentry.captureMessage(
+      `Price sanitization: ${field ?? "price"} nulled for slab ${slabAddress ?? "unknown"} (value=${v})`,
+      {
+        level: "warning",
+        tags: { endpoint: "/api/markets", sanitization: "price", field: field ?? "price" },
+        // Fingerprint collapses all events for the same bad (field, slab) pair into a
+        // single Sentry issue instead of one event per poll cycle.
+        fingerprint: ["price-sanitization", field ?? "price", slabAddress ?? "unknown"],
+        extra: { rawValue: v, field, slabAddress, maxSanePriceUsd: MAX_SANE_PRICE_USD },
+      },
+    );
     return null;
   }
   return v;


### PR DESCRIPTION
## Investigation: PERC-801

### 31 Sentry events FRONTEND-2C-2G

**Slabs:** `GYpukkn94*` and `2Zta2EPRR*`
**Values:** `mark_price=11100011` ($11.1M) and `mark_price=92100011` ($92.1M)

### Root cause

1. **Corrupt admin oracle prices on-chain.** StatsCollector correctly divides `authorityPriceE6 / 1_000_000` to get USD. For these slabs to have `mark_price = 11100011` in the DB, the on-chain `authorityPriceE6` must be `11,100,011,000,000` (= $11.1M). This is a genuinely wrong oracle price — likely set with incorrect units or from garbage initialisation.

2. **$1M sanitization cap is working correctly.** The `sanitizePrice` guard in `/api/markets` is doing its job — protecting the UI from these bad values.

3. **31 events = ~5 minutes of frontend polling.** Since `sanitizePrice` fires on every `GET /api/markets` call and the frontend polls every ~10s, each bad slab generates one Sentry event per poll. Without fingerprinting this accumulates indefinitely.

4. **oracle_markets not seeded.** Migration 041 (`oracle_markets` table) has its INSERT commented out. If these are HYPERP-candidate markets, they have no `dex_pool_address` registered → oracle-keeper can't crank `UpdateHyperpMark` → stale/wrong prices.

### Code fix

Add Sentry **fingerprint** `['price-sanitization', field, slab]` so all events for the same bad (field, slab) pair collapse into ONE Sentry issue instead of N events per poll cycle. Added extra context (`rawValue`, `maxSanePriceUsd`) and a doc comment explaining known causes.

### Operational follow-ups (devops/admin — not code)

| Action | Owner |
|--------|-------|
| If HYPERP markets: INSERT into `oracle_markets` with `dex_pool_address` | devops |
| If admin-mode markets: use Admin UI → pushPrice with correct `price_e6` ($11.10 = 11100000, not 11100011000000) | devops/Khubair |
| Check Railway indexer logs — oracle_prices stale >23h (separate issue per devops) | devops |

## Tests
954 passing, 34 skipped (unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error tracking and diagnostics for price validation to improve issue reporting and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->