### PR TITLE
fix(dashboard): traders display + trade_count_24h schema

### DIFF
--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -89,7 +89,7 @@ export async function GET() {
       .from("markets_with_stats")
       .select(
         "slab_address,mint_address,symbol,name,decimals,deployer,logo_url,max_leverage,trading_fee_bps," +
-        "last_price,mark_price,volume_24h,open_interest_long,open_interest_short,total_open_interest," +
+        "last_price,mark_price,volume_24h,trade_count_24h,open_interest_long,open_interest_short,total_open_interest," +
         "insurance_fund,insurance_balance,total_accounts,funding_rate,net_lp_pos,lp_sum_abs,c_tot," +
         "vault_balance,created_at,stats_updated_at,oracle_mode,dex_pool_address,mainnet_ca,oracle_authority"
       );

--- a/app/components/marketing/HeroSection.tsx
+++ b/app/components/marketing/HeroSection.tsx
@@ -62,9 +62,17 @@ export function HeroSection({ marketsCount }: HeroSectionProps = {}) {
     }
     async function loadHeroStats() {
       try {
-        const { data } = await getSupabase()
-          .from("markets_with_stats")
-          .select("volume_24h, total_accounts, last_price, decimals, total_open_interest, open_interest_long, open_interest_short");
+        // Fetch market data and platform stats in parallel.
+        // Use /api/stats for totalTraders — it counts unique trader wallet addresses
+        // from the trades table, which is the correct definition.
+        // Do NOT sum total_accounts across markets: that counts sub-accounts per slab
+        // (which is ~500 per market × 191 markets ≈ 99,000 — wildly misleading).
+        const [{ data }, statsRes] = await Promise.all([
+          getSupabase()
+            .from("markets_with_stats")
+            .select("volume_24h, last_price, decimals, total_open_interest, open_interest_long, open_interest_short"),
+          fetch("/api/stats", { cache: "no-store" }).then((r) => r.ok ? r.json() : null).catch(() => null),
+        ]);
         if (data && data.length > 0) {
           const activeData = data.filter(isActiveMarket);
           const volume = activeData.reduce((s: number, m: { volume_24h: number | null; last_price: number | null; decimals: number | null }) => {
@@ -72,7 +80,8 @@ export function HeroSection({ marketsCount }: HeroSectionProps = {}) {
             const price = m.last_price ?? 0;
             return s + (Number(m.volume_24h || 0) / d) * price;
           }, 0);
-          const traders = activeData.reduce((s: number, m: { total_accounts: number | null }) => s + (m.total_accounts ?? 0), 0);
+          // Prefer /api/stats totalTraders (unique wallets). Fall back to 0 if unavailable.
+          const traders: number = (statsRes as { totalTraders?: number } | null)?.totalTraders ?? 0;
           setStats({ markets: activeData.length, volume, traders });
         }
       } catch {

--- a/supabase/migrations/20260314010000_add_trade_count_24h.sql
+++ b/supabase/migrations/20260314010000_add_trade_count_24h.sql
@@ -1,0 +1,54 @@
+-- Migration 044: Add trade_count_24h to market_stats
+-- StatsCollector already computes tradeCount via get24hVolume() but never stores it.
+-- This adds the column and rebuilds the view so the API can expose it.
+-- With an empty trades table, trade_count_24h will be 0 (not null) — cleaner than None.
+
+ALTER TABLE market_stats
+  ADD COLUMN IF NOT EXISTS trade_count_24h INT4 DEFAULT 0;
+
+-- Rebuild markets_with_stats view to include the new column.
+-- (PostgreSQL SELECT * in views is expanded at creation time, so we must DROP+recreate.)
+DROP VIEW IF EXISTS markets_with_stats;
+
+CREATE VIEW markets_with_stats AS
+SELECT
+  m.*,
+  s.last_price,
+  s.mark_price,
+  s.index_price,
+  s.volume_24h,
+  s.trade_count_24h,
+  s.volume_total,
+  s.open_interest_long,
+  s.open_interest_short,
+  s.insurance_fund,
+  s.total_accounts,
+  s.funding_rate,
+  -- Columns from migration 007 (hidden features)
+  s.total_open_interest,
+  s.net_lp_pos,
+  s.lp_sum_abs,
+  s.lp_max_abs,
+  s.insurance_balance,
+  s.insurance_fee_revenue,
+  s.warmup_period_slots,
+  -- Columns from migration 010 (complete risk engine)
+  s.vault_balance,
+  s.lifetime_liquidations,
+  s.lifetime_force_closes,
+  s.c_tot,
+  s.pnl_pos_tot,
+  s.last_crank_slot,
+  s.max_crank_staleness_slots,
+  s.maintenance_fee_per_slot,
+  s.liquidation_fee_bps,
+  s.liquidation_fee_cap,
+  s.liquidation_buffer_bps,
+  s.updated_at as stats_updated_at
+FROM markets m
+LEFT JOIN market_stats s ON m.slab_address = s.slab_address;
+
+COMMENT ON VIEW markets_with_stats IS 'Combined view of markets + stats. Includes trade_count_24h (migration 044) — 0 when trades table has no recent rows, null only for markets with no stats row yet.';
+
+-- Notify PostgREST to reload schema cache
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
Fixes PM dashboard audit findings (filed 2026-03-14).

## Changes

### HeroSection — traders count fix (closes #<traders-bug>)
Replaces wrong `sum(total_accounts)` approach with `/api/stats` `totalTraders` field.

**Before**: summed `total_accounts` across 191 markets → ~99,000 (sub-accounts, not users)
**After**: `/api/stats` returns 18 unique trader wallet addresses from `trades` table

Both requests (`markets_with_stats` + `/api/stats`) are fetched in parallel.

### Migration 044 — trade_count_24h column (closes #<trade_count-issue>)
Adds `trade_count_24h INT4 DEFAULT 0` to `market_stats`.
Rebuilds `markets_with_stats` view to include the column.

**Before**: field absent from API → PM saw `trade_count_24h: None`
**After**: returns `0` when no recent trades, actual count when trades exist

### GET /api/markets route
Added `trade_count_24h` to SELECT list so the column is returned to API consumers.

## Testing
- 954 tests passing ✅
- `/api/stats` confirmed: `totalTraders: 18, trades24h: 0`
- Volume_24h=0 is correct — no devnet trading in last 24h (separate infra investigation needed)

## Cross-repo dependency
percolator-indexer PR needed to wire tradeCount → upsertMarketStats (see dcccrypto/percolator-indexer#17)

## DevOps action needed
After merge: run `supabase db push` to apply migration 044