### PR TITLE
fix(oi): PERC-817 — widen phantom OI guard to vault ≤ 1M (inclusive boundary)

### DIFF
--- a/packages/indexer/src/services/StatsCollector.ts
+++ b/packages/indexer/src/services/StatsCollector.ts
@@ -411,14 +411,17 @@ export class StatsCollector {
               oiShort = oiLong;
             }
 
-            // PERC-816: Dust vault guard — enforce the invariant that OI must be 0
+            // PERC-816/817: Dust vault guard — enforce the invariant that OI must be 0
             // when the vault has no meaningful liquidity. This prevents phantom OI from
             // being re-written by the indexer for markets that were created but never
             // received real LP deposits (e.g. creation-deposit splits leave dust in vault).
-            // Threshold: 1,000,000 micro-units (< 1 USDC at 6 decimals, dust at 9 decimals).
+            // Threshold: 1,000,000 micro-units (≤ 1 USDC at 6 decimals, dust at 9 decimals).
+            // Uses inclusive (<=) to catch vault == 1_000_000 — the exact creation-deposit
+            // seed amount the program writes at market creation. A market with vault at
+            // the creation boundary has received no real LP deposits.
             // Also enforces: total_accounts = 0 → OI must be 0 (no open positions).
             const MIN_VAULT_FOR_OI = 1_000_000n;
-            const hasDustVault = engine.vault > 0n && engine.vault < MIN_VAULT_FOR_OI;
+            const hasDustVault = engine.vault <= MIN_VAULT_FOR_OI;
             const hasNoAccounts = engine.numUsedAccounts === 0;
             if (hasDustVault || hasNoAccounts) {
               oiLong = 0n;

--- a/supabase/migrations/050_zero_creation_deposit_oi.sql
+++ b/supabase/migrations/050_zero_creation_deposit_oi.sql
@@ -1,0 +1,45 @@
+-- Migration 050: Zero phantom OI for markets at the creation-deposit boundary — PERC-817
+--
+-- Context: Migrations 047–049 left 39 markets with phantom OI. Root cause:
+--
+--   1. vault_balance = 1,000,000 (creation-deposit seeded markets):
+--      Migration 049 used vault_balance < 1,000,000 (strictly less than), missing
+--      markets whose vault is exactly 1,000,000 — the amount the program seeds into
+--      the vault at market creation (PERC-623: 70/30 keeper/vault split).
+--      These markets received no real LP deposits: vault == 1,000,000 = creation dust.
+--      Having OI (up to 2,660,054,000,000 atoms) with only a creation-deposit vault
+--      is physically impossible via the on-chain program; this is parsed phantom data
+--      from wrong slab layout reads during early indexer versions.
+--
+--   2. vault_balance = 0 with OI surviving migration 048:
+--      Four markets (LOBSTAR, WCLD, JOS, BTC) have vault=0, accounts=0 but still
+--      show non-zero OI. These slabs are no longer discovered by the indexer so
+--      StatsCollector never runs its per-tick guard, and the DB rows retain stale
+--      values from before migrations 047–048 zeroed the bulk.
+--
+-- Fix: widen the dust threshold to vault_balance <= 1,000,000 (inclusive).
+-- 39 rows are affected. The StatsCollector guard is updated in the same commit
+-- to enforce `engine.vault <= MIN_VAULT_FOR_OI` on future writes.
+
+DO $$
+DECLARE
+  MIN_VAULT_INCLUSIVE CONSTANT NUMERIC := 1000000;  -- creation-deposit boundary (inclusive)
+  rows_updated INT;
+BEGIN
+  UPDATE market_stats
+  SET
+    open_interest_long  = 0,
+    open_interest_short = 0,
+    total_open_interest = 0
+  WHERE total_open_interest > 0
+    AND vault_balance <= MIN_VAULT_INCLUSIVE;
+
+  GET DIAGNOSTICS rows_updated = ROW_COUNT;
+  RAISE NOTICE 'Migration 050: zeroed phantom OI for % market_stats rows (vault <= %)', rows_updated, MIN_VAULT_INCLUSIVE;
+END $$;
+
+-- Sanity check: should return 0 rows after apply
+-- SELECT slab_address, vault_balance, total_accounts, total_open_interest
+-- FROM market_stats
+-- WHERE total_open_interest > 0
+--   AND vault_balance <= 1000000;


### PR DESCRIPTION
## Problem
39 markets retained phantom OI after migrations 047–049:

**Root cause 1 — vault = 1,000,000 (creation-deposit boundary)**
Migration 049 used `vault_balance < 1,000,000` (strict). The on-chain program seeds exactly 1,000,000 micro-units into vault at market creation (PERC-623). Markets that received no real LP deposits have vault = exactly 1,000,000, which was missed by the strict predicate.

**Root cause 2 — vault = 0 still showing OI**
LOBSTAR, WCLD, JOS, BTC: vault=0 in DB but indexer keeps writing back OI. Old guard: `engine.vault > 0n && engine.vault < MIN_VAULT_FOR_OI` — the `> 0n` condition causes vault=0 to skip the dust check entirely. If on-chain `numUsedAccounts > 0` (stale counter), `hasNoAccounts = false` and OI is written back. Confirmed by `updated_at` timestamps showing writes 2-6s after migration 050 applied.

## Fix

### Migration 050 (already applied to prod)
- Zeros OI for all `vault_balance <= 1,000,000` rows
- 39 rows zeroed

### StatsCollector guard (this PR)
Change `hasDustVault` from:
```ts
const hasDustVault = engine.vault > 0n && engine.vault < MIN_VAULT_FOR_OI;
```
to:
```ts
const hasDustVault = engine.vault <= MIN_VAULT_FOR_OI;
```

This ensures vault=0 AND vault=1,000,000 both zero OI on future indexer writes.

## Testing
- Migration 050 already applied: 39 rows zeroed
- TypeScript: no new errors (pre-existing StatsCollector.ts:344 unrelated)
- WCLD (Dk5YUN7X) and BTC (AB3ZN1vx): confirmed OI=0 after migration
- LOBSTAR (FCusfsg4) and JOS (BgdMZb6o): still re-populated by live indexer — will be fixed once this PR is deployed

## Verification query
```sql
SELECT slab_address, vault_balance, total_accounts, total_open_interest
FROM market_stats
WHERE total_open_interest > 0 AND vault_balance <= 1000000;
-- Should return 0 rows after indexer redeploy
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Open Interest calculation logic to properly reset positions for markets at or below the creation-deposit threshold. Applied retroactive fix to 39 affected markets to ensure accurate position data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->