### PR TITLE
fix(page): apply MAX_SANE_PRICE_USD cap to toUsd() in loadStats() (GH#1193)

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -140,21 +140,21 @@ export default function Home() {
           // 2. Clamp decimals to sane range (0-18) — some on-chain mints have garbage
           // 3. Cap per-market USD contribution to $10B to prevent overflow from bad data
           const MAX_PER_MARKET_USD = 10_000_000_000; // $10B cap — no single market should exceed this
+          // GH#1187/1193: corrupt devnet last_price values (e.g. $11M–$100M/token) cause
+          // hero stats (volume, OI) to show absurd numbers. Cap price at $10K/token —
+          // no Percolator collateral token should legitimately exceed this on devnet.
+          const MAX_SANE_PRICE_USD = 10_000; // $10K — reject as corrupt above this
           const toUsd = (raw: number, decimals: number | null, price: number | null): number => {
             if (!isSaneMarketValue(raw)) return 0;
             const d = Math.min(Math.max(decimals ?? 6, 0), 18); // clamp decimals 0–18
-            const p = price ?? 0;
+            const p = (price != null && price > 0 && price <= MAX_SANE_PRICE_USD) ? price : 0;
             if (p <= 0) return 0;
             const usd = (raw / 10 ** d) * p;
             return usd > MAX_PER_MARKET_USD ? 0 : usd; // discard absurd values
           };
           // For insurance/TVL: when price is missing, fall back to raw token amount
-          // (correct for stablecoins like USDC where 1 token ≈ $1)
-          // GH#1187: corrupt devnet last_price values (e.g. $11M–$100M/token) multiply
-          // small but legitimate insurance balances into billions. Cap price at $10K/token
-          // — no Percolator collateral token should legitimately exceed this on devnet.
+          // (correct for stablecoins like USDC where 1 token ≈ $1).
           // Corrupt prices fall back to the stablecoin assumption (p=0 → raw/10^d).
-          const MAX_SANE_PRICE_USD = 10_000; // $10K — reject as corrupt above this
           const toUsdWithFallback = (raw: number, decimals: number | null, price: number | null): number => {
             if (!isSaneMarketValue(raw)) return 0;
             const d = Math.min(Math.max(decimals ?? 6, 0), 18);


### PR DESCRIPTION
## Problem
Hero stats (volume, OI) showed corrupt values like $106,689.9M because `toUsd()` in `app/app/page.tsx` used `price ?? 0` without the $10K sanity cap that already guards `toUsdWithFallback()` and `/api/stats/route.ts`.

## Root Cause
`MAX_SANE_PRICE_USD` was defined *after* `toUsd()`, so `toUsd()` couldn't use it. The guard was only applied in `toUsdWithFallback()` (PR #1190) and the API route (PR #1192).

## Fix
- Move `MAX_SANE_PRICE_USD = 10_000` constant before `toUsd()`
- Change `const p = price ?? 0` → `const p = (price != null && price > 0 && price <= MAX_SANE_PRICE_USD) ? price : 0`
- This brings `toUsd()` in line with `toUsdWithFallback()` and the API stats pattern

## How to Test
1. Visit `/` on devnet — hero stats should show sane volume/OI values (not hundreds of millions)
2. No TypeScript errors (`pnpm tsc --noEmit` passes)

Closes #1193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced price validation in USD conversion to handle missing or out-of-range values, preventing abnormally high prices from inflating statistics.
  * Improved fallback price conversion logic for more consistent validation across calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->