### PR TITLE
fix(stats): GH#1314 phantom OI — mirror /api/markets strict < 1M guard (PERC-1227)

### DIFF
--- a/app/__tests__/api/stats-phantom-oi-guard.test.ts
+++ b/app/__tests__/api/stats-phantom-oi-guard.test.ts
@@ -1,25 +1,34 @@
 /**
- * GH#1300: /api/stats phantom OI vault boundary regression tests.
+ * GH#1314: /api/stats phantom OI vault boundary tests.
  *
- * PR#1299 fixed GH#1297 but used an exclusive boundary (vault_balance < 1_000_000)
- * that let markets at vault=1_000_000 (creation-deposit only, no real LP) contribute
- * phantom OI to the platform total. This PR tightens it to inclusive (<= 1_000_000).
+ * History:
+ * - PR#1299 (GH#1297): first vault guard, strict < 1M. Correct, but also fixed $1 fallback.
+ * - PR#1303 (GH#1300): changed to inclusive <= 1M. Incorrectly excluded vault=1M real markets
+ *   (usdEkK5G $59,994, MOLTBOT $4,620) → stats showed $0 instead of $64K.
+ * - PR#1307 (GH#1304): over-corrected to (vaultBal <= 1M && rawOi === 0). Left a gap:
+ *   markets with vault < 1M AND rawOi > 0 were not phantom in stats but were in /api/markets,
+ *   causing $42K residual phantom OI ($107K vs $64K).
+ * - PR#this (GH#1314): revert to strict < 1M, mirroring /api/markets exactly.
+ *
+ * Rule: isPhantomOI = accountsCount === 0 || vaultBal < 1_000_000  (strict <)
  *
  * Coverage:
- * - vault=0 → excluded (empty, no positions)
- * - vault=1_000_000 → excluded (creation deposit only, boundary case)
- * - vault=1_000_001 → included (real LP above threshold)
- * - accounts=0 → excluded regardless of vault
+ * - vault=0         → phantom (no vault at all)
+ * - vault=999_999   → phantom (below threshold, dust)
+ * - vault=1_000_000 → NOT phantom (creation-deposit markets like usdEkK5G / MOLTBOT)
+ * - vault=1_000_001 → NOT phantom (real LP above threshold)
+ * - accounts=0      → phantom regardless of vault
+ * - GH#1314 regression: vault < 1M + rawOi > 0 → phantom (excluded)
  */
 
 import { describe, it, expect } from "vitest";
 
-/** Mirrors the vault boundary constant and guard in app/app/api/stats/route.ts */
+/** Mirrors the vault boundary constant in app/app/api/stats/route.ts */
 const MIN_VAULT_FOR_OI_STATS = 1_000_000;
 
+/** GH#1314: strict < mirroring /api/markets isPhantomOI exactly */
 function isPhantomMarket(vaultBal: number, accountsCount: number): boolean {
-  // GH#1300: inclusive boundary — vault <= 1_000_000 suppresses phantom OI
-  return accountsCount === 0 || vaultBal <= MIN_VAULT_FOR_OI_STATS;
+  return accountsCount === 0 || vaultBal < MIN_VAULT_FOR_OI_STATS;
 }
 
 function simulateOISum(
@@ -31,16 +40,21 @@ function simulateOISum(
   }, 0);
 }
 
