### PR TITLE
fix(stats+wizard): GH#1300 inclusive OI vault boundary + GH#1301 wizard balance guard (PERC-1221/1222)

### DIFF
--- a/app/__tests__/api/stats-phantom-oi-guard.test.ts
+++ b/app/__tests__/api/stats-phantom-oi-guard.test.ts
@@ -1,0 +1,81 @@
+/**
+ * GH#1300: /api/stats phantom OI vault boundary regression tests.
+ *
+ * PR#1299 fixed GH#1297 but used an exclusive boundary (vault_balance < 1_000_000)
+ * that let markets at vault=1_000_000 (creation-deposit only, no real LP) contribute
+ * phantom OI to the platform total. This PR tightens it to inclusive (<= 1_000_000).
+ *
+ * Coverage:
+ * - vault=0 → excluded (empty, no positions)
+ * - vault=1_000_000 → excluded (creation deposit only, boundary case)
+ * - vault=1_000_001 → included (real LP above threshold)
+ * - accounts=0 → excluded regardless of vault
+ */
+
+import { describe, it, expect } from "vitest";
+
+/** Mirrors the vault boundary constant and guard in app/app/api/stats/route.ts */
+const MIN_VAULT_FOR_OI_STATS = 1_000_000;
+
+function isPhantomMarket(vaultBal: number, accountsCount: number): boolean {
+  // GH#1300: inclusive boundary — vault <= 1_000_000 suppresses phantom OI
+  return accountsCount === 0 || vaultBal <= MIN_VAULT_FOR_OI_STATS;
+}
+
+function simulateOISum(
+  markets: Array<{ vault_balance: number; total_accounts: number; total_open_interest: number }>
+): number {
+  return markets.reduce((sum, m) => {
+    if (isPhantomMarket(m.vault_balance, m.total_accounts)) return sum;
+    return sum + m.total_open_interest;
+  }, 0);
+}
+
+describe("GH#1300: /api/stats phantom OI inclusive boundary", () => {
+  it("excludes markets with vault_balance=0 (empty vault)", () => {
+    const markets = [{ vault_balance: 0, total_accounts: 5, total_open_interest: 50_000 }];
+    expect(simulateOISum(markets)).toBe(0);
+  });
+
+  it("excludes markets with vault_balance=1_000_000 (creation-deposit only, boundary case — GH#1300)", () => {
+    // This was the regression in PR#1299: strict < 1M let vault=1M slip through
+    const markets = [{ vault_balance: 1_000_000, total_accounts: 3, total_open_interest: 42_909 }];
+    expect(simulateOISum(markets)).toBe(0);
+  });
+
+  it("includes markets with vault_balance=1_000_001 (real LP above threshold)", () => {
+    const markets = [{ vault_balance: 1_000_001, total_accounts: 5, total_open_interest: 64_614 }];
+    expect(simulateOISum(markets)).toBe(64_614);
+  });
+
+  it("excludes markets with accounts_count=0 regardless of vault", () => {
+    const markets = [{ vault_balance: 999_999_999, total_accounts: 0, total_open_interest: 100_000 }];
+    expect(simulateOISum(markets)).toBe(0);
+  });
+
+  it("correctly filters mixed set — only non-phantom markets contribute OI", () => {
+    const markets = [
+      // Phantom: vault=0
+      { vault_balance: 0, total_accounts: 2, total_open_interest: 10_000 },
+      // Phantom: vault=1M (boundary)
+      { vault_balance: 1_000_000, total_accounts: 5, total_open_interest: 42_909 },
+      // Phantom: no accounts
+      { vault_balance: 5_000_000, total_accounts: 0, total_open_interest: 20_000 },
+      // Real: vault > 1M with accounts
+      { vault_balance: 5_000_000, total_accounts: 3, total_open_interest: 64_614 },
+      { vault_balance: 2_000_000, total_accounts: 1, total_open_interest: 43_000 },
+    ];
+    // Only last two contribute
+    expect(simulateOISum(markets)).toBe(64_614 + 43_000);
+  });
+
+  it("reproduces GH#1300 scenario: totalOI=$107,523 → $64,614 after guard", () => {
+    // Before fix: vault=1M markets added $42,909 phantom OI → $107,523 total
+    // After fix: vault=1M excluded → $64,614 correct total
+    const markets = [
+      { vault_balance: 1_000_000, total_accounts: 5, total_open_interest: 42_909 }, // phantom
+      { vault_balance: 5_000_000, total_accounts: 10, total_open_interest: 64_614 }, // real
+    ];
+    expect(simulateOISum(markets)).toBe(64_614);
+  });
+});

