### PR TITLE
fix(oi,watchlist,trade): GH#1271 phantom OI migration + GH#1270 Watchlist display + GH#1272 vault-empty guard

### DIFF
--- a/app/__tests__/api/markets-price-sanitize.test.ts
+++ b/app/__tests__/api/markets-price-sanitize.test.ts
@@ -43,7 +43,7 @@ function mkMarket(overrides: Record<string, unknown> = {}) {
     net_lp_pos: 0,
     lp_sum_abs: 0,
     c_tot: 0,
-    vault_balance: 0,
+    vault_balance: 10_000,
     created_at: "2026-01-01T00:00:00Z",
     stats_updated_at: "2026-01-01T00:00:00Z",
     oracle_mode: "admin",

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -169,8 +169,19 @@ export async function GET() {
       // misleading solvency signals (OI > 0 with vault = 0 and no accounts).
       // Indexer-level fix (StatsCollector.ts) will clear OI for future syncs; this is a
       // defensive display-layer fallback.
+      // GH#1271: Also suppress when vault_balance = 0 (no LP liquidity → no real positions).
       const accountsCount = (m.total_accounts as number) ?? 0;
-      const displayOiUsd = accountsCount === 0 ? null : total_open_interest_usd;
+      const vaultBal = (m.vault_balance as number) ?? 0;
+      const displayOiUsd = (accountsCount === 0 || vaultBal === 0) ? null : total_open_interest_usd;
+
+      // GH#1270: Pre-compute volume_24h in USD so consumers (e.g. Watchlist) don't need
+      // to divide by 10^decimals manually. Mirrors the total_open_interest_usd pattern.
+      // Raw volume_24h is preserved in the response for backward compatibility.
+      const volume_24h_usd = rawToUsd(
+        m.volume_24h as number | null,
+        m.decimals as number | null,
+        sanitizedPrice,
+      );
 
       return {
         ...m,
@@ -187,8 +198,11 @@ export async function GET() {
         // #1160: Pre-converted OI in USD (null when price unavailable or value is a sentinel).
         // Raw open_interest_long / open_interest_short / total_open_interest remain
         // in the response for backward compatibility.
-        // GH#1250: Suppressed (null) when total_accounts == 0 — stale on-chain OI guard.
+        // GH#1250/1271: Suppressed (null) when total_accounts == 0 or vault_balance == 0.
         total_open_interest_usd: displayOiUsd,
+        // GH#1270: Pre-converted 24h volume in USD. Null when price unavailable or raw
+        // value is a sentinel. Raw volume_24h preserved for backward compatibility.
+        volume_24h_usd,
         // GH#1208: Sanitize c_tot — near-sentinel values (e.g. 7.997e17) pass the
         // isSaneMarketValue 1e18 check but are clearly corrupt LP collateral totals.
         c_tot: sanitizeCtot(m.c_tot as number | null),

--- a/app/components/dashboard/Watchlist.tsx
+++ b/app/components/dashboard/Watchlist.tsx
@@ -6,8 +6,11 @@ import Link from "next/link";
 interface MarketEntry {
   slab_address: string;
   symbol?: string;
-  volume_24h?: number | null;
-  total_open_interest?: number | null;
+  // GH#1270: Use pre-computed USD fields from /api/markets so we don't display
+  // raw token micro-units (which produce "$2000.0B" instead of "$2.0K").
+  // The API computes these via rawToUsd(raw, decimals, price) in the GET handler.
+  volume_24h_usd?: number | null;
+  total_open_interest_usd?: number | null;
 }
 
 function formatCompact(val: number): string {
@@ -65,10 +68,10 @@ export function Watchlist() {
               </span>
               <div className="flex-1 text-right">
                 <p className="text-[9px] text-[var(--text-muted)]">
-                  Vol: {m.volume_24h ? formatCompact(m.volume_24h) : "--"}
+                  Vol: {m.volume_24h_usd != null && m.volume_24h_usd > 0 ? formatCompact(m.volume_24h_usd) : "--"}
                 </p>
                 <p className="text-[9px] text-[var(--text-dim)]">
-                  OI: {m.total_open_interest ? formatCompact(m.total_open_interest) : "--"}
+                  OI: {m.total_open_interest_usd != null && m.total_open_interest_usd > 0 ? formatCompact(m.total_open_interest_usd) : "--"}
                 </p>
               </div>
             </Link>

--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -78,6 +78,13 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
   const vaultBalance = engine?.vault ?? 0n;
   const riskGateActive = riskThreshold > 0n && vaultBalance <= riskThreshold;
 
+  // GH#1272: Vault-empty guard — when engine is loaded but vault = 0, no trades can
+  // execute on-chain (no LP counterparty). Without this guard the button appears
+  // clickable but the transaction fails silently with no user feedback.
+  // Only active once engine is loaded (engine !== null) to avoid false positives
+  // during the initial loading phase where vault defaults to 0n.
+  const vaultEmpty = engine !== null && vaultBalance === 0n && !mockMode;
+
   const [direction, setDirection] = useState<"long" | "short">("long");
   const [marginInput, setMarginInput] = useState("");
   const [leverage, setLeverage] = useState(1);
@@ -251,8 +258,19 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
   return (
     <div className="relative rounded-none bg-[var(--bg)]/80 border border-[var(--border)]/50 p-3">
 
+      {/* GH#1272: Vault-empty warning — shown when no LP has deposited. Prevents
+          silent button failures by surfacing the real reason trading is blocked. */}
+      {vaultEmpty && (
+        <div className="mb-3 rounded-none border border-[var(--warning)]/30 bg-[var(--warning)]/5 p-2.5">
+          <p className="text-[9px] font-bold uppercase tracking-[0.15em] text-[var(--warning)]">No Vault Liquidity</p>
+          <p className="mt-1 text-[9px] text-[var(--text-secondary)] leading-relaxed">
+            This market has no LP deposits. Trading will be enabled once liquidity is added to the vault.
+          </p>
+        </div>
+      )}
+
       {/* LP underfunded warning */}
-      {lpUnderfunded && (
+      {lpUnderfunded && !vaultEmpty && (
         <div className="mb-3 rounded-none border border-[var(--warning)]/30 bg-[var(--warning)]/5 p-2.5">
           <p className="text-[9px] font-bold uppercase tracking-[0.15em] text-[var(--warning)]">Liquidity Unavailable</p>
           <p className="mt-1 text-[9px] text-[var(--text-secondary)] leading-relaxed">
@@ -460,7 +478,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
             if (!marginInput || !userAccount || positionSize <= 0n || exceedsMargin || riskGateActive || header?.paused || tradePhase !== "idle" || loading || (!priceUsd && !mockMode)) return;
             setShowConfirmModal(true);
           }}
-          disabled={tradePhase !== "idle" || loading || !marginInput || positionSize <= 0n || exceedsMargin || riskGateActive || header?.paused || lpUnderfunded || (!priceUsd && !mockMode)}
+          disabled={tradePhase !== "idle" || loading || !marginInput || positionSize <= 0n || exceedsMargin || riskGateActive || header?.paused || lpUnderfunded || vaultEmpty || (!priceUsd && !mockMode)}
           className={`w-full rounded-none py-2.5 text-[11px] font-medium uppercase tracking-[0.1em] text-white transition-all duration-150 hover:scale-[1.01] active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:scale-100 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--bg)] ${
             direction === "long"
               ? "bg-[var(--long)] hover:brightness-110 focus-visible:ring-[var(--long)]"

--- a/supabase/migrations/048_zero_empty_vault_oi.sql
+++ b/supabase/migrations/048_zero_empty_vault_oi.sql
@@ -1,0 +1,42 @@
+-- Migration 048: Zero stale OI for markets with empty vault — GH#1271
+--
+-- Context: Migration 047 zeroed OI for markets where total_accounts = 0.
+-- However, 9+ markets still show phantom trillion-scale OI (2000000000000)
+-- because their vault_balance = 0 but total_accounts > 0 at the time 047
+-- ran — so those rows were skipped.
+--
+-- Root cause: The on-chain totalOpenInterest counter is not decremented when
+-- positions are force-closed or accounts are reclaimed (PERC-511 path). The
+-- indexer historically wrote engine.totalOpenInterest directly (now fixed in
+-- StatsCollector.ts via GH#1250 to use oiLong + oiShort from parsed accounts).
+--
+-- Definitive predicate: vault_balance = 0 means NO LP has deposited liquidity.
+-- Without any vault balance, no position can ever be opened — the on-chain
+-- program enforces this — so any non-zero OI in these markets is stale/phantom.
+--
+-- Affected markets confirmed in GH#1271 (partial list):
+--   8eFFEFBY3HHbBgzxJJP5hyxdzMNMAumnYNhkWXErBM4c
+--   3bmCyPee8GWJR5aPGTyN5EyyQJLzYyD8Wkg9m1Afd1SD
+--   Aiwhg31d3sgC3PS9ciorxzcbGFE5g4NjbtAz8EA5mcW5
+--   GYpukkn94KKDU9ufNURjDZVMGPp3LTadZrdoPtE2cdc1
+--   3YDqCJGz88xGiPBiRvx4vrM51mWTiTZPZ95hxYDZqKpJ
+--   F3YUro7KXNVfNZ6FJmMCm25uQ2nxpfypxJ91wxobxBUT
+--   2Zta2EPRR444Hp2WbH2L9vfM38Stwr9chDpNk66eevzU
+--   5pX7ycPtKwr7xfTxoUUgcWirq8tSz8B1Sq8PJShfFstt
+--   5S4gkqX8Jz9MQPmtQ3qCU3698PnY5dFnyTdeq7fu12sW
+--
+-- Applied as a general vault_balance = 0 predicate (not slab-specific)
+-- so any future market that launches empty is also covered.
+
+UPDATE market_stats
+SET
+  open_interest_long  = 0,
+  open_interest_short = 0,
+  total_open_interest = 0
+WHERE vault_balance = 0
+  AND total_open_interest > 0;
+
+-- Verify: no rows should remain with vault=0 and OI>0
+-- SELECT slab_address, vault_balance, total_accounts, total_open_interest
+-- FROM market_stats
+-- WHERE vault_balance = 0 AND total_open_interest > 0;


### PR DESCRIPTION
## Summary
Fixes 3 P1 bugs from QA live testing — all blocking mainnet readiness.

---

### PERC-812 / GH#1271 — Phantom trillion OI in DB (Migration 047 incomplete)

**Root cause:** Migration 047 zeroed OI where `total_accounts = 0`, but 9+ markets had `total_accounts > 0` at migration time while still carrying phantom OI (no vault deposits = no real positions ever existed).

**Fix:**
- New migration `048_zero_empty_vault_oi.sql`: `UPDATE market_stats SET oi = 0 WHERE vault_balance = 0 AND total_open_interest > 0`
- API-level guard: `displayOiUsd` now also returns `null` when `vault_balance = 0` (display-layer defence until migration lands)

---

### PERC-814 / GH#1270 — Dashboard Watchlist shows $2000.0B instead of $2.0K

**Root cause:** `Watchlist.tsx` read raw `total_open_interest` and `volume_24h` (token micro-units) from `/api/markets` and passed them directly to `formatCompact` without dividing by `10^decimals`.

**Fix:**
- Added `volume_24h_usd` to `/api/markets` GET response (mirrors existing `total_open_interest_usd` via `rawToUsd()`)
- Updated `Watchlist.tsx` to use `total_open_interest_usd` and `volume_24h_usd`

---

### PERC-813 / GH#1272 — 'Create Account & Deposit' silently fails on empty vault

**Root cause:** `lpUnderfunded` guard only fires when `hasValidLP === true` — but markets with no accounts at all have no LP entry, so the button was clickable despite the transaction being guaranteed to fail on-chain.

**Fix:**
- Added `vaultEmpty = engine !== null && vaultBalance === 0n && !mockMode` guard
- Added 'No Vault Liquidity' warning banner (consistent with existing LP underfunded / risk gate banners)
- Added `vaultEmpty` to button `disabled` condition

---

## Testing
- All 1006 tests pass (`pnpm test`)
- Updated `mkMarket` test default: `vault_balance: 0 → 10_000` (more realistic; markets with OI have non-zero vault)

## How to verify
1. **GH#1271**: Run migration 048 on devnet DB — confirm no rows with `vault_balance=0 AND total_open_interest>0`
2. **GH#1270**: Check dashboard Watchlist — markets should show e.g. `OI: $2.0K` not `OI: $2000.0B`
3. **GH#1272**: Navigate to a market with Vault=0 — should see 'No Vault Liquidity' banner and disabled button

Closes #1270, #1271, #1272