### PR TITLE
fix(stats): use $1 price fallback in ProtocolStatsBar — GH#1274

### DIFF
--- a/app/__tests__/components/ProtocolStatsBar.test.tsx
+++ b/app/__tests__/components/ProtocolStatsBar.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * GH#1274 — ProtocolStatsBar OI underreport regression tests.
+ *
+ * Root cause: price fallback was `0`, making toUsd() short-circuit to 0 for
+ * every market without an oracle price. Fix: fallback to $1 (matches api/stats).
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { ProtocolStatsBar } from "@/components/dashboard/ProtocolStatsBar";
+import "@testing-library/jest-dom";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+// The query chain is: getSupabase().from().select().returns()
+// We need to mock the full chain correctly.
+const mockReturns = vi.fn();
+const mockSelect = vi.fn(() => ({ returns: mockReturns }));
+const mockFrom = vi.fn(() => ({ select: mockSelect }));
+
+vi.mock("@/lib/supabase", () => ({
+  getSupabase: () => ({ from: mockFrom }),
+}));
+
+vi.mock("@/lib/blocklist", () => ({
+  isBlockedSlab: vi.fn(() => false),
+}));
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+type MarketRow = {
+  slab_address: string;
+  symbol: string | null;
+  volume_24h: number | null;
+  last_price: number | null;
+  decimals: number | null;
+  total_open_interest: number | null;
+  open_interest_long: number | null;
+  open_interest_short: number | null;
+};
+
+function makeRow(overrides: Partial<MarketRow> = {}): MarketRow {
+  return {
+    slab_address: "slab-abc",
+    symbol: "TST-PERP",
+    volume_24h: null,
+    last_price: null,
+    decimals: 6,
+    total_open_interest: null,
+    open_interest_long: null,
+    open_interest_short: null,
+    ...overrides,
+  };
+}
+
+function mockSupabase(rows: MarketRow[]) {
+  mockReturns.mockResolvedValue({ data: rows });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("ProtocolStatsBar — GH#1274 price fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows $0 OI when there are no markets", async () => {
+    mockSupabase([]);
+    render(<ProtocolStatsBar />);
+    await waitFor(() => {
+      expect(screen.getByText("Open Interest")).toBeInTheDocument();
+      expect(screen.getAllByText("$0").length).toBeGreaterThan(0);
+    });
+  });
+
+  it("shows non-zero OI when last_price is null — GH#1274 regression", async () => {
+    // Simulates the actual GH#1274 scenario: $53.8K OI across admin-mode markets
+    // 53,800 tokens at $1 fallback = $53.8K; raw = 53800 × 10^6 = 53_800_000_000
+    const rawOi = 53_800 * 1_000_000;
+    mockSupabase([
+      makeRow({
+        slab_address: "slab-admin-1",
+        last_price: null,  // no oracle price — must fall back to $1
+        total_open_interest: rawOi,
+        decimals: 6,
+      }),
+    ]);
+
+    render(<ProtocolStatsBar />);
+
+    await waitFor(() => {
+      // $53,800 → "$53.8K"
+      expect(screen.getByText("$53.8K")).toBeInTheDocument();
+    });
+  });
+
+  it("shows correct OI when last_price is provided", async () => {
+    // 1000 tokens at $2 each = $2000 OI; raw = 1000 × 10^6
+    const rawOi = 1000 * 1_000_000;
+    mockSupabase([
+      makeRow({
+        slab_address: "slab-oracle-1",
+        last_price: 2.0,
+        total_open_interest: rawOi,
+        decimals: 6,
+      }),
+    ]);
+
+    render(<ProtocolStatsBar />);
+
+    await waitFor(() => {
+      expect(screen.getByText("$2.0K")).toBeInTheDocument();
+    });
+  });
+
+  it("OI must not be $0 when raw OI is sane and last_price is null", async () => {
+    // 100K tokens × 10^6 = 10^11 raw → $100K at $1 fallback
+    const rawOi = 100_000 * 1_000_000;
+    mockSupabase([
+      makeRow({
+        slab_address: "slab-no-price",
+        last_price: null,
+        total_open_interest: rawOi,
+        decimals: 6,
+      }),
+    ]);
+
+    render(<ProtocolStatsBar />);
+
+    await waitFor(() => {
+      expect(screen.getByText("$100.0K")).toBeInTheDocument();
+    });
+  });
+
+  it("counts active markets when last_price is null but OI is sane", async () => {
+    const rawOi = 1_000_000 * 1_000_000;
+    mockSupabase([
+      makeRow({ slab_address: "s1", last_price: null, total_open_interest: rawOi }),
+      makeRow({ slab_address: "s2", last_price: null, total_open_interest: rawOi }),
+      makeRow({ slab_address: "s3", last_price: null, total_open_interest: rawOi }),
+    ]);
+
+    render(<ProtocolStatsBar />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Active Markets")).toBeInTheDocument();
+      expect(screen.getByText("3")).toBeInTheDocument();
+    });
+  });
+
+  it("ignores blocked slabs", async () => {
+    const { isBlockedSlab } = await import("@/lib/blocklist");
+    (isBlockedSlab as ReturnType<typeof vi.fn>).mockImplementation(
+      (addr: string) => addr === "slab-blocked"
+    );
+
+    const rawOi = 50_000 * 1_000_000;
+    mockSupabase([
+      makeRow({ slab_address: "slab-blocked", last_price: null, total_open_interest: rawOi }),
+      makeRow({ slab_address: "slab-ok", last_price: null, total_open_interest: rawOi }),
+    ]);
+
+    render(<ProtocolStatsBar />);
+
+    await waitFor(() => {
+      // Only slab-ok counts: 1 active market, $50K OI
+      expect(screen.getByText("$50.0K")).toBeInTheDocument();
+      expect(screen.getByText("1")).toBeInTheDocument();
+    });
+  });
+});

