### PR TITLE
fix: GH#1298 auto-launch on wizard resume + GH#1297 phantom OI in /api/stats

### DIFF
--- a/app/app/api/stats/route.ts
+++ b/app/app/api/stats/route.ts
@@ -66,7 +66,8 @@ export async function GET(request: NextRequest) {
   const [statsRes, tradersRes] = await Promise.all([
     // GH#1218: include slab_address so we can filter blocked markets (same as /api/markets)
     // GH#1265: also fetch trade_count_24h so we can sum it directly (replaces buggy trades table count query)
-    supabase.from("markets_with_stats").select("slab_address, volume_24h, trade_count_24h, open_interest_long, open_interest_short, total_open_interest, last_price, decimals").limit(500),
+    // GH#1297: include vault_balance + total_accounts to apply phantom OI guard (consistent with /api/markets)
+    supabase.from("markets_with_stats").select("slab_address, volume_24h, trade_count_24h, open_interest_long, open_interest_short, total_open_interest, last_price, decimals, vault_balance, total_accounts").limit(500),
     supabase.from("trades").select("trader").limit(5000),
   ]);
 
@@ -108,8 +109,18 @@ export async function GET(request: NextRequest) {
     (sum, m) => sum + toUsd(m.volume_24h ?? 0, m),
     0
   );
+  // GH#1297: Phantom OI guard — mirrors /api/markets isPhantomOI logic.
+  // Markets with accounts_count=0 or vault<1M are stale/orphaned; their raw OI atoms
+  // are not backed by real positions. Without this filter, the $1 fallback (GH#1265)
+  // inflated /api/stats totalOpenInterest to $117K vs /api/markets sum of $64K.
+  const MIN_VAULT_FOR_OI_STATS = 1_000_000;
   const totalOpenInterest = activeData.reduce(
     (sum, m) => {
+      // GH#1297: Skip phantom markets (no accounts or dust/empty vault) — same guard as /api/markets
+      const accountsCount = (m as Record<string, unknown>).total_accounts as number ?? 0;
+      const vaultBal = (m as Record<string, unknown>).vault_balance as number ?? 0;
+      if (accountsCount === 0 || vaultBal < MIN_VAULT_FOR_OI_STATS) return sum;
+
       const rawOi = isSaneMarketValue(m.total_open_interest)
         ? m.total_open_interest!
         : (isSaneMarketValue((m.open_interest_long ?? 0) + (m.open_interest_short ?? 0))
@@ -120,10 +131,12 @@ export async function GET(request: NextRequest) {
       // (admin-mode markets not yet cranked), fall back to $1/token — correct for devnet
       // markets. Without this fallback, only price-cranked markets contributed to OI,
       // causing ~8.57× underreporting (only 3 out of 35+ OI-bearing markets had prices).
+      // GH#1297: The $1 fallback now only applies to non-phantom markets (vault+accounts
+      // guard above), keeping it safe for legitimate admin-oracle devnet markets.
       const d = Math.min(Math.max((m as Record<string, unknown>).decimals as number ?? 6, 0), 18);
       const p = (m.last_price != null && m.last_price > 0 && m.last_price <= MAX_SANE_PRICE_USD)
         ? m.last_price
-        : 1; // $1 fallback for markets without oracle price
+        : 1; // $1 fallback for non-phantom markets without oracle price
       const usd = (rawOi / 10 ** d) * p;
       return sum + (usd > MAX_PER_MARKET_USD ? 0 : usd);
     },

--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -86,10 +86,21 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
       const persisted = typeof window !== "undefined" ? localStorage.getItem(WIZARD_STORAGE_KEY) : null;
       if (persisted) {
         const parsed = JSON.parse(persisted);
+        // GH#1298: Don't restore directly to the Review page (step 4) — require the user to
+        // navigate there explicitly in the current session. Restoring to step 4 with all fields
+        // pre-populated (PERC-1219) leaves the LAUNCH MARKET button enabled on first render,
+        // risking accidental market creation (0.46 SOL lost in QA). Clamp to the last
+        // navigable form step so the user must click CONTINUE once more before launching.
+        const restoredStep = Number(parsed.step ?? 1);
+        const safeStep: WizardStep = restoredStep >= 4
+          ? (parsed.mode === "quick" ? 2 : 3)
+          : restoredStep as WizardStep;
         // Restore serializable fields only — bigint and complex objects need special handling
         return {
           ...DEFAULT_STATE,
           ...parsed,
+          // GH#1298: Never restore to Review directly
+          step: safeStep,
           // bigint fields can't survive JSON — restore as bigint or null
           walletBalance: parsed.walletBalance != null ? BigInt(parsed.walletBalance) : null,
           // DexPoolResult is a plain object, survives JSON
@@ -111,15 +122,19 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
   // If the previous session reached step N, steps 1..N-1 were completed.
   // This ensures WizardProgress shows correct state after a reload and allows
   // the user to click back to previous steps during resume.
+  // GH#1298: Use safeStep (same clamping as wizard state above) so completedSteps
+  // doesn't mark step 3 as complete when we've rewound to step 2/3.
   const [completedSteps, setCompletedSteps] = useState<Set<number>>(() => {
     try {
       const persisted = typeof window !== "undefined" ? localStorage.getItem(WIZARD_STORAGE_KEY) : null;
       if (persisted) {
         const parsed = JSON.parse(persisted);
         const step = Number(parsed.step ?? 1);
-        if (step > 1) {
+        // GH#1298: Apply same safe-step clamping as wizard state above
+        const safeStep = step >= 4 ? (parsed.mode === "quick" ? 2 : 3) : step;
+        if (safeStep > 1) {
           const steps = new Set<number>();
-          for (let i = 1; i < step; i++) steps.add(i);
+          for (let i = 1; i < safeStep; i++) steps.add(i);
           return steps;
         }
       }


### PR DESCRIPTION
## Critical: GH#1298 — Wizard Resume Auto-Launches Market Without User Click

### Root Cause
PERC-1219 fixed resume mode by restoring `mintExistsOnNetwork=true` from localStorage. This unintentionally made `allValid=true` on page load when `wizard.step=4` was persisted — leaving the LAUNCH MARKET button **enabled on first render** before the user took any action in the current session.

**Impact**: QA lost 0.46 SOL from unintended market creation on devnet. On mainnet = real fund loss (0.4–7 SOL).

### Fix
Clamp the restored `wizard.step` to the last navigable form step:
- **Quick mode**: step 4 → restore to **step 2** (Slab Tier) — user must click CONTINUE
- **Manual mode**: step 4 → restore to **step 3** (Parameters) — user must click CONTINUE

The user must navigate to Review in the current session before LAUNCH MARKET is enabled. `mintExistsOnNetwork` restoration (PERC-1219) is preserved. `completedSteps` uses the same clamped step for consistency.

### Files Changed
- `app/components/create/CreateMarketWizard.tsx` — wizard + completedSteps state initializers

---

## Medium: GH#1297 — /api/stats totalOpenInterest inflated ($117K vs $64K)

### Root Cause
`/api/stats` lacked the phantom OI guard present in `/api/markets`. The GH#1265 $1 fallback for admin-oracle markets applied to 200+ phantom markets (zero accounts, empty vault) that have stale raw OI atoms. Result: $52K of phantom OI in `totalOpenInterest` despite migrations 047–051 zeroing the DB fields.

### Fix
Add `vault_balance` + `total_accounts` to the stats query and apply the same `isPhantomOI` guard (`accountsCount === 0 || vaultBal < 1_000_000`). The $1 fallback is preserved for legitimate non-phantom admin-oracle markets.

### Files Changed
- `app/app/api/stats/route.ts` — query + OI reducer

---

## Test Results
All 74 tests pass. TypeScript: clean.

Closes GH#1298, GH#1297

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed market statistics calculations to exclude invalid markets from inflating open interest data.
  * Improved the market creation wizard to prevent users from resuming at invalid steps and ensure proper progress tracking when reloading saved sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->