### PR TITLE
fix(devnet-mm): expand KNOWN_FEEDS — add BONK/WIF/JUP/RAY/JTO/PYTH/RNDR (PERC-806)

### DIFF
--- a/bots/devnet-mm/src/market.ts
+++ b/bots/devnet-mm/src/market.ts
@@ -106,9 +106,25 @@ export interface TradeResult {
 // ═══════════════════════════════════════════════════════════════
 
 const KNOWN_FEEDS: Record<string, string> = {
+  // ── Core assets ─────────────────────────────────────────────────────────────
   ef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d: "SOL",
   e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43: "BTC",
   ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace: "ETH",
+  // ── Solana ecosystem (devnet markets observed on-chain) ──────────────────────
+  // BONK/USD — feed seen on devnet slabs (7xozYEbK, 8pKtAV3z)
+  "72b021217ca3fe68922a19aaf990109cb9d84e9ad004b4d2025ad6f529314419": "BONK",
+  // WIF/USD
+  "4ca4beeca86f0d164160323817a4e42b10010a724c2217c6ee41b54cd4cc61fc": "WIF",
+  // JUP/USD
+  "0a0408d619e9380abad35060f9192039ed5042fa6f82301d0e48bb52be830996": "JUP",
+  // RAY/USD
+  "91568baa8beb53db23eb3fb7f22c6e8bd303d103919e19733f2bb642d3e7987a": "RAY",
+  // JTO/USD
+  b43660a5f790c69354b0729a5ef9d50d68f1df92107540210b9cccba1f947cc2: "JTO",
+  // PYTH/USD
+  "0bbf28e9a841a1cc788f6a361b17ca072d0ea3098a1e5df1c3922d06719579ff": "PYTH",
+  // RNDR/USD
+  "3d4a2bd9535be6ce8059d75eadeba507b043257321aa544717c56fa19b49e35d": "RNDR",
 };
 
 /**


### PR DESCRIPTION
## Summary

**PERC-806 root cause:** `inferSymbol()` in `market.ts` resolved Pyth-mode devnet markets as UNKNOWN because `KNOWN_FEEDS` only contained SOL/BTC/ETH.

On devnet, 2 slabs use the **BONK/USD** Pyth feed (`72b021...`). More Solana ecosystem markets may be created by users.

## Change
Syncs `KNOWN_FEEDS` with the full set of symbols already supported by `prices.ts` (Binance + CoinGecko + Pyth Hermes fallback):
- BONK → `72b021...` (confirmed from devnet slab scan)
- WIF, JUP, RAY, JTO, PYTH, RNDR (from `PYTH_FEED_IDS` in `prices.ts`)

## Remaining devops action needed (not a code change)
For **55 HYPERP (admin-oracle) markets** with zero oracle price on cold start, set:
```
MARKET_SYMBOL_OVERRIDES=7eubYRwJiQdJgXsw1VdaNQ7YHvHbgChe7wbPNQw74S23:BTC,CkcwQtUuPe1MjeVhyMR2zZcLsKEzP2cqGzspwmgTuZRp:BTC,AB3ZN1vxbBEh8FZRfrL55QQUUaLCwawqvCYzTDpgbuLF:BTC,H5Vunzd2yAMygnpFiGUASDSx2s8P3bfPTzjCfrRsPeph:ETH,GGU89iQLmceyXRDK8vgAxVvdi9RJb9JsPhXZ2NoFSENV:SOL
BOT_MODE=all
```

HYPERP markets with prices already on-chain (BTC ~$71K, ETH ~$5K, SOL ~$148) will resolve via `inferSymbolFromPrice()` after the bot restarts. The overrides guarantee cold-start correctness.

## Testing
- No test changes needed (unit coverage of `inferSymbol` is covered by the existing constant lookup path)
- Devnet: restart devnet-mm after setting env vars, confirm markets resolve to BTC/ETH/SOL/BONK in logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded market feed support to include core assets (SOL, BTC, ETH) and additional Solana devnet markets (BONK, WIF, JUP, RAY, JTO, PYTH, RNDR), enabling trading across a broader range of supported market pairs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->