### PR TITLE
fix: resolve market count inconsistency between /api/stats and /api/markets (GH#1172)

### DIFF
--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -5,7 +5,7 @@ import { parseHeader } from "@percolator/sdk";
 import { getServiceClient } from "@/lib/supabase";
 import { getConfig } from "@/lib/config";
 import * as Sentry from "@sentry/nextjs";
-import { isSaneMarketValue } from "@/lib/activeMarketFilter";
+import { isSaneMarketValue, isActiveMarket } from "@/lib/activeMarketFilter";
 import { BLOCKED_SLAB_ADDRESSES as HARDCODED_BLOCKED_MARKETS } from "@/lib/blocklist";
 
 /**
@@ -165,7 +165,10 @@ export async function GET() {
 
     // #1168: Include total count so API consumers can get market count without
     // fetching all records. Reflects post-filter count (blocked markets excluded).
-    return NextResponse.json({ total: sanitized.length, markets: sanitized }, {
+    // #1172: Add activeTotal — markets with at least one sane stat (price/volume/OI).
+    // This matches the count shown by /api/stats totalMarkets.
+    const activeTotal = sanitized.filter((m) => isActiveMarket(m as Parameters<typeof isActiveMarket>[0])).length;
+    return NextResponse.json({ total: sanitized.length, activeTotal, markets: sanitized }, {
       headers: {
         "Cache-Control": "public, s-maxage=10, stale-while-revalidate=30",
       },

--- a/app/app/api/stats/route.ts
+++ b/app/app/api/stats/route.ts
@@ -111,6 +111,9 @@ export async function GET(request: NextRequest) {
 
   return NextResponse.json({
     totalMarkets,
+    // #1172: totalListedMarkets includes all non-blocked markets (even those with
+    // zero stats). totalMarkets counts only "active" markets (at least one sane stat).
+    totalListedMarkets: statsData.length,
     totalVolume24h,
     totalOpenInterest,
     totalTraders: uniqueTraders,


### PR DESCRIPTION
## Problem
`/api/stats` returns `totalMarkets: 164` (active markets only) while `/api/markets` returns 194 markets (all non-blocked). This 30-market discrepancy confuses consumers.

## Solution
Both endpoints now expose both counts:
- **`/api/stats`**: adds `totalListedMarkets` (all non-blocked, including zero-stat markets)
- **`/api/markets`**: adds `activeTotal` (markets with at least one sane stat — matches `/api/stats.totalMarkets`)

Consumers can now choose which count to display. The shared `isActiveMarket()` filter ensures consistency.

## Testing
- `/api/stats` response includes `totalListedMarkets` alongside existing `totalMarkets`
- `/api/markets` response includes `activeTotal` alongside existing `total`
- Both `totalMarkets` (stats) and `activeTotal` (markets) use the same filter

Closes #1172