### PR TITLE
fix(oracle-keeper+ux): markets scope bug, wallet drain guard, non-mirror token UX — closes #1210

### DIFF
--- a/app/app/trade/[slab]/page.tsx
+++ b/app/app/trade/[slab]/page.tsx
@@ -163,8 +163,8 @@ function TradePageInner({ slab }: { slab: string }) {
   const pageRef = useRef<HTMLDivElement>(null);
   const shortAddress = `${slab.slice(0, 4)}…${slab.slice(-4)}`;
 
-  // Fetch Supabase market data (symbol, name, logo) as fallback for on-chain resolution
-  const [supabaseMarket, setSupabaseMarket] = useState<{ symbol?: string; name?: string; logo_url?: string } | null>(null);
+  // Fetch Supabase market data (symbol, name, logo, mainnet_ca) as fallback for on-chain resolution
+  const [supabaseMarket, setSupabaseMarket] = useState<{ symbol?: string; name?: string; logo_url?: string; mainnet_ca?: string | null } | null>(null);
   useEffect(() => {
     let cancelled = false;
     fetch(`/api/markets/${slab}`)
@@ -175,6 +175,8 @@ function TradePageInner({ slab }: { slab: string }) {
             symbol: d.market.symbol ?? undefined,
             name: d.market.name ?? undefined,
             logo_url: d.market.logo_url ?? undefined,
+            // GH#1210: used to determine whether Get Token button should be shown
+            mainnet_ca: d.market.mainnet_ca ?? null,
           });
         }
       })
@@ -321,7 +323,7 @@ function TradePageInner({ slab }: { slab: string }) {
               {header.admin.toBase58() === "11111111111111111111111111111111" ? "Admin Renounced" : "Admin Active"}
             </span>
           )}
-          <AirdropButton mintAddress={mintAddress} symbol={symbol} />
+          <AirdropButton mintAddress={mintAddress} symbol={symbol} isDevnetMirror={!!supabaseMarket?.mainnet_ca} />
           <ShareButton
             slabAddress={slab}
             marketName={symbol}
