### PR TITLE
feat(PERC-810): wallet-aware oracle batch fix — delegate/push for market creators

### DIFF
--- a/app/components/admin/OracleFreshnessSection.tsx
+++ b/app/components/admin/OracleFreshnessSection.tsx
@@ -1,11 +1,20 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { useWalletCompat } from "@/hooks/useWalletCompat";
+import { useMarketDiscovery } from "@/hooks/useMarketDiscovery";
+import { useAdminActions } from "@/hooks/useAdminActions";
+import type { DiscoveredMarket } from "@percolator/sdk";
 
 // ─── Style tokens ──────────────────────────────────────────────────────────────
 const card = "rounded-none bg-[var(--panel-bg)] border border-[var(--border)]";
 const labelStyle =
   "text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-muted)]";
+
+/** Keeper wallet — the permanent oracle authority for devnet auto-price-push */
+const KEEPER_WALLET = "FF7KFfU5Bb3Mze2AasDHCCZuyhdaSLjUZy2K3JvjdB7x";
+/** Default devnet price to push ($1.00 = 1_000_000 e6) */
+const DEFAULT_PRICE_E6 = "1000000";
 
 function SectionHeader({ children }: { children: React.ReactNode }) {
   return (
@@ -32,7 +41,21 @@ function truncatePk(pk: string, chars = 6) {
   return `${pk.slice(0, chars)}…${pk.slice(-4)}`;
 }
 
-function OracleStaleRow({ market }: { market: StaleMarket }) {
+// ─── Row with action buttons ───────────────────────────────────────────────────
+
+function OracleStaleRow({
+  market,
+  canAct,
+  onPushPrice,
+  onDelegateToKeeper,
+  busy,
+}: {
+  market: StaleMarket;
+  canAct: boolean;
+  onPushPrice?: (m: StaleMarket) => void;
+  onDelegateToKeeper?: (m: StaleMarket) => void;
+  busy: boolean;
+}) {
   const totalOI =
     (market.open_interest_long ?? 0) + (market.open_interest_short ?? 0);
   const hasOI = totalOI > 0;
@@ -42,7 +65,7 @@ function OracleStaleRow({ market }: { market: StaleMarket }) {
     <div className="grid grid-cols-[1fr_auto_auto_auto] gap-3 items-center px-4 py-3 border-b border-[var(--border)] last:border-0">
       {/* Market identity */}
       <div className="min-w-0">
-        <div className="flex items-center gap-2 mb-0.5">
+        <div className="flex items-center gap-2 mb-0.5 flex-wrap">
           <span
             className="inline-block w-[6px] h-[6px] rounded-full shrink-0"
             style={{ backgroundColor: "var(--short)" }}
@@ -76,6 +99,25 @@ function OracleStaleRow({ market }: { market: StaleMarket }) {
             <span className="font-mono text-[var(--cyan)]">
               {truncatePk(market.oracle_authority)}
             </span>
+          </div>
+        )}
+        {/* Action buttons for markets where connected wallet is the authority */}
+        {canAct && (
+          <div className="flex items-center gap-2 mt-1.5">
+            <button
+              onClick={() => onPushPrice?.(market)}
+              disabled={busy}
+              className="text-[9px] uppercase tracking-wider px-2 py-1 border border-[var(--long)] text-[var(--long)] hover:bg-[var(--long)] hover:text-black transition-colors disabled:opacity-40 font-mono"
+            >
+              {busy ? "…" : "push $1"}
+            </button>
+            <button
+              onClick={() => onDelegateToKeeper?.(market)}
+              disabled={busy}
+              className="text-[9px] uppercase tracking-wider px-2 py-1 border border-[var(--cyan)] text-[var(--cyan)] hover:bg-[var(--cyan)] hover:text-black transition-colors disabled:opacity-40 font-mono"
+            >
+              {busy ? "…" : "→ keeper"}
+            </button>
           </div>
         )}
       </div>
@@ -129,21 +171,45 @@ function OracleStaleRow({ market }: { market: StaleMarket }) {
   );
 }
 
+// ─── Batch action result ───────────────────────────────────────────────────────
+
+interface BatchResult {
+  slab: string;
+  symbol: string | null;
+  status: "ok" | "err";
+  detail: string;
+}
+
 /**
  * OracleFreshnessSection
  *
- * Fetches all admin-oracle markets from the public /api/markets endpoint and
- * shows those with mark_price = null, sorted by user count desc.
- * This gives admins an at-a-glance view of which markets need an oracle price push.
+ * Fetches all admin-oracle markets from /api/markets and shows those with
+ * mark_price = null sorted by user count desc.
+ *
+ * If a wallet is connected and is the oracle_authority for any stale market,
+ * it shows per-market "Push $1" and "→ Keeper" action buttons, plus a
+ * "Fix All My Markets" batch button.
  */
 export function OracleFreshnessSection() {
+  const wallet = useWalletCompat();
+  const walletAddr = wallet.publicKey?.toBase58() ?? "";
+
+  // On-chain discovered markets (needed for programId + pushPrice/setOracleAuthority)
+  const { markets: discoveredMarkets } = useMarketDiscovery();
+  const { pushPrice, setOracleAuthority } = useAdminActions();
+
   const [staleMarkets, setStaleMarkets] = useState<StaleMarket[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loadingFetch, setLoadingFetch] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [lastFetched, setLastFetched] = useState<Date | null>(null);
 
+  // Batch action state
+  const [batchRunning, setBatchRunning] = useState(false);
+  const [batchResults, setBatchResults] = useState<BatchResult[]>([]);
+  const [singleBusy, setSingleBusy] = useState<string | null>(null); // slab_address
+
   const fetchStaleMarkets = useCallback(async () => {
-    setLoading(true);
+    setLoadingFetch(true);
     setError(null);
     try {
       const res = await fetch("/api/markets");
@@ -163,16 +229,14 @@ export function OracleFreshnessSection() {
             m.oracle_authority !== "" &&
             (m.mark_price === null || m.mark_price === undefined || m.mark_price === 0)
         )
-        .sort(
-          (a, b) => (b.total_accounts ?? 0) - (a.total_accounts ?? 0)
-        );
+        .sort((a, b) => (b.total_accounts ?? 0) - (a.total_accounts ?? 0));
 
       setStaleMarkets(stale);
       setLastFetched(new Date());
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
-      setLoading(false);
+      setLoadingFetch(false);
     }
   }, []);
 
@@ -180,8 +244,88 @@ export function OracleFreshnessSection() {
     fetchStaleMarkets();
   }, [fetchStaleMarkets]);
 
+  // Markets where connected wallet IS the oracle_authority
+  const myMarkets = walletAddr
+    ? staleMarkets.filter((m) => m.oracle_authority === walletAddr)
+    : [];
+
   const withUsers = staleMarkets.filter((m) => (m.total_accounts ?? 0) > 0);
   const withoutUsers = staleMarkets.filter((m) => (m.total_accounts ?? 0) === 0);
+
+  // Find on-chain DiscoveredMarket for a slab address (needed for actions)
+  function getDiscovered(slabAddress: string): DiscoveredMarket | undefined {
+    return discoveredMarkets.find(
+      (dm) => dm.slabAddress.toBase58() === slabAddress
+    );
+  }
+
+  async function handlePushPrice(m: StaleMarket) {
+    const dm = getDiscovered(m.slab_address);
+    if (!dm) {
+      setBatchResults((r) => [
+        ...r,
+        { slab: m.slab_address, symbol: m.symbol, status: "err", detail: "Market not discovered on-chain yet, retry in 30s" },
+      ]);
+      return;
+    }
+    setSingleBusy(m.slab_address);
+    try {
+      const sig = await pushPrice(dm, DEFAULT_PRICE_E6);
+      setBatchResults((r) => [
+        ...r,
+        { slab: m.slab_address, symbol: m.symbol, status: "ok", detail: sig?.slice(0, 20) + "…" },
+      ]);
+      // Optimistically remove from stale list
+      setStaleMarkets((prev) => prev.filter((x) => x.slab_address !== m.slab_address));
+    } catch (err) {
+      setBatchResults((r) => [
+        ...r,
+        { slab: m.slab_address, symbol: m.symbol, status: "err", detail: err instanceof Error ? err.message.slice(0, 80) : String(err) },
+      ]);
+    } finally {
+      setSingleBusy(null);
+    }
+  }
+
+  async function handleDelegateToKeeper(m: StaleMarket) {
+    const dm = getDiscovered(m.slab_address);
+    if (!dm) {
+      setBatchResults((r) => [
+        ...r,
+        { slab: m.slab_address, symbol: m.symbol, status: "err", detail: "Market not discovered on-chain yet, retry in 30s" },
+      ]);
+      return;
+    }
+    setSingleBusy(m.slab_address);
+    try {
+      const sig = await setOracleAuthority(dm, KEEPER_WALLET);
+      setBatchResults((r) => [
+        ...r,
+        { slab: m.slab_address, symbol: m.symbol, status: "ok", detail: `→ keeper: ${sig?.slice(0, 20)}…` },
+      ]);
+      setStaleMarkets((prev) => prev.filter((x) => x.slab_address !== m.slab_address));
+    } catch (err) {
+      setBatchResults((r) => [
+        ...r,
+        { slab: m.slab_address, symbol: m.symbol, status: "err", detail: err instanceof Error ? err.message.slice(0, 80) : String(err) },
+      ]);
+    } finally {
+      setSingleBusy(null);
+    }
+  }
+
+  async function handleBatchFixAll() {
+    if (!myMarkets.length || batchRunning) return;
+    setBatchRunning(true);
+    setBatchResults([]);
+    for (const m of myMarkets) {
+      // Prefer delegation to keeper so price auto-updates going forward
+      await handleDelegateToKeeper(m);
+    }
+    setBatchRunning(false);
+    // Refresh after batch
+    await fetchStaleMarkets();
+  }
 
   return (
     <div className="mb-8">
@@ -192,16 +336,28 @@ export function OracleFreshnessSection() {
         <div className="flex flex-wrap gap-6 items-center justify-between">
           <div className="flex gap-6">
             <div>
-              <div className="text-[24px] font-bold tabular-nums" style={{ fontFamily: "var(--font-jetbrains-mono)", color: staleMarkets.length > 0 ? "var(--short)" : "var(--long)" }}>
-                {loading ? "…" : staleMarkets.length}
+              <div
+                className="text-[24px] font-bold tabular-nums"
+                style={{
+                  fontFamily: "var(--font-jetbrains-mono)",
+                  color: staleMarkets.length > 0 ? "var(--short)" : "var(--long)",
+                }}
+              >
+                {loadingFetch ? "…" : staleMarkets.length}
               </div>
               <div className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-muted)]">
                 admin markets w/o price
               </div>
             </div>
             <div>
-              <div className="text-[24px] font-bold tabular-nums" style={{ fontFamily: "var(--font-jetbrains-mono)", color: withUsers.length > 0 ? "var(--warning)" : "var(--long)" }}>
-                {loading ? "…" : withUsers.length}
+              <div
+                className="text-[24px] font-bold tabular-nums"
+                style={{
+                  fontFamily: "var(--font-jetbrains-mono)",
+                  color: withUsers.length > 0 ? "var(--warning)" : "var(--long)",
+                }}
+              >
+                {loadingFetch ? "…" : withUsers.length}
               </div>
               <div className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-muted)]">
                 with trapped users
@@ -212,15 +368,15 @@ export function OracleFreshnessSection() {
           <div className="flex items-center gap-3">
             {lastFetched && (
               <span className="text-[10px] text-[var(--text-dim)] font-mono">
-                fetched {lastFetched.toLocaleTimeString()}
+                {lastFetched.toLocaleTimeString()}
               </span>
             )}
             <button
               onClick={fetchStaleMarkets}
-              disabled={loading}
+              disabled={loadingFetch}
               className="text-[10px] uppercase tracking-[0.15em] px-3 py-1.5 border border-[var(--border)] text-[var(--text-dim)] hover:border-[var(--accent)] hover:text-[var(--accent)] transition-colors disabled:opacity-40"
             >
-              {loading ? "refreshing…" : "refresh"}
+              {loadingFetch ? "refreshing…" : "refresh"}
             </button>
           </div>
         </div>
@@ -230,15 +386,86 @@ export function OracleFreshnessSection() {
             ✗ Failed to load: {error}
           </div>
         )}
-
-        {!loading && !error && staleMarkets.length === 0 && (
+        {!loadingFetch && !error && staleMarkets.length === 0 && (
           <div className="mt-3 text-[11px] text-[var(--long)]">
             ✓ All admin-oracle markets have a price pushed. No action needed.
           </div>
         )}
       </div>
 
-      {/* Markets with trapped users — highest priority */}
+      {/* ── MY MARKETS (wallet-aware batch fix) ──────────────────────────── */}
+      {walletAddr && myMarkets.length > 0 && (
+        <div className={`${card} overflow-hidden mb-4`} style={{ borderColor: "var(--long)" }}>
+          <div className="border-b px-4 py-3 flex items-center justify-between gap-3" style={{ borderColor: "var(--long)" }}>
+            <div className="flex items-center gap-2">
+              <span
+                className="inline-block w-[6px] h-[6px] rounded-full"
+                style={{ backgroundColor: "var(--long)" }}
+              />
+              <span className={labelStyle}>
+                {myMarkets.length} of your market{myMarkets.length !== 1 ? "s" : ""} need price — fix now
+              </span>
+            </div>
+            <button
+              onClick={handleBatchFixAll}
+              disabled={batchRunning || !wallet.signTransaction}
+              className="text-[10px] uppercase tracking-[0.15em] px-3 py-1.5 border font-bold transition-colors disabled:opacity-40"
+              style={{
+                borderColor: "var(--cyan)",
+                color: "var(--cyan)",
+              }}
+            >
+              {batchRunning ? "fixing…" : `delegate all ${myMarkets.length} → keeper`}
+            </button>
+          </div>
+          <div>
+            {myMarkets.map((m) => (
+              <OracleStaleRow
+                key={m.slab_address}
+                market={m}
+                canAct={!!wallet.signTransaction}
+                onPushPrice={handlePushPrice}
+                onDelegateToKeeper={handleDelegateToKeeper}
+                busy={batchRunning || singleBusy === m.slab_address}
+              />
+            ))}
+          </div>
+          <div className="border-t border-[var(--border)] px-4 py-3 bg-[rgba(0,255,136,0.02)]">
+            <p className="text-[10px] text-[var(--text-dim)]">
+              <strong className="text-[var(--long)]">Delegate → Keeper</strong> transfers oracle
+              authority to {truncatePk(KEEPER_WALLET)} so prices auto-update going forward.{" "}
+              <strong className="text-[var(--long)]">Push $1</strong> sets a one-time $1.00 devnet
+              price immediately (authority stays with you).
+            </p>
+          </div>
+
+          {/* Batch results */}
+          {batchResults.length > 0 && (
+            <div className="border-t border-[var(--border)] px-4 py-3 space-y-1">
+              {batchResults.map((r, i) => (
+                <div key={i} className="flex items-center gap-2 text-[10px] font-mono">
+                  <span style={{ color: r.status === "ok" ? "var(--long)" : "var(--short)" }}>
+                    {r.status === "ok" ? "✓" : "✗"}
+                  </span>
+                  <span className="text-[var(--text-secondary)]">{r.symbol ?? truncatePk(r.slab)}</span>
+                  <span className="text-[var(--text-dim)] truncate">{r.detail}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ── Wallet prompt when there are stale markets but no wallet ──────── */}
+      {!walletAddr && withUsers.length > 0 && (
+        <div className={`${card} p-4 mb-4 border-[var(--warning)]`}>
+          <p className="text-[11px] text-[var(--warning)]">
+            ⚠ Connect your wallet to see and fix markets where you are the oracle authority.
+          </p>
+        </div>
+      )}
+
+      {/* ── Markets with trapped users — all (highest priority) ───────────── */}
       {withUsers.length > 0 && (
         <div className={`${card} overflow-hidden mb-4`}>
           <div className="border-b border-[var(--border)] px-4 py-3 flex items-center gap-2">
@@ -252,31 +479,47 @@ export function OracleFreshnessSection() {
           </div>
           <div>
             {withUsers.map((m) => (
-              <OracleStaleRow key={m.slab_address} market={m} />
+              <OracleStaleRow
+                key={m.slab_address}
+                market={m}
+                canAct={walletAddr === m.oracle_authority && !!wallet.signTransaction}
+                onPushPrice={handlePushPrice}
+                onDelegateToKeeper={handleDelegateToKeeper}
+                busy={batchRunning || singleBusy === m.slab_address}
+              />
             ))}
           </div>
           <div className="border-t border-[var(--border)] px-4 py-3 bg-[rgba(255,183,0,0.03)]">
             <p className="text-[10px] text-[var(--text-dim)]">
-              These markets have depositors with open interest but no oracle price. New position
-              opens are blocked. The oracle authority for each market must call{" "}
-              <span className="font-mono text-[var(--cyan)]">PushOraclePrice</span> on-chain.
-              Use the Oracle Authority section above to delegate push rights to the keeper wallet.
+              Each market's oracle authority must connect their wallet here and click{" "}
+              <strong className="text-[var(--cyan)]">→ keeper</strong> or{" "}
+              <strong className="text-[var(--long)]">push $1</strong> to unblock their users.
+              Keeper wallet:{" "}
+              <span className="font-mono text-[var(--cyan)]">{truncatePk(KEEPER_WALLET, 8)}</span>
             </p>
           </div>
         </div>
       )}
 
-      {/* Markets without users — lower priority */}
+      {/* ── Markets without users — lower priority ────────────────────────── */}
       {withoutUsers.length > 0 && (
         <div className={`${card} overflow-hidden`}>
           <div className="border-b border-[var(--border)] px-4 py-3">
             <span className={labelStyle}>
-              {withoutUsers.length} uninitialised market{withoutUsers.length !== 1 ? "s" : ""} (no users)
+              {withoutUsers.length} uninitialised market
+              {withoutUsers.length !== 1 ? "s" : ""} (no users)
             </span>
           </div>
           <div className="max-h-[300px] overflow-y-auto">
             {withoutUsers.map((m) => (
-              <OracleStaleRow key={m.slab_address} market={m} />
+              <OracleStaleRow
+                key={m.slab_address}
+                market={m}
+                canAct={walletAddr === m.oracle_authority && !!wallet.signTransaction}
+                onPushPrice={handlePushPrice}
+                onDelegateToKeeper={handleDelegateToKeeper}
+                busy={batchRunning || singleBusy === m.slab_address}
+              />
             ))}
           </div>
         </div>


### PR DESCRIPTION
## Problem
155 admin-oracle markets have no price. 115 have trapped users (cannot open trades). The keeper wallet (FF7KFfU5) can only push prices to markets where IT is the oracle authority — but only 1 market qualifies (NNOB, 0 users). BREW (248 users) and TEST (248 users) have their original market creator wallets as oracle authority.

## Root Cause
PushOraclePrice requires the oracle_authority to sign. Markets created before PR #779 (Mar 8) didn't auto-delegate to the keeper. Those market creators must either push a price or delegate authority to the keeper themselves.

## Solution
Enhanced OracleFreshnessSection in /admin with wallet-aware actions:

**For market creators:**
1. Connect your wallet at /admin
2. A new **"My Markets"** panel appears showing all your stale markets
3. Per-market: **"Push $1"** (sets devnet price, keeps your authority) or **"→ keeper"** (delegates to keeper for permanent auto-push)
4. **"Delegate All → Keeper"** button for one-click batch fix of all your markets

**For all users:**
- Full read-only list of all 155 markets is still shown with authority info
- Updated footer instructs: market creators must connect their wallet here

## What Changed
- : +272 lines
  - Added wallet detection via 
  - Added  for on-chain programId lookup (needed for TX construction)
  - Added  for  + 
  - New  with conditional action buttons (push/delegate)
  - New "My Markets" batch panel with "Delegate All → Keeper" button
  - Batch results log (✓/✗ per market with signature or error)

## Testing
- 1001/1001 app tests ✅
- 123/123 api tests ✅  
- 46/46 keeper tests ✅
- 69/69 indexer tests ✅
- tsc clean ✅

## Important Notes
- KEEPER_WALLET constant = `FF7KFfU5Bb3Mze2AasDHCCZuyhdaSLjUZy2K3JvjdB7x`
- Keeper SOL balance (0.0484 SOL) is sufficient for 155 pushes (~5k lamports each) once delegated
- BREW (oracle_auth=4NK1W8...) and TEST (oracle_auth=BTpwsgqw...) creators need to connect their wallets — we cannot push for them without their keypairs
- After delegation, keeper auto-discovers and pushes prices on its next crank cycle