### PR TITLE
fix(indexer): guard against null/zero initialMarginBps — skip corrupted slabs

### DIFF
--- a/packages/indexer/src/services/StatsCollector.ts
+++ b/packages/indexer/src/services/StatsCollector.ts
@@ -118,6 +118,18 @@ export class StatsCollector {
           const oracleAuthority = market.config.oracleAuthority.toBase58();
           const priceE6 = Number(market.config.authorityPriceE6);
           const initialMarginBps = Number(market.params.initialMarginBps);
+
+          // Guard: skip slabs with invalid/zero initialMarginBps — division by zero
+          // gives Infinity which violates the NOT NULL integer constraint in DB.
+          // These are corrupted/incomplete on-chain accounts; skip gracefully.
+          if (!initialMarginBps || initialMarginBps <= 0 || !Number.isFinite(initialMarginBps)) {
+            logger.warn("Skipping market registration — invalid initialMarginBps (corrupted slab?)", {
+              slabAddress,
+              initialMarginBps,
+            });
+            continue;
+          }
+
           const maxLeverage = Math.floor(10000 / initialMarginBps);
           
           // Try to resolve token metadata from on-chain (Helius DAS / Metaplex)


### PR DESCRIPTION
## Problem
Market `EbUAhSm36CpQiH8sXrrjQPdAdKh6rCupnojP7nJq2RhA` fails to register in the indexer:
```
null value in max_leverage violates not-null constraint
```
Root cause: on-chain slab has `initialMarginBps = 0`. Division gives `Infinity`, which Postgres rejects as an integer.

172/173 markets update fine — this single slab appears corrupted/incomplete on-chain.

## Fix
In `StatsCollector.ts`, before computing `maxLeverage = Math.floor(10000 / initialMarginBps)`:
- Guard for falsy, ≤0, or non-finite `initialMarginBps`
- Log a warning and `continue` to skip the bad slab
- All other markets continue registering normally

## Tests
- All 123 API tests pass
- Indexer build clean (tsc)

## Notes
- The /funding/:slab 404 guard (devops Sentry alert) is already in main via `d9f53398`
- PR #1157 (fix/frontend-bug-blitz) already has the oracle banner removed — banner conflict with #1158 is resolved
