### PR TITLE
fix(ui): round sub-$1K OI values in homepage Active Markets table

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -22,7 +22,7 @@ function formatCompact(n: number): string {
   if (abs >= 1_000_000_000) return `$${(n / 1_000_000_000).toFixed(1)}B`;
   if (abs >= 1_000_000) return `$${(n / 1_000_000).toFixed(1)}M`;
   if (abs >= 1_000) return `$${(n / 1_000).toFixed(1)}K`;
-  return `$${n.toLocaleString()}`;
+  return `$${Math.round(n)}`;
 }
 
 const HOW_STEPS = [


### PR DESCRIPTION
## Summary

Fixes #1229 — raw decimal OI values (e.g. `$995.009`) displayed on the homepage Active Markets table for markets with OI < $1,000.

## Root Cause

`formatCompact()` in `app/app/page.tsx` correctly abbreviates values ≥$1K to K notation, but the sub-$1K branch passed the raw float through `toLocaleString()` with no rounding:
```ts
// Before
return `$${n.toLocaleString()}`; // → $995.009
```

## Fix

Apply `Math.round()` for sub-$1K OI values, consistent with the whole-number display style used across the table:
```ts
// After  
return `$${Math.round(n)}`; // → $995
```

## Test
- JOS/USD OI: $995.008955 → now shows **$995** ✅
- LOBSTAR/USD: $4000.018 → still shows **$4.0K** ✅ (unaffected)
- CHET/USD: $1284.27 → would show **$1.3K** ✅ (≥1K branch)

## Severity
LOW — cosmetic only, no functional impact.