-describe("GH#1300: /api/stats phantom OI inclusive boundary", () => {
+describe("GH#1314: /api/stats phantom OI strict < 1M boundary (mirrors /api/markets)", () => {
   it("excludes markets with vault_balance=0 (empty vault)", () => {
     const markets = [{ vault_balance: 0, total_accounts: 5, total_open_interest: 50_000 }];
     expect(simulateOISum(markets)).toBe(0);
   });
 
-  it("excludes markets with vault_balance=1_000_000 (creation-deposit only, boundary case — GH#1300)", () => {
-    // This was the regression in PR#1299: strict < 1M let vault=1M slip through
-    const markets = [{ vault_balance: 1_000_000, total_accounts: 3, total_open_interest: 42_909 }];
+  it("excludes markets with vault_balance=999_999 (dust/sub-threshold)", () => {
+    const markets = [{ vault_balance: 999_999, total_accounts: 3, total_open_interest: 42_909 }];
     expect(simulateOISum(markets)).toBe(0);
+  });
+
+  it("includes markets with vault_balance=1_000_000 (creation-deposit — usdEkK5G / MOLTBOT pattern)", () => {
+    // GH#1314: strict < means vault=1M is NOT phantom. PR#1303 broke this with <=.
+    const markets = [{ vault_balance: 1_000_000, total_accounts: 3, total_open_interest: 64_614 }];
+    expect(simulateOISum(markets)).toBe(64_614);
   });
 
   it("includes markets with vault_balance=1_000_001 (real LP above threshold)", () => {
@@ -53,29 +67,38 @@ describe("GH#1300: /api/stats phantom OI inclusive boundary", () => {
     expect(simulateOISum(markets)).toBe(0);
   });
 
+  it("GH#1314 regression: excludes vault<1M markets with non-zero rawOi (PR#1307 gap)", () => {
+    // PR#1307 used (vaultBal <= 1M && rawOi === 0) — let vault=500K + rawOi>0 slip through.
+    // /api/markets filters these (vaultBal < 1M), so stats was overcounting by ~$42K.
+    const markets = [{ vault_balance: 500_000, total_accounts: 5, total_open_interest: 42_909 }];
+    expect(simulateOISum(markets)).toBe(0);
+  });
+
   it("correctly filters mixed set — only non-phantom markets contribute OI", () => {
     const markets = [
       // Phantom: vault=0
       { vault_balance: 0, total_accounts: 2, total_open_interest: 10_000 },
-      // Phantom: vault=1M (boundary)
-      { vault_balance: 1_000_000, total_accounts: 5, total_open_interest: 42_909 },
+      // Phantom: vault=999_999 (dust, below threshold) — GH#1314 regression case
+      { vault_balance: 999_999, total_accounts: 5, total_open_interest: 42_909 },
       // Phantom: no accounts
       { vault_balance: 5_000_000, total_accounts: 0, total_open_interest: 20_000 },
+      // Real: vault=1_000_000 (creation-deposit, like usdEkK5G / MOLTBOT)
+      { vault_balance: 1_000_000, total_accounts: 3, total_open_interest: 59_994 },
       // Real: vault > 1M with accounts
-      { vault_balance: 5_000_000, total_accounts: 3, total_open_interest: 64_614 },
-      { vault_balance: 2_000_000, total_accounts: 1, total_open_interest: 43_000 },
+      { vault_balance: 2_000_000, total_accounts: 1, total_open_interest: 4_620 },
     ];
-    // Only last two contribute
-    expect(simulateOISum(markets)).toBe(64_614 + 43_000);
+    // Only last two contribute: 59_994 + 4_620 = 64_614
+    expect(simulateOISum(markets)).toBe(59_994 + 4_620);
   });
 
-  it("reproduces GH#1300 scenario: totalOI=$107,523 → $64,614 after guard", () => {
-    // Before fix: vault=1M markets added $42,909 phantom OI → $107,523 total
-    // After fix: vault=1M excluded → $64,614 correct total
+  it("reproduces GH#1314 scenario: $107K → $64K after correcting phantom guard", () => {
+    // Before fix (PR#1307): vault=500K markets with rawOi>0 slipped through → $107K
+    // After fix (strict <): vault<1M excluded → $64,614 matches /api/markets
     const markets = [
-      { vault_balance: 1_000_000, total_accounts: 5, total_open_interest: 42_909 }, // phantom
-      { vault_balance: 5_000_000, total_accounts: 10, total_open_interest: 64_614 }, // real
+      { vault_balance: 500_000, total_accounts: 5, total_open_interest: 42_909 },  // phantom, excluded
+      { vault_balance: 1_000_000, total_accounts: 3, total_open_interest: 59_994 }, // real (usdEkK5G)
+      { vault_balance: 1_000_000, total_accounts: 2, total_open_interest: 4_620 },  // real (MOLTBOT)
     ];
-    expect(simulateOISum(markets)).toBe(64_614);
+    expect(simulateOISum(markets)).toBe(59_994 + 4_620); // = 64_614
   });
 });

--- a/app/app/api/stats/route.ts
+++ b/app/app/api/stats/route.ts
@@ -119,17 +119,22 @@ export async function GET(request: NextRequest) {
       // GH#1297: Skip phantom markets (no accounts or dust/empty vault) — same guard as /api/markets
       const accountsCount = (m as Record<string, unknown>).total_accounts as number ?? 0;
       const vaultBal = (m as Record<string, unknown>).vault_balance as number ?? 0;
-      // GH#1304: Compute rawOi first so we can distinguish phantom markets (vault=1M, no OI)
-      // from real markets (vault=1M, actual positions). Previous inclusive guard (<= 1M)
-      // incorrectly filtered out usdEkK5G and MOLTBOT which have vault=1M + real OI.
+      // GH#1314: Mirror /api/markets phantom guard exactly — strict < 1M (not <=).
+      // vault=1M (creation-deposit only) markets like usdEkK5G and MOLTBOT are NOT
+      // phantom (strict < excludes only vault < 1M). PR #1303 used <= which incorrectly
+      // filtered them; PR #1307 over-corrected with (vaultBal <= 1M && rawOi === 0)
+      // which let through markets with vault < 1M + stale non-zero rawOi, causing the
+      // residual $42K phantom OI. The /api/markets condition is the single source of truth.
       const rawOi = isSaneMarketValue(m.total_open_interest)
         ? m.total_open_interest!
         : (isSaneMarketValue((m.open_interest_long ?? 0) + (m.open_interest_short ?? 0))
             ? (m.open_interest_long ?? 0) + (m.open_interest_short ?? 0)
             : 0);
       if (!isSaneMarketValue(rawOi)) return sum;
-      // Skip phantom markets: no accounts, OR low/seed vault with zero actual OI
-      if (accountsCount === 0 || (vaultBal <= MIN_VAULT_FOR_OI_STATS && rawOi === 0)) return sum;
+      // Skip phantom markets: no accounts, OR vault below creation-deposit threshold.
+      // Strict < mirrors /api/markets isPhantomOI exactly (vault=1M is NOT phantom).
+      const isPhantomOI = accountsCount === 0 || vaultBal < MIN_VAULT_FOR_OI_STATS;
+      if (isPhantomOI) return sum;
       // GH#1265: OI is tracked in collateral micro-units. When no oracle price is available
       // (admin-mode markets not yet cranked), fall back to $1/token — correct for devnet
       // markets. Without this fallback, only price-cranked markets contributed to OI,


### PR DESCRIPTION
## Problem

`/api/stats.totalOpenInterest` still shows $107,523 vs `/api/markets` sum of $64,614 — delta ~$42,909 phantom OI — after PR #1307 merged.

## Root Cause

**PR #1307** over-corrected the PR #1303 regression with this guard:
```ts
if (accountsCount === 0 || (vaultBal <= MIN_VAULT_FOR_OI_STATS && rawOi === 0)) return sum;
```

This only excludes markets with *both* `vaultBal <= 1M` **and** `rawOi === 0`. Markets with `vault < 1M` **and** stale non-zero rawOi in the DB slip through and are counted with the $1 fallback.

Meanwhile `/api/markets` uses:
```ts
const isPhantomOI = accountsCount === 0 || vaultBal < MIN_VAULT_FOR_OI;  // strict <
```
These markets are phantom in `/api/markets` → not counted. The two endpoints diverged, producing the $42K gap.

## Fix

Replace the compound condition with the exact same guard `/api/markets` uses — strict `< 1M`:
```ts
const isPhantomOI = accountsCount === 0 || vaultBal < MIN_VAULT_FOR_OI_STATS;
if (isPhantomOI) return sum;
```

- `vault < 1M` → phantom (excluded) ✓  
- `vault = 1M` → **NOT phantom** (usdEkK5G $59,994, MOLTBOT $4,620 pass through) ✓  
- `vault > 1M` → NOT phantom ✓

## Tests

Updated `stats-phantom-oi-guard.test.ts`:
- Explicit GH#1314 regression case: vault=500K + rawOi>0 → excluded
- GH#1314 full scenario: $107K → $64,614 after guard
- Updated all vault=1M expectations from *excluded* to *included*

**1035/1035 passing ✅ · tsc clean ✅**

## How to Test

```bash
curl https://percolatorlaunch.com/api/stats | jq .totalOpenInterest
# Should be ≈ 64614 (matching /api/markets sum)
curl 'https://percolatorlaunch.com/api/markets?limit=200' | jq '[.markets[].total_open_interest_usd // 0] | add'
# Should be ≈ 64614
```

Closes GH#1314