### PR TITLE
fix(homepage): Featured markets visibility + zero display fixes

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -179,7 +179,7 @@ export default function Home() {
             symbol: m.symbol,
             volume_24h: toUsd(Number(m.volume_24h || 0), m.decimals, m.last_price),
             last_price: m.last_price,
-            total_open_interest: toUsd(Number(m.total_open_interest || 0), m.decimals, m.last_price),
+            total_open_interest: toUsd(Number(m.total_open_interest ?? ((m.open_interest_long ?? 0) + (m.open_interest_short ?? 0))), m.decimals, m.last_price),
           }));
           // #1159: Sort by volume first, fall back to OI when volume is 0 for all
           const sorted = converted.sort((a, b) => {


### PR DESCRIPTION
## Frontend Bug Blitz — Batch 2

### Homepage (#1159)
- **Featured markets section hidden**: `hasMarkets` only checked `volume_24h > 0` — on devnet with 0 trades, the entire featured section was invisible. Now also checks `total_open_interest > 0`.
- **Sort by OI fallback**: When all volumes are 0, sort by OI so markets with LP capital appear first.
- **Zero displays**: Featured market cards show **—** instead of $0 for zero volume/OI.

**Tests:** 954/954 passing
**TypeScript:** clean

Closes #1159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated featured markets sorting to prioritize volume, with open interest as a secondary tiebreaker.
  * Enhanced market visibility to include markets with open interest even when volume is zero.
  * Improved table formatting: volume and open interest now display as formatted numbers when available; empty values show a dash (—).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->