### PR TITLE
fix(ui): #1146 search false positive + #1145 market count inconsistency

### DIFF
--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -229,16 +229,20 @@ function MarketsPageInner() {
     let list = activeMarkets;
     // Text search — matches on-chain symbol, name, slab address, mint address,
     // OR Supabase market name/symbol (e.g. "BTC-PERP-1", "BTC") — fixes #1132
+    // Fix #1146: address fields (slab/mint) are only searched when query is ≥8 chars
+    // to prevent short token queries (e.g. "btc") from matching random substrings
+    // inside base58 addresses (e.g. slab HC4...1HbTCu9wK contains "btc" lowercased).
     if (debouncedSearch.trim()) {
       const q = debouncedSearch.toLowerCase();
+      const isAddressSearch = q.length >= 8;
       list = list.filter((m) => {
         const onChainMeta = tokenMetaMap.get(m.mintAddress);
         return onChainMeta?.symbol?.toLowerCase().includes(q) ||
           onChainMeta?.name?.toLowerCase().includes(q) ||
           m.supabase?.name?.toLowerCase().includes(q) ||
           m.supabase?.symbol?.toLowerCase().includes(q) ||
-          m.slabAddress.toLowerCase().includes(q) ||
-          m.mintAddress.toLowerCase().includes(q);
+          (isAddressSearch && m.slabAddress.toLowerCase().includes(q)) ||
+          (isAddressSearch && m.mintAddress.toLowerCase().includes(q));
       });
     }
     // Leverage filter — exclude markets with invalid leverage (0, NaN, Infinity)

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -201,7 +201,8 @@ export default function Home() {
     <div className="relative">
       {/* ═══════════════════════ HERO (PERC-158 refresh) ═══════════════════════ */}
       <ErrorBoundary label="Hero Section">
-        <HeroSection />
+        {/* Pass marketsCount so hero and "Built Different" show the same number (#1145) */}
+        <HeroSection marketsCount={statsLoaded ? stats.markets : undefined} />
       </ErrorBoundary>
 
       {/* ═══════════════════════ STATS ═══════════════════════ */}

--- a/app/components/marketing/HeroSection.tsx
+++ b/app/components/marketing/HeroSection.tsx
@@ -14,7 +14,14 @@ import { HeroCtaGroup } from "./HeroCtaGroup";
 import { LiveMarketCard } from "./LiveMarketCard";
 import { HeroDataChip } from "./HeroDataChip";
 
-export function HeroSection() {
+interface HeroSectionProps {
+  /** When provided, overrides the hero's independently-fetched market count.
+   *  Pass `stats.markets` from the parent Home component to ensure the hero
+   *  and "Built Different" section always show the same number (#1145). */
+  marketsCount?: number;
+}
+
+export function HeroSection({ marketsCount }: HeroSectionProps = {}) {
   const containerRef = useRef<HTMLElement>(null);
   const prefersReduced = usePrefersReducedMotion();
   const [network] = useState(getConfig().network);
@@ -173,9 +180,10 @@ export function HeroSection() {
             </span>
           </p>
 
-          {/* Stats row */}
+          {/* Stats row — use marketsCount from parent (Home) when available so
+              hero and "Built Different" section always show the same number (#1145) */}
           <HeroStats
-            markets={stats.markets}
+            markets={marketsCount ?? stats.markets}
             volume={stats.volume}
             traders={stats.traders}
             isDevnet={network !== "mainnet"}


### PR DESCRIPTION
## Summary

Two fresh bugs from today, both low severity.

---

### Fix #1146 — BTC search returns false positive TEST/USD market

**Root cause:** The base58 slab address `HC4soK7sEjHNzVwek4z7vUtTg96Vr35eJAB1HbTCu9wK`, when lowercased, contains the substring `btc` (`1HbTCu9wK` → `1hbtcu9wk`). The markets search was doing substring matching on *all* address fields unconditionally.

**Fix:** Guard address-field matching behind `q.length >= 8`. Short queries like `btc`, `sol`, `eth` now only match on symbol/name fields. Address paste (8+ chars) still works as before.

---

### Fix #1145 — Homepage shows inconsistent market counts (hero: 62 vs Built Different: 161)

**Root cause:** `HeroSection` and the `Home` component both make independent Supabase queries to `markets_with_stats` and apply `isActiveMarket` filters — but they can return different counts due to separate execution contexts, caching, or timing.

**Fix:** Add `marketsCount?: number` prop to `HeroSection`. `Home` passes its authoritative `stats.markets` (from its own already-resolved query) to `HeroSection` so both panels always show the same number. `HeroSection` falls back to its own fetched count when the prop is not yet available.

---

## How to test

- **#1146:** Go to `/markets`, search `BTC` → should see 4 results (not 5). TEST/USD should be gone.
- **#1145:** Homepage hero stat "Markets" and "Built Different → Markets Live" should show identical numbers.

## Files changed
- `app/app/markets/page.tsx` — address search guard
- `app/components/marketing/HeroSection.tsx` — accept marketsCount prop
- `app/app/page.tsx` — pass stats.markets to HeroSection

Closes #1145 Closes #1146