--- a/app/components/dashboard/ProtocolStatsBar.tsx
+++ b/app/components/dashboard/ProtocolStatsBar.tsx
@@ -76,9 +76,11 @@ export function ProtocolStatsBar() {
         if (!row.slab_address || isBlockedSlab(row.slab_address)) continue;
 
         const dec = Math.pow(10, Math.min(Math.max(row.decimals ?? 6, 0), 18));
+        // Use $1 fallback when last_price is missing/invalid — matches api/stats route logic
+        // so admin-mode markets (no oracle price) are still counted at face value (GH#1274)
         const price = (row.last_price != null && row.last_price > 0 && row.last_price <= MAX_SANE_PRICE_USD)
           ? row.last_price
-          : 0;
+          : 1;
 
         const toUsd = (raw: number): number => {
           if (!isSaneMarketValue(raw) || price <= 0) return 0;


### PR DESCRIPTION
## Summary

Fixes GH#1274 — ProtocolStatsBar showing $6.3K OI instead of correct ~$53.8K.

## Root Cause

`ProtocolStatsBar.tsx` used `price = 0` as the fallback when `last_price` is null. The `toUsd()` helper short-circuits to `0` when `price <= 0`, so every admin-mode market (markets without oracle prices) contributed $0 to the OI total. Only 4 out of 95 active markets had oracle prices — the rest were silently dropped.

## Fix

One-line change: `last_price ?? 0` → `last_price ?? 1`

This matches the behaviour of `api/stats/route.ts` which already uses `price = 1` as the fallback for the same category of markets.

## Testing

Added `ProtocolStatsBar.test.tsx` with 6 regression tests:
- `last_price: null` → OI correctly calculated at $1 fallback (GH#1274 scenario)
- `last_price: 2.0` → OI uses actual oracle price
- Blocked slabs excluded
- Active market count correct when only OI is sane (no oracle price)
- All 6 tests pass ✅

## How to Test

Visit the dashboard — Open Interest should now show ~$53.8K+ instead of ~$6.3K.

Closes #1274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected price fallback behavior in protocol statistics calculations. When market price data is unavailable, the system now defaults to $1 instead of $0, improving accuracy of Open Interest and volume USD conversions.

* **Tests**
  * Added comprehensive test coverage for protocol statistics including price fallback scenarios, Open Interest rendering, and market counting edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->