### PR TITLE
fix(devnet-mm): create real matcher context account for LP init

### DIFF
--- a/bots/devnet-mm/src/market.ts
+++ b/bots/devnet-mm/src/market.ts
@@ -11,6 +11,7 @@ import {
   PublicKey,
   Transaction,
   ComputeBudgetProgram,
+  SystemProgram,
   SYSVAR_CLOCK_PUBKEY,
   LAMPORTS_PER_SOL,
 } from "@solana/web3.js";
@@ -65,6 +66,9 @@ async function withRpc<T>(
   if (rpc) return rpc.withRetry(op, label);
   return op(connection);
 }
+
+/** Matcher context account size required by the reference AMM matcher. */
+const MATCHER_CTX_SIZE = 320;
 
 // ═══════════════════════════════════════════════════════════════
 // Types
@@ -446,10 +450,35 @@ export async function setupMarketAccounts(
     await ensureSolBalance(connection, wallet, symbol, rpc);
     // Ensure walletAta exists before attempting LP init (fee is debited from it)
     walletAta = await ensureWalletAta(connection, wallet, wallet.publicKey, mint, symbol, config.dryRun, rpc);
+
+    // Create a real matcher context account (320 bytes, owned by matcher program).
+    // PublicKey.default cannot be used — it's the system program address and cannot
+    // be marked writable, causing ExpectedWritable (0xb) on TradeCpi.
+    const matcherCtxKp = Keypair.generate();
+    log("setup", `${symbol}: creating matcher context account ${matcherCtxKp.publicKey.toBase58().slice(0, 16)}...`);
+    const matcherRent = await withRpc(rpc, connection,
+      (c) => c.getMinimumBalanceForRentExemption(MATCHER_CTX_SIZE),
+      `${symbol} matcherRent`,
+    );
+    const createCtxIx = SystemProgram.createAccount({
+      fromPubkey: wallet.publicKey,
+      newAccountPubkey: matcherCtxKp.publicKey,
+      lamports: matcherRent,
+      space: MATCHER_CTX_SIZE,
+      programId: config.matcherProgramId,
+    });
+    const ctxSig = await sendTx(connection, [createCtxIx], [wallet, matcherCtxKp],
+      `${symbol} CreateMatcherCtx`, 50_000, config.dryRun, rpc);
+    if (!ctxSig) {
+      logError("setup", `${symbol}: failed to create matcher context account`);
+      return null;
+    }
+    await sleep(1000);
+
     log("setup", `${symbol}: creating LP account...`);
     const initLpData = encodeInitLP({
       matcherProgram: config.matcherProgramId,
-      matcherContext: PublicKey.default,
+      matcherContext: matcherCtxKp.publicKey,
       feePayment: "1000000",
     });
     const initLpKeys = buildAccountMetas(ACCOUNTS_INIT_LP, [


### PR DESCRIPTION
## Problem

BID orders on devnet-mm bots fail with `Custom error 0xb (11) — Simulation failed`.

Error 0xb = `ExpectedWritable` in PercolatorError enum. The on-chain TradeCpi handler calls `expect_writable(a_matcher_ctx)`, but the matcher context was set to `PublicKey.default` (all-zeros = system program native address), which **cannot be marked writable** in Solana transactions.

## Root Cause

`setupMarketAccounts()` in `market.ts` passed `PublicKey.default` as `matcherContext` when calling `encodeInitLP()`. The deploy script (`deploy-devnet-mm.ts`) correctly creates a 320-byte account owned by the matcher program, but the bot's runtime LP creation path didn't.

## Fix

Before calling InitLP, the bot now:
1. Generates a new keypair for the matcher context account
2. Calls `SystemProgram.createAccount` with 320 bytes, owned by the matcher program
3. Passes the real account as `matcherContext` in `encodeInitLP()`

This matches the deploy script behavior.

## Testing

- All 59 existing tests pass
- TypeScript compiles clean (`tsc --noEmit`)

## Note for Devops

If existing LPs on devnet were created by the **bot** (not the deploy script), those LPs are stuck with `PublicKey.default` as matcherContext and cannot be used for trading. They need to be re-initialized by redeploying the market with `deploy-devnet-mm.ts`.

If the LPs were created by the deploy script, they already have correct context accounts and this fix prevents future bot-created LPs from having the same issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced liquidity provider setup: Matcher context accounts are now automatically created and configured during LP initialization. The system dynamically generates account keypairs, calculates required funding, and establishes accounts with proper configurations, streamlining the initialization process and reducing manual setup requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->