### PR TITLE
fix(ux): GH-1293 — remove devnet mint prefill from Create Market button

### DIFF
--- a/app/app/devnet-mint/devnet-mint-content.tsx
+++ b/app/app/devnet-mint/devnet-mint-content.tsx
@@ -732,8 +732,14 @@ const DevnetMintContent: FC = () => {
                 </button>
               </div>
 
-              <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
-                <Link href={`/create?mint=${mintAddress}`} className={`${btnPrimary} text-center`}>
+              <p className="mt-4 text-xs text-[var(--text-muted)]">
+                This is a <span className="text-[var(--accent)]">devnet-only</span> token. Market creation requires a{" "}
+                <span className="text-white">mainnet</span> token CA — paste it directly on the{" "}
+                <Link href="/create" className="underline hover:text-[var(--accent)]">Create Market</Link> page.
+              </p>
+
+              <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+                <Link href="/create" className={`${btnPrimary} text-center`}>
                   Create Market →
                 </Link>
                 <a href={`https://explorer.solana.com/address/${mintAddress}?cluster=devnet`} target="_blank" rel="noopener noreferrer" className="text-xs text-[var(--text-muted)] hover:text-[var(--accent)] underline">


### PR DESCRIPTION
## Summary
The 'Create Market' button on the Token Factory success screen (/devnet-mint) was navigating to /create?mint=<devnetMint>. The /create wizard expects a mainnet token CA, so this immediately surfaced a 'Failed to mirror mainnet token' error and disabled the CONTINUE button.

## Changes
- Removed ?mint=${mintAddress} prefill from the button href — now links to /create cleanly
- Added inline note explaining this is a devnet-only token and market creation requires a mainnet CA

## How to Test
1. Go to /devnet-mint, create a token
2. On success screen: note reads 'This is a devnet-only token. Market creation requires a mainnet token CA...'
3. Click 'Create Market' — lands on /create with empty input (no error)

## Type Checks
pnpm tsc --noEmit — clean

Closes #1293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced devnet token creation flow with informational guidance explaining mainnet requirements for market creation
  * Restructured action layout with separate buttons for creating markets and exploring devnet tokens
  * Added logo upload and token creation reset functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->