### PR TITLE
fix: GH#1195 guard corrupt volume_24h raw values (>1e13) on homepage

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -143,7 +143,7 @@ export default function Home() {
           // GH#1187/1193: corrupt devnet last_price values (e.g. $11M–$100M/token) cause
           // hero stats (volume, OI) to show absurd numbers. Cap price at $10K/token —
           // no Percolator collateral token should legitimately exceed this on devnet.
-          const MAX_SANE_PRICE_USD = 10_000; // $10K — reject as corrupt above this
+          const MAX_SANE_PRICE_USD = 100_000; // $100K — reject as corrupt above this (covers BTC/ETH; raised from $10K per GH#1195 QA review)
           const toUsd = (raw: number, decimals: number | null, price: number | null): number => {
             if (!isSaneMarketValue(raw)) return 0;
             const d = Math.min(Math.max(decimals ?? 6, 0), 18); // clamp decimals 0–18
@@ -172,7 +172,15 @@ export default function Home() {
             .filter(isActiveMarket);
           setStats({
             markets: activeData.length,
-            volume: activeData.reduce((s, m) => s + toUsd(Number(m.volume_24h || 0), m.decimals, m.last_price), 0),
+            volume: activeData.reduce((s, m) => {
+              // Sanity cap: raw volume_24h values > 1e13 micro-units are corrupt data
+              // (same guard as insurance_fund). Corrupt values (1e14-1e17) pass
+              // isSaneMarketValue (allows up to 1e18) but produce $10B+ per market
+              // and $106B+ in total after capping. GH#1195.
+              const raw = Number(m.volume_24h || 0);
+              if (raw > 1e13) return s;
+              return s + toUsd(raw, m.decimals, m.last_price);
+            }, 0),
             insurance: activeData.reduce((s, m) => {
               // Use insurance_fund (raw on-chain value in token micro-units) consistent with earn page.
               // Fall back to insurance_balance if insurance_fund is missing.
@@ -192,7 +200,13 @@ export default function Home() {
           const converted = data.map((m) => ({
             slab_address: m.slab_address,
             symbol: m.symbol,
-            volume_24h: toUsd(Number(m.volume_24h || 0), m.decimals, m.last_price),
+            volume_24h: (() => {
+              // Same 1e13 raw guard as stats.volume — prevents corrupt markets from
+              // dominating the featured-markets sort (GH#1195).
+              const raw = Number(m.volume_24h || 0);
+              if (raw > 1e13) return 0;
+              return toUsd(raw, m.decimals, m.last_price);
+            })(),
             last_price: m.last_price,
             total_open_interest: toUsd(Number(m.total_open_interest ?? ((m.open_interest_long ?? 0) + (m.open_interest_short ?? 0))), m.decimals, m.last_price),
           }));


### PR DESCRIPTION
## Summary

Fixes hero stat showing **$106,689.9M Volume 24h** on the homepage.

## Root Cause

Corrupt `volume_24h` raw token amounts (1e14–1e17) in the DB pass `isSaneMarketValue()` (allows up to 1e18), get multiplied by a legitimate price (e.g. $1.00 USDC), produce ~$10.7B/market, get capped at `MAX_PER_MARKET_USD` ($10B), and sum to ~$106.7B across ~11 affected markets.

PR #1194's price cap didn't help because the corruption is in the **raw token amount**, not the price.

## Fix

Apply the same `raw > 1e13` guard already used for `insurance_fund` (line ~181) to `volume_24h` in two places:

1. **`stats.volume` accumulator in `setStats()`** — fixes the hero number directly
2. **`volume_24h` in the `converted` map** — prevents corrupt markets from topping the featured-markets sort

Also raises `MAX_SANE_PRICE_USD` from $10K → $100K so BTC/ETH markets aren't silently excluded from aggregation (per QA side-effect note on PRs #1192/#1194).

## Expected Result

- Hero Volume 24h: ~$15K (consistent with `/api/stats`)
- Featured markets: sorted by legitimate volume only

## Testing

- `pnpm tsc --noEmit` passes clean ✓
- Verify hero stat on Vercel preview shows ~$15K, not $106B

Closes #1195