### PR TITLE
fix(frontend): apply client-side blocklist to anon Supabase queries (GH#1184, GH#1181)

### DIFF
--- a/app/__tests__/lib/blocklist.test.ts
+++ b/app/__tests__/lib/blocklist.test.ts
@@ -1,0 +1,27 @@
+import { BLOCKED_SLAB_ADDRESSES, isBlockedSlab } from "@/lib/blocklist";
+
+describe("blocklist", () => {
+  it("contains BxJPaMaC stale market", () => {
+    expect(BLOCKED_SLAB_ADDRESSES.has("BxJPaMaCfEGTBsjZ8wfj3Yfzf4wpasmxKAEvqZZRcGPP")).toBe(true);
+  });
+
+  it("isBlockedSlab returns true for known bad address", () => {
+    expect(isBlockedSlab("BxJPaMaCfEGTBsjZ8wfj3Yfzf4wpasmxKAEvqZZRcGPP")).toBe(true);
+  });
+
+  it("isBlockedSlab returns false for a valid market address", () => {
+    expect(isBlockedSlab("SomeValidMarketAddressNotInBlocklist1234567")).toBe(false);
+  });
+
+  it("isBlockedSlab returns false for null", () => {
+    expect(isBlockedSlab(null)).toBe(false);
+  });
+
+  it("isBlockedSlab returns false for undefined", () => {
+    expect(isBlockedSlab(undefined)).toBe(false);
+  });
+
+  it("isBlockedSlab returns false for empty string", () => {
+    expect(isBlockedSlab("")).toBe(false);
+  });
+});

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -7,6 +7,7 @@ import { getConfig } from "@/lib/config";
 import { isMockMode } from "@/lib/mock-mode";
 import { MOCK_SLAB_ADDRESSES, getMockMarketData } from "@/lib/mock-trade-data";
 import { isActiveMarket, isSaneMarketValue } from "@/lib/activeMarketFilter";
+import { isBlockedSlab } from "@/lib/blocklist";
 import { ScrollReveal } from "@/components/ui/ScrollReveal";
 import { GradientText } from "@/components/ui/GradientText";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
@@ -158,8 +159,12 @@ export default function Home() {
           };
 
           // Filter out empty/abandoned markets using shared active-market filter
-          // (consistent with /api/stats and markets page)
-          const activeData = data.filter(isActiveMarket);
+          // (consistent with /api/stats and markets page). Also exclude blocked/stale
+          // slab addresses — these pass isActiveMarket (last_price > 0) but are bad
+          // on-chain data that corrupt insurance and volume aggregates (GH#1181).
+          const activeData = data
+            .filter((m) => !isBlockedSlab(m.slab_address))
+            .filter(isActiveMarket);
           setStats({
             markets: activeData.length,
             volume: activeData.reduce((s, m) => s + toUsd(Number(m.volume_24h || 0), m.decimals, m.last_price), 0),

--- a/app/hooks/useAllMarketStats.ts
+++ b/app/hooks/useAllMarketStats.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
+import { isBlockedSlab } from "@/lib/blocklist";
 import type { Database } from "@/lib/database.types";
 
 type MarketWithStats = Database['public']['Views']['markets_with_stats']['Row'];
@@ -39,7 +40,9 @@ export function useAllMarketStats() {
         } else {
           const map = new Map<string, MarketWithStats>();
           data?.forEach((market) => {
-            if (market.slab_address) {
+            // Skip blocked/stale markets — they are excluded from /api/markets but
+            // still visible to the Supabase anon client via markets_with_stats.
+            if (market.slab_address && !isBlockedSlab(market.slab_address)) {
               map.set(market.slab_address, market);
             }
           });

--- a/app/hooks/useEarnStats.ts
+++ b/app/hooks/useEarnStats.ts
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { getBackendUrl } from '@/lib/config';
 import { getSupabase } from '@/lib/supabase';
 import { isMockMode } from '@/lib/mock-mode';
+import { isBlockedSlab } from '@/lib/blocklist';
 
 // ═══════════════════════════════════════════════════════════════
 // Types
@@ -199,6 +200,8 @@ export function useEarnStats() {
       }
 
       const markets: MarketVaultInfo[] = data
+        // Skip blocked/stale slabs — excluded from /api/markets but visible to anon client.
+        .filter((m) => !isBlockedSlab(m.slab_address))
         .filter((m) => m.status === 'active' || m.status === 'Active')
         .map((m) => {
           const oiLongRaw = m.open_interest_long ?? 0;

--- a/app/lib/blocklist.ts
+++ b/app/lib/blocklist.ts
@@ -1,0 +1,25 @@
+/**
+ * Client-side blocklist for known-bad / stale market slab addresses.
+ *
+ * These are markets that have been blocked in the API route
+ * (app/api/markets/route.ts HARDCODED_BLOCKED_MARKETS) but whose rows
+ * are still visible via the Supabase anon client in
+ * markets_with_stats. Any hook or page that queries the view directly
+ * MUST filter these out before rendering or aggregating values.
+ *
+ * Keep in sync with the server-side HARDCODED_BLOCKED_MARKETS set in
+ * app/api/markets/route.ts.
+ */
+export const BLOCKED_SLAB_ADDRESSES: ReadonlySet<string> = new Set([
+  // Stale SOL/USD slab — on-chain slab no longer exists; shows $100 last_price
+  // causing "Failed to load market" on click. Blocked via PR #1179.
+  "BxJPaMaCfEGTBsjZ8wfj3Yfzf4wpasmxKAEvqZZRcGPP",
+]);
+
+/**
+ * Returns true if the slab address should be excluded from UI rendering.
+ */
+export function isBlockedSlab(slabAddress: string | null | undefined): boolean {
+  if (!slabAddress) return false;
+  return BLOCKED_SLAB_ADDRESSES.has(slabAddress);
+}


### PR DESCRIPTION
## Summary

Fixes **GH#1184** (HIGH) and **GH#1181** (medium).

## Root Cause

`/api/markets` has `HARDCODED_BLOCKED_MARKETS` that excludes `BxJPaMaC` (stale SOL/USD slab). But three places query `markets_with_stats` **directly via the Supabase anon client**, bypassing that server-side blocklist:

| File | Impact |
|------|--------|
| `useAllMarketStats.ts` | /markets page shows stale market → click → "Failed to load market" (GH#1184) |
| `useEarnStats.ts` | /earn page includes stale market stats |
| `page.tsx` (homepage) | Insurance Fund aggregate includes BxJPaMaC corrupt value → $29.8B display (GH#1181) |

`BxJPaMaC` has `last_price=$100` so it passes `isActiveMarket()` and slips into all aggregates.

## Changes

- **New: `app/lib/blocklist.ts`** — `BLOCKED_SLAB_ADDRESSES` set + `isBlockedSlab()` helper, client-accessible. Mirrors `HARDCODED_BLOCKED_MARKETS` from the API route.
- **`useAllMarketStats.ts`** — filter `isBlockedSlab` when building the `statsMap`
- **`useEarnStats.ts`** — pre-filter blocked slabs before the status/active filter chain
- **`page.tsx`** — filter blocked slabs before `activeData` aggregation

## Testing

- 6 new unit tests in `__tests__/lib/blocklist.test.ts`
- Full suite: **972 passed** (0 failures)
- TypeScript: clean

## How to Verify

1. Visit `/markets` — BxJPaMaCfEGTBsjZ8wfj3Yfzf4wpasmxKAEvqZZRcGPP should no longer appear
2. Visit homepage — Insurance Fund should show ~$1,117 (same as /earn page)
3. Visit `/earn` — no stale SOL/USD market in vault list

Closes #1184
Closes #1181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented a blocklist to filter out known problematic and stale market addresses from the application, affecting market displays and related calculations across the platform.

* **Tests**
  * Added tests to verify blocklist functionality, including validation of filtered addresses and proper handling of edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->