### PR TITLE
fix(earn): add USD-value cap to lp_collateral sentinel filter (GH#1165)

### DIFF
--- a/app/__tests__/hooks/earnStatsTvlSentinel.test.ts
+++ b/app/__tests__/hooks/earnStatsTvlSentinel.test.ts
@@ -1,0 +1,106 @@
+/**
+ * GH#1165 — /earn TVL sentinel filter for lp_collateral
+ *
+ * Root cause: corrupt lp_collateral values (e.g. ~4e14 at 6 decimals = $400M)
+ * passed the existing sentinel filter (isSentinel = v > 1e18) but produced
+ * wildly inflated TVL on the /earn page.
+ *
+ * Fix: add a USD-value cap after dividing by 10^decimals. Any vault claiming
+ * > $10M USD is corrupt and should be treated as 0 (MAX_VAULT_USD = 10_000_000).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// ─── Inline the same logic as hooks/useEarnStats.ts ───────────────────────
+const isSentinel = (v: number) => v > 1e18;
+const MAX_VAULT_USD = 10_000_000; // $10M cap per vault
+
+function computeVaultBalance(lp_collateral: number | null, collDivisor: number): number {
+  const vaultBalanceRaw = lp_collateral ?? 0;
+  const vaultBalanceHuman = isSentinel(vaultBalanceRaw) ? Infinity : vaultBalanceRaw / collDivisor;
+  return vaultBalanceHuman > MAX_VAULT_USD ? 0 : vaultBalanceRaw;
+}
+
+function computeTvl(markets: { lp_collateral: number | null; decimals: number }[]): number {
+  return markets.reduce((s, m) => {
+    const collDivisor = 10 ** m.decimals;
+    const vaultBalance = computeVaultBalance(m.lp_collateral, collDivisor);
+    return s + vaultBalance / collDivisor;
+  }, 0);
+}
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('useEarnStats — lp_collateral sentinel filter (GH#1165)', () => {
+  it('passes legitimate USDC LP (e.g. 1,000 USDC at 6 decimals)', () => {
+    const raw = 1_000 * 1e6; // 1,000 USDC
+    const bal = computeVaultBalance(raw, 1e6);
+    expect(bal).toBe(raw);
+  });
+
+  it('passes legitimate SOL LP (e.g. 500 SOL at 9 decimals)', () => {
+    const raw = 500 * 1e9; // 500 SOL
+    const bal = computeVaultBalance(raw, 1e9);
+    expect(bal).toBe(raw);
+    expect(bal / 1e9).toBe(500); // 500 SOL in human units
+  });
+
+  it('blocks corrupt USDC value producing $400M TVL (4e14 at 6 decimals)', () => {
+    // 4e14 / 1e6 = 4e8 = $400M — should be zeroed
+    const corrupt = 4e14;
+    const bal = computeVaultBalance(corrupt, 1e6);
+    expect(bal).toBe(0);
+  });
+
+  it('blocks corrupt SOL value producing $400M TVL (4e17 at 9 decimals)', () => {
+    // 4e17 / 1e9 = 4e8 = $400M SOL (at any price this is huge) — should be zeroed
+    const corrupt = 4e17;
+    const bal = computeVaultBalance(corrupt, 1e9);
+    expect(bal).toBe(0);
+  });
+
+  it('blocks sentinel values > 1e18', () => {
+    const sentinel = 1.844e19; // u64::MAX approx
+    const bal = computeVaultBalance(sentinel, 1e6);
+    expect(bal).toBe(0);
+  });
+
+  it('handles null lp_collateral as 0', () => {
+    const bal = computeVaultBalance(null, 1e6);
+    expect(bal).toBe(0);
+  });
+
+  it('TVL with one corrupt market is not inflated', () => {
+    const markets = [
+      { lp_collateral: 1_000 * 1e6, decimals: 6 },   // 1,000 USDC — legit
+      { lp_collateral: 4e14, decimals: 6 },            // $400M USDC — corrupt
+      { lp_collateral: 500 * 1e9, decimals: 9 },      // 500 SOL — legit
+    ];
+    const tvl = computeTvl(markets);
+    // Should only include the two legit vaults: 1,000 + 500 = 1,500 human units
+    expect(tvl).toBe(1_500);
+  });
+
+  it('TVL with all legit markets aggregates correctly', () => {
+    const markets = [
+      { lp_collateral: 100 * 1e6, decimals: 6 },   // 100 USDC
+      { lp_collateral: 200 * 1e6, decimals: 6 },   // 200 USDC
+      { lp_collateral: 50 * 1e9,  decimals: 9 },   // 50 SOL
+    ];
+    const tvl = computeTvl(markets);
+    expect(tvl).toBeCloseTo(350, 5); // 100 + 200 + 50
+  });
+
+  it('$9.9M vault is allowed (just under cap)', () => {
+    // $9,900,000 in USDC micro-units
+    const raw = 9_900_000 * 1e6; // 9.9e12
+    const bal = computeVaultBalance(raw, 1e6);
+    expect(bal).toBe(raw);
+  });
+
+  it('$10.1M vault is blocked (just over cap)', () => {
+    // $10,100,000 in USDC micro-units
+    const raw = 10_100_000 * 1e6; // 1.01e13
+    const bal = computeVaultBalance(raw, 1e6);
+    expect(bal).toBe(0);
+  });
+});

--- a/app/hooks/useEarnStats.ts
+++ b/app/hooks/useEarnStats.ts
@@ -213,7 +213,14 @@ export function useEarnStats() {
           const totalOI = isSentinel(totalOIRaw) ? 0 : totalOIRaw / collDivisor;
           const maxLeverage = m.max_leverage ?? 10;
           const vaultBalanceRaw = m.lp_collateral ?? 0;
-          const vaultBalance = isSentinel(vaultBalanceRaw) ? 0 : vaultBalanceRaw;
+          // Two-stage filter for lp_collateral:
+          // 1. Sentinel guard: u64::MAX (>1e18) leaks from uninitialized on-chain fields.
+          // 2. USD cap: compute human-readable amount and reject if > $10M per vault.
+          //    Without this, a corrupt lp_collateral of ~4e14 at 6 decimals = $400M TVL
+          //    passes the sentinel filter but produces wildly inflated TVL (GH#1165).
+          const MAX_VAULT_USD = 10_000_000; // $10M per vault — generous devnet ceiling
+          const vaultBalanceHuman = isSentinel(vaultBalanceRaw) ? Infinity : vaultBalanceRaw / collDivisor;
+          const vaultBalance = vaultBalanceHuman > MAX_VAULT_USD ? 0 : vaultBalanceRaw;
           const tradingFeeBpsRaw = m.trading_fee_bps ?? 10;
           const tradingFeeBps = tradingFeeBpsRaw > 5_000 ? 0 : tradingFeeBpsRaw;
           const volume24hRaw = m.volume_24h ?? 0;


### PR DESCRIPTION
## Problem

`/earn` page displayed **$400M Total Value Locked** (or similar inflated values) due to corrupt `lp_collateral` values in the DB that bypassed the existing sentinel filter.

The existing filter only blocks values > 1e18 (u64::MAX). But corrupt values like `4e14` at 6 decimals = **$400M USDC** or `4e17` at 9 decimals = **$400M SOL** pass the sentinel check.

## Root Cause

Same bug class as the insurance_fund inflation fixed in PR #1157/#1176. The `isSentinel` guard in `useEarnStats.ts` was too permissive for `lp_collateral`.

## Fix

Add a two-stage filter to `lp_collateral`:
1. Sentinel guard (existing): `> 1e18` → 0
2. **New USD cap**: compute human-readable amount (`raw / 10^decimals`), reject if > $10M per vault

$10M is a generous ceiling for devnet — corrupt values produce $100M–$400M+ so this catches them without affecting any legitimate LP deposits.

## Tests

10 new unit tests in `earnStatsTvlSentinel.test.ts`:
- Legit USDC/SOL LP passes through
- $400M corrupt values (both 6-decimal and 9-decimal) are zeroed
- Sentinel (>1e18) still caught
- Boundary: $9.9M allowed, $10.1M blocked
- TVL aggregate ignores corrupt markets

## Checklist
- [x] Tests pass (976/976)
- [x] No breaking changes — display-only fix in `useEarnStats.ts`
- [x] Follows existing insurance_fund sanity cap pattern

Closes #1165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TVL calculation accuracy by implementing a per-vault balance cap to filter corrupt collateral values.

* **Tests**
  * Added comprehensive test coverage for TVL filtering logic across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->