### PR TITLE
fix(indexer): skip market with null/0 initialMarginBps to prevent max_leverage constraint violation

### DIFF
--- a/packages/indexer/src/services/StatsCollector.ts
+++ b/packages/indexer/src/services/StatsCollector.ts
@@ -118,6 +118,10 @@ export class StatsCollector {
           const oracleAuthority = market.config.oracleAuthority.toBase58();
           const priceE6 = Number(market.config.authorityPriceE6);
           const initialMarginBps = Number(market.params.initialMarginBps);
+          if (!initialMarginBps || initialMarginBps <= 0) {
+            logger.warn("Skipping market with invalid initialMarginBps — slab may be uninitialized", { slabAddress, initialMarginBps });
+            continue;
+          }
           const maxLeverage = Math.floor(10000 / initialMarginBps);
           
           // Try to resolve token metadata from on-chain (Helius DAS / Metaplex)


### PR DESCRIPTION
## Problem
Market `EbUAhSm36CpQiH8sXrrjQPdAdKh6rCupnojP7nJq2RhA` has `initialMarginBps=null` on-chain, causing:
- `Math.floor(10000 / 0) = Infinity` → stored as null in DB
- DB not-null constraint on `max_leverage` → insert fails for entire market batch
- 172/173 markets updating fine; this slab appears corrupted/uninitialized

## Fix
Added guard before computing `maxLeverage`: if `initialMarginBps` is 0 or null, log a warning and `continue` (skip registration). The slab is likely uninitialized on-chain and not tradeable.

## Testing
- 172 valid markets continue registering normally
- Corrupted slab is skipped with a warning log
- No DB constraint errors

Fixes devops report: indexer crashing on market `EbUAhSm36CpQiH8sXrrjQPdAdKh6rCupnojP7nJq2RhA`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented validation for market registration to prevent processing invalid configurations. Markets with invalid or zero initial margin values are now skipped with warning logs, preventing erroneous leverage computations and improving system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->