### PR TITLE
feat(PERC-808): auto-faucet + auto-deposit on wallet connect

### DIFF
--- a/app/components/devnet/DevnetFaucetModal.tsx
+++ b/app/components/devnet/DevnetFaucetModal.tsx
@@ -102,7 +102,7 @@ export const DevnetFaucetModal: FC = () => {
 
   const solSufficient = faucet.solBalance !== null && faucet.solBalance >= 0.05;
   const usdcSufficient =
-    faucet.usdcBalance !== null && faucet.usdcBalance >= 1;
+    faucet.usdcBalance !== null && faucet.usdcBalance >= 1000;
 
   const solStepStatus = faucet.solDone || solSufficient
     ? "done"

--- a/app/hooks/useAutoDeposit.ts
+++ b/app/hooks/useAutoDeposit.ts
@@ -45,6 +45,8 @@ import { useUserAccount } from "@/hooks/useUserAccount";
 import { useInitUser } from "@/hooks/useInitUser";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { useAutoFundResult } from "@/components/providers/AutoFundProvider";
+import { useFaucetComplete } from "@/hooks/useDevnetFaucet";
+// PERC-808: useFaucetComplete returns true within 30s of faucet modal completion
 
 const AUTO_DEPOSIT_AMOUNT = 500_000_000n; // 500 USDC (6 decimals) — reasonable starter
 const MIN_WALLET_BALANCE = 10_000_000n; // 10 USDC minimum to bother depositing
@@ -69,6 +71,7 @@ export function useAutoDeposit(slabAddress: string): AutoDepositState {
   const { initUser } = useInitUser(slabAddress);
   const { config: mktConfig } = useSlabState();
   const { result: fundResult } = useAutoFundResult();
+  const faucetComplete = useFaucetComplete();
 
   const [depositing, setDepositing] = useState(false);
   const [deposited, setDeposited] = useState(false);
@@ -135,10 +138,11 @@ export function useAutoDeposit(slabAddress: string): AutoDepositState {
     // Don't auto-deposit if user already has an account
     if (userAccount) return;
 
-    // GH#1107: only auto-deposit when auto-fund JUST completed.
+    // GH#1107: only auto-deposit when auto-fund JUST completed or faucet modal
+    // was completed and dismissed (PERC-808).
     // Without this guard any wallet navigation to a trade page with no Percolator
     // account would immediately pop the Privy "Confirm transaction" modal.
-    if (!fundResult?.funded) return;
+    if (!fundResult?.funded && !faucetComplete) return;
 
     // Wait a short delay to let auto-fund balances settle on-chain
     const timer = setTimeout(() => {
@@ -146,7 +150,7 @@ export function useAutoDeposit(slabAddress: string): AutoDepositState {
     }, 2000);
 
     return () => clearTimeout(timer);
-  }, [connected, publicKey, userAccount, fundResult, isDevnet, attemptAutoDeposit]);
+  }, [connected, publicKey, userAccount, fundResult, faucetComplete, isDevnet, attemptAutoDeposit]);
 
   return { depositing, deposited, error, signature, amountUsdc };
 }

