### PR TITLE
fix: CSP lite.jup.ag (P0) + resume mode wizard (P1) — PERC-1217/1219

### DIFF
--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -107,7 +107,27 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
     }
     return { ...DEFAULT_STATE, mintAddress: initialMint ?? "" };
   });
-  const [completedSteps, setCompletedSteps] = useState<Set<number>>(new Set());
+  // GH#1280: Restore completedSteps based on the persisted wizard step.
+  // If the previous session reached step N, steps 1..N-1 were completed.
+  // This ensures WizardProgress shows correct state after a reload and allows
+  // the user to click back to previous steps during resume.
+  const [completedSteps, setCompletedSteps] = useState<Set<number>>(() => {
+    try {
+      const persisted = typeof window !== "undefined" ? localStorage.getItem(WIZARD_STORAGE_KEY) : null;
+      if (persisted) {
+        const parsed = JSON.parse(persisted);
+        const step = Number(parsed.step ?? 1);
+        if (step > 1) {
+          const steps = new Set<number>();
+          for (let i = 1; i < step; i++) steps.add(i);
+          return steps;
+        }
+      }
+    } catch {
+      // Corrupted data — ignore
+    }
+    return new Set<number>();
+  });
   /**
    * PERC-513: Track which step to resume from when recovering a stuck slab.
    * Set by onResume from RecoverSolBanner; null = fresh creation (step 0).
@@ -135,7 +155,21 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
   const quickLaunch = useQuickLaunch(quickMintForHook);
 
   // On-chain mint network validation (set by StepTokenSelect)
-  const [mintExistsOnNetwork, setMintExistsOnNetwork] = useState(false);
+  // GH#1280: Initialize to true when restoring from localStorage with a valid tokenMeta.
+  // The token was already validated in the previous session — re-validating is unnecessary
+  // and would block Step 4 Review during resume since StepTokenSelect hasn't rendered.
+  const [mintExistsOnNetwork, setMintExistsOnNetwork] = useState<boolean>(() => {
+    try {
+      const persisted = typeof window !== "undefined" ? localStorage.getItem(WIZARD_STORAGE_KEY) : null;
+      if (persisted) {
+        const parsed = JSON.parse(persisted);
+        return !!(parsed.tokenMeta && parsed.mintAddress && (parsed.mintAddress as string).length >= 32);
+      }
+    } catch {
+      // Corrupted data — ignore
+    }
+    return false;
+  });
   // Devnet mirror mint address (different from mainnet CA entered by user)
   const [devnetMintAddress, setDevnetMintAddress] = useState<string | null>(null);
 

--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -328,7 +328,9 @@ function addSecurityHeaders(response: NextResponse, nonce?: string) {
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "font-src 'self' https://fonts.gstatic.com",
     "img-src 'self' data: https: blob:",
-    "connect-src 'self' https://*.solana.com wss://*.solana.com https://*.supabase.co wss://*.supabase.co https://*.vercel-insights.com https://api.coingecko.com https://api.geckoterminal.com https://*.helius-rpc.com wss://*.helius-rpc.com https://api.dexscreener.com https://hermes.pyth.network https://*.up.railway.app wss://*.up.railway.app https://token.jup.ag https://tokens.jup.ag https://auth.privy.io https://embedded-wallets.privy.io https://*.privy.systems https://*.rpc.privy.systems https://explorer-api.walletconnect.com wss://relay.walletconnect.com wss://relay.walletconnect.org wss://www.walletlink.org blob:",
+    // GH#1283: Added https://lite.jup.ag — used by useCreateMarket to fetch token price
+    // via /v6/price endpoint for HYPERP/Pump.fun oracle markets during deposit flow.
+    "connect-src 'self' https://*.solana.com wss://*.solana.com https://*.supabase.co wss://*.supabase.co https://*.vercel-insights.com https://api.coingecko.com https://api.geckoterminal.com https://*.helius-rpc.com wss://*.helius-rpc.com https://api.dexscreener.com https://hermes.pyth.network https://*.up.railway.app wss://*.up.railway.app https://lite.jup.ag https://token.jup.ag https://tokens.jup.ag https://auth.privy.io https://embedded-wallets.privy.io https://*.privy.systems https://*.rpc.privy.systems https://explorer-api.walletconnect.com wss://relay.walletconnect.com wss://relay.walletconnect.org wss://www.walletlink.org blob:",
     // Removed https://*.vercel.app wildcard (issue #635) — no legitimate use case for embedding
     // arbitrary Vercel-hosted content in iframes. frame-src controls outbound iframe embedding.
     "frame-src 'self' https://auth.privy.io https://embedded-wallets.privy.io https://*.privy.systems https://phantom.app https://solflare.com https://verify.walletconnect.com https://verify.walletconnect.org",


### PR DESCRIPTION
## Summary

### PERC-1217 (P0) — GH#1283: CSP blocks lite.jup.ag

**Root cause:** `useCreateMarket` fetches token price from `lite.jup.ag/v6/price` for HYPERP/Pump.fun oracle markets during deposit flow. The domain was absent from CSP `connect-src`, so the fetch failed silently → deposit tx builder received `undefined` price → Privy never called.

**Fix:** Add `https://lite.jup.ag` to `connect-src` in `middleware.ts addSecurityHeaders()`.

### PERC-1218 (P1) — GH#1281: Already fixed

The 'Get Test Tokens' button validation (`isValidBase58Pubkey` guard) was already shipped in `efa0ee87` (GH#1139). Closed GH#1281 as duplicate.

### PERC-1219 (P1) — GH#1280: Resume mode blocked

**Root cause:** After page reload, wizard state is restored from localStorage, but two pieces of React state were NOT restored:
1. `completedSteps` (Set<number>) — always started as empty, so WizardProgress showed all steps as "Upcoming"
2. `mintExistsOnNetwork` — always started as `false`, so `step1Valid=false` → Review step showed "⚠️ Mint not found on devnet" and disabled Launch

**Fix:** Lazy-initialize both from persisted localStorage state:
- `completedSteps`: infer from stored `wizard.step` (if step=4, mark 1/2/3 as done)
- `mintExistsOnNetwork`: true when `tokenMeta + mintAddress` exist in persisted state (token was already validated on-chain in the previous session — no re-check needed)

## Testing
- `pnpm tsc --noEmit` ✅ (no type errors)
- `pnpm vitest run` ✅ (1018 passed, 34 skipped — same as baseline)

## Issues Closed
- Fixes GH#1283
- Fixes GH#1280
- Closes GH#1281 (duplicate of #1139)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed wizard progress not persisting across sessions.

* **Improvements**
  * Enhanced network detection for mints using cached session data.
  * Updated security policies to support token price fetching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->