### PR TITLE
fix(markets): filter blocked slabs from on-chain discovery + price sanity cap [GH#1189, GH#1187]

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -150,10 +150,15 @@ export default function Home() {
           };
           // For insurance/TVL: when price is missing, fall back to raw token amount
           // (correct for stablecoins like USDC where 1 token ≈ $1)
+          // GH#1187: corrupt devnet last_price values (e.g. $11M–$100M/token) multiply
+          // small but legitimate insurance balances into billions. Cap price at $10K/token
+          // — no Percolator collateral token should legitimately exceed this on devnet.
+          // Corrupt prices fall back to the stablecoin assumption (p=0 → raw/10^d).
+          const MAX_SANE_PRICE_USD = 10_000; // $10K — reject as corrupt above this
           const toUsdWithFallback = (raw: number, decimals: number | null, price: number | null): number => {
             if (!isSaneMarketValue(raw)) return 0;
             const d = Math.min(Math.max(decimals ?? 6, 0), 18);
-            const p = price ?? 0;
+            const p = (price != null && price > 0 && price <= MAX_SANE_PRICE_USD) ? price : 0;
             const usd = p > 0 ? (raw / 10 ** d) * p : raw / 10 ** d;
             return usd > MAX_PER_MARKET_USD ? 0 : usd;
           };

--- a/app/hooks/useMarketDiscovery.ts
+++ b/app/hooks/useMarketDiscovery.ts
@@ -5,6 +5,7 @@ import { PublicKey } from "@solana/web3.js";
 import { useConnectionCompat } from "@/hooks/useWalletCompat";
 import { discoverMarkets, type DiscoveredMarket } from "@percolator/sdk";
 import { getConfig } from "@/lib/config";
+import { isBlockedSlab } from "@/lib/blocklist";
 
 /** Get all unique program IDs to scan (default + all slab tier programs) */
 function getAllProgramIds(): PublicKey[] {
@@ -45,11 +46,14 @@ export function useMarketDiscovery() {
         if (!cancelled) {
           // GH#1115: deduplicate across program-ID scans — same slab can appear from
           // multiple discoverMarkets calls if programsBySlabTier overlaps with programId.
+          // GH#1189: also filter out blocked slab addresses from the on-chain discovery
+          // path. PR #1186 only patched the Supabase path; this closes the on-chain gap.
           const seenSlabs = new Set<string>();
           const flat = results.flat().filter((m) => {
             const addr = m.slabAddress.toBase58();
             if (seenSlabs.has(addr)) return false;
             seenSlabs.add(addr);
+            if (isBlockedSlab(addr)) return false; // GH#1189: exclude blocked slabs
             return true;
           });
           setMarkets(flat);


### PR DESCRIPTION
## Summary

Two P0 security/display fixes.

### GH#1189 — Blocked market visible via on-chain path (HIGH severity)

**Root cause:** `useMarketDiscovery` performs RPC discovery of all markets from on-chain program accounts but had no blocklist filter. PR #1186 only patched the Supabase path. `HjBePQZ` (blocked: wrong oracle_authority, price manipulation risk per GH#837) remained visible and tradeable on `/markets` via the on-chain discovery loop.

**Fix:** Import `isBlockedSlab` from `@/lib/blocklist` in `useMarketDiscovery.ts` and reject blocked slab addresses during deduplication — consistent with how the Supabase and API paths handle them.

### GH#1187 — Homepage shows $29.8B insurance fund

**Root cause:** Corrupt `last_price` values in Supabase for devnet markets (e.g. $11M–$100M/token). Raw insurance balances (~5.66e10 micro-units) legitimately pass the existing `> 1e13` guard but when multiplied by a corrupt $100K price give ~$5.6B per market. Multiple such markets sum to ~$29.8B.

**Fix:** Add `MAX_SANE_PRICE_USD = $10K` cap in `toUsdWithFallback` in `app/page.tsx`. Prices above $10K are treated as corrupt devnet noise and fall back to the stablecoin assumption (`raw / 10^decimals`).

## Testing
- `pnpm tsc --noEmit` — clean
- `pnpm test` — 982 passed, 0 failures

## Checklist
- [x] Blocked slab `HjBePQZ` now filtered from on-chain RPC discovery
- [x] Insurance fund display sanitised against corrupt price oracles
- [x] No new TS errors
- [x] All tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced price validation to properly handle edge cases including missing values, non-positive amounts, and unusually high prices in currency conversion operations. When prices fall outside acceptable ranges, the system now falls back to alternative conversion methods.
  * Implemented filtering of blocked market addresses from discovery results, improving data quality by preventing blocked addresses from appearing in on-chain discovery deduplication and processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->