### PR TITLE
fix(PERC-17): increase useDevnetFaucet test timeout for dynamic import

### DIFF
--- a/app/__tests__/hooks/useDevnetFaucet.test.ts
+++ b/app/__tests__/hooks/useDevnetFaucet.test.ts
@@ -31,9 +31,13 @@ describe("useDevnetFaucet", () => {
     expect(process.env.NEXT_PUBLIC_SOLANA_NETWORK).toBe("mainnet");
   });
 
-  it("should export correct types", async () => {
-    // Type-level test — ensure the module exports expected types
-    const mod = await import("@/hooks/useDevnetFaucet");
-    expect(typeof mod.useDevnetFaucet).toBe("function");
-  });
+  it(
+    "should export correct types",
+    async () => {
+      // Type-level test — ensure the module exports expected types
+      const mod = await import("@/hooks/useDevnetFaucet");
+      expect(typeof mod.useDevnetFaucet).toBe("function");
+    },
+    30000
+  ); // Increased timeout for dynamic import
 });


### PR DESCRIPTION
- Increased test timeout from default 10000ms to 30000ms
- Resolves flaky test when dynamic import takes longer to resolve
- Test now consistently passes with adequate timeout margin