### PR TITLE
fix(wizard): stabilize effect deps + increase retries for Token Factory wizard (GH#1258)

### DIFF
--- a/app/components/create/StepTokenSelect.tsx
+++ b/app/components/create/StepTokenSelect.tsx
@@ -55,6 +55,11 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
   // True when the mint is a devnet-native token (not a mainnet mirror). Used to suppress
   // the "🪞 Devnet mirror" label for tokens created directly on devnet (PERC-1093).
   const [isNativeDevnetMint, setIsNativeDevnetMint] = useState(false);
+  // Token program ID resolved from on-chain account owner.
+  // TOKEN_PROGRAM_ID for standard SPL mints, TOKEN_2022_PROGRAM_ID for Token-2022 mints.
+  // Used by the balance effect so getAssociatedTokenAddress/getAccount target the right
+  // program and don't silently return zero for Token-2022 mints. GH#1261.
+  const [tokenProgramId, setTokenProgramId] = useState<PublicKey>(TOKEN_PROGRAM_ID);
   // Use live RPC endpoint to detect devnet (not build-time env var which may be wrong in prod).
   const isDevnet = isDevnetEndpoint(connection.rpcEndpoint) || getNetwork() === "devnet";
 
@@ -111,6 +116,7 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
       setIsNativeDevnetMint(false);
       onTokenResolvedRef.current(null);
       onMintNetworkValidChangeRef.current?.(false);
+      setTokenProgramId(TOKEN_PROGRAM_ID);
       return;
     }
     // Capture the mint address string at effect start so fetch bodies are consistent
@@ -139,7 +145,14 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
               await new Promise(r => setTimeout(r, 2000));
             }
             if (cancelled) return;
-            accountInfo = await connection.getAccountInfo(mintPk);
+            try {
+              // GH#1258 follow-up: wrap in try/catch so transient RPC throws also
+              // retry instead of escaping to the outer catch and skipping remaining attempts.
+              accountInfo = await connection.getAccountInfo(mintPk);
+            } catch (e) {
+              if (attempt === 4) throw e;
+              continue;
+            }
             if (accountInfo) break;
           }
           if (cancelled) return;
@@ -152,6 +165,8 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
             if (isTokenMint) {
               // Mint already exists on devnet — use it directly, no mirror needed.
               // Mark as native so we don't show the "mainnet mirror" label (PERC-1093).
+              // GH#1261: record resolved program ID so balance fetch targets the right program.
+              setTokenProgramId(accountInfo.owner);
               const devnetMeta = {
                 name: tokenMeta?.name ?? `Token ${mintAddr.slice(0, 6)}`,
                 symbol: tokenMeta?.symbol ?? mintAddr.slice(0, 4).toUpperCase(),
@@ -234,6 +249,8 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
             onMintNetworkValidChangeRef.current?.(false);
             return;
           }
+          // GH#1261: record resolved program ID so balance fetch targets the right program.
+          setTokenProgramId(accountInfo.owner);
           setMintNetworkStatus("valid");
           onMintNetworkValidChangeRef.current?.(true);
           return;
@@ -275,13 +292,19 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
   // mid-retry. Only restart on genuine address/wallet/network changes.
   useEffect(() => {
     if (!publicKey || !mintValid) {
+      // GH#1260: clear loading flag so spinner doesn't get stuck when wallet disconnects
+      // or mint is cleared while an ATA retry loop is in-flight.
+      setBalanceLoading(false);
       setBalance(null);
       onBalanceChangeRef.current(null);
       return;
     }
-    // Capture mint pubkey at effect start to avoid stale closure issues.
+    // Capture mint pubkey and resolved token program ID at effect start.
+    // GH#1261: tokenProgramId is set by the validation effect from accountInfo.owner so
+    // Token-2022 mints derive/query against TOKEN_2022_PROGRAM_ID instead of TOKEN_PROGRAM_ID.
     const mintPkForBalance = mintPk;
     if (!mintPkForBalance) return;
+    const capturedTokenProgramId = tokenProgramId;
     let cancelled = false;
     setBalanceLoading(true);
     (async () => {
@@ -293,8 +316,8 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
         }
         if (cancelled) return;
         try {
-          const ata = await getAssociatedTokenAddress(mintPkForBalance, publicKey);
-          const account = await getAccount(connection, ata);
+          const ata = await getAssociatedTokenAddress(mintPkForBalance, publicKey, false, capturedTokenProgramId);
+          const account = await getAccount(connection, ata, undefined, capturedTokenProgramId);
           if (!cancelled) {
             const amount = account.amount;
             setBalance(amount);
@@ -315,8 +338,9 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
       cancelled = true;
     };
     // GH#1258: onBalanceChange excluded — accessed via stable ref.
+    // GH#1261: tokenProgramId added so effect re-runs when validation resolves Token-2022 owner.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [connection, publicKey, mintPk, mintValid, isNativeDevnetMint]);
+  }, [connection, publicKey, mintPk, mintValid, isNativeDevnetMint, tokenProgramId]);
 
   const showInvalid = debounced.length > 0 && !mintValid;
   const effectiveMeta = tokenMeta ?? mirrorMeta;


### PR DESCRIPTION
## Summary

Fixes GH#1258 — PR #1257 fix ineffective in the `?mint=` navigation case.

## Root Cause

The validation `useEffect` in `StepTokenSelect` had `onMintNetworkValidChange`, `onDevnetMintResolved`, and `debounced` in its dependency array.

When the user clicks **Create Market →** from the Token Factory success card, the browser navigates to `/create?mint=<addr>`. The wallet connection hooks fire within the first ~1s, causing parent re-renders with new function references for all callback props. This **cancelled the ongoing `getAccountInfo` retry loop** and restarted it from attempt 0. The new loop ran attempt 0 → parent re-renders again → cancelled again → repeat. The retry window never completed, so the code always fell through to the mainnet mirror path, which correctly fails (`Token may not exist...`).

## Fixes

- **Add stable `useRef` wrappers** for all callback props (`onTokenResolved`, `onMintNetworkValidChange`, `onDevnetMintResolved`, `onBalanceChange`). Refs are updated synchronously on every render but don't cause effect re-runs.
- **Remove callbacks from effect dep arrays** — accessed via refs instead. Added `eslint-disable-next-line react-hooks/exhaustive-deps` with comment explaining the intentional exclusion.
- **Remove `debounced` from validation effect deps** — use `mintPk.toBase58()` captured at effect start instead.
- **Increase devnet getAccountInfo retries**: 3×1.5s → 5×2s (4.5s total → 10s) for RPC propagation under load.
- **Increase ATA balance retries**: 3×2s → 5×3s (6s → 15s) — same RPC lag issue for GH#1256.

## Tests
- 1002/1002 passing ✅
- `tsc --noEmit` clean ✅

## How to Test
1. Go to `/devnet-mint`, connect wallet, create any token
2. Immediately click **Create Market →** (within 5s of token creation)
3. Wizard Step 1 should show spinner then **✓ Native devnet token** card — no mirror error
4. Wallet balance should show > 0 within ~15s

Closes #1258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token selection stability and reliability during validation processes.
  * Enhanced retry strategy for devnet mint existence and balance validation checks.
  * Clarified status messaging to better reflect validation and confirmation progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->