### PR TITLE
fix(devnet-mint): throw timeout error on confirmation polling (GH#1312)

### DIFF
--- a/app/app/devnet-mint/devnet-mint-content.tsx
+++ b/app/app/devnet-mint/devnet-mint-content.tsx
@@ -347,14 +347,19 @@ const DevnetMintContent: FC = () => {
 
       const startTime = Date.now();
       const TIMEOUT_MS = 60_000;
+      let confirmed = false;
       while (Date.now() - startTime < TIMEOUT_MS) {
         const { value } = await connection.getSignatureStatuses([sig]);
         const s = value?.[0];
         if (s?.confirmationStatus === "confirmed" || s?.confirmationStatus === "finalized") {
           if (s.err) throw new Error(`Transaction failed: ${JSON.stringify(s.err)}`);
+          confirmed = true;
           break;
         }
         await new Promise(r => setTimeout(r, 2000));
+      }
+      if (!confirmed) {
+        throw new Error("Transaction confirmation timeout after 60s");
       }
 
       const colorHash = mintKeypair.publicKey.toBuffer().slice(0, 3);
@@ -448,14 +453,19 @@ const DevnetMintContent: FC = () => {
       setMintMoreStatus("Confirming...");
 
       const startTime = Date.now();
+      let mintMoreConfirmed = false;
       while (Date.now() - startTime < 60_000) {
         const { value } = await connection.getSignatureStatuses([sig]);
         const s = value?.[0];
         if (s?.confirmationStatus === "confirmed" || s?.confirmationStatus === "finalized") {
           if (s.err) throw new Error(`Transaction failed: ${JSON.stringify(s.err)}`);
+          mintMoreConfirmed = true;
           break;
         }
         await new Promise(r => setTimeout(r, 2000));
+      }
+      if (!mintMoreConfirmed) {
+        throw new Error("Transaction confirmation timeout after 60s");
       }
       setMintMoreStatus(`Minted ${Number(mintMoreAmount).toLocaleString()} tokens!`);
       await refreshBalance();


### PR DESCRIPTION
## Problem
After the 60-second `getSignatureStatuses` while loop times out, two code paths in `devnet-mint-content.tsx` fell through unconditionally to show success:
- **Create Token**: called `setMintAddress()` even without confirmed tx
- **Mint More**: called `setMintMoreStatus('Minted X tokens!')` even without confirmed tx

The airdrop flow already had the correct pattern; the other two didn't.

## Fix
Track a `confirmed` / `mintMoreConfirmed` boolean in each while loop, set it before `break`, then throw `"Transaction confirmation timeout after 60s"` if the loop exits without confirmation.

## Changed files
- `app/app/devnet-mint/devnet-mint-content.tsx` — 2 while loops patched

## Testing
- Let a tx land but don't confirm → should now show error message, not success
- Happy path: tx confirms within 60s → unchanged behaviour

Fixes #1312

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction confirmation handling by adding 60-second timeouts to token creation, mint-and-create, and mint-more flows. The system now properly detects and reports unconfirmed transactions, preventing indefinite hangs and providing clearer error feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->