### PR TITLE
fix: clamp uninitialized insuranceFund.balance (u64::MAX) — GH#1278

### DIFF
--- a/app/__tests__/hooks/useInsuranceLP.test.ts
+++ b/app/__tests__/hooks/useInsuranceLP.test.ts
@@ -207,8 +207,9 @@ describe("useInsuranceLP", () => {
 
       const { result, unmount } = renderHook(() => useInsuranceLP());
 
+      // Wait for hook to settle — when no mint, balance is 0n (uninitialized guard)
       await waitFor(() => {
-        expect(result.current.state.insuranceBalance).toBe(1000000n);
+        expect(result.current.state.mintExists).toBe(false);
       });
 
       const callsBefore = mockConnection.getAccountInfo.mock.calls.length;
@@ -225,13 +226,46 @@ describe("useInsuranceLP", () => {
   });
 
   describe("Insurance Balance Calculations", () => {
-    it("should read insurance balance from engine state", async () => {
-      mockConnection.getAccountInfo.mockResolvedValue(null); // No mint yet
+    it("should return 0 for insurance balance when LP mint does not exist (no mint = uninitialized)", async () => {
+      // When mintExists=false the on-chain balance field may be garbage (u64::MAX).
+      // The hook must clamp it to 0 so the UI shows the correct pool size.
+      mockConnection.getAccountInfo.mockResolvedValue(null); // No mint
 
       const { result } = renderHook(() => useInsuranceLP());
 
       await waitFor(() => {
-        expect(result.current.state.insuranceBalance).toBe(1000000n);
+        expect(result.current.state.insuranceBalance).toBe(0n);
+      });
+    });
+
+    it("should read insurance balance from engine state when LP mint exists", async () => {
+      // Balance is trusted only when the LP mint is live
+      mockConnection.getAccountInfo.mockResolvedValue({
+        data: Buffer.alloc(82),
+        executable: false,
+        lamports: 1_000_000,
+        owner: new PublicKey("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"),
+      });
+      (unpackMint as any).mockReturnValue({ supply: 0n, decimals: 6, isInitialized: true });
+
+      const { result } = renderHook(() => useInsuranceLP());
+
+      await waitFor(() => {
+        expect(result.current.state.insuranceBalance).toBe(1_000_000n);
+      });
+    });
+
+    it("should clamp u64::MAX uninitialized balance to 0 (GH#1278)", async () => {
+      // Simulates the TEST/USD bug: on-chain field is uninitialised → u64::MAX
+      const U64_MAX = 18_446_744_073_709_551_615n;
+      mockSlabState.engine.insuranceFund.balance = U64_MAX - 65n; // ~u64::MAX as observed
+      mockConnection.getAccountInfo.mockResolvedValue(null); // No LP mint
+
+      const { result } = renderHook(() => useInsuranceLP());
+
+      await waitFor(() => {
+        expect(result.current.state.insuranceBalance).toBe(0n);
+        expect(result.current.state.mintExists).toBe(false);
       });
     });
 
@@ -247,10 +281,16 @@ describe("useInsuranceLP", () => {
       });
     });
 
-    it("should handle large insurance balances without overflow", async () => {
-      const largeBalance = 1_000_000_000_000n; // 1 million SOL
+    it("should handle large insurance balances without overflow when mint exists", async () => {
+      const largeBalance = 1_000_000_000_000n; // 1 million SOL equivalent
       mockSlabState.engine.insuranceFund.balance = largeBalance;
-      mockConnection.getAccountInfo.mockResolvedValue(null);
+      mockConnection.getAccountInfo.mockResolvedValue({
+        data: Buffer.alloc(82),
+        executable: false,
+        lamports: 1_000_000,
+        owner: new PublicKey("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"),
+      });
+      (unpackMint as any).mockReturnValue({ supply: 0n, decimals: 6, isInitialized: true });
 
       const { result } = renderHook(() => useInsuranceLP());
 

--- a/app/hooks/useInsuranceLP.ts
+++ b/app/hooks/useInsuranceLP.ts
@@ -92,12 +92,17 @@ export function useInsuranceLP() {
     if (!slabState || !lpMintInfo || !connection) return;
 
     try {
-      // Get insurance balance from engine state
-      const insuranceBalance = slabState.engine?.insuranceFund?.balance ?? 0n;
-
-      // Check if LP mint exists on-chain
+      // Check if LP mint exists on-chain first — needed to sanitize insuranceBalance
       const mintInfo = await connection.getAccountInfo(lpMintInfo.mintPda);
       const mintExists = mintInfo !== null && mintInfo.data.length > 0;
+
+      // Get insurance balance from engine state.
+      // Guard: Solana uninitialised u64 fields read as u64::MAX (2^64-1).
+      // Only trust the value when the LP mint is live; otherwise clamp to 0.
+      const U64_MAX = 18_446_744_073_709_551_615n;
+      const rawBalance = slabState.engine?.insuranceFund?.balance ?? 0n;
+      const insuranceBalance =
+        mintExists && rawBalance <= U64_MAX / 2n ? rawBalance : 0n;
 
       let lpSupply = 0n;
       let userLpBalance = 0n;


### PR DESCRIPTION
## Problem
TEST/USD Risk tab → Insurance Pool → **Pool Size** showed `18,446,744,073,709,550 TEST` (~u64::MAX).

The on-chain `insuranceFund.balance` field is **uninitialised** for markets that have never had an LP mint created. Solana initialises unset u64 fields to `u64::MAX`.

## Root Cause
`refreshState()` in `useInsuranceLP.ts` read `engine.insuranceFund.balance` **before** checking whether the LP mint exists, so the garbage value flowed straight into the display.

## Fix
1. **Reorder**: move the `mintInfo / mintExists` check before the balance read.
2. **Guard**: only trust `rawBalance` when `mintExists && rawBalance <= u64::MAX / 2`; otherwise clamp to `0n`.

No UI changes needed — the component already renders correctly when `insuranceBalance = 0n`.

## Tests
- Adds regression test: *"should clamp u64::MAX uninitialized balance to 0 (GH#1278)"*
- Updates 3 existing tests that expected `insuranceBalance > 0` with `mintExists = false` (incorrect expectation)
- All 1014 tests pass

## Severity
Low (display only, no financial risk — LP Supply was already showing 0 correctly)

Fixes #1278

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved insurance LP balance calculation to handle uninitialized mint states. The balance now correctly clamps to zero when the LP mint does not exist, preventing potential errors from reading uninitialized on-chain values.

* **Tests**
  * Expanded test coverage for edge cases, including uninitialized LP mint scenarios and large balance handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->