### PR TITLE
fix(PERC-806/807): skip UNKNOWN markets on cold start + document MARKET_SYMBOL_OVERRIDES for Railway

### DIFF
--- a/bots/devnet-mm/README.md
+++ b/bots/devnet-mm/README.md
@@ -111,7 +111,10 @@ TEST_USDC_MINT       = DvH13uxzTzo1xVFwkbJ6YASkZWs6bm3vFDH4xu7kUYTs
 BOT_MODE             = all
 HELIUS_API_KEY       = <your-helius-api-key>
 MARKETS_FILTER       = SOL,BTC
+MARKET_SYMBOL_OVERRIDES = GGU89iQLmceyXRDK8vgAxVvdi9RJb9JsPhXZ2NoFSENV:SOL,CkcwQtUuPe1MjeVhyMR2zZcLsKEzP2cqGzspwmgTuZRp:BTC
 ```
+
+> ℹ️ **`MARKET_SYMBOL_OVERRIDES`** pins specific slab addresses to symbols on cold start (before the oracle keeper has pushed the first price). Format: `<slabAddress>:<SYMBOL>,…`. The two addresses above are the canonical devnet SOL-PERP and BTC-PERP markets on the Small program. Without this, authority-oracle markets with `authorityPriceE6 = 0` resolve as UNKNOWN and are skipped.
 
 > ⚠️ **Do NOT add `MINT_AUTHORITY_KEYPAIR_JSON` to the Railway service.** It is only needed for the one-off `npx tsx src/fund-devnet-bots.ts` funding script run locally. Exposing it in a long-running service unnecessarily widens blast radius.
 
@@ -188,7 +191,8 @@ The maker creates the appearance of an active, liquid market:
 | `SKEW_MAX_MULTIPLIER` | `3.0` | Spread multiplier at max exposure |
 | `SPREAD_NOISE_BPS` | `4` | Random spread noise |
 | `SIZE_JITTER` | `0.25` | Size randomization factor |
-| `MARKETS_FILTER` | all | Comma-separated symbols (e.g. `SOL,BTC`) |
+| `MARKETS_FILTER` | all | Comma-separated symbols (e.g. `SOL,BTC`) — **required** for production |
+| `MARKET_SYMBOL_OVERRIDES` | — | `<slabAddr>:<SYMBOL>,...` pins authority-oracle markets on cold start |
 
 ## Monitoring
 

--- a/bots/devnet-mm/src/market.ts
+++ b/bots/devnet-mm/src/market.ts
@@ -390,9 +390,18 @@ export async function discoverAllMarkets(
 
   const filtered = discovered.filter((m) => {
     if (m.header.resolved || m.header.paused) return false;
+    const sym = inferSymbol(m);
     if (config.marketsFilter) {
-      const sym = inferSymbol(m);
       return config.marketsFilter.includes(sym);
+    }
+    // When no MARKETS_FILTER is set, still skip UNKNOWN markets to prevent
+    // LP/User setup failures on cold start (hyperp markets with price=0 resolve
+    // as UNKNOWN before the oracle keeper has pushed a price).
+    // Operators: set MARKET_SYMBOL_OVERRIDES=<slab>:BTC,<slab>:SOL to include
+    // specific authority-oracle markets on cold start.
+    if (sym === "UNKNOWN") {
+      log("discovery", `Skipping UNKNOWN market ${m.slabAddress.toBase58().slice(0, 16)}... — set MARKET_SYMBOL_OVERRIDES to include it`);
+      return false;
     }
     return true;
   });


### PR DESCRIPTION
## Problem

`devnet-mm` deployed on Railway fails with:
```
[setup] ❌ UNKNOWN: no LP account available / user not found after init
```

**Root cause**: Authority-oracle (hyperp) markets with `authorityPriceE6 = 0` on cold start resolve as UNKNOWN via `inferSymbol()`. Without `MARKETS_FILTER` set, ALL discovered markets (including UNKNOWN ones) reach `setupMarketAccounts`, which then fails LP/User init.

Also: `BOT_MODE=both` was set on Railway instead of `all`, so the trader fleet (PERC-807) wasn't running.

## Fix

### Code (`bots/devnet-mm/src/market.ts`)
`discoverAllMarkets()` now filters out UNKNOWN markets when no `marketsFilter` env is configured. Markets already known (price > $50 from previous oracle push) still pass through. Operators who need cold-start support set `MARKET_SYMBOL_OVERRIDES`.

### Docs (`bots/devnet-mm/README.md`)
Added `MARKET_SYMBOL_OVERRIDES` to Railway env vars block with the canonical devnet slab addresses:
- SOL-PERP: `GGU89iQLmceyXRDK8vgAxVvdi9RJb9JsPhXZ2NoFSENV` (~$148 on Small program)
- BTC-PERP: `CkcwQtUuPe1MjeVhyMR2zZcLsKEzP2cqGzspwmgTuZRp` (~$71k on Small program)

## Railway Env Vars to Set (DevOps action required)
```
BOT_MODE=all
MARKETS_FILTER=SOL,BTC
MARKET_SYMBOL_OVERRIDES=GGU89iQLmceyXRDK8vgAxVvdi9RJb9JsPhXZ2NoFSENV:SOL,CkcwQtUuPe1MjeVhyMR2zZcLsKEzP2cqGzspwmgTuZRp:BTC
```

## Testing
- 59/59 tests pass (`pnpm vitest run`)
- Slab addresses verified live on devnet (Helius RPC)

## Resolves
- PERC-806 (wallet keygen / smoke test blocked by UNKNOWN symbols)
- PERC-807 (trader fleet not running because BOT_MODE=both)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated production configuration guidance for market filtering requirements
  * Added MARKET_SYMBOL_OVERRIDES environment variable documentation with usage examples

* **Improvements**
  * Enhanced market discovery logic to better handle unknown market symbols during cold start with diagnostic logging suggestions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->