### PR TITLE
fix: use correct decimal divisor for leaderboard volume (GH#1199)

### DIFF
--- a/app/app/leaderboard/page.tsx
+++ b/app/app/leaderboard/page.tsx
@@ -74,15 +74,7 @@ function fmtVolume(raw: string): string {
     if (units >= 1_000_000_000) return `${(units / 1_000_000_000).toFixed(2)}B`;
     if (units >= 1_000_000) return `${(units / 1_000_000).toFixed(2)}M`;
     if (units >= 1_000) return `${(units / 1_000).toFixed(1)}K`;
-    if (units < 1 && n > 0n) {
-      // Raw units might not need division — show raw with compact suffix
-      const rawN = Number(n);
-      if (rawN >= 1_000_000_000) return `${(rawN / 1_000_000_000).toFixed(2)}B`;
-      if (rawN >= 1_000_000) return `${(rawN / 1_000_000).toFixed(2)}M`;
-      if (rawN >= 1_000) return `${(rawN / 1_000).toFixed(1)}K`;
-      return rawN.toLocaleString();
-    }
-    return units.toLocaleString(undefined, { maximumFractionDigits: 2 });
+    return units.toLocaleString(undefined, { maximumFractionDigits: units < 1 ? 6 : 2 });
   } catch {
     return "—";
   }


### PR DESCRIPTION
## Problem
Leaderboard shows 14.96M instead of $14,955. Volume formatter divided raw values by 10^6 (USDC micro-units) instead of 10^9 (actual devnet market collateral decimals).

## Fix
Change `MICRO_UNIT_DIVISOR` from `1_000_000` to `1_000_000_000` (renamed to `BASE_UNIT_DIVISOR`). All active devnet markets use 9-decimal collateral tokens.

Added TODO for proper per-market decimal handling when multi-collateral support lands.

Closes #1199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected leaderboard volume scaling to the proper token decimal base so volumes display accurately.
  * Improved volume formatting: clearer thousands/millions/billions thresholds and more precise decimal handling for small values.
  * Removed inconsistent raw-value fallback; small volumes now show formatted precision instead of raw units.
  * Preserves error fallback to a placeholder when volume cannot be computed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->