### PR TITLE
fix(data): block NL slab + apply blocklist to /api/stats + indexer exclusion — GH#1218

### DIFF
--- a/app/app/api/stats/route.ts
+++ b/app/app/api/stats/route.ts
@@ -6,6 +6,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServiceClient } from "@/lib/supabase";
 import { isActiveMarket, isSaneMarketValue } from "@/lib/activeMarketFilter";
+import { BLOCKED_SLAB_ADDRESSES } from "@/lib/blocklist";
 import type { Database } from "@/lib/database.types";
 export const dynamic = "force-dynamic";
 
@@ -63,7 +64,8 @@ export async function GET(request: NextRequest) {
   const supabase = getServiceClient();
 
   const [statsRes, tradersRes, recentTradesRes] = await Promise.all([
-    supabase.from("markets_with_stats").select("volume_24h, open_interest_long, open_interest_short, total_open_interest, last_price, decimals").limit(500),
+    // GH#1218: include slab_address so we can filter blocked markets (same as /api/markets)
+    supabase.from("markets_with_stats").select("slab_address, volume_24h, open_interest_long, open_interest_short, total_open_interest, last_price, decimals").limit(500),
     supabase.from("trades").select("trader").limit(5000),
     supabase
       .from("trades")
@@ -71,7 +73,19 @@ export async function GET(request: NextRequest) {
       .gte("created_at", new Date(Date.now() - 86400000).toISOString()),
   ]);
 
-  const statsData = statsRes.data ?? [];
+  // GH#1218: filter blocked slabs before aggregating — mirrors /api/markets behaviour.
+  // Previously this endpoint had no blocklist filter, allowing corrupt markets (e.g. NL
+  // with 9e12 raw OI → $89.2M false open interest) to pollute global stats.
+  const BLOCKED_MARKET_ADDRESSES: ReadonlySet<string> = new Set([
+    ...BLOCKED_SLAB_ADDRESSES,
+    ...(process.env.BLOCKED_MARKET_ADDRESSES ?? "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean),
+  ]);
+  const statsData = (statsRes.data ?? []).filter(
+    (m) => !BLOCKED_MARKET_ADDRESSES.has((m as Record<string, unknown>).slab_address as string ?? ""),
+  );
 
   // Count only active markets using shared filter (consistent with homepage & markets page)
   const activeData = statsData.filter(isActiveMarket);

--- a/app/lib/blocklist.ts
+++ b/app/lib/blocklist.ts
@@ -16,6 +16,10 @@ export const BLOCKED_SLAB_ADDRESSES: ReadonlySet<string> = new Set([
   "BxJPaMaCfEGTBsjZ8wfj3Yfzf4wpasmxKAEvqZZRcGPP",
   // GH#837: wrong oracle_authority — price manipulation risk. Blocked via security review.
   "HjBePQZnoZVftg9B52gyeuHGjBvt2f8FNCVP4FeoP3YT",
+  // GH#1218: NL/USD slab — corrupt on-chain OI state (9e12 micro-units per side → $89.2M
+  // false total OI). Migration 045 zeroed the DB but the indexer re-synced from on-chain.
+  // Blocked permanently until on-chain state is corrected. PR #1219.
+  "H5Vunzd2yAMygnpFiGUASDSx2s8P3bfPTzjCfrRsPeph",
 ]);
 
 /**

--- a/packages/indexer/src/services/StatsCollector.ts
+++ b/packages/indexer/src/services/StatsCollector.ts
@@ -334,13 +334,29 @@ export class StatsCollector {
       const markets = this.marketProvider.getMarkets();
       if (markets.size === 0) return;
 
+      // GH#1218: load indexer_excluded flags from DB to skip corrupt slabs.
+      // These are slabs where on-chain state is permanently corrupt and re-syncing
+      // would overwrite the zeroed DB values with garbage data.
+      let excludedSlabs: Set<string> = new Set();
+      try {
+        const dbMarkets = await getMarkets();
+        excludedSlabs = new Set(
+          dbMarkets.filter((m) => m.indexer_excluded === true).map((m) => m.slab_address),
+        );
+        if (excludedSlabs.size > 0) {
+          logger.info("StatsCollector: skipping indexer_excluded slabs", { count: excludedSlabs.size, slabs: Array.from(excludedSlabs) });
+        }
+      } catch {
+        // Non-fatal — proceed without exclusion list rather than halting all stats collection
+      }
+
       const connection = getConnection();
       let updated = 0;
       let errors = 0;
 
       // Process markets in batches of 5 to avoid RPC rate limits
       // Use getMultipleAccountsInfo for batch fetching to reduce RPC round trips
-      const entries = Array.from(markets.entries());
+      const entries = Array.from(markets.entries()).filter(([slabAddress]) => !excludedSlabs.has(slabAddress));
       for (let i = 0; i < entries.length; i += 5) {
         const batch = entries.slice(i, i + 5);
         const slabPubkeys = batch.map(([slabAddress]) => new PublicKey(slabAddress));

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -17,6 +17,8 @@ export interface MarketRow {
   status: string;
   created_at: string;
   updated_at: string;
+  /** GH#1218: when true the indexer must NOT write market_stats for this slab (on-chain state is corrupt). */
+  indexer_excluded?: boolean;
 }
 
 export interface MarketStatsRow {

--- a/supabase/migrations/046_zero_nl_oi_fields.sql
+++ b/supabase/migrations/046_zero_nl_oi_fields.sql
@@ -1,0 +1,38 @@
+-- Migration 046: Zero NL slab OI fields + add indexer-exclusion flag — GH#1218
+--
+-- Context: Migration 045 zeroed corrupted NL slab stats but the indexer subsequently
+-- re-synced open_interest_long/short/total_open_interest from the on-chain state
+-- (which contains corrupt raw u64 values: 9006000000000 ≈ 9e12 per side → $89.2M OI).
+--
+-- The c_tot guard (sanitizeCtot from PR #1212) correctly nulled c_tot at the API layer,
+-- but the OI fields were NOT sanitized — they pass isSaneMarketValue (9e12 < 1e18).
+--
+-- Fix:
+--   1. Zero the OI columns again for NL slab in market_stats.
+--   2. Add markets.indexer_excluded boolean column to let the indexer skip writing
+--      stats for permanently-corrupted slabs.
+--   3. Mark the NL slab as indexer_excluded = true.
+--
+-- API-level: the NL slab is also added to BLOCKED_SLAB_ADDRESSES in blocklist.ts
+-- so /api/markets and /api/stats both exclude it regardless of indexer state.
+
+-- Step 1: Zero OI fields for NL slab
+UPDATE market_stats
+SET
+  open_interest_long  = 0,
+  open_interest_short = 0,
+  total_open_interest = 0
+WHERE slab_address = 'H5Vunzd2yAMygnpFiGUASDSx2s8P3bfPTzjCfrRsPeph';
+
+-- Step 2: Add indexer_excluded column to markets table (if not exists)
+ALTER TABLE markets
+  ADD COLUMN IF NOT EXISTS indexer_excluded boolean NOT NULL DEFAULT false;
+
+-- Step 3: Mark NL slab as excluded from indexer writes
+UPDATE markets
+SET indexer_excluded = true
+WHERE slab_address = 'H5Vunzd2yAMygnpFiGUASDSx2s8P3bfPTzjCfrRsPeph';
+
+-- Note: indexer code must be updated to respect this flag (check indexer_excluded before
+-- writing market_stats for a slab). This migration adds the schema; the indexer change
+-- is a separate PR to prevent re-population of corrupt on-chain state.


### PR DESCRIPTION
## Summary

GH#1218 / GH#1219: NL/USD slab (`H5Vunzd2yAMygnpFiGUASDSx2s8P3bfPTzjCfrRsPeph`) has corrupt on-chain OI state.

**Root cause:** Migration 045 zeroed the DB but the indexer re-synced `open_interest_long/short = 9e12` from on-chain, restoring the corrupt values. At the NL token price (~$4.95), these produce **$89.2M false total open interest** in both `/api/markets` and `/api/stats`.

The `c_tot` was already sanitized (PR #1212) but the OI fields pass `isSaneMarketValue` (9e12 < 1e18), so they slipped through.

## Changes

| File | Change |
|------|--------|
| `app/lib/blocklist.ts` | Add NL slab to `BLOCKED_SLAB_ADDRESSES` |
| `app/app/api/stats/route.ts` | Import + apply blocklist filter — **previously missing**: `/api/stats` had NO blocklist guard, so blocked markets still polluted `totalOpenInterest` |
| `supabase/migrations/046` | Re-zero NL slab OI fields + add `indexer_excluded` column to `markets` table |
| `packages/shared/src/db/queries.ts` | Add `indexer_excluded?: boolean` to `MarketRow` interface |
| `packages/indexer/src/services/StatsCollector.ts` | Skip `indexer_excluded` slabs in `collect()` — prevents indexer from re-syncing corrupt on-chain state on top of zeroed DB values |

## How to Test

1. After migration 046 runs: `/api/stats` `totalOpenInterest` should show ~$0 (no NL contribution)
2. `/api/markets` should not include the NL slab
3. Indexer logs should show: `StatsCollector: skipping indexer_excluded slabs { count: 1 }`
4. Restarting the indexer should NOT restore the $89.2M OI

## Severity
MEDIUM — misleading financial data, no funds at risk.

Closes #1218
Closes #1219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Excluded problematic markets from stats data and API endpoints to prevent corrupt information from being displayed.
  * Reset open interest figures for affected markets.
  * Implemented a blocklist mechanism to filter excluded markets at both the indexer and API level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->