### PR TITLE
fix(GH-1300,GH-1301): phantom OI boundary and wizard token balance validation

### DIFF
--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -180,7 +180,7 @@ export async function GET() {
       // and migration 051. Suppressing only total_open_interest_usd left the raw
       // total_open_interest atom value in the response, which fed phantom OI into
       // computeMarketHealthFromStats and the markets page sort/filter.
-      const isPhantomOI = accountsCount === 0 || vaultBal < MIN_VAULT_FOR_OI;
+      const isPhantomOI = accountsCount === 0 || vaultBal <= MIN_VAULT_FOR_OI;
       const displayOiUsd = isPhantomOI ? null : total_open_interest_usd;
 
       // GH#1270: Pre-compute volume_24h in USD so consumers (e.g. Watchlist) don't need

--- a/app/app/api/stats/route.ts
+++ b/app/app/api/stats/route.ts
@@ -119,7 +119,7 @@ export async function GET(request: NextRequest) {
       // GH#1297: Skip phantom markets (no accounts or dust/empty vault) — same guard as /api/markets
       const accountsCount = (m as Record<string, unknown>).total_accounts as number ?? 0;
       const vaultBal = (m as Record<string, unknown>).vault_balance as number ?? 0;
-      if (accountsCount === 0 || vaultBal < MIN_VAULT_FOR_OI_STATS) return sum;
+      if (accountsCount === 0 || vaultBal <= MIN_VAULT_FOR_OI_STATS) return sum;
 
       const rawOi = isSaneMarketValue(m.total_open_interest)
         ? m.total_open_interest!

--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -254,7 +254,19 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
   // (devnetMintAddress differs from the user's input = mirror flow ran).
   // False for custom tokens entered directly (user = mint authority; no auto-airdrop).
   const isPercolatorMirror = devnetMintAddress !== null && devnetMintAddress !== wizard.mintAddress;
-  const allValid = step1Valid && step2Valid && step3Valid && (isDevnet || (hasTokens && hasSufficientTokensForSeed)) && hasSufficientSol;
+  // GH#1301: Only skip token balance check for Percolator mirror mints (which get auto-airdropped).
+  // Non-mirror tokens (e.g. SOL, custom mints) need real balance validation even on devnet.
+  const skipTokenBalanceCheck = isDevnet && isPercolatorMirror;
+  // GH#1301: Compute total tokens required (LP collateral + insurance) for balance validation
+  const totalTokensRequired = useMemo(() => {
+    const lp = parseFloat(wizard.lpCollateral || "0");
+    const ins = parseFloat(wizard.insuranceAmount || "0");
+    return lp + ins;
+  }, [wizard.lpCollateral, wizard.insuranceAmount]);
+  const hasSufficientTokensForLaunch = wizard.walletBalance !== null
+    ? Number(wizard.walletBalance) / Math.pow(10, decimals) >= totalTokensRequired
+    : false;
+  const allValid = step1Valid && step2Valid && step3Valid && (skipTokenBalanceCheck || (hasTokens && hasSufficientTokensForSeed && hasSufficientTokensForLaunch)) && hasSufficientSol;
 
   // Quick Launch auto-advance: step 1 → step 2 when token is resolved and params ready
   const quickAutoAdvancedRef = useRef(false);
@@ -837,6 +849,9 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
             requiredSol={requiredSol}
             hasTokens={hasTokens}
             hasSufficientTokensForSeed={hasSufficientTokensForSeed}
+            hasSufficientTokensForLaunch={hasSufficientTokensForLaunch}
+            totalTokensRequired={totalTokensRequired}
+            skipTokenBalanceCheck={skipTokenBalanceCheck}
             feeConflict={feeConflict}
             isPercolatorMirror={isPercolatorMirror}
             onBack={goBack}

--- a/app/components/create/StepReview.tsx
+++ b/app/components/create/StepReview.tsx
@@ -31,6 +31,12 @@ interface StepReviewProps {
   requiredSol?: number;
   hasTokens: boolean;
   hasSufficientTokensForSeed: boolean;
+  /** GH#1301: Whether wallet has enough tokens for LP collateral + insurance */
+  hasSufficientTokensForLaunch?: boolean;
+  /** GH#1301: Total tokens needed (LP + insurance) */
+  totalTokensRequired?: number;
+  /** GH#1301: True when token balance check is skipped (devnet mirror mints) */
+  skipTokenBalanceCheck?: boolean;
   feeConflict: boolean;
   /**
    * GH#1117: True only when the token is a Percolator-managed devnet mirror
@@ -77,6 +83,9 @@ export const StepReview: FC<StepReviewProps> = ({
   requiredSol,
   hasTokens,
   hasSufficientTokensForSeed,
+  hasSufficientTokensForLaunch = true,
+  totalTokensRequired = 0,
+  skipTokenBalanceCheck = false,
   feeConflict,
   isPercolatorMirror = false,
   onBack,
@@ -99,13 +108,17 @@ export const StepReview: FC<StepReviewProps> = ({
     if (!walletConnected) return "Connect Wallet to Launch";
     if (!mintValid) return "❌ Invalid Mint Address";
     if (!mintExistsOnNetwork) return "❌ Mint Not Found on Network";
-    if (!isDevnet && !hasTokens) return "No Tokens — Mint First";
-    if (!isDevnet && !hasSufficientTokensForSeed) return "Insufficient Tokens for Vault Seed (500)";
+    if (!skipTokenBalanceCheck && !hasTokens) return "No Tokens — Mint First";
+    if (!skipTokenBalanceCheck && !hasSufficientTokensForSeed) return "Insufficient Tokens for Vault Seed (500)";
+    // GH#1301: Check total token balance (LP collateral + insurance) unless auto-airdropped
+    if (!skipTokenBalanceCheck && !hasSufficientTokensForLaunch) {
+      return `Insufficient Balance — Need ${totalTokensRequired.toLocaleString(undefined, { maximumFractionDigits: 2 })} Tokens`;
+    }
     if (feeConflict) return "Fix Parameters to Continue";
     if (!hasSufficientBalance) return "Insufficient SOL";
     if (isDevnet) return isPercolatorMirror ? "LAUNCH & MINT TOKENS →" : "LAUNCH MARKET →";
     return "LAUNCH MARKET →";
-  }, [walletConnected, mintValid, mintExistsOnNetwork, hasTokens, hasSufficientTokensForSeed, feeConflict, hasSufficientBalance, isDevnet, isPercolatorMirror]);
+  }, [walletConnected, mintValid, mintExistsOnNetwork, hasTokens, hasSufficientTokensForSeed, hasSufficientTokensForLaunch, totalTokensRequired, skipTokenBalanceCheck, feeConflict, hasSufficientBalance, isDevnet, isPercolatorMirror]);
 
   return (
     <div className="space-y-5">
@@ -123,6 +136,13 @@ export const StepReview: FC<StepReviewProps> = ({
       {mintValid && mintExistsOnNetwork && (
         <div className="p-3 bg-green-500/20 border border-green-500 rounded text-green-500 text-sm">
           ✅ Mint verified on {getNetwork() === "devnet" ? "devnet" : "mainnet"}
+        </div>
+      )}
+
+      {/* GH#1301: Insufficient token balance warning */}
+      {!skipTokenBalanceCheck && !hasSufficientTokensForLaunch && walletConnected && (
+        <div className="p-3 bg-red-500/20 border border-red-500 rounded text-red-400 text-sm">
+          ⚠️ Insufficient balance: you need <strong>{totalTokensRequired.toLocaleString(undefined, { maximumFractionDigits: 2 })}</strong> {tokenSymbol} (LP + Insurance) but your wallet balance is too low.
         </div>
       )}
 


### PR DESCRIPTION
## Changes

### GH-1300: Phantom OI boundary fix
- `/api/stats` and `/api/markets` used `vault_balance < 1_000_000` (exclusive), allowing markets with vault_balance exactly at 1M micro-units (≈1 USDC) to pass through and inflate totalOpenInterest
- Changed to `<=` to match the indexer StatsCollector which already used inclusive comparison
- Closes the $42,909 phantom OI delta between `/api/stats` and `/api/markets`

### GH-1301: Wizard balance validation at review step
- Previously ALL token balance checks were skipped on devnet — but non-mirror mints (e.g. SOL, custom tokens) don't get auto-airdropped
- Now only Percolator mirror mints skip the balance check (`skipTokenBalanceCheck`)
- Added total token requirement validation (LP collateral + insurance) against wallet balance
- Red warning banner shown when balance is insufficient
- Launch button disabled and shows descriptive text ("Insufficient Balance — Need X Tokens")

## Testing
- `tsc --noEmit` passes clean
- All 74 indexer tests pass
- Manual: markets with vault=1M excluded from OI sum; wizard shows warning when wallet < required tokens

Closes #1300
Closes #1301

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed vault balance threshold boundary condition handling to correctly identify and process markets where balance exactly equals the minimum required threshold

## New Features
- Enhanced market launch validation with improved token balance verification to ensure sufficient funds for LP collateral and insurance requirements
- Added insufficient balance warning notifications during the market creation review step to alert users of potential funding shortfalls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->