### PR TITLE
feat(insurance): render InsuranceLPPanel on trade page Risk tab (PERC-815)

### DIFF
--- a/app/app/trade/[slab]/page.tsx
+++ b/app/app/trade/[slab]/page.tsx
@@ -24,6 +24,7 @@ import { KeeperFundCard } from "@/components/market/KeeperFundCard";
 import { SystemCapitalCard } from "@/components/trade/SystemCapitalCard";
 import { OpenInterestCard } from "@/components/market/OpenInterestCard";
 import { InsuranceDashboard } from "@/components/market/InsuranceDashboard";
+import { InsuranceLPPanel } from "@/components/trade/InsuranceLPPanel";
 import { HealthBadge } from "@/components/market/HealthBadge";
 import { ShareButton } from "@/components/market/ShareCard";
 import { MarketLogo } from "@/components/market/MarketLogo";
@@ -464,6 +465,7 @@ function TradePageInner({ slab }: { slab: string }) {
           <ErrorBoundary label="RiskAnalytics">
             <OpenInterestCard slabAddress={slab} />
             <div className="mt-2"><InsuranceDashboard slabAddress={slab} /></div>
+            <div className="mt-2"><InsuranceLPPanel /></div>
             <div className="mt-2"><CrankHealthCard /></div>
             <div className="mt-2"><KeeperFundCard /></div>
             <div className="mt-2"><LiquidationAnalytics /></div>
@@ -516,6 +518,7 @@ function TradePageInner({ slab }: { slab: string }) {
             <ErrorBoundary label="RiskAnalytics">
               <OpenInterestCard slabAddress={slab} />
               <div className="mt-1.5"><InsuranceDashboard slabAddress={slab} /></div>
+              <div className="mt-1.5"><InsuranceLPPanel /></div>
               <div className="mt-1.5"><KeeperFundCard /></div>
               <div className="mt-1.5"><LiquidationAnalytics /></div>
               <div className="mt-1.5"><SystemCapitalCard /></div>


### PR DESCRIPTION
## Summary

Wires up the `InsuranceLPPanel` component (previously built but unrendered) in the trade page **Risk** tab, immediately below `InsuranceDashboard` on both mobile and desktop layouts.

## What changed
- Added `InsuranceLPPanel` import to `app/trade/[slab]/page.tsx`
- Rendered panel in mobile Risk tab (after `InsuranceDashboard`)
- Rendered panel in desktop Risk tab (after `InsuranceDashboard`)

## Location decision
Placed directly below the Insurance Fund stats widget — users viewing insurance health naturally want the ability to deposit/withdraw LP in the same spot.

## How to test
1. Navigate to any trade page (e.g. `/trade/<slab>`)
2. Select the **Risk** tab
3. Confirm **Insurance Pool** panel renders below the Insurance Fund widget
4. If mint exists: deposit/withdraw tabs should be interactive
5. If admin wallet: Create Insurance LP Mint button should appear

## TypeScript
`pnpm exec tsc --noEmit` — clean (0 errors)

Closes PERC-815