### PR TITLE
fix(stats): add MAX_SANE_PRICE_USD cap to /api/stats toUsd() (GH#1191)

### DIFF
--- a/app/app/api/stats/route.ts
+++ b/app/app/api/stats/route.ts
@@ -80,10 +80,14 @@ export async function GET(request: NextRequest) {
   // Convert raw on-chain token micro-units to USD using decimals + price
   // Without this, sentinel-like values (2e12) leak through as $2T (#1154)
   const MAX_PER_MARKET_USD = 10_000_000_000; // $10B cap — no single market should exceed this
+  // GH#1191: corrupt devnet last_price values (e.g. $7.9T/token) multiply small but
+  // legitimate token amounts into billions. Cap price at $10K/token — no Percolator
+  // collateral token should legitimately exceed this. Same fix applied to page.tsx in PR #1190 (GH#1187).
+  const MAX_SANE_PRICE_USD = 10_000; // $10K — reject as corrupt above this
   const toUsd = (raw: number, m: { decimals?: number | null; last_price?: number | null }): number => {
     if (!isSaneMarketValue(raw)) return 0;
     const d = Math.min(Math.max((m as Record<string, unknown>).decimals as number ?? 6, 0), 18);
-    const p = m.last_price ?? 0;
+    const p = (m.last_price != null && m.last_price > 0 && m.last_price <= MAX_SANE_PRICE_USD) ? m.last_price : 0;
     if (p <= 0) return 0;
     const usd = (raw / 10 ** d) * p;
     return usd > MAX_PER_MARKET_USD ? 0 : usd;


### PR DESCRIPTION
## Problem

Corrupt devnet `last_price` values (e.g. $7.9T/token for market `3M2M4y29`) multiplied by small but legitimate raw volumes produce inflated `totalVolume24h` in `/api/stats`.

Example: 13.5M micro-tokens × ($7.9e12 / 10^9 decimals) = **~$106M fake volume** from a single test trade.

## Root Cause

`/api/stats/route.ts` `toUsd()` had no price sanity cap — only a per-market USD cap of $10B. Prices above $10K that produce results under $10B slip through unchecked.

## Fix

Add `MAX_SANE_PRICE_USD = $10K` to `toUsd()` in the stats route — same guard added to `page.tsx` via PR #1190 (GH#1187). Prices above $10K fall back to 0 (market is skipped for volume/OI aggregation).

```ts
const p = (m.last_price != null && m.last_price > 0 && m.last_price <= MAX_SANE_PRICE_USD) ? m.last_price : 0;
```

## Tests

982 passed, 0 failures

## Context

Discovered during GH#1171 volume investigation — indexer was not redeployed after PRs #1173/#1174 merged. Manual DB fix applied to restore non-zero volume immediately. Indexer redeploy pending (devops notified).

Closes #1191
Related: GH#1187 (same bug class on homepage, fixed in PR #1190)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USD calculation validation in stats endpoint to prevent corrupt or invalid price data from producing incorrect values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->