--- a/app/hooks/useDevnetFaucet.ts
+++ b/app/hooks/useDevnetFaucet.ts
@@ -58,8 +58,17 @@ export interface DevnetFaucetState {
 
 const PUBLIC_DEVNET_RPC = "https://api.devnet.solana.com";
 const SOL_THRESHOLD = 0.05 * LAMPORTS_PER_SOL;
-const USDC_THRESHOLD = 1_000_000n; // 1 USDC (6 decimals)
+const USDC_THRESHOLD = 1_000_000_000n; // 1,000 USDC (6 decimals) — PERC-808
 const DISMISSED_KEY = "percolator:faucet-dismissed";
+
+/**
+ * PERC-808: Helius devnet faucet for SOL airdrop (more reliable than Solana's).
+ * Falls back to Solana devnet faucet if Helius is unavailable.
+ */
+const HELIUS_API_KEY = process.env.NEXT_PUBLIC_HELIUS_API_KEY ?? "";
+const HELIUS_DEVNET_RPC = HELIUS_API_KEY
+  ? `https://devnet.helius-rpc.com/?api-key=${HELIUS_API_KEY}`
+  : "";
 
 export function useDevnetFaucet(): DevnetFaucetState {
   const { publicKey, connected } = useWalletCompat();
@@ -135,16 +144,16 @@ export function useDevnetFaucet(): DevnetFaucetState {
     refreshBalances();
   }, [connected, publicKey, isDevnet, checked, refreshBalances]);
 
-  // Determine whether to show the modal
+  // PERC-808: Show modal when wallet USDC < 1000 or SOL < 0.05
+  // Also show for users without a Percolator account (first-time setup)
   const shouldShow =
     isDevnet &&
     connected &&
     !!publicKey &&
     !dismissed &&
-    !userAccount && // No existing Percolator account
     checked &&
     solBalance !== null &&
-    (solBalance < 0.05 || (usdcBalance !== null && usdcBalance < 1));
+    (!userAccount || (usdcBalance !== null && usdcBalance < 1000) || solBalance < 0.05);
 
   const dismiss = useCallback(() => {
     setDismissed(true);
@@ -152,7 +161,11 @@ export function useDevnetFaucet(): DevnetFaucetState {
       const key = `${DISMISSED_KEY}:${publicKey.toBase58()}`;
       localStorage.setItem(key, Date.now().toString());
     }
-  }, [publicKey]);
+    // PERC-808: Signal faucet completion so auto-deposit can trigger
+    if (solDone && usdcDone) {
+      markFaucetComplete();
+    }
+  }, [publicKey, solDone, usdcDone]);
 
   const airdropSol = useCallback(async () => {
     if (!publicKey) return;
@@ -160,21 +173,46 @@ export function useDevnetFaucet(): DevnetFaucetState {
     setLoading(true);
     setError(null);
     try {
-      const sig = await airdropConnection.current.requestAirdrop(
-        publicKey,
-        2 * LAMPORTS_PER_SOL,
-      );
-      // Poll for confirmation
-      const start = Date.now();
-      while (Date.now() - start < 60_000) {
-        const { value } = await airdropConnection.current.getSignatureStatuses([sig]);
-        const s = value?.[0];
-        if (s?.confirmationStatus === "confirmed" || s?.confirmationStatus === "finalized") {
-          if (s.err) throw new Error("SOL airdrop transaction failed");
-          break;
+      // PERC-808: Try Helius devnet faucet first (more reliable, higher limits)
+      let sig: string | null = null;
+      if (HELIUS_DEVNET_RPC) {
+        try {
+          const heliusConn = new Connection(HELIUS_DEVNET_RPC, "confirmed");
+          sig = await heliusConn.requestAirdrop(publicKey, 2 * LAMPORTS_PER_SOL);
+          // Confirm via Helius
+          const start = Date.now();
+          while (Date.now() - start < 60_000) {
+            const { value } = await heliusConn.getSignatureStatuses([sig]);
+            const s = value?.[0];
+            if (s?.confirmationStatus === "confirmed" || s?.confirmationStatus === "finalized") {
+              if (s.err) throw new Error("SOL airdrop transaction failed");
+              break;
+            }
+            await new Promise((r) => setTimeout(r, 2000));
+          }
+        } catch {
+          sig = null; // Fall through to Solana faucet
         }
-        await new Promise((r) => setTimeout(r, 2000));
       }
+
+      // Fallback: Solana devnet faucet
+      if (!sig) {
+        sig = await airdropConnection.current.requestAirdrop(
+          publicKey,
+          2 * LAMPORTS_PER_SOL,
+        );
+        const start = Date.now();
+        while (Date.now() - start < 60_000) {
+          const { value } = await airdropConnection.current.getSignatureStatuses([sig]);
+          const s = value?.[0];
+          if (s?.confirmationStatus === "confirmed" || s?.confirmationStatus === "finalized") {
+            if (s.err) throw new Error("SOL airdrop transaction failed");
+            break;
+          }
+          await new Promise((r) => setTimeout(r, 2000));
+        }
+      }
+
       setSolDone(true);
       await refreshBalances();
     } catch (e) {
@@ -253,4 +291,49 @@ export function useDevnetFaucet(): DevnetFaucetState {
     fundAll,
     refreshBalances,
   };
+}
+
+// ────────────────────────────────────────────────────────────────
+// PERC-808: Faucet completion signal
+// Uses sessionStorage so useAutoDeposit can detect faucet completion
+// without needing shared React context across different component trees.
+// ────────────────────────────────────────────────────────────────
+
+const FAUCET_COMPLETE_KEY = "percolator:faucet-complete";
+const FAUCET_COMPLETE_WINDOW_MS = 30_000; // 30s window for auto-deposit to react
+
+/** Mark faucet as complete (called on dismiss after successful funding). */
+export function markFaucetComplete(): void {
+  try {
+    sessionStorage.setItem(FAUCET_COMPLETE_KEY, Date.now().toString());
+  } catch {
+    // SSR guard
+  }
+}
+
+/**
+ * Returns true if faucet completed within the last 30 seconds.
+ * Used by useAutoDeposit to trigger deposit after faucet modal dismiss.
+ */
+export function useFaucetComplete(): boolean {
+  const [complete, setComplete] = useState(false);
+
+  useEffect(() => {
+    const check = () => {
+      try {
+        const ts = sessionStorage.getItem(FAUCET_COMPLETE_KEY);
+        if (ts && Date.now() - parseInt(ts, 10) < FAUCET_COMPLETE_WINDOW_MS) {
+          setComplete(true);
+        }
+      } catch {
+        // SSR guard
+      }
+    };
+    check();
+    // Re-check periodically in case faucet completes while auto-deposit is mounted
+    const interval = setInterval(check, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return complete;
 }


### PR DESCRIPTION
## PERC-808: Auto-faucet + auto-deposit on wallet connect

Implements DEVNET-STRATEGY-PERC-353 Strategy 1A: zero-friction onboarding for devnet users.

### Changes

**1. USDC threshold bump (1 → 1,000 USDC)**
- Faucet modal now shows for any connected wallet with < 1,000 USDC (was < 1)
- Catches users who connected before but didn't get enough funds

**2. Helius devnet faucet (primary SOL source)**
- Uses `NEXT_PUBLIC_HELIUS_API_KEY` env var to route SOL airdrops through Helius
- More reliable than Solana's devnet faucet (fewer rate limits, faster)
- Falls back to Solana devnet faucet if Helius unavailable or fails

**3. Faucet → auto-deposit pipeline**
- When user completes faucet flow (SOL + USDC done) and dismisses modal, a `sessionStorage` signal fires
- `useAutoDeposit` picks up this signal within 30s and auto-triggers `initUser + deposit(500 USDC)`
- Previously auto-deposit only fired from `AutoFundProvider` — now also fires from the faucet modal path

**4. Modal threshold alignment**
- `DevnetFaucetModal` sufficient threshold updated to match (1,000 USDC)

### What was already done
- Volume + OI already displayed on trade page (`OpenInterestCard`, `TradeStatsPanel`) and dashboard (`HeroStats`) — no changes needed

### Testing
- All 1,000 app tests pass
- TypeScript compiles clean
- No changes to existing test expectations (mocked at hook level)

### Env vars needed
- `NEXT_PUBLIC_HELIUS_API_KEY` — optional; enables Helius faucet for SOL airdrops


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Helius devnet faucet for faster SOL airdrops with automatic fallback to Solana faucet
  * Enhanced account funding workflow with improved completion signaling

* **Changes**
  * Increased USDC balance requirement from 1 to 1,000 for marking the funding step complete
  * Auto-deposit now properly waits for faucet completion before initiating transfers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->