### PR TITLE
fix(GH#1224): exclude blocked slabs from homepage Active Markets table

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -196,7 +196,10 @@ export default function Home() {
           });
           setStatsLoaded(true);
           // Convert to USD first, then sort by converted volume
-          const converted = data.map((m) => ({
+          // GH#1224: exclude blocked slab addresses (same filter as activeData/stats)
+          const converted = data
+            .filter((m) => !isBlockedSlab(m.slab_address))
+            .map((m) => ({
             slab_address: m.slab_address,
             symbol: m.symbol,
             // GH#1195: same $10M USD per-market cap as stats.volume above.


### PR DESCRIPTION
## Problem
Homepage Active Markets table showed NL/USD with $89.2M corrupt OI despite being in `BLOCKED_SLAB_ADDRESSES`.

## Root Cause
`converted = data.map()` on line ~199 of `app/app/page.tsx` used the unfiltered raw data — not `activeData` which had the blocklist filter applied.

## Fix
Added `.filter((m) => !isBlockedSlab(m.slab_address))` before `.map()` on the `converted` array — same guard already applied to `activeData` / stats.

```ts
// Before
const converted = data.map((m) => ({

// After  
const converted = data
  .filter((m) => !isBlockedSlab(m.slab_address))
  .map((m) => ({
```

## Testing
- TypeScript compiles clean (`tsc --noEmit`)
- NL/USD will no longer appear in homepage Active Markets table
- No other changes

Closes #1224. Related: #1181, PR #1220.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed featured markets calculation to properly exclude blocked slabs from results, ensuring consistent data filtering across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->