### PR TITLE
fix: GH#1177 block stale SOL/USD market + GH#1178 default slab tier to SMALL

### DIFF
--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -87,6 +87,9 @@ const HARDCODED_BLOCKED_MARKETS: ReadonlySet<string> = new Set([
   // issue #837: wrong oracle_authority (5Eb8PY personal wallet), hardcoded $1 price,
   // never timestamped — price manipulation risk on devnet.
   "HjBePQZnoZVftg9B52gyeuHGjBvt2f8FNCVP4FeoP3YT",
+  // GH#1177: Stale SOL/USD admin-oracle market — slab no longer exists on-chain
+  // (shows $100 while SOL oracle is ~$178, causes "Failed to load market" on trade page).
+  "BxJPaMaCfEGTBsjZ8wfj3Yfzf4wpasmxKAEvqZZRcGPP",
 ]);
 
 const BLOCKED_MARKET_ADDRESSES: ReadonlySet<string> = new Set([

--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -299,7 +299,9 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
         dexPool: null,
         pythFeed: null,
         // Reset slab tier to mode-appropriate default
-        slabTier: mode === "quick" ? "small" : "large",
+        // GH#1178: Always default to small — cheapest/safest for new users.
+        // Manual mode users can still change to medium/large in the picker.
+        slabTier: "small",
       }));
     },
     []


### PR DESCRIPTION
## Summary

Two medium-severity bugs from QA.

### GH#1178 — Market wizard defaults to LARGE slab instead of SMALL
**Impact:** New users could accidentally deploy a LARGE slab costing ~7 SOL.
**Fix:** `handleModeChange` in `CreateMarketWizard.tsx` was setting `slabTier: 'large'` when switching to manual mode. Changed to always default `slabTier: 'small'`. Users can still pick medium/large via the picker.

### GH#1177 — SOL/USD market shows Healthy on /markets but fails on trade page
**Impact:** Stale DB entry for `BxJPaMaCfEGTBsjZ8wfj3Yfzf4wpasmxKAEvqZZRcGPP` — slab no longer exists on-chain. Shows $100 price (SOL is ~$178), "Healthy" status, but trade page throws "Failed to load market".
**Fix:** Added market address to `HARDCODED_BLOCKED_MARKETS` in `/api/markets/route.ts` — same pattern used for #837.

## Tests
- 79 test files, 957 tests — all passing

## How to Test
- GH#1178: Go to /create → Manual Setup → Step 3 → Slab Tier should default to **SMALL**
- GH#1177: `BxJPaMaCfEGTBsjZ8wfj3Yfzf4wpasmxKAEvqZZRcGPP` should no longer appear on /markets