### PR TITLE
fix(#1139, #1141): address validation on faucet button + mint URL repopulated after clear

### DIFF
--- a/app/app/devnet-mint/devnet-mint-content.tsx
+++ b/app/app/devnet-mint/devnet-mint-content.tsx
@@ -31,6 +31,7 @@ import { ShimmerSkeleton } from "@/components/ui/ShimmerSkeleton";
 import { LogoUpload } from "@/components/create/LogoUpload";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
 import { getBatchRpc } from "@/lib/batchRpc";
+import { isValidBase58Pubkey } from "@/lib/createWizardUtils";
 
 /**
  * Use the server-side RPC proxy to avoid exposing HELIUS_API_KEY in the client bundle.
@@ -465,6 +466,9 @@ const DevnetMintContent: FC = () => {
     }
   }, [publicKey, signTransaction, existingMint, mintMoreAmount, recipient, refreshBalance]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Issue #1139: Validate faucet mint is a real Solana address before enabling the button
+  const isFaucetMintValid = isValidBase58Pubkey(faucetMint.trim());
+
   const cardClass = "bg-[var(--panel-bg)] border border-[var(--border)] p-4 sm:p-6";
   const btnPrimary = "border border-[var(--accent)]/40 text-[var(--accent)] bg-transparent px-5 py-2.5 text-sm font-semibold transition-all duration-200 hover:border-[var(--accent)]/70 hover:bg-[var(--accent)]/[0.08] active:scale-[0.98] disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:scale-100";
   const inputClass = "w-full bg-[var(--panel-bg)] border border-[var(--border)] px-3 py-2 text-sm text-white placeholder-[var(--text-muted)] focus:border-[var(--accent)]/40 focus:outline-none transition-shadow duration-200";
@@ -543,9 +547,12 @@ const DevnetMintContent: FC = () => {
                     setFaucetRateLimited(null);
                   }}
                   placeholder="Paste devnet mint address..."
-                  className={inputClass}
+                  className={`${inputClass} ${faucetMint && !isFaucetMintValid ? "border-[var(--short)]/60" : ""}`}
                   disabled={faucetLoading}
                 />
+                {faucetMint && !isFaucetMintValid && (
+                  <p className="mt-1 text-[11px] text-[var(--short)]/80">Not a valid Solana address (base58, 32–44 chars)</p>
+                )}
               </div>
               {/* Inline status */}
               {faucetLoading && (
@@ -578,7 +585,7 @@ const DevnetMintContent: FC = () => {
               <button
                 className={`${btnPrimary} w-full`}
                 onClick={handleFaucetClaim}
-                disabled={faucetLoading || !faucetMint || !walletReady}
+                disabled={faucetLoading || !faucetMint || !isFaucetMintValid || !walletReady}
               >
                 {!walletReady
                   ? "Connect Wallet First"

--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -487,9 +487,11 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
   };
 
   // Reset wizard completely
+  // Issue #1141: Re-apply initialMint from URL param so 'Clear & Start Fresh'
+  // doesn't lose the ?mint= address the user navigated here with.
   const handleReset = () => {
     resetCreate();
-    setWizard({ ...DEFAULT_STATE });
+    setWizard({ ...DEFAULT_STATE, mintAddress: initialMint ?? "" });
     setCompletedSteps(new Set());
     setDevnetMintAddress(null);
     // PERC-516: Clear persisted wizard state


### PR DESCRIPTION
## Summary

Fixes two low-severity UX bugs filed by QA on 2026-03-13.

---

### Fix #1139 — `Get Test Tokens` button enabled for non-address input

**Root cause:** Button `disabled` prop only checked `!faucetMint` (truthy), not whether the value is a valid Solana address.

**Fix:**
- Import `isValidBase58Pubkey` from `@/lib/createWizardUtils`
- Compute `isFaucetMintValid` and gate the button behind it
- Show inline hint (`Not a valid Solana address`) when input is non-empty but invalid
- Highlight input border red-tinted on invalid state

---

### Fix #1141 — `?mint=` URL param lost after 'Clear & Start Fresh'

**Root cause:** `handleReset()` set wizard back to `DEFAULT_STATE` (which has `mintAddress: ""`), ignoring the `initialMint` prop passed from the URL `?mint=` param.

**Fix:** One-liner — `setWizard({ ...DEFAULT_STATE, mintAddress: initialMint ?? "" })`

---

## Testing
- `/devnet-mint`: type "hello world" → button stays disabled, red hint shows; paste valid mint address → button enables ✓  
- `/create?mint=<addr>` → wizard loads at step 4 (stale state detected) → click **CLEAR & START FRESH** → wizard resets to step 1 with mint field pre-populated ✓

## Build
`pnpm build` + `pnpm tsc --noEmit` both pass clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for Solana addresses in the faucet mint input field with inline error feedback.
  * Displays helper text when an invalid address is entered.

* **Bug Fixes**
  * Mint address now persists when using the "Clear & Start Fresh" option, preserving URL-provided mints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->