### PR TITLE
feat(PERC-808): global devnet faucet modal + live protocol Volume/OI on dashboard

### DIFF
--- a/app/app/dashboard/page.tsx
+++ b/app/app/dashboard/page.tsx
@@ -32,6 +32,12 @@ const StatsBar = dynamic(
   { ssr: false, loading: () => <div className="h-20 animate-pulse bg-[var(--panel-bg)] border border-[var(--border)]" /> }
 );
 
+// PERC-808: Live protocol-wide Volume + OI strip
+const ProtocolStatsBar = dynamic(
+  () => import("@/components/dashboard/ProtocolStatsBar").then((m) => m.ProtocolStatsBar),
+  { ssr: false, loading: () => <div className="h-12 animate-pulse bg-[var(--panel-bg)] border border-[var(--border)]" /> }
+);
+
 const TradeHistory = dynamic(
   () => import("@/components/dashboard/TradeHistory").then((m) => m.TradeHistory),
   { ssr: false, loading: () => <div className="h-[400px] animate-pulse bg-[var(--panel-bg)] border border-[var(--border)]" /> }
@@ -149,7 +155,14 @@ export default function DashboardPage() {
             </div>
           </ScrollReveal>
 
-          {/* Row 2: Stats Bar */}
+          {/* Row 2: Protocol stats (live Volume + OI) — PERC-808 */}
+          <ScrollReveal delay={0.1}>
+            <div className="mb-2">
+              <ProtocolStatsBar />
+            </div>
+          </ScrollReveal>
+
+          {/* Row 3: Personal Stats Bar */}
           <ScrollReveal delay={0.15}>
             <div className="mb-4">
               <StatsBar />
@@ -201,6 +214,7 @@ export default function DashboardPage() {
           {/* Mobile tab content */}
           {mobileTab === "overview" && (
             <div className="space-y-4">
+              <ProtocolStatsBar />
               <StatsBar />
               <div style={{ minHeight: 300 }}>
                 <PnlChart />

--- a/app/app/trade/[slab]/page.tsx
+++ b/app/app/trade/[slab]/page.tsx
@@ -37,7 +37,7 @@ import { isPlaceholderSymbol, SLUG_ALIASES } from "@/lib/symbol-utils";
 import { OracleBadge } from "@/components/oracle/OracleBadge";
 import { useOracleFreshness } from "@/hooks/useOracleFreshness";
 import { AutoDepositProvider } from "@/components/providers/AutoDepositProvider";
-import { DevnetFaucetModal } from "@/components/devnet/DevnetFaucetModal";
+// DevnetFaucetModal moved to WalletProvider (PERC-808: global placement on all pages)
 import { AirdropButton } from "@/components/trade/AirdropButton";
 
 /* ── Reusable tiny components ─────────────────────────────── */
@@ -641,7 +641,6 @@ export default function TradePage({ params }: { params: Promise<{ slab: string }
     <SlabProvider slabAddress={slab}>
       <UsdToggleProvider>
         <AutoDepositProvider slabAddress={slab}>
-          <DevnetFaucetModal />
           <TradePageInner slab={slab} />
         </AutoDepositProvider>
       </UsdToggleProvider>

--- a/app/components/dashboard/ProtocolStatsBar.tsx
+++ b/app/components/dashboard/ProtocolStatsBar.tsx
@@ -1,0 +1,169 @@
+/**
+ * PERC-808: Live protocol Volume + OI bar for the dashboard
+ *
+ * Fetches aggregated 24h volume and total open interest from
+ * the markets_with_stats Supabase view and displays them as
+ * a compact stats strip. Polls every 30 seconds for live updates.
+ */
+
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { getSupabase } from "@/lib/supabase";
+import { isActiveMarket } from "@/lib/activeMarketFilter";
+import { isBlockedSlab } from "@/lib/blocklist";
+
+interface ProtocolStats {
+  volume24h: number;
+  openInterest: number;
+  activeMarkets: number;
+  traders: number | null;
+}
+
+function formatUsd(val: number): string {
+  if (val === 0) return "$0";
+  if (val >= 1_000_000) return `$${(val / 1_000_000).toFixed(2)}M`;
+  if (val >= 1_000) return `$${(val / 1_000).toFixed(1)}K`;
+  return `$${val.toFixed(0)}`;
+}
+
+function Pulse() {
+  return (
+    <span className="relative flex h-1.5 w-1.5">
+      <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[var(--long)] opacity-60" />
+      <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-[var(--long)]" />
+    </span>
+  );
+}
+
+const POLL_INTERVAL_MS = 30_000;
+const MAX_USD_PER_MARKET = 10_000_000; // $10M cap per market to filter corrupted data
+
+export function ProtocolStatsBar() {
+  const [stats, setStats] = useState<ProtocolStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  async function fetchStats() {
+    try {
+      const { data } = await getSupabase()
+        .from("markets_with_stats")
+        .select("slab_address, symbol, volume_24h, last_price, decimals, total_open_interest, open_interest_long, open_interest_short")
+        .returns<{
+          slab_address: string;
+          symbol: string | null;
+          volume_24h: number | null;
+          last_price: number | null;
+          decimals: number | null;
+          total_open_interest: number | null;
+          open_interest_long: number | null;
+          open_interest_short: number | null;
+        }[]>();
+
+      if (!data || data.length === 0) {
+        setStats({ volume24h: 0, openInterest: 0, activeMarkets: 0, traders: null });
+        return;
+      }
+
+      const scaleFactor = (decimals: number | null) => Math.pow(10, decimals ?? 6);
+
+      let vol24h = 0;
+      let oi = 0;
+      let activeCount = 0;
+
+      for (const row of data) {
+        if (!row.slab_address || isBlockedSlab(row.slab_address)) continue;
+
+        const price = row.last_price ?? 0;
+        const dec = scaleFactor(row.decimals);
+
+        // Volume: stored in token units, convert to USD
+        const rawVol = Number(row.volume_24h ?? 0);
+        const volUsd = rawVol > 0 ? (rawVol / dec) * price : 0;
+
+        // OI: stored in token units, convert to USD
+        const rawOi = Number(row.total_open_interest ?? 0);
+        const oiUsd = rawOi > 0 ? (rawOi / dec) * price : 0;
+
+        // Sanity cap: skip markets with absurdly high values (corrupted data)
+        const capVol = volUsd > MAX_USD_PER_MARKET ? 0 : volUsd;
+        const capOi = oiUsd > MAX_USD_PER_MARKET ? 0 : oiUsd;
+
+        if (isActiveMarket({ volume_24h: capVol, total_open_interest: capOi })) {
+          activeCount++;
+        }
+
+        vol24h += capVol;
+        oi += capOi;
+      }
+
+      setStats({
+        volume24h: vol24h,
+        openInterest: oi,
+        activeMarkets: activeCount,
+        traders: null, // Not available in current view
+      });
+    } catch {
+      // non-fatal — keep showing stale stats
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    fetchStats();
+    timerRef.current = setInterval(fetchStats, POLL_INTERVAL_MS);
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, []);
+
+  const items = [
+    {
+      label: "24h Volume",
+      value: loading ? null : formatUsd(stats?.volume24h ?? 0),
+      live: true,
+      color: (stats?.volume24h ?? 0) > 0 ? "text-[var(--long)]" : "text-[var(--text-muted)]",
+    },
+    {
+      label: "Open Interest",
+      value: loading ? null : formatUsd(stats?.openInterest ?? 0),
+      live: false,
+      color: (stats?.openInterest ?? 0) > 0 ? "text-white" : "text-[var(--text-muted)]",
+    },
+    {
+      label: "Active Markets",
+      value: loading ? null : String(stats?.activeMarkets ?? 0),
+      live: false,
+      color: "text-[var(--accent)]",
+    },
+  ];
+
+  return (
+    <div className="flex items-center gap-px overflow-hidden border border-[var(--border)] bg-[var(--border)]">
+      {items.map((item) => (
+        <div
+          key={item.label}
+          className="flex flex-1 items-center justify-between bg-[var(--panel-bg)] px-4 py-3 transition-colors hover:bg-[var(--bg-elevated)]"
+        >
+          <div className="flex items-center gap-1.5">
+            {item.live && <Pulse />}
+            <span className="text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-dim)]">
+              {item.label}
+            </span>
+          </div>
+          {item.value !== null ? (
+            <span
+              className={`text-sm font-bold tabular-nums ${item.color}`}
+              style={{ fontFamily: "var(--font-jetbrains-mono)" }}
+            >
+              {item.value}
+            </span>
+          ) : (
+            <span className="h-4 w-12 animate-pulse rounded bg-[var(--border)]" />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/components/providers/WalletProvider.tsx
+++ b/app/components/providers/WalletProvider.tsx
@@ -4,6 +4,7 @@ import { Component, FC, ReactNode, useMemo, useState, useEffect } from "react";
 import dynamic from "next/dynamic";
 import { AutoFundProvider } from "./AutoFundProvider";
 import { PrivyAvailableContext, PrivyLoginContext } from "@/hooks/usePrivySafe";
+import { DevnetFaucetModal } from "@/components/devnet/DevnetFaucetModal";
 import {
   PreferredWalletContext,
   usePreferredWalletState,
@@ -77,6 +78,9 @@ export const WalletProvider: FC<{ children: ReactNode }> = ({ children }) => {
           <PrivyProviderClient appId={appId}>
             <AutoFundProvider>
               {children}
+              {/* PERC-808: Global devnet faucet modal — shown on any page when wallet
+                  has < 0.05 SOL or < 1,000 USDC. Decoupled from SlabProvider. */}
+              <DevnetFaucetModal />
             </AutoFundProvider>
           </PrivyProviderClient>
         </PreferredWalletContext.Provider>

--- a/app/hooks/useDevnetFaucet.ts
+++ b/app/hooks/useDevnetFaucet.ts
@@ -1,13 +1,17 @@
 /**
  * PERC-376: Devnet faucet hook
+ * PERC-808: Decoupled from SlabProvider — can run on any page (global placement)
  *
  * Manages a multi-step faucet flow for devnet:
  *   Step 1: Airdrop SOL (via Solana devnet requestAirdrop)
  *   Step 2: Airdrop USDC (via /api/faucet mint endpoint)
- *   Step 3: Auto-deposit into Percolator account
+ *   Step 3: Auto-deposit into Percolator account (handled by AutoDepositProvider)
  *
  * Target: wallet connect → trading in <60 seconds.
  * Rate limit: 1 claim per wallet per 24h (enforced server-side).
+ *
+ * PERC-808: Threshold raised to 1,000 USDC so users with small leftover
+ * balances still see the welcome modal and get a proper top-up.
  */
 
 "use client";
@@ -16,8 +20,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Connection, LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
 import { getAssociatedTokenAddressSync } from "@solana/spl-token";
 import { useWalletCompat, useConnectionCompat } from "@/hooks/useWalletCompat";
-import { useSlabState } from "@/components/providers/SlabProvider";
-import { useUserAccount } from "@/hooks/useUserAccount";
+import { getConfig } from "@/lib/config";
 
 export type FaucetStep = "idle" | "sol" | "usdc" | "deposit" | "done" | "error";
 
@@ -73,9 +76,18 @@ const HELIUS_DEVNET_RPC = HELIUS_API_KEY
 export function useDevnetFaucet(): DevnetFaucetState {
   const { publicKey, connected } = useWalletCompat();
   const { connection } = useConnectionCompat();
-  const { config: mktConfig } = useSlabState();
-  const userAccount = useUserAccount();
   const isDevnet = process.env.NEXT_PUBLIC_SOLANA_NETWORK === "devnet";
+
+  // PERC-808: Use global config testUsdcMint instead of SlabProvider — works on all pages
+  const usdcMintPk = (() => {
+    try {
+      const cfg = getConfig() as Record<string, unknown>;
+      const mint = cfg.testUsdcMint as string | undefined;
+      return mint ? new PublicKey(mint) : null;
+    } catch {
+      return null;
+    }
+  })();
 
   const [step, setStep] = useState<FaucetStep>("idle");
   const [loading, setLoading] = useState(false);
@@ -87,7 +99,7 @@ export function useDevnetFaucet(): DevnetFaucetState {
   // depositDone is intentionally never set to true here — the actual deposit
   // completion is tracked by AutoDepositProvider. This flag exists in the
   // return type for UI consumers that need a unified status interface.
-  const [depositDone, setDepositDone] = useState(false);
+  const [depositDone] = useState(false);
   const [rateLimited, setRateLimited] = useState(false);
   const [nextClaimAt, setNextClaimAt] = useState<string | null>(null);
   const [dismissed, setDismissed] = useState(true); // default true to avoid flash
@@ -101,7 +113,6 @@ export function useDevnetFaucet(): DevnetFaucetState {
     const key = `${DISMISSED_KEY}:${publicKey.toBase58()}`;
     const stored = typeof window !== "undefined" ? localStorage.getItem(key) : null;
     if (stored) {
-      // Check if stored timestamp is within 24h
       const ts = parseInt(stored, 10);
       if (Date.now() - ts < 24 * 60 * 60 * 1000) {
         setDismissed(true);
@@ -118,15 +129,14 @@ export function useDevnetFaucet(): DevnetFaucetState {
     try {
       const bal = await connection.getBalance(publicKey);
       setSolBalance(bal / LAMPORTS_PER_SOL);
-
       if (bal >= SOL_THRESHOLD) setSolDone(true);
     } catch {
       // non-fatal
     }
 
-    if (mktConfig?.collateralMint) {
+    if (usdcMintPk) {
       try {
-        const ata = getAssociatedTokenAddressSync(mktConfig.collateralMint, publicKey);
+        const ata = getAssociatedTokenAddressSync(usdcMintPk, publicKey);
         const info = await connection.getTokenAccountBalance(ata);
         const amount = BigInt(info.value.amount);
         setUsdcBalance(Number(amount) / 1_000_000);
@@ -135,7 +145,7 @@ export function useDevnetFaucet(): DevnetFaucetState {
         setUsdcBalance(0);
       }
     }
-  }, [publicKey, connection, mktConfig]);
+  }, [publicKey, connection, usdcMintPk]);
 
   // Initial balance check after connect
   useEffect(() => {
@@ -144,8 +154,7 @@ export function useDevnetFaucet(): DevnetFaucetState {
     refreshBalances();
   }, [connected, publicKey, isDevnet, checked, refreshBalances]);
 
-  // PERC-808: Show modal when wallet USDC < 1000 or SOL < 0.05
-  // Also show for users without a Percolator account (first-time setup)
+  // PERC-808: Show when SOL < 0.05 OR USDC < 1,000 (no longer gated on userAccount)
   const shouldShow =
     isDevnet &&
     connected &&
@@ -153,7 +162,7 @@ export function useDevnetFaucet(): DevnetFaucetState {
     !dismissed &&
     checked &&
     solBalance !== null &&
-    (!userAccount || (usdcBalance !== null && usdcBalance < 1000) || solBalance < 0.05);
+    (solBalance < 0.05 || (usdcBalance !== null && usdcBalance < 1000));
 
   const dismiss = useCallback(() => {
     setDismissed(true);
@@ -256,18 +265,14 @@ export function useDevnetFaucet(): DevnetFaucetState {
     if (!publicKey) return;
     setError(null);
 
-    // Step 1: SOL (if needed)
     if (!solDone && (solBalance === null || solBalance < 0.05)) {
       await airdropSol();
-      // If SOL airdrop failed, try to continue anyway (user might already have some)
     }
 
-    // Step 2: USDC (if needed)
-    if (!usdcDone && (usdcBalance === null || usdcBalance < 1)) {
+    if (!usdcDone && (usdcBalance === null || usdcBalance < 1000)) {
       await airdropUsdc();
     }
 
-    // Step 3: Mark done — auto-deposit is handled by AutoDepositProvider
     if (!error) {
       setStep("done");
     }


### PR DESCRIPTION
## PERC-808: In-app devnet auto-faucet + auto-deposit on wallet connect

### Problem
The DevnetFaucetModal was only shown on `/trade/[slab]` pages, meaning users landing on the home page, markets, or dashboard never got funded automatically. The USDC threshold was 1 USDC (too low) and the modal was wired to SlabProvider (trade-page-only context).

### Changes

**1. Decouple `useDevnetFaucet` from `SlabProvider`**
- Uses `getConfig().testUsdcMint` directly (always available) instead of `mktConfig?.collateralMint`
- Removed `useUserAccount()` guard — modal shows on balance alone, not Percolator account state
- USDC threshold raised: 1 USDC → **1,000 USDC** (spec requires <1,000 USDC to trigger)

**2. `DevnetFaucetModal` moved to `WalletProvider` (global)**
- Renders on every page when wallet connects with low SOL or USDC
- Removed from `trade/[slab]/page.tsx` (was duplicate; now covered by global placement)

**3. New `ProtocolStatsBar` component (PERC-808: live Volume+OI)**
- Polls `markets_with_stats` every 30s
- Shows: 24h Volume (green, pulsing live dot), Open Interest, Active Markets
- Added above `StatsBar` on dashboard (both desktop grid and mobile overview tab)

### Testing
- TypeScript clean (`tsc --noEmit`)
- All 1,239 tests pass

### Flow after merge
1. User connects wallet on any page (home, markets, dashboard, trade)
2. If SOL < 0.05 or USDC < 1,000 → DevnetFaucetModal appears
3. One-click 'Fund My Account' → 2 SOL airdrop + 10,000 USDC mint
4. User navigates to trade page → AutoDepositProvider auto-deposits + creates account
5. Dashboard shows live Volume + OI from all active markets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard now displays live protocol statistics including 24-hour trading volume, total open interest, and active markets count with real-time updates refreshing every 30 seconds.
  * Devnet faucet functionality is now globally available across all pages, providing users easier access to testnet funds throughout the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->