### PR TITLE
fix: prevent AirdropButton 'Devnet Faucet' flash on mirror tokens

### DIFF
--- a/app/app/trade/[slab]/page.tsx
+++ b/app/app/trade/[slab]/page.tsx
@@ -323,7 +323,7 @@ function TradePageInner({ slab }: { slab: string }) {
               {header.admin.toBase58() === "11111111111111111111111111111111" ? "Admin Renounced" : "Admin Active"}
             </span>
           )}
-          <AirdropButton mintAddress={mintAddress} symbol={symbol} isDevnetMirror={!!supabaseMarket?.mainnet_ca} />
+          <AirdropButton mintAddress={mintAddress} symbol={symbol} isDevnetMirror={supabaseMarket ? !!supabaseMarket.mainnet_ca : true} />
           <ShareButton
             slabAddress={slab}
             marketName={symbol}
@@ -391,7 +391,7 @@ function TradePageInner({ slab }: { slab: string }) {
 
         {/* Right-aligned controls */}
         <div className="ml-auto flex items-center gap-3">
-          <AirdropButton mintAddress={mintAddress} symbol={symbol} isDevnetMirror={!!supabaseMarket?.mainnet_ca} />
+          <AirdropButton mintAddress={mintAddress} symbol={symbol} isDevnetMirror={supabaseMarket ? !!supabaseMarket.mainnet_ca : true} />
           <UsdToggleButton />
           <ShareButton
             slabAddress={slab}


### PR DESCRIPTION
## What
When `supabaseMarket` is `null` (loading state), `isDevnetMirror` defaulted to `false`, causing a brief flash of the 'Devnet Faucet →' link before switching to the airdrop button.

## Fix
Default `isDevnetMirror` to `true` while loading, matching AirdropButton's own default.

```tsx
// Before
isDevnetMirror={!!supabaseMarket?.mainnet_ca}
// After  
isDevnetMirror={supabaseMarket ? !!supabaseMarket.mainnet_ca : true}
```

## Testing
1. Open any mirror token trade page (e.g. WENDYS)
2. Confirm no flash of 'Devnet Faucet →' on load
3. Non-mirror tokens still show faucet link correctly after load

Fixes #1215