--- a/app/__tests__/components/StepReview.test.tsx
+++ b/app/__tests__/components/StepReview.test.tsx
@@ -180,3 +180,82 @@ describe("StepReview — SOL balance display", () => {
     expect(screen.getByText(/need ~0\.4600 SOL/)).toBeDefined();
   });
 });
+
+/**
+ * GH#1301: Token balance check — the Launch button must be disabled when the wallet
+ * does not have enough tokens to cover the full market creation cost (seed + LP
+ * collateral + insurance), not just the MIN_INIT_MARKET_SEED (500 tokens).
+ *
+ * The devnet bypass (`isPercolatorMirror=true`) skips this check because tokens are
+ * auto-airdropped after creation. For non-mirror tokens (custom tokens, native SOL
+ * collateral), the check must remain active even on devnet.
+ */
+describe("StepReview — GH#1301: token balance checks (PERC-1222)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("disables Launch and shows 'Insufficient Tokens' for custom devnet token with low wallet balance", () => {
+    // devnet, NOT a Percolator mirror (e.g. SOL-PERP — user has 5 SOL, needs 1100 SOL tokens)
+    render(
+      <StepReview
+        {...baseProps}
+        isPercolatorMirror={false}
+        hasTokens={true}
+        hasSufficientTokensForSeed={false}
+        canLaunch={false}
+      />
+    );
+    const btn = screen.getByRole("button", { name: /Insufficient Tokens/i });
+    expect(btn).toBeDefined();
+    expect(btn.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("enables Launch for Percolator mirror token even when hasSufficientTokensForSeed=false (auto-airdrop)", () => {
+    // devnet, IS a Percolator mirror token — tokens will be airdropped after creation
+    render(
+      <StepReview
+        {...baseProps}
+        isPercolatorMirror={true}
+        hasTokens={false}
+        hasSufficientTokensForSeed={false}
+        canLaunch={true}          // CreateMarketWizard sets skipTokenBalanceCheck=true here
+      />
+    );
+    const btn = screen.getByRole("button", { name: /LAUNCH & MINT TOKENS/i });
+    expect(btn).toBeDefined();
+    expect(btn.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("disables Launch on mainnet when hasSufficientTokensForSeed=false", async () => {
+    const { getNetwork } = await import("@/lib/config");
+    (getNetwork as ReturnType<typeof vi.fn>).mockReturnValue("mainnet-beta");
+
+    render(
+      <StepReview
+        {...baseProps}
+        isPercolatorMirror={false}
+        hasTokens={true}
+        hasSufficientTokensForSeed={false}
+        canLaunch={false}
+      />
+    );
+    const btn = screen.getByRole("button", { name: /Insufficient Tokens/i });
+    expect(btn.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("enables Launch when both token and SOL balance are sufficient (happy path)", () => {
+    render(
+      <StepReview
+        {...baseProps}
+        isPercolatorMirror={false}
+        hasTokens={true}
+        hasSufficientTokensForSeed={true}
+        hasSufficientBalance={true}
+        canLaunch={true}
+      />
+    );
+    const btn = screen.getByRole("button", { name: /LAUNCH MARKET/i });
+    expect(btn.hasAttribute("disabled")).toBe(false);
+  });
+});

--- a/app/app/api/stats/route.ts
+++ b/app/app/api/stats/route.ts
@@ -119,7 +119,10 @@ export async function GET(request: NextRequest) {
       // GH#1297: Skip phantom markets (no accounts or dust/empty vault) — same guard as /api/markets
       const accountsCount = (m as Record<string, unknown>).total_accounts as number ?? 0;
       const vaultBal = (m as Record<string, unknown>).vault_balance as number ?? 0;
-      if (accountsCount === 0 || vaultBal < MIN_VAULT_FOR_OI_STATS) return sum;
+      // GH#1300: Use inclusive boundary (<= 1M) to match StatsCollector in percolator-indexer.
+      // PR#1299 used strict < 1M — markets at exactly vault=1_000_000 (creation-deposit only,
+      // vault=LP seed amount) slipped through and added phantom OI. Inclusive guard closes it.
+      if (accountsCount === 0 || vaultBal <= MIN_VAULT_FOR_OI_STATS) return sum;
 
       const rawOi = isSaneMarketValue(m.total_open_interest)
         ? m.total_open_interest!

--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -217,8 +217,16 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
   const maxLeverage = Math.floor(10000 / wizard.initialMarginBps);
   const feeConflict = wizard.tradingFeeBps >= wizard.initialMarginBps;
   const hasTokens = wizard.walletBalance !== null && wizard.walletBalance > 0n;
-  const hasSufficientTokensForSeed = wizard.walletBalance !== null && wizard.walletBalance >= MIN_INIT_MARKET_SEED;
   const decimals = wizard.tokenMeta?.decimals ?? 6;
+  // GH#1301: Check against the full token requirement (seed + LP collateral + insurance),
+  // not just MIN_INIT_MARKET_SEED (500 tokens). A user with 600 tokens but 1100 LP
+  // collateral entered would previously pass the check and reach a failed on-chain tx.
+  const totalTokensRequired = useMemo((): bigint => {
+    const lpRaw = parseHumanAmount(wizard.lpCollateral || "0", decimals);
+    const insRaw = parseHumanAmount(wizard.insuranceAmount, decimals);
+    return MIN_INIT_MARKET_SEED + lpRaw + insRaw;
+  }, [wizard.lpCollateral, wizard.insuranceAmount, decimals]);
+  const hasSufficientTokensForSeed = wizard.walletBalance !== null && wizard.walletBalance >= totalTokensRequired;
   const symbol = wizard.tokenMeta?.symbol ?? "Token";
 
   // Step validation
@@ -248,13 +256,18 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
     return slabRentSol + tokenAccountRentSol + TX_FEE_ESTIMATE_SOL;
   }, [wizard.slabTier]);
   const hasSufficientSol = solBalance !== null && solBalance >= requiredSol;
-  // On devnet, tokens are auto-airdropped after market creation — skip token balance checks
   const isDevnet = getNetwork() === "devnet";
   // GH#1117: True only when the selected token is a Percolator mirror mint
   // (devnetMintAddress differs from the user's input = mirror flow ran).
   // False for custom tokens entered directly (user = mint authority; no auto-airdrop).
   const isPercolatorMirror = devnetMintAddress !== null && devnetMintAddress !== wizard.mintAddress;
-  const allValid = step1Valid && step2Valid && step3Valid && (isDevnet || (hasTokens && hasSufficientTokensForSeed)) && hasSufficientSol;
+  // GH#1301: On devnet, tokens are auto-airdropped — but ONLY for Percolator-managed mirror mints.
+  // Custom tokens (user = mint authority) and native-SOL collateral markets (e.g., SOL-PERP with
+  // 1100 SOL LP collateral) cannot be auto-funded. Tightening the bypass from `isDevnet` to
+  // `isDevnet && isPercolatorMirror` prevents the Launch button from being enabled when the user
+  // has 5 SOL but entered 1100 SOL as LP collateral.
+  const skipTokenBalanceCheck = isDevnet && isPercolatorMirror;
+  const allValid = step1Valid && step2Valid && step3Valid && (skipTokenBalanceCheck || (hasTokens && hasSufficientTokensForSeed)) && hasSufficientSol;
 
   // Quick Launch auto-advance: step 1 → step 2 when token is resolved and params ready
   const quickAutoAdvancedRef = useRef(false);

--- a/app/components/create/StepReview.tsx
+++ b/app/components/create/StepReview.tsx
@@ -95,17 +95,23 @@ export const StepReview: FC<StepReviewProps> = ({
 
   const isDevnet = getNetwork() === "devnet";
 
+  // GH#1301: mirrors CreateMarketWizard skipTokenBalanceCheck logic.
+  // Token balance check is skipped only for Percolator-managed mirror mints on devnet
+  // (tokens auto-airdropped post-creation). Custom tokens and native-SOL collateral markets
+  // still require sufficient token balance.
+  const skipTokenBalanceCheck = isDevnet && isPercolatorMirror;
+
   const launchButtonLabel = useMemo(() => {
     if (!walletConnected) return "Connect Wallet to Launch";
     if (!mintValid) return "❌ Invalid Mint Address";
     if (!mintExistsOnNetwork) return "❌ Mint Not Found on Network";
-    if (!isDevnet && !hasTokens) return "No Tokens — Mint First";
-    if (!isDevnet && !hasSufficientTokensForSeed) return "Insufficient Tokens for Vault Seed (500)";
+    if (!skipTokenBalanceCheck && !hasTokens) return "No Tokens — Mint First";
+    if (!skipTokenBalanceCheck && !hasSufficientTokensForSeed) return "Insufficient Tokens — Check Wallet Balance";
     if (feeConflict) return "Fix Parameters to Continue";
     if (!hasSufficientBalance) return "Insufficient SOL";
     if (isDevnet) return isPercolatorMirror ? "LAUNCH & MINT TOKENS →" : "LAUNCH MARKET →";
     return "LAUNCH MARKET →";
-  }, [walletConnected, mintValid, mintExistsOnNetwork, hasTokens, hasSufficientTokensForSeed, feeConflict, hasSufficientBalance, isDevnet, isPercolatorMirror]);
+  }, [walletConnected, mintValid, mintExistsOnNetwork, hasTokens, hasSufficientTokensForSeed, feeConflict, hasSufficientBalance, isDevnet, isPercolatorMirror, skipTokenBalanceCheck]);
 
   return (
     <div className="space-y-5">


### PR DESCRIPTION
## Summary

Two P1 regression fixes. Both are S-effort, 1-commit, 1032/1032 tests passing.

---

### PERC-1221 — GH#1300: Phantom OI $42,909 delta still in `/api/stats` after PR#1299

**Root cause**: PR#1299 added the phantom OI guard to `/api/stats/route.ts` but used a strict boundary (`vaultBal < 1_000_000`). Markets at exactly `vault_balance = 1_000_000` (creation-deposit only, no real LP) slipped through and added $42,909 phantom OI ($107,523 vs $64,614 in `/api/markets`).

**Fix**: Changed to inclusive `<= 1_000_000` to match the `StatsCollector` in `percolator-indexer` (PR#1288 used `engine.vault <= MIN_VAULT_FOR_OI`).

### PERC-1222 — GH#1301: Wizard step 4 Launch button enabled with insufficient balance

**Root cause 1**: `hasSufficientTokensForSeed` checked `walletBalance >= MIN_INIT_MARKET_SEED` (500 tokens) instead of the full token requirement (seed + LP collateral + insurance). A user with 600 tokens but 1100 LP collateral set would pass and hit a failed on-chain tx.

**Root cause 2**: The devnet bypass (`isDevnet || ...`) skipped token balance checks entirely — including for native-SOL collateral markets (SOL-PERP with 1100 SOL LP collateral). You can't auto-airdrop 1100 SOL.

**Fix**: Compute `totalTokensRequired = MIN_INIT_MARKET_SEED + lpCollateralRaw + insuranceAmountRaw`. Tighten devnet bypass from `isDevnet` to `isDevnet && isPercolatorMirror` (only skip when Percolator can actually auto-airdrop). Update `StepReview` label to remove hardcoded `(500)`.

## Tests

+10 new unit tests:
- 6 OI boundary tests (vault=0, vault=1M, vault=1M+1, accounts=0, mixed set, GH#1300 exact repro)
- 4 StepReview balance tests (custom devnet token disabled, mirror token enabled, mainnet disabled, happy path)

**1032/1032 passing ✅ · tsc clean ✅**

## How to test

1. Create a SOL-PERP market on devnet with LP collateral = 1100, wallet balance = 5 SOL → Launch button should be disabled
2. Create a mainnet-mirrored token market on devnet → Launch button should be enabled (auto-airdrop)
3. Hit `/api/stats` → `totalOpenInterest` should match `/api/markets` sum ($64,614)

Closes GH#1300, GH#1301

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected total open interest (OI) calculation to properly exclude phantom markets using inclusive boundary logic for vault balances.

* **New Features**
  * Enhanced token balance validation during market creation to account for seed funding, LP collateral, and insurance requirements in total calculation.
  * Improved error messaging for insufficient token balance to better guide users.

* **Tests**
  * Added comprehensive test suites for phantom market detection and token balance verification during market launch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->