### PR TITLE
fix(api): add total count field to GET /api/markets response (#1168)

### DIFF
--- a/app/__tests__/api/markets-price-sanitize.test.ts
+++ b/app/__tests__/api/markets-price-sanitize.test.ts
@@ -222,6 +222,40 @@ describe("GET /api/markets — price sanitization (#856)", () => {
     expect(fallback?.total_open_interest_usd).toBeCloseTo(0.001, 6); // (600+400) / 1e6 * 1.0
   });
 
+  it("includes total field matching markets array length (#1168)", async () => {
+    mockMarkets = [
+      mkMarket({ symbol: "A" }),
+      mkMarket({ symbol: "B" }),
+      mkMarket({ symbol: "C" }),
+    ];
+
+    vi.resetModules();
+    const { GET } = await import("@/app/api/markets/route");
+    const res = await GET();
+    const body = (await res.json()) as { total: number; markets: unknown[] };
+
+    expect(body.total).toBe(3);
+    expect(body.total).toBe(body.markets.length);
+  });
+
+  it("total excludes blocked markets (#1168)", async () => {
+    vi.stubEnv("BLOCKED_MARKET_ADDRESSES", "BlockedSlab11111111111111111111111111111111");
+    mockMarkets = [
+      mkMarket({ slab_address: "BlockedSlab11111111111111111111111111111111", symbol: "BLOCKED" }),
+      mkMarket({ symbol: "GOOD_A" }),
+      mkMarket({ symbol: "GOOD_B" }),
+    ];
+
+    vi.resetModules();
+    const { GET } = await import("@/app/api/markets/route");
+    const res = await GET();
+    const body = (await res.json()) as { total: number; markets: unknown[] };
+
+    // BLOCKED market excluded → total = 2
+    expect(body.total).toBe(2);
+    expect(body.total).toBe(body.markets.length);
+  });
+
   it("sanitizes index_price with same bounds as last_price/mark_price (#855)", async () => {
     mockMarkets = [
       // Corrupt index_price — should be nulled

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -170,7 +170,9 @@ export async function GET() {
       };
     });
 
-    return NextResponse.json({ markets: sanitized }, {
+    // #1168: Include total count so API consumers can get market count without
+    // fetching all records. Reflects post-filter count (blocked markets excluded).
+    return NextResponse.json({ total: sanitized.length, markets: sanitized }, {
       headers: {
         "Cache-Control": "public, s-maxage=10, stale-while-revalidate=30",
       },


### PR DESCRIPTION
## Summary
Fixes #1168.

`/api/markets` returned `{markets: [...]}` with `total: null` — API consumers could not get a market count without fetching all records.

## Change
Added `total: sanitized.length` to the JSON response. Count reflects the post-filter result (blocked markets excluded). Fully backward-compatible — the `markets` array is unchanged.

```json
{ "total": 164, "markets": [...] }
```

## Tests
- 2 new vitest cases: total count matches array length, total excludes blocked markets
- All 11 existing tests still pass

## How to Test
```bash
curl https://percolatorlaunch.com/api/markets | jq '.total'
# Returns: 164 (integer, not null)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Markets API endpoint now includes a market count in the response, providing immediate visibility into how many markets are available for your needs. The count automatically excludes any restricted or blocked markets, ensuring you receive accurate information about accessible markets without manual counting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->