@@ -389,7 +391,7 @@ function TradePageInner({ slab }: { slab: string }) {
 
         {/* Right-aligned controls */}
         <div className="ml-auto flex items-center gap-3">
-          <AirdropButton mintAddress={mintAddress} symbol={symbol} />
+          <AirdropButton mintAddress={mintAddress} symbol={symbol} isDevnetMirror={!!supabaseMarket?.mainnet_ca} />
           <UsdToggleButton />
           <ShareButton
             slabAddress={slab}

--- a/app/components/trade/AirdropButton.tsx
+++ b/app/components/trade/AirdropButton.tsx
@@ -21,9 +21,16 @@ interface AirdropButtonProps {
   symbol: string;
   /** Only show on user-created markets (not SOL-PERP, etc.) */
   isUserCreated?: boolean;
+  /**
+   * GH#1210: Whether this token was created via the mainnet CA mirror flow.
+   * When false the /api/devnet-airdrop endpoint rejects it.
+   * Defaults to true (unknown → show button, let API gate it) so existing
+   * call sites without the prop keep working; trade page passes this explicitly.
+   */
+  isDevnetMirror?: boolean;
 }
 
-export function AirdropButton({ mintAddress, symbol, isUserCreated = true }: AirdropButtonProps) {
+export function AirdropButton({ mintAddress, symbol, isUserCreated = true, isDevnetMirror = true }: AirdropButtonProps) {
   const { publicKey, connected } = useWalletCompat();
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<{ amount: number; nextClaimAt: string } | null>(null);
@@ -92,6 +99,25 @@ export function AirdropButton({ mintAddress, symbol, isUserCreated = true }: Air
   // Don't render on mainnet, non-user-created markets, or missing mint
   if (!isDevnet || !isUserCreated || !mintAddress) return null;
   if (!connected) return null;
+
+  // GH#1210: For tokens NOT created via the mainnet CA mirror flow, the airdrop
+  // endpoint will reject with "not a known devnet mirror mint". Instead of showing
+  // the button and a confusing inline error, show a clear message with a link to
+  // /devnet-mint where users can mint test tokens for any market.
+  if (!isDevnetMirror) {
+    return (
+      <div className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md bg-[var(--bg-elevated)] border border-[var(--border)] text-[10px]">
+        <span className="text-[var(--text-muted)]">Get {symbol}:</span>
+        <a
+          href="/devnet-mint"
+          className="text-[var(--accent)] hover:underline font-medium"
+          title="Mint test tokens for this market on the Devnet Faucet page"
+        >
+          Devnet Faucet →
+        </a>
+      </div>
+    );
+  }
 
   // Already claimed — show countdown
   if (countdown) {

--- a/bots/oracle-keeper/index.ts
+++ b/bots/oracle-keeper/index.ts
@@ -314,6 +314,22 @@ function isPriceValid(price: number): boolean {
 const stats = new Map<string, MarketStats>();
 let startTime = Date.now();
 
+// ── Wallet Balance Guard ─────────────────────────────────────
+// Minimum keeper wallet balance (lamports) before pushing is paused.
+// Devops audit 2026-03-14: wallet FF7KFfU5 exhausted twice in one day from
+// ~20+ markets per 3-second cycle. Guard prevents on-chain txn drain when
+// balance is low. Default: 0.05 SOL (50_000_000 lamports).
+const MIN_KEEPER_BALANCE_LAMPORTS = Number(
+  process.env.MIN_KEEPER_BALANCE_SOL
+    ? Math.round(parseFloat(process.env.MIN_KEEPER_BALANCE_SOL) * 1e9)
+    : 50_000_000,
+);
+// Interval between balance refreshes (default: every 30 s = ~10 push cycles at 3s interval)
+const BALANCE_CHECK_INTERVAL_MS = Number(process.env.BALANCE_CHECK_INTERVAL_MS ?? "30000");
+let walletBalanceLamports: number | null = null;
+let lastBalanceCheckAt = 0;
+let walletLow = false;
+
 function getOrCreateStats(market: MarketInfo): MarketStats {
   let s = stats.get(market.slab);
   if (!s) {
@@ -600,10 +616,19 @@ function startHealthServer() {
         };
       }
 
+      // If wallet is low, override status to degraded regardless of market staleness
+      if (walletLow) healthy = false;
+
       const body = JSON.stringify({
         status: healthy ? "ok" : "degraded",
         uptime: `${uptimeS}s`,
         pushIntervalMs: PUSH_INTERVAL_MS,
+        wallet: {
+          address: admin.publicKey.toBase58(),
+          balanceSol: walletBalanceLamports != null ? walletBalanceLamports / 1e9 : null,
+          minBalanceSol: MIN_KEEPER_BALANCE_LAMPORTS / 1e9,
+          low: walletLow,
+        },
         markets,
       }, null, 2);
 
@@ -623,6 +648,12 @@ function startHealthServer() {
 
 // ── Supabase Market Discovery ───────────────────────────────
 const knownSlabs = new Set<string>();
+// Module-level markets array — must be at module scope so discovery functions
+// (discoverHyperpFromOracleTable, discoverNewMarkets) can read/mutate it.
+// Bug fix: was previously `const markets` inside main(), making it inaccessible
+// to module-level async functions → ReferenceError "markets is not defined" on
+// every discovery cycle (oracle_markets discovery error). (Devops audit 2026-03-14)
+let markets: MarketInfo[] = [];
 
 /**
  * Poll Supabase `oracle_markets` table for explicitly-registered oracle configs.
@@ -824,7 +855,8 @@ async function main() {
 
   const deploy = deployRaw ? JSON.parse(deployRaw) : { programId: process.env.PROGRAM_ID, markets: [] };
   const programId = new PublicKey(deploy.programId);
-  const markets: MarketInfo[] = (deploy.markets as MarketInfo[]).filter(m => {
+  // Assign to module-level `markets` so discovery functions can access it.
+  markets = (deploy.markets as MarketInfo[]).filter(m => {
     if (ORACLE_KEEPER_BLOCKED_MARKETS.has(m.slab)) {
       log(`⛔ STARTUP: ${m.label} (${m.slab.slice(0, 12)}...) — in ORACLE_KEEPER_BLOCKED_MARKETS, skipping`);
       return false;
@@ -961,6 +993,31 @@ async function main() {
       } catch (e) {
         log(`⚠️ Discovery poll error: ${(e as Error).message?.slice(0, 60)}`);
       }
+    }
+
+    // ── Wallet balance guard ─────────────────────────────────
+    // Refresh balance every BALANCE_CHECK_INTERVAL_MS; pause all pushes if low.
+    // Devops audit 2026-03-14: wallet exhausted twice in one day from ~20+ markets per cycle.
+    if (now - lastBalanceCheckAt > BALANCE_CHECK_INTERVAL_MS) {
+      lastBalanceCheckAt = now;
+      try {
+        walletBalanceLamports = await conn.getBalance(admin.publicKey, "confirmed");
+        const prevLow = walletLow;
+        walletLow = walletBalanceLamports < MIN_KEEPER_BALANCE_LAMPORTS;
+        if (walletLow && !prevLow) {
+          log(`🚨 WALLET LOW: ${(walletBalanceLamports / 1e9).toFixed(4)} SOL — below ${MIN_KEEPER_BALANCE_LAMPORTS / 1e9} SOL threshold. PAUSING ALL PUSHES. Refund ${admin.publicKey.toBase58().slice(0, 8)}...`);
+        } else if (!walletLow && prevLow) {
+          log(`✅ WALLET REFUNDED: ${(walletBalanceLamports / 1e9).toFixed(4)} SOL — resuming pushes.`);
+        }
+      } catch (e) {
+        log(`⚠️ Wallet balance check failed: ${(e as Error).message?.slice(0, 60)}`);
+      }
+    }
+
+    if (walletLow) {
+      log(`⏸ Wallet balance low (${walletBalanceLamports != null ? (walletBalanceLamports / 1e9).toFixed(4) : "??"} SOL) — skipping push cycle`);
+      await new Promise(r => setTimeout(r, PUSH_INTERVAL_MS));
+      continue;
     }
 
     // Batch-fetch all Pyth prices in a single request


### PR DESCRIPTION
## Changes

### oracle-keeper: `markets is not defined` bug (devops audit 2026-03-14)
- Lift `markets: MarketInfo[]` to module scope (was declared with `const` inside `main()`)
- `discoverHyperpFromOracleTable()` is a module-level function that references `markets`; declaring it inside `main()` caused a `ReferenceError: markets is not defined` on every 30s discovery cycle
- Fixes: `oracle_markets discovery error: markets is not defined` spamming logs every ~30s

### oracle-keeper: wallet drain guard
- Add wallet balance check every `BALANCE_CHECK_INTERVAL_MS` (default 30s)
- **Pause all oracle pushes** when `walletBalanceLamports < MIN_KEEPER_BALANCE_SOL` (default 0.05 SOL)
- Log clear WALLET LOW / WALLET REFUNDED events with address + current balance
- Expose `wallet.balanceSol`, `wallet.minBalanceSol`, `wallet.low` on `/health` endpoint
- Fixes: wallet FF7KFfU5 exhausted twice on 2026-03-14 (03:10 UTC and 17:41 UTC) from ~20+ markets × 3s push interval

### GH#1210: Get [Token] button UX for non-mirror tokens
- `AirdropButton` accepts new `isDevnetMirror` prop (default `true` for backwards compat)
- When `isDevnetMirror=false`: render `Get {symbol}: Devnet Faucet →` link to `/devnet-mint` instead of a button that silently fails with a cryptic inline error
- Trade page (`/trade/[slab]`) fetches `mainnet_ca` from `/api/markets/[slab]` and passes `isDevnetMirror={!!supabaseMarket?.mainnet_ca}` to both AirdropButton instances (mobile + desktop header)

## Testing
- `pnpm tsc --noEmit` — no errors
- `pnpm test` — 69/69 tests pass
- oracle-keeper: manually verified TypeScript compiles without errors

Fixes #1210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Airdrop Button to intelligently display either the standard airdrop interface or a Devnet Faucet link based on network configuration.
  * Implemented wallet balance monitoring to pause keeper operations when balance falls below the minimum threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->