### PR TITLE
fix(volume): use USD-value cap instead of raw guard; fix HeroSection.tsx (GH#1195 v2)

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -172,7 +172,14 @@ export default function Home() {
             .filter(isActiveMarket);
           setStats({
             markets: activeData.length,
-            volume: activeData.reduce((s, m) => s + toUsd(Number(m.volume_24h || 0), m.decimals, m.last_price), 0),
+            // GH#1195: apply USD-value cap per market AFTER decimal conversion.
+            // Raw-token guards (e.g. raw > 1e13) are decimal-unaware and block
+            // legitimate TEST market (raw=1.5e13, dec=9, price=$1 → $15K USD).
+            // Instead, skip per-market contributions > $10M USD as corrupt.
+            volume: activeData.reduce((s, m) => {
+              const usd = toUsd(Number(m.volume_24h || 0), m.decimals, m.last_price);
+              return usd > 10_000_000 ? s : s + usd;
+            }, 0),
             insurance: activeData.reduce((s, m) => {
               // Use insurance_fund (raw on-chain value in token micro-units) consistent with earn page.
               // Fall back to insurance_balance if insurance_fund is missing.
@@ -192,7 +199,11 @@ export default function Home() {
           const converted = data.map((m) => ({
             slab_address: m.slab_address,
             symbol: m.symbol,
-            volume_24h: toUsd(Number(m.volume_24h || 0), m.decimals, m.last_price),
+            // GH#1195: same $10M USD per-market cap as stats.volume above.
+            volume_24h: (() => {
+              const usd = toUsd(Number(m.volume_24h || 0), m.decimals, m.last_price);
+              return usd > 10_000_000 ? 0 : usd;
+            })(),
             last_price: m.last_price,
             total_open_interest: toUsd(Number(m.total_open_interest ?? ((m.open_interest_long ?? 0) + (m.open_interest_short ?? 0))), m.decimals, m.last_price),
           }));

--- a/app/components/marketing/HeroSection.tsx
+++ b/app/components/marketing/HeroSection.tsx
@@ -75,10 +75,25 @@ export function HeroSection({ marketsCount }: HeroSectionProps = {}) {
         ]);
         if (data && data.length > 0) {
           const activeData = data.filter(isActiveMarket);
+          // GH#1195: sanitise raw volume → USD with the same guards as page.tsx.
+          // Without these, corrupt devnet price oracles (e.g. $11M–$100M/token) or
+          // huge raw values produce absurd hero stats (e.g. $106B volume).
+          // Rules (mirror page.tsx loadStats):
+          //   1. Clamp decimals to 0–18.
+          //   2. Reject price > $100K as corrupt (covers BTC/ETH; blocks bad oracle data).
+          //   3. Cap per-market USD contribution at $10M — no devnet market should exceed.
+          const MAX_HERO_PRICE_USD = 100_000; // $100K — same as page.tsx
+          const MAX_HERO_PER_MARKET_USD = 10_000_000; // $10M per market
+          const heroToUsd = (raw: number, decimals: number | null, price: number | null): number => {
+            if (raw <= 0 || !Number.isFinite(raw) || raw >= 1e18) return 0;
+            const d = Math.min(Math.max(decimals ?? 6, 0), 18);
+            const p = (price != null && price > 0 && price <= MAX_HERO_PRICE_USD) ? price : 0;
+            if (p <= 0) return 0;
+            const usd = (raw / 10 ** d) * p;
+            return usd > MAX_HERO_PER_MARKET_USD ? 0 : usd;
+          };
           const volume = activeData.reduce((s: number, m: { volume_24h: number | null; last_price: number | null; decimals: number | null }) => {
-            const d = 10 ** (m.decimals ?? 6);
-            const price = m.last_price ?? 0;
-            return s + (Number(m.volume_24h || 0) / d) * price;
+            return s + heroToUsd(Number(m.volume_24h || 0), m.decimals, m.last_price);
           }, 0);
           // Prefer /api/stats totalTraders (unique wallets). Fall back to 0 if unavailable.
           const traders: number = (statsRes as { totalTraders?: number } | null)?.totalTraders ?? 0;


### PR DESCRIPTION
## What

Supersedes #1196 (closed — two bugs found by QA).

### Bug 1: Raw guard is decimal-unaware (Protocol Metrics → $0)

PR #1196 added `if (raw > 1e13) return s` to the volume reduce. TEST market has `raw=1.5e13`, `decimals=9`, `price=$1` → **$15K USD** (legitimate). But `1.5e13 > 1e13` so the guard blocked it and Protocol Metrics 24H Volume regressed to $0/dash.

**Fix:** Replace the raw guard with a USD-value cap applied _after_ decimal conversion:
```ts
const usd = toUsd(raw, m.decimals, m.last_price);
return usd > 10_000_000 ? s : s + usd; // skip $10M+ per-market as corrupt
```
This correctly passes TEST ($15K) and blocks any corrupt market contribution > $10M USD.

### Bug 2: HeroSection.tsx untouched — hero still shows $106B

`HeroSection.tsx loadHeroStats()` runs its own Supabase query with zero guards. PR #1196 only patched `page.tsx`.

**Fix:** Added `heroToUsd()` helper to `HeroSection.tsx` with the same logic as `page.tsx` `toUsd()`:
- Clamp decimals to 0–18
- Reject price > $100K as corrupt
- Cap per-market contribution at $10M USD

## Files changed
- `app/app/page.tsx` — replace raw guard with USD cap in `stats.volume` reduce and featured volume map
- `app/components/marketing/HeroSection.tsx` — add `heroToUsd()` with USD guards to `loadHeroStats()`

## Expected after deploy
- Hero Volume 24h: ~$15K
- Protocol Metrics 24H Volume: ~$15K
- No legitimate markets filtered

## Testing
- `pnpm tsc --noEmit` ✅ clean
- Full test suite ✅ 115 tests passed (app + indexer + keeper)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved volume calculation accuracy by implementing per-market caps to filter outlier values.
  * Enhanced volume data validation with bounds checking and decimal precision handling.

* **Chores**
  * Added guards and comments clarifying volume calculation logic across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->