### PR TITLE
fix(ui): Frontend Bug Blitz 1 — zero/null displays + OI conversion + no-oracle banner

### DIFF
--- a/app/app/admin/page.tsx
+++ b/app/app/admin/page.tsx
@@ -742,7 +742,7 @@ export default function AdminDashboard() {
             <div className="text-2xl font-bold mt-1 text-[var(--accent)]">
               {statsLoading
                 ? "—"
-                : platformStats
+                : platformStats && platformStats.totalVolume24h > 0
                 ? formatCompact(platformStats.totalVolume24h)
                 : "—"}
             </div>
@@ -752,7 +752,7 @@ export default function AdminDashboard() {
             <div className="text-2xl font-bold mt-1 text-[var(--cyan)]">
               {statsLoading
                 ? "—"
-                : platformStats
+                : platformStats && platformStats.totalOpenInterest > 0
                 ? formatCompact(platformStats.totalOpenInterest)
                 : "—"}
             </div>

--- a/app/app/api/stats/route.ts
+++ b/app/app/api/stats/route.ts
@@ -63,7 +63,7 @@ export async function GET(request: NextRequest) {
   const supabase = getServiceClient();
 
   const [statsRes, tradersRes, recentTradesRes] = await Promise.all([
-    supabase.from("markets_with_stats").select("volume_24h, open_interest_long, open_interest_short, total_open_interest, last_price").limit(500),
+    supabase.from("markets_with_stats").select("volume_24h, open_interest_long, open_interest_short, total_open_interest, last_price, decimals").limit(500),
     supabase.from("trades").select("trader").limit(5000),
     supabase
       .from("trades")
@@ -77,18 +77,30 @@ export async function GET(request: NextRequest) {
   const activeData = statsData.filter(isActiveMarket);
   const totalMarkets = activeData.length;
 
+  // Convert raw on-chain token micro-units to USD using decimals + price
+  // Without this, sentinel-like values (2e12) leak through as $2T (#1154)
+  const MAX_PER_MARKET_USD = 10_000_000_000; // $10B cap — no single market should exceed this
+  const toUsd = (raw: number, m: { decimals?: number | null; last_price?: number | null }): number => {
+    if (!isSaneMarketValue(raw)) return 0;
+    const d = Math.min(Math.max((m as Record<string, unknown>).decimals as number ?? 6, 0), 18);
+    const p = m.last_price ?? 0;
+    if (p <= 0) return 0;
+    const usd = (raw / 10 ** d) * p;
+    return usd > MAX_PER_MARKET_USD ? 0 : usd;
+  };
+
   const totalVolume24h = activeData.reduce(
-    (sum, m) => sum + (isSaneMarketValue(m.volume_24h) ? m.volume_24h! : 0),
+    (sum, m) => sum + toUsd(m.volume_24h ?? 0, m),
     0
   );
   const totalOpenInterest = activeData.reduce(
     (sum, m) => {
-      const oi = isSaneMarketValue(m.total_open_interest)
+      const rawOi = isSaneMarketValue(m.total_open_interest)
         ? m.total_open_interest!
         : (isSaneMarketValue((m.open_interest_long ?? 0) + (m.open_interest_short ?? 0))
             ? (m.open_interest_long ?? 0) + (m.open_interest_short ?? 0)
             : 0);
-      return sum + oi;
+      return sum + toUsd(rawOi, m);
     },
     0
   );

--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -628,14 +628,18 @@ function MarketsPageInner() {
                     : null;
                   
                   // Display values (USD or tokens) — cap token display at 2dp for table readability
-                  // #865: null → "—", known zero → "$0.00" / "0.00" (never bare "0")
-                  const oiDisplay = showUsd && lastPrice != null
-                    ? formatNum(Math.round((Number(oiTokensRaw) / tokenDivisor) * lastPrice * 100) / 100)
-                    : formatStatValue(oiTokensRaw, 'number', mintDecimals);
-                  const insuranceDisplay = showUsd && lastPrice != null
-                    ? formatNum(Math.round((Number(insuranceTokensRaw) / tokenDivisor) * lastPrice * 100) / 100)
-                    : formatStatValue(insuranceTokensRaw, 'number', mintDecimals);
-                  const volumeDisplay = volume24hRaw != null
+                  // #1152/#1153: null/zero → "—" (not "$0.00" which looks broken on devnet)
+                  const oiUsd = showUsd && lastPrice != null
+                    ? Math.round((Number(oiTokensRaw) / tokenDivisor) * lastPrice * 100) / 100
+                    : null;
+                  const oiDisplay = oiTokensRaw === 0n ? "—"
+                    : oiUsd != null ? (oiUsd > 0 ? formatNum(oiUsd) : "—") : formatStatValue(oiTokensRaw, 'number', mintDecimals);
+                  const insUsd = showUsd && lastPrice != null
+                    ? Math.round((Number(insuranceTokensRaw) / tokenDivisor) * lastPrice * 100) / 100
+                    : null;
+                  const insuranceDisplay = insuranceTokensRaw === 0n ? "—"
+                    : insUsd != null ? (insUsd > 0 ? formatNum(insUsd) : "—") : formatStatValue(insuranceTokensRaw, 'number', mintDecimals);
+                  const volumeDisplay = volume24hRaw != null && volume24hRaw > 0n
                     ? (showUsd && lastPrice != null
                         ? formatNum(Math.round((Number(volume24hRaw) / tokenDivisor) * lastPrice * 100) / 100)
                         : formatTokenAmount(volume24hRaw, mintDecimals, 2))

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -231,7 +231,7 @@ export default function Home() {
                   },
                   {
                     label: "24h Volume",
-                    value: statsLoaded ? (stats.volume > 0 ? formatCompact(stats.volume) : "$0") : null,
+                    value: statsLoaded ? (stats.volume > 0 ? formatCompact(stats.volume) : "—") : null,
                     suffix: network !== "mainnet" ? " (devnet)" : undefined,
                     color: stats.volume > 0 ? "text-[var(--long)]" : "text-[var(--text-secondary)]",
                   },

--- a/app/app/trade/[slab]/page.tsx
+++ b/app/app/trade/[slab]/page.tsx
@@ -272,8 +272,20 @@ function TradePageInner({ slab }: { slab: string }) {
     );
   }
 
+  // #1155: Show warning banner when market has loaded but no oracle price available
+  const hasNoPriceData = !slabLoading && engine && priceUsd == null;
+
   return (
     <div ref={pageRef} className="mx-auto max-w-[1920px] overflow-x-hidden gsap-fade">
+
+      {/* #1155: No oracle price banner */}
+      {hasNoPriceData && (
+        <div className="border-b border-[var(--warning)]/30 bg-[var(--warning)]/5 px-4 py-2.5 text-center">
+          <p className="text-[11px] font-medium text-[var(--warning)]">
+            ⚠ No oracle price available for this market — prices may be stale or unavailable
+          </p>
+        </div>
+      )}
 
       {/* ── MOBILE: Sticky header ── */}
       <div className="sticky top-0 z-30 border-b border-[var(--border)]/50 bg-[var(--bg)]/95 px-3 py-2 backdrop-blur-sm lg:hidden">


### PR DESCRIPTION
## Frontend Bug Blitz — Batch 1

Fixes 5 issues across 4 pages:

### Markets page (#1152, #1153)
- Zero OI/volume/insurance → **—** instead of $0.00 (misleading on devnet)
- Volume guard tightened: only show when `volume24hRaw > 0n`

### Homepage (#1156)
- 24h Volume $0 → **—** when no trades

### /api/stats (#1154) — **P0 data fix**
- `totalOpenInterest` was summing raw on-chain token micro-units directly as USD
- Result: API reported $75T OI (should be near $0)
- Fix: converts using `decimals + last_price`, matching homepage client-side logic
- Caps per-market contribution at $10B to prevent sentinel leakage

### Admin dashboard
- Volume/OI zero → **—** instead of $0

### Trade page (#1155)
- Added warning banner when market loads successfully but has no oracle price data

**Tests:** 954 app + 123 api + 46 keeper + 67 indexer = all passing
**TypeScript:** clean

Closes #1152, #1153, #1154, #1155, #1156