### PR TITLE
fix(indexer): add TradeCpiV2 (tag=35) to TRADE_TAGS — GH#1171

### DIFF
--- a/packages/indexer/src/routes/webhook.ts
+++ b/packages/indexer/src/routes/webhook.ts
@@ -5,7 +5,7 @@ import { config, insertTrade, eventBus, decodeBase58, readU128LE, parseTradeSize
 
 const logger = createLogger("indexer:webhook");
 
-const TRADE_TAGS = new Set<number>([IX_TAG.TradeNoCpi, IX_TAG.TradeCpi]);
+const TRADE_TAGS = new Set<number>([IX_TAG.TradeNoCpi, IX_TAG.TradeCpi, IX_TAG.TradeCpiV2]);
 const PROGRAM_IDS = new Set(config.allProgramIds);
 const BASE58_PUBKEY = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
 
@@ -180,12 +180,14 @@ function extractTradesFromEnhancedTx(tx: any): TradeData[] {
     if (!TRADE_TAGS.has(tag)) continue;
 
     // Parse: tag(1) + lpIdx(u16=2) + userIdx(u16=2) + size(i128=16)
+    // TradeCpiV2 adds an extra bump(u8) at byte 21 — same size offset, different total length (22 vs 21)
     const { sizeValue, side } = parseTradeSize(data.slice(5, 21));
 
     // Account layout (from core/abi/accounts.ts):
     // PERC-199: clock sysvar removed from trade instructions
-    // TradeNoCpi: [0]=user(signer), [1]=lp(signer), [2]=slab(writable), [3]=oracle
-    // TradeCpi:   [0]=user(signer), [1]=lpOwner,    [2]=slab(writable), [3]=oracle, ...
+    // TradeNoCpi:  [0]=user(signer), [1]=lp(signer), [2]=slab(writable), [3]=oracle
+    // TradeCpi:    [0]=user(signer), [1]=lpOwner,    [2]=slab(writable), [3]=oracle, ...
+    // TradeCpiV2:  [0]=user(signer), [1]=lpOwner,    [2]=slab(writable), [3]=oracle, ... (same layout, adds bump in data)
     const accounts: string[] = ix.accounts ?? [];
     const trader = accounts[0] ?? "";
     const slabAddress = accounts.length > 2 ? accounts[2] : "";

--- a/packages/indexer/src/services/TradeIndexer.ts
+++ b/packages/indexer/src/services/TradeIndexer.ts
@@ -5,7 +5,7 @@ import { config, getConnection, insertTrade, tradeExistsBySignature, getMarkets,
 const logger = createLogger("indexer:trade-indexer");
 
 /** Trade instruction tags we want to index */
-const TRADE_TAGS = new Set<number>([IX_TAG.TradeNoCpi, IX_TAG.TradeCpi]);
+const TRADE_TAGS = new Set<number>([IX_TAG.TradeNoCpi, IX_TAG.TradeCpi, IX_TAG.TradeCpiV2]);
 
 /** How many recent signatures to fetch per slab per cycle */
 const MAX_SIGNATURES = 50;
@@ -259,6 +259,7 @@ export class TradeIndexerPolling {
 
       // This is a trade instruction! Parse it.
       // Layout: tag(1) + lpIdx(u16=2) + userIdx(u16=2) + size(i128=16) = 21 bytes
+      // TradeCpiV2 adds bump(u8) at byte 21, total 22 bytes — size offset unchanged.
       if (data.length < 21) continue;
 
       // Parse size as signed i128 (little-endian)

--- a/packages/indexer/tests/routes/webhook.test.ts
+++ b/packages/indexer/tests/routes/webhook.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as nodeCrypto from 'node:crypto';
 
 vi.mock('@percolator/sdk', () => ({
-  IX_TAG: { TradeNoCpi: 10, TradeCpi: 11 },
+  IX_TAG: { TradeNoCpi: 10, TradeCpi: 11, TradeCpiV2: 35 },
   // detectSlabLayout: returns a V1-style layout so engineOff + engineMarkPriceOff = 1040,
   // matching the mock slab buffers built in tests below.
   detectSlabLayout: vi.fn((dataLen: number) => {
@@ -282,6 +282,34 @@ describe('POST /webhook/trades — price extraction', () => {
     };
     const res = await app.fetch(makeRequest([tx]));
     expect(res.status).toBe(200);
+  });
+
+  it('indexes TradeCpiV2 (tag=35, 22-byte layout) — GH#1171 regression', async () => {
+    // TradeCpiV2 adds a bump byte at position 21, total 22 bytes.
+    // The TRADE_TAGS set must include IX_TAG.TradeCpiV2 or all such trades are silently dropped.
+    const mockDecodeBase58 = vi.mocked(shared.decodeBase58);
+    mockDecodeBase58.mockReturnValueOnce((() => {
+      const buf = new Uint8Array(22); // 22-byte TradeCpiV2
+      buf[0] = 35; // IX_TAG.TradeCpiV2
+      buf[5] = 0x40; buf[6] = 0x42; buf[7] = 0x0f; // size bytes
+      buf[21] = 0xfe; // bump byte
+      return buf;
+    })());
+
+    const tx = {
+      signature: SIG,
+      instructions: makeBaseInstructions(),
+      innerInstructions: [],
+      accountData: [],
+      logs: ['Program log: 1500000, 2000000, 3000000, 4000000, 5000000'],
+    };
+    await app.fetch(makeRequest([tx]));
+
+    // Must have been indexed — not silently skipped
+    expect(shared.insertTrade).toHaveBeenCalledOnce();
+    expect(shared.insertTrade).toHaveBeenCalledWith(
+      expect.objectContaining({ side: 'long', size: '1000000' })
+    );
   });
 
   it('returns 400 for invalid JSON body', async () => {

--- a/packages/indexer/tests/services/TradeIndexer.test.ts
+++ b/packages/indexer/tests/services/TradeIndexer.test.ts
@@ -5,7 +5,7 @@ const mockGetSignaturesForAddress = vi.fn();
 const mockGetParsedTransaction = vi.fn();
 
 vi.mock('@percolator/sdk', () => ({
-  IX_TAG: { TradeNoCpi: 10, TradeCpi: 11 },
+  IX_TAG: { TradeNoCpi: 10, TradeCpi: 11, TradeCpiV2: 35 },
 }));
 
 vi.mock('@percolator/shared', () => ({
@@ -272,6 +272,40 @@ describe('TradeIndexerPolling', () => {
       await new Promise(r => setTimeout(r, 6500));
 
       expect(shared.insertTrade).not.toHaveBeenCalled();
+    }, 10000);
+
+    it('should index TradeCpiV2 (tag=35, 22-byte layout) — GH#1171 regression', async () => {
+      // TradeCpiV2 was not in TRADE_TAGS, causing all post-PR#18 trades to be silently dropped.
+      vi.mocked(shared.tradeExistsBySignature).mockResolvedValue(false);
+      vi.mocked(shared.getMarkets).mockResolvedValue([{ slab_address: SLAB } as any]);
+      vi.mocked(shared.parseTradeSize).mockReturnValue({ sizeValue: 5_000_000n, side: 'short' as const });
+
+      mockGetSignaturesForAddress.mockResolvedValue([{ signature: VALID_SIG, err: null }]);
+
+      const ixData = new Uint8Array(22); // TradeCpiV2 is 22 bytes
+      ixData[0] = 35; // IX_TAG.TradeCpiV2
+      vi.mocked(shared.decodeBase58).mockReturnValue(ixData);
+
+      mockGetParsedTransaction.mockResolvedValue({
+        meta: { err: null, logMessages: [] },
+        transaction: {
+          message: {
+            instructions: [{
+              programId: new PublicKey(PROGRAM_ID),
+              accounts: [new PublicKey(TRADER), new PublicKey(TRADER), new PublicKey(SLAB)],
+              data: 'somedata',
+            }],
+          },
+        },
+      });
+
+      indexer.start();
+      await new Promise(r => setTimeout(r, 6500));
+
+      expect(shared.insertTrade).toHaveBeenCalledOnce();
+      expect(shared.insertTrade).toHaveBeenCalledWith(
+        expect.objectContaining({ side: 'short', size: '5000000', slab_address: SLAB })
+      );
     }, 10000);
 
     it('should skip non-trade instruction tags', async () => {


### PR DESCRIPTION
## Root Cause

**GH#1171**: `volume_24h = 0` for all 194 markets despite `trades24h=5`.

`IX_TAG.TradeCpiV2` (tag=35) was **missing from `TRADE_TAGS`** in both `webhook.ts` and `TradeIndexer.ts`. All trades using the new `TradeCpiV2` instruction (merged in PR#18) were silently dropped after the tag check, so no volume was ever written to `market_stats`.

## Layout Note

`TradeCpiV2` is 22 bytes (adds `bump(u8)` at position 21). The `size` field is at the same offset `5..21` as `TradeCpi`, so `parseTradeSize` works correctly. Only `TRADE_TAGS` needed updating.

## Changes

- `webhook.ts`: add `IX_TAG.TradeCpiV2` to `TRADE_TAGS`
- `TradeIndexer.ts`: add `IX_TAG.TradeCpiV2` to `TRADE_TAGS`
- Both: updated layout comments to document TradeCpiV2
- `webhook.test.ts`: add regression test for tag=35 22-byte indexing
- `TradeIndexer.test.ts`: add regression test for tag=35 22-byte indexing

## Tests

69/69 pass including 2 new TradeCpiV2 regression tests.

## Deployment

After merge, indexer must be **redeployed immediately** to activate. Poller will backfill recent trades on startup.

Closes #1171