### PR TITLE
fix(earn/trade): normalize earn volume24h from raw units + oracle price null guard

### DIFF
--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -291,6 +291,19 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
         </div>
       )}
 
+      {/* No oracle price warning — trading requires a valid oracle price to calculate
+          PnL and liquidation levels. When priceUsd is null (WebSocket not connected or
+          oracle feed unavailable), we disable the trade button to prevent 0-price
+          transactions that would fail on-chain with a cryptic error. */}
+      {!priceUsd && !mockMode && (
+        <div className="mb-3 rounded-none border border-[var(--warning)]/30 bg-[var(--warning)]/5 p-2.5">
+          <p className="text-[9px] font-bold uppercase tracking-[0.15em] text-[var(--warning)]">No Oracle Price</p>
+          <p className="mt-1 text-[9px] text-[var(--text-secondary)] leading-relaxed">
+            Waiting for price feed. Trades will be enabled once oracle data is available.
+          </p>
+        </div>
+      )}
+
       {/* Direction toggle */}
       <div className="mb-3 flex gap-1">
         <button
@@ -444,10 +457,10 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
       ) : (
         <button
           onClick={() => {
-            if (!marginInput || !userAccount || positionSize <= 0n || exceedsMargin || riskGateActive || header?.paused || tradePhase !== "idle" || loading) return;
+            if (!marginInput || !userAccount || positionSize <= 0n || exceedsMargin || riskGateActive || header?.paused || tradePhase !== "idle" || loading || (!priceUsd && !mockMode)) return;
             setShowConfirmModal(true);
           }}
-          disabled={tradePhase !== "idle" || loading || !marginInput || positionSize <= 0n || exceedsMargin || riskGateActive || header?.paused || lpUnderfunded}
+          disabled={tradePhase !== "idle" || loading || !marginInput || positionSize <= 0n || exceedsMargin || riskGateActive || header?.paused || lpUnderfunded || (!priceUsd && !mockMode)}
           className={`w-full rounded-none py-2.5 text-[11px] font-medium uppercase tracking-[0.1em] text-white transition-all duration-150 hover:scale-[1.01] active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:scale-100 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--bg)] ${
             direction === "long"
               ? "bg-[var(--long)] hover:brightness-110 focus-visible:ring-[var(--long)]"

--- a/app/hooks/useEarnStats.ts
+++ b/app/hooks/useEarnStats.ts
@@ -217,7 +217,11 @@ export function useEarnStats() {
           const tradingFeeBpsRaw = m.trading_fee_bps ?? 10;
           const tradingFeeBps = tradingFeeBpsRaw > 5_000 ? 0 : tradingFeeBpsRaw;
           const volume24hRaw = m.volume_24h ?? 0;
-          const volume24h = isSentinel(volume24hRaw) ? 0 : volume24hRaw;
+          // Normalize to human-readable collateral units (same as totalOI).
+          // volume_24h is stored as raw on-chain micro-units — divide by collDivisor
+          // before using in APY calculation or display. Without this, a $100K USDC
+          // market would show "$100B" volume and ~73,000,000% APY.
+          const volume24h = isSentinel(volume24hRaw) ? 0 : volume24hRaw / collDivisor;
           const insuranceRaw = m.insurance_fund ?? 0;
           // Sanity cap: insurance_fund values > 10 billion USDC micro-units ($10M)
           // are corrupt data from bad slab tier detection — clamp to 0


### PR DESCRIPTION
## Summary
Two frontend bugs from the PM-assigned bug blitz.

## Bug 1 — Earn page: volume24h raw unit overflow

**Root cause:** `useEarnStats.ts` stored `volume_24h` as raw on-chain micro-units without dividing by `collDivisor` (unlike `totalOI` which was correctly normalized). VaultCard displayed it directly as USD.

**Impact:**
- $100K USDC volume shown as "$100.00B" on VaultCard
- APY calculation massively inflated (e.g., ~73,000,000% instead of ~73%)
- Daily fee revenue stats on earn header also incorrect

**Fix:** Divide `volume24h` by `collDivisor` in the mapping step, consistent with how `totalOI` is handled.

## Bug 2 — Trade page: no oracle price state

**Root cause:** `TradeForm` passed `0n` as `oracleE6` when `priceUsd` was null (WebSocket not connected or oracle feed unavailable). Trade button remained enabled, leading to on-chain tx failure with a cryptic error.

**Impact:**
- Trade button enabled with no oracle → silent on-chain rejection
- No user-facing feedback that price data is missing

**Fix:**
- Add "No Oracle Price" warning banner when `priceUsd` is null
- Disable trade button when `priceUsd` is null (unless mock mode)

## Testing
- ✅ `pnpm test` — 67/67 tests pass
- ✅ `tsc --noEmit` — no TypeScript errors
- Earn page: volume and APY should now show realistic values
- Trade page: button disabled + warning shown when oracle unavailable