### PR TITLE
fix(stake): reset stale loading/error on pool switch in useStakeDepositByPool

### DIFF
--- a/app/hooks/useStakeDepositByPool.ts
+++ b/app/hooks/useStakeDepositByPool.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { PublicKey, TransactionInstruction } from '@solana/web3.js';
 import { useWalletCompat, useConnectionCompat } from '@/hooks/useWalletCompat';
 import {
@@ -48,6 +48,15 @@ export function useStakeDepositByPool({ slabAddress, collateralMint }: StakeDepo
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inflightRef = useRef(false);
+
+  // Reset UI state when the selected pool changes so stale loading/error
+  // indicators from a previous pool don't bleed through. Do NOT touch
+  // inflightRef.current — the in-flight guard must stay intact until the
+  // deposit's finally block clears it.
+  useEffect(() => {
+    setError(null);
+    setLoading(false);
+  }, [slabAddress, collateralMint]);
 
   const deposit = useCallback(
     async (amount: bigint) => {


### PR DESCRIPTION
## What

Fixes stale `loading`/`error` state persisting when the user switches between pools in `useStakeDepositByPool`.

Supersedes #1143 (concept correct, but had two blocking issues).

## Changes

- Add missing `useEffect` import (omission in #1143 would cause `ReferenceError` at runtime)
- Add `useEffect` that clears `error` + `loading` whenever `slabAddress` or `collateralMint` changes
- **Do NOT** reset `inflightRef.current` in the effect — the concurrency guard must remain until the deposit's `finally` block clears it (clearing mid-flight could allow a second deposit to start before the first finishes, risking double-spend)

## How to test

1. Start a stake deposit on Pool A
2. Before it completes, switch to Pool B
3. Confirm loading spinner / error from Pool A do not appear on Pool B

## CI

10/10 existing tests pass.