### PR TITLE
fix(earn): clamp maxOI display to prevent 'Max: $343 / Current: $57K' confusion

### DIFF
--- a/app/hooks/useEarnStats.ts
+++ b/app/hooks/useEarnStats.ts
@@ -241,7 +241,11 @@ export function useEarnStats() {
 
           // Max OI = vault collateral × max leverage (simplified)
           const vaultUsd = vaultBalance / collDivisor;
-          const maxOI = vaultUsd * maxLeverage;
+          const rawMaxOI = vaultUsd * maxLeverage;
+          // GH#1231: on devnet, vault deposits can be tiny while accumulated OI is large.
+          // Clamp displayMaxOI so it is never less than totalOI — prevents confusing
+          // "Max: $343" display when Current OI is already $57K.
+          const maxOI = Math.max(rawMaxOI, totalOI);
           const oiUtilPct = maxOI > 0 ? (totalOI / maxOI) * 100 : 0;
 
           // Estimated APY: (daily fees × 365) / TVL × 100


### PR DESCRIPTION
## Summary

Fixes GH#1231 — OI Capacity meter on /earn showed `Current: $57.1K / Max: $343 at 100%` which looks like a unit bug.

## Root Cause

On devnet, vault LP deposits are tiny (`vault_balance ~$34`) while `total_open_interest` accumulated from trades is large (`~$57K`). Both values are correctly normalized by `collDivisor`. The data inconsistency is a devnet-only issue (real mainnet vaults will have matching LP capital).

## Fix

```ts
// Before
const maxOI = vaultUsd * maxLeverage;  // could be 

// After — clamp so display maxOI is never less than current OI
const rawMaxOI = vaultUsd * maxLeverage;
const maxOI = Math.max(rawMaxOI, totalOI);  // prevents confusing UI state
```

The underlying data consistency issue is tracked in GH#1231 (indexer-level fix needed).

## Testing

- Visit /earn on devnet — OI Capacity meter should no longer show Max < Current
- Utilization pct stays accurate (never > 100%)

Reported by: designer via Collector API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed display issue where current open interest could exceed the maximum capacity indicator. The system now ensures the maximum open interest value accurately reflects actual conditions, preventing confusing or misleading information in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->