### PR TITLE
fix(oi): PERC-816 — permanent fix for 25 phantom-OI markets with dust vault_balance

### DIFF
--- a/app/__tests__/api/markets-price-sanitize.test.ts
+++ b/app/__tests__/api/markets-price-sanitize.test.ts
@@ -43,7 +43,7 @@ function mkMarket(overrides: Record<string, unknown> = {}) {
     net_lp_pos: 0,
     lp_sum_abs: 0,
     c_tot: 0,
-    vault_balance: 10_000,
+    vault_balance: 500_000_000,  // 500 USDC at 6dp — realistic LP deposit above dust threshold
     created_at: "2026-01-01T00:00:00Z",
     stats_updated_at: "2026-01-01T00:00:00Z",
     oracle_mode: "admin",
@@ -280,5 +280,65 @@ describe("GET /api/markets — price sanitization (#856)", () => {
     expect(a?.index_price).toBeNull();   // corrupt value nulled
     expect(b?.index_price).toBe(42_500); // legit value preserved
     expect(c?.index_price).toBeNull();   // already-null preserved
+  });
+
+  // PERC-816: Dust vault guard — phantom OI suppression for markets with dust vault_balance.
+  describe("PERC-816 — phantom OI suppression for dust vault_balance", () => {
+    it("suppresses total_open_interest_usd when vault_balance is zero", async () => {
+      mockMarkets = [
+        mkMarket({ symbol: "ZERO_VAULT", vault_balance: 0, total_open_interest: 2_000_000_000_000, last_price: 1.0 }),
+      ];
+      vi.resetModules();
+      const { GET } = await import("@/app/api/markets/route");
+      const res = await GET();
+      const body = (await res.json()) as { markets: { symbol: string; total_open_interest_usd: number | null }[] };
+      const m = body.markets.find((m) => m.symbol === "ZERO_VAULT");
+      expect(m?.total_open_interest_usd).toBeNull();
+    });
+
+    it("suppresses total_open_interest_usd when vault_balance is dust (< 1,000,000)", async () => {
+      mockMarkets = [
+        mkMarket({ symbol: "DUST_1", vault_balance: 1, total_open_interest: 2_000_000_000_000, last_price: 1.0 }),
+        mkMarket({ symbol: "DUST_100", vault_balance: 100, total_open_interest: 2_000_000_000_000, last_price: 1.0 }),
+        mkMarket({ symbol: "DUST_999999", vault_balance: 999_999, total_open_interest: 2_000_000_000_000, last_price: 1.0 }),
+      ];
+      vi.resetModules();
+      const { GET } = await import("@/app/api/markets/route");
+      const res = await GET();
+      const body = (await res.json()) as { markets: { symbol: string; total_open_interest_usd: number | null }[] };
+      for (const sym of ["DUST_1", "DUST_100", "DUST_999999"]) {
+        const m = body.markets.find((m) => m.symbol === sym);
+        expect(m?.total_open_interest_usd).toBeNull(); // dust vault → phantom OI suppressed
+      }
+    });
+
+    it("passes through total_open_interest_usd when vault_balance >= 1,000,000 (real liquidity)", async () => {
+      mockMarkets = [
+        // exactly at threshold boundary — real liquidity starts here
+        mkMarket({ symbol: "AT_THRESHOLD", vault_balance: 1_000_000, total_open_interest: 1_000, decimals: 6, last_price: 1.0 }),
+        // well above threshold — typical LP deposit
+        mkMarket({ symbol: "REAL_VAULT", vault_balance: 500_000_000, total_open_interest: 1_000, decimals: 6, last_price: 1.0 }),
+      ];
+      vi.resetModules();
+      const { GET } = await import("@/app/api/markets/route");
+      const res = await GET();
+      const body = (await res.json()) as { markets: { symbol: string; total_open_interest_usd: number | null }[] };
+      const atThreshold = body.markets.find((m) => m.symbol === "AT_THRESHOLD");
+      const realVault = body.markets.find((m) => m.symbol === "REAL_VAULT");
+      expect(atThreshold?.total_open_interest_usd).toBeCloseTo(0.001, 6); // 1000 / 1e6 * 1.0
+      expect(realVault?.total_open_interest_usd).toBeCloseTo(0.001, 6);
+    });
+
+    it("suppresses total_open_interest_usd when total_accounts = 0 regardless of vault_balance", async () => {
+      mockMarkets = [
+        mkMarket({ symbol: "NO_ACCOUNTS", total_accounts: 0, vault_balance: 500_000_000, total_open_interest: 2_000_000_000_000, last_price: 1.0 }),
+      ];
+      vi.resetModules();
+      const { GET } = await import("@/app/api/markets/route");
+      const res = await GET();
+      const body = (await res.json()) as { markets: { symbol: string; total_open_interest_usd: number | null }[] };
+      const m = body.markets.find((m) => m.symbol === "NO_ACCOUNTS");
+      expect(m?.total_open_interest_usd).toBeNull();
+    });
   });
 });

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -170,9 +170,12 @@ export async function GET() {
       // Indexer-level fix (StatsCollector.ts) will clear OI for future syncs; this is a
       // defensive display-layer fallback.
       // GH#1271: Also suppress when vault_balance = 0 (no LP liquidity → no real positions).
+      // PERC-816: Extend to suppress for dust vault_balance (0 < vault < 1,000,000 micro-units).
+      // Mirrors the invariant enforced by StatsCollector and migration 049.
+      const MIN_VAULT_FOR_OI = 1_000_000; // < 1 USDC at 6 decimals; dust at 9 decimals
       const accountsCount = (m.total_accounts as number) ?? 0;
       const vaultBal = (m.vault_balance as number) ?? 0;
-      const displayOiUsd = (accountsCount === 0 || vaultBal === 0) ? null : total_open_interest_usd;
+      const displayOiUsd = (accountsCount === 0 || vaultBal < MIN_VAULT_FOR_OI) ? null : total_open_interest_usd;
 
       // GH#1270: Pre-compute volume_24h in USD so consumers (e.g. Watchlist) don't need
       // to divide by 10^decimals manually. Mirrors the total_open_interest_usd pattern.
@@ -198,7 +201,7 @@ export async function GET() {
         // #1160: Pre-converted OI in USD (null when price unavailable or value is a sentinel).
         // Raw open_interest_long / open_interest_short / total_open_interest remain
         // in the response for backward compatibility.
-        // GH#1250/1271: Suppressed (null) when total_accounts == 0 or vault_balance == 0.
+        // GH#1250/1271/PERC-816: Suppressed (null) when total_accounts == 0 or vault_balance < 1_000_000.
         total_open_interest_usd: displayOiUsd,
         // GH#1270: Pre-converted 24h volume in USD. Null when price unavailable or raw
         // value is a sentinel. Raw volume_24h preserved for backward compatibility.

--- a/packages/indexer/src/services/StatsCollector.ts
+++ b/packages/indexer/src/services/StatsCollector.ts
@@ -411,6 +411,20 @@ export class StatsCollector {
               oiShort = oiLong;
             }
 
+            // PERC-816: Dust vault guard — enforce the invariant that OI must be 0
+            // when the vault has no meaningful liquidity. This prevents phantom OI from
+            // being re-written by the indexer for markets that were created but never
+            // received real LP deposits (e.g. creation-deposit splits leave dust in vault).
+            // Threshold: 1,000,000 micro-units (< 1 USDC at 6 decimals, dust at 9 decimals).
+            // Also enforces: total_accounts = 0 → OI must be 0 (no open positions).
+            const MIN_VAULT_FOR_OI = 1_000_000n;
+            const hasDustVault = engine.vault > 0n && engine.vault < MIN_VAULT_FOR_OI;
+            const hasNoAccounts = engine.numUsedAccounts === 0;
+            if (hasDustVault || hasNoAccounts) {
+              oiLong = 0n;
+              oiShort = 0n;
+            }
+
             // Use on-chain price with oracle-mode-aware resolution
             // Oracle modes:
             //   - pyth-pinned: oracleAuthority == [0;32] → use lastEffectivePriceE6

--- a/packages/indexer/tests/services/StatsCollector.test.ts
+++ b/packages/indexer/tests/services/StatsCollector.test.ts
@@ -346,6 +346,96 @@ describe('StatsCollector', () => {
       expect(shared.upsertMarketStats).not.toHaveBeenCalled();
     });
 
+    // PERC-816: Dust vault guard — OI must be zeroed when vault is below meaningful threshold
+    it('should zero OI when vault_balance is dust (0 < vault < 1_000_000)', async () => {
+      const markets = new Map([[SLAB1, makeMockMarket(SLAB1)]]);
+      vi.mocked(mockMarketProvider.getMarkets).mockReturnValue(markets);
+      mockGetAccountInfo.mockResolvedValue({ data: new Uint8Array(2048) });
+      mockGetMultipleAccountsInfo.mockResolvedValue([{ data: new Uint8Array(2048) }]);
+
+      // Dust vault: 500 micro-units (< 1_000_000 threshold)
+      vi.mocked(core.parseEngine).mockReturnValue(
+        makeEngineState({ vault: 500n, numUsedAccounts: 3 })
+      );
+      vi.mocked(core.parseConfig).mockReturnValue(makeConfig());
+      vi.mocked(core.parseParams).mockReturnValue(makeParams());
+      // Accounts have positions — but vault is dust so OI should be zeroed
+      vi.mocked(core.parseAllAccounts).mockReturnValue([
+        { account: { positionSize: 600_000_000n } },
+        { account: { positionSize: -400_000_000n } },
+      ] as any);
+
+      statsCollector.start();
+      await vi.advanceTimersByTimeAsync(10_500);
+
+      expect(shared.upsertMarketStats).toHaveBeenCalledWith(
+        expect.objectContaining({
+          slab_address: SLAB1,
+          open_interest_long: 0,   // zeroed: dust vault
+          open_interest_short: 0,  // zeroed: dust vault
+          total_open_interest: 0,  // zeroed: dust vault
+          vault_balance: 500,      // vault_balance still written as-is (for observability)
+        })
+      );
+    });
+
+    it('should zero OI when numUsedAccounts = 0 regardless of vault_balance', async () => {
+      const markets = new Map([[SLAB1, makeMockMarket(SLAB1)]]);
+      vi.mocked(mockMarketProvider.getMarkets).mockReturnValue(markets);
+      mockGetAccountInfo.mockResolvedValue({ data: new Uint8Array(2048) });
+      mockGetMultipleAccountsInfo.mockResolvedValue([{ data: new Uint8Array(2048) }]);
+
+      // No accounts but vault has real liquidity — still phantom OI
+      vi.mocked(core.parseEngine).mockReturnValue(
+        makeEngineState({ vault: 500_000_000n, numUsedAccounts: 0, totalOpenInterest: 2_000_000_000_000n })
+      );
+      vi.mocked(core.parseConfig).mockReturnValue(makeConfig());
+      vi.mocked(core.parseParams).mockReturnValue(makeParams());
+      vi.mocked(core.parseAllAccounts).mockReturnValue([] as any);
+
+      statsCollector.start();
+      await vi.advanceTimersByTimeAsync(10_500);
+
+      expect(shared.upsertMarketStats).toHaveBeenCalledWith(
+        expect.objectContaining({
+          slab_address: SLAB1,
+          open_interest_long: 0,
+          open_interest_short: 0,
+          total_open_interest: 0,
+        })
+      );
+    });
+
+    it('should NOT zero OI when vault_balance >= 1_000_000 (real liquidity)', async () => {
+      const markets = new Map([[SLAB1, makeMockMarket(SLAB1)]]);
+      vi.mocked(mockMarketProvider.getMarkets).mockReturnValue(markets);
+      mockGetAccountInfo.mockResolvedValue({ data: new Uint8Array(2048) });
+      mockGetMultipleAccountsInfo.mockResolvedValue([{ data: new Uint8Array(2048) }]);
+
+      // Real vault: 500M micro-units, 10 accounts, OI computed from accounts
+      vi.mocked(core.parseEngine).mockReturnValue(
+        makeEngineState({ vault: 500_000_000n, numUsedAccounts: 10 })
+      );
+      vi.mocked(core.parseConfig).mockReturnValue(makeConfig());
+      vi.mocked(core.parseParams).mockReturnValue(makeParams());
+      vi.mocked(core.parseAllAccounts).mockReturnValue([
+        { account: { positionSize: 600_000_000n } },
+        { account: { positionSize: -400_000_000n } },
+      ] as any);
+
+      statsCollector.start();
+      await vi.advanceTimersByTimeAsync(10_500);
+
+      expect(shared.upsertMarketStats).toHaveBeenCalledWith(
+        expect.objectContaining({
+          slab_address: SLAB1,
+          open_interest_long: 600_000_000,   // preserved: real vault
+          open_interest_short: 400_000_000,  // preserved: real vault
+          total_open_interest: 1_000_000_000,
+        })
+      );
+    });
+
     it('should handle values near u64 max gracefully', async () => {
       const markets = new Map([[SLAB1, makeMockMarket(SLAB1)]]);
       vi.mocked(mockMarketProvider.getMarkets).mockReturnValue(markets);

--- a/supabase/migrations/049_zero_dust_vault_oi.sql
+++ b/supabase/migrations/049_zero_dust_vault_oi.sql
@@ -1,0 +1,47 @@
+-- Migration 049: Zero phantom OI for markets with dust vault_balance — PERC-816
+--
+-- Context: Migrations 047 and 048 zeroed OI for markets where:
+--   047: total_accounts = 0   AND total_open_interest > 0
+--   048: vault_balance = 0    AND total_open_interest > 0
+--
+-- 25 markets remain with phantom OI despite near-zero (dust) vault_balance.
+-- Root cause: These markets have vault_balance > 0 but below any meaningful
+-- LP threshold — likely from creation-deposit splits (70/30 keeper/vault from
+-- PERC-623) or parser artifacts from wrong slab layout reads.
+--
+-- The Percolator program enforces: no position can be opened without sufficient
+-- vault liquidity. A vault_balance below 1,000,000 micro-units (< 1 USDC at
+-- 6 decimals, < 0.001 SOL at 9 decimals) cannot sustain any real open interest.
+--
+-- Fix: zero OI whenever vault is dust OR total_accounts = 0 (belt-and-suspenders
+-- in case migrations 047/048 were applied before the indexer updated those rows).
+-- The StatsCollector is also patched to enforce this invariant on all future writes
+-- so re-population of phantom OI cannot recur.
+
+DO $$
+DECLARE
+  MIN_VAULT_FOR_OI CONSTANT NUMERIC := 1000000;  -- 1 micro-token (< 1 USDC at 6dp)
+  rows_updated INT;
+BEGIN
+  UPDATE market_stats
+  SET
+    open_interest_long  = 0,
+    open_interest_short = 0,
+    total_open_interest = 0
+  WHERE total_open_interest > 0
+    AND (
+      -- Dust vault: non-zero but below minimum meaningful LP threshold
+      (vault_balance > 0 AND vault_balance < MIN_VAULT_FOR_OI)
+      -- Belt-and-suspenders: no accounts → no open positions → OI must be 0
+      OR total_accounts = 0
+    );
+
+  GET DIAGNOSTICS rows_updated = ROW_COUNT;
+  RAISE NOTICE 'Migration 049: zeroed phantom OI for % market_stats rows', rows_updated;
+END $$;
+
+-- Sanity check (uncomment to verify after applying):
+-- SELECT slab_address, vault_balance, total_accounts, total_open_interest
+-- FROM market_stats
+-- WHERE total_open_interest > 0
+--   AND (total_accounts = 0 OR (vault_balance > 0 AND vault_balance < 1000000));


### PR DESCRIPTION
## Summary
Resolves the 25 phantom-OI markets that persisted after migrations 047 and 048. Root cause: their `vault_balance` was non-zero but below any meaningful LP threshold (dust — e.g. `500` micro-units from creation-deposit splits), so the `vault_balance = 0` predicate missed them.

## Root Cause
The on-chain `totalOpenInterest` counter is never decremented when positions are force-closed or accounts reclaimed (PERC-511 path). Combined with a tiny dust `vault_balance` (not exactly 0), these markets slipped past migrations 047 and 048 which only caught `total_accounts = 0` or `vault_balance = 0`.

## Fix — 3 Layers

### 1. Migration 049 (`supabase/migrations/049_zero_dust_vault_oi.sql`)
Zeros OI in `market_stats` for all rows where:
- `vault_balance > 0 AND vault_balance < 1,000,000` (dust threshold), OR
- `total_accounts = 0` (belt-and-suspenders for future indexer re-runs)

**Threshold rationale:** 1,000,000 micro-units = 1 USDC at 6 decimals, or 0.001 SOL at 9 decimals. No real LP deposit at this scale can sustain open interest; the program enforces minimum vault before allowing trades.

### 2. StatsCollector guard (`packages/indexer/src/services/StatsCollector.ts`)
Enforces the invariant on every future indexer write:
```typescript
const MIN_VAULT_FOR_OI = 1_000_000n;
const hasDustVault = engine.vault > 0n && engine.vault < MIN_VAULT_FOR_OI;
const hasNoAccounts = engine.numUsedAccounts === 0;
if (hasDustVault || hasNoAccounts) { oiLong = 0n; oiShort = 0n; }
```
Prevents phantom OI from being re-populated after migration runs.

### 3. Display-layer guard (`app/app/api/markets/route.ts`)
Extends the GH#1271 suppression from `vaultBal === 0` to `vaultBal < 1_000_000`. Defensive fallback that works even before migration is applied.

## Tests
- **+4 API route tests** — dust vault suppression at various levels (1, 100, 999999), threshold boundary (1_000_000 passes), total_accounts=0 still suppresses
- **+3 StatsCollector tests** — dust vault zeroes OI, no accounts zeroes OI, real vault preserves OI
- **1088 existing tests all green** (1016 app + 72 indexer)
- TypeScript clean (`tsc --noEmit` exit 0)

## DevOps Action Required
After merge, run `supabase db push` to apply migration 049. No service restart needed (display-layer and StatsCollector guards are live immediately post-deploy).

Closes PERC-816.