### PR TITLE
fix: add getSignatureStatuses to UNBATCHABLE_METHODS (GH#1310)

### DIFF
--- a/app/lib/batchRpc.ts
+++ b/app/lib/batchRpc.ts
@@ -18,14 +18,23 @@
  */
 
 /**
- * Methods that mutate on-chain state and must NOT be batched or deduplicated.
- * These are sent directly to the RPC endpoint, bypassing the batch queue entirely.
- * This prevents "Missing response from batch" errors when the upstream RPC returns
- * a response with a null/mismatched id for write operations.
+ * Methods that must NOT be batched or deduplicated.
+ *
+ * Mutating methods (sendTransaction, simulateTransaction) are excluded to prevent
+ * "Missing response from batch" errors when the upstream RPC returns a response with
+ * a null/mismatched id for write operations.
+ *
+ * Confirmation/status polling methods (getSignatureStatuses) are also excluded because
+ * the superstruct validator in @solana/web3.js v1 rejects responses with wrong id types
+ * when they pass through the batch layer — causing "Expected the value to satisfy a
+ * union of type | type, but received: [object Object]" errors in the Token Factory
+ * confirmation flow (GH#1310).
  */
 const UNBATCHABLE_METHODS = new Set([
   "sendTransaction",
   "simulateTransaction",
+  // Confirmation polling — must bypass batch to avoid superstruct id-type validation errors
+  "getSignatureStatuses",
 ]);
 
 /** Pending request waiting to be batched */


### PR DESCRIPTION
## Problem

Token Factory (/devnet-mint) fails at the confirmation polling stage after PR #1309. The `sendTransaction` bypass works (Privy shows "Transaction signed!") but Step 4 shows:

```
Error: Expected the value to satisfy a union of `type | type`, but received: [object Object]
```

## Root Cause

`getSignatureStatuses` still goes through the batch RPC layer. The `@solana/web3.js` v1 superstruct validator rejects batch responses when the id type doesn't match what it expects for this method — causing the confirmation polling loop to throw instead of returning the signature status.

PR #1309 only bypassed `sendTransaction` and `simulateTransaction`. This is the missing piece.

## Fix

Add `getSignatureStatuses` to `UNBATCHABLE_METHODS` in `batchRpc.ts`. It now follows the same bypass path as `sendTransaction` — sent directly via `globalThis.fetch`, skipping the batch queue entirely.

All three `getSignatureStatuses` call sites in `devnet-mint-content.tsx` (lines 194, 351, 452) are covered by this single change.

## Testing

1. Go to /devnet-mint
2. Create a token (fill name, symbol, supply)
3. Click Create + Mint → approve in Privy
4. Confirm Step 4 completes and success screen shows mint address (no superstruct error)

## Related
- Closes #1310
- Follows up on PR #1309