### PR TITLE
fix: GH#1265 stats trades24h=0 + OI 8.57x underreport, GH#1266 MINT&TRADE navigate on mint fail

### DIFF
--- a/app/app/api/stats/route.ts
+++ b/app/app/api/stats/route.ts
@@ -63,14 +63,11 @@ export async function GET(request: NextRequest) {
   }
   const supabase = getServiceClient();
 
-  const [statsRes, tradersRes, recentTradesRes] = await Promise.all([
+  const [statsRes, tradersRes] = await Promise.all([
     // GH#1218: include slab_address so we can filter blocked markets (same as /api/markets)
-    supabase.from("markets_with_stats").select("slab_address, volume_24h, open_interest_long, open_interest_short, total_open_interest, last_price, decimals").limit(500),
+    // GH#1265: also fetch trade_count_24h so we can sum it directly (replaces buggy trades table count query)
+    supabase.from("markets_with_stats").select("slab_address, volume_24h, trade_count_24h, open_interest_long, open_interest_short, total_open_interest, last_price, decimals").limit(500),
     supabase.from("trades").select("trader").limit(5000),
-    supabase
-      .from("trades")
-      .select("id", { count: "exact", head: true })
-      .gte("created_at", new Date(Date.now() - 86400000).toISOString()),
   ]);
 
   // GH#1218: filter blocked slabs before aggregating — mirrors /api/markets behaviour.
@@ -118,14 +115,27 @@ export async function GET(request: NextRequest) {
         : (isSaneMarketValue((m.open_interest_long ?? 0) + (m.open_interest_short ?? 0))
             ? (m.open_interest_long ?? 0) + (m.open_interest_short ?? 0)
             : 0);
-      return sum + toUsd(rawOi, m);
+      if (!isSaneMarketValue(rawOi)) return sum;
+      // GH#1265: OI is tracked in collateral micro-units. When no oracle price is available
+      // (admin-mode markets not yet cranked), fall back to $1/token — correct for devnet
+      // markets. Without this fallback, only price-cranked markets contributed to OI,
+      // causing ~8.57× underreporting (only 3 out of 35+ OI-bearing markets had prices).
+      const d = Math.min(Math.max((m as Record<string, unknown>).decimals as number ?? 6, 0), 18);
+      const p = (m.last_price != null && m.last_price > 0 && m.last_price <= MAX_SANE_PRICE_USD)
+        ? m.last_price
+        : 1; // $1 fallback for markets without oracle price
+      const usd = (rawOi / 10 ** d) * p;
+      return sum + (usd > MAX_PER_MARKET_USD ? 0 : usd);
     },
     0
   );
   const uniqueTraders = new Set(
     (tradersRes.data ?? []).map((r) => r.trader)
   ).size;
-  const trades24h = recentTradesRes.count ?? 0;
+  // GH#1265: trades table count query (head:true) returns 0 — likely a column name mismatch
+  // or supabase HEAD count limitation. Use trade_count_24h from markets_with_stats instead,
+  // which is the same source used by /api/markets and is reliable.
+  const trades24h = activeData.reduce((sum, m) => sum + (m.trade_count_24h ?? 0), 0);
 
   return NextResponse.json({
     totalMarkets,

--- a/app/components/create/LaunchSuccess.tsx
+++ b/app/components/create/LaunchSuccess.tsx
@@ -53,7 +53,9 @@ export const LaunchSuccess: FC<LaunchSuccessProps> = ({
   const { publicKey } = useWalletCompat();
   const router = useRouter();
 
-  /** PERC-475: Mint $500 worth of devnet tokens then navigate to the trade page. */
+  /** PERC-475: Mint $500 worth of devnet tokens then navigate to the trade page.
+   *  GH#1266: Always navigate to trade page regardless of auto-mint outcome.
+   *  Mint failure is non-fatal — user can get tokens via the airdrop button on the trade page. */
   const handleMintAndTrade = useCallback(async () => {
     if (!publicKey || !devnetMint || mintLoading) return;
     setMintLoading(true);
@@ -67,16 +69,16 @@ export const LaunchSuccess: FC<LaunchSuccessProps> = ({
           walletAddress: publicKey.toBase58(),
         }),
       });
-      // On 429 (rate limited) still navigate — wallet may already have tokens
+      // GH#1266: On mint failure, show a brief warning but still navigate.
+      // Previously we returned early here, leaving the user stranded with an error banner.
       if (!resp.ok && resp.status !== 429) {
-        const d = await resp.json();
-        setMintError(d.error ?? "Mint failed — try again");
-        setMintLoading(false);
-        return;
+        const d = await resp.json().catch(() => ({}));
+        setMintError(d.error ?? "Auto-mint failed — you can airdrop tokens from the trade page");
       }
     } catch {
       // Network error — still navigate
     }
+    // Always navigate regardless of mint outcome
     router.push(`/trade/${marketAddress}`);
   }, [publicKey, devnetMint, mintLoading, marketAddress, router]);
 

--- a/app/hooks/useCreateMarket.ts
+++ b/app/hooks/useCreateMarket.ts
@@ -1013,6 +1013,9 @@ export function useCreateMarket() {
           loading: false,
           step: 5,
           stepLabel: "Market created!",
+          // GH#1266: Defensively re-set slabAddress from slabPk at completion to guard
+          // against any state-update race where a prior step's address is stale.
+          slabAddress: slabPk.toBase58(),
         }));
       } catch (e) {
         const msg = parseMarketCreationError(e);

--- a/app/lib/database.types.ts
+++ b/app/lib/database.types.ts
@@ -795,6 +795,7 @@ export type Database = {
           symbol: string | null
           total_accounts: number | null
           total_open_interest: number | null
+          trade_count_24h: number | null
           trading_fee_bps: number | null
           updated_at: string | null
           vault_balance: number | null


### PR DESCRIPTION
## Summary

Fixes two P1 bugs from QA live testing.

---

## GH#1265 — /api/stats incorrect data

### Bug 1: `trades24h` stuck at 0

**Root cause:** The stats route was querying the `trades` table directly with Supabase's `head: true` count which was returning 0 (likely a column name or query limitation).

**Fix:** Remove the separate trades table query. Sum `trade_count_24h` from `markets_with_stats` directly — this is the same source `/api/markets` uses and it reliably reports 5 trades.

### Bug 2: `totalOpenInterest` underreported 8.57× ($6,279 vs $53,808)

**Root cause:** The OI formula used `rawOi / 10^decimals * last_price`. Markets without a cranked oracle price (`last_price = null`) contributed $0 each. Only 3 of 35+ OI-bearing markets had a price, so the rest were silently dropped.

**Fix:** Fall back to `$1` per token when `last_price` is unavailable. This is correct for devnet admin-mode markets (default oracle price = $1). Also add `trade_count_24h` to the `markets_with_stats` TS type (column exists in DB, types were stale).

---

## GH#1266 — Create market success screen bugs

### Bug 1: MINT & TRADE button fails to navigate when auto-mint errors

**Root cause:** On any non-429 error from `/api/devnet-airdrop`, the handler called `return` before `router.push()`, stranding the user with an error banner.

**Fix:** Always navigate to `/trade/<marketAddress>` after mint attempt. Auto-mint failure is non-fatal — the user can airdrop tokens from the trade page.

### Bug 2: Defensive slabAddress guard

**Fix:** Explicitly set `slabAddress: slabPk.toBase58()` in the step-5 final state update to protect against any state-race where a prior step's address could be stale.

---

## Tests

```
Test Files: 85 passed | 2 skipped (87)
Tests: 1006 passed | 34 skipped (1040)
```

Zero TypeScript errors.