### PR TITLE
fix(health-card): sanitize u64 overflow in Health tab (GH#1316)

### DIFF
--- a/app/components/trade/EngineHealthCard.tsx
+++ b/app/components/trade/EngineHealthCard.tsx
@@ -6,7 +6,7 @@ import { useSlabState } from "@/components/providers/SlabProvider";
 import { useTokenMeta } from "@/hooks/useTokenMeta";
 import { useUsdToggle } from "@/components/providers/UsdToggleProvider";
 import { useLivePrice } from "@/hooks/useLivePrice";
-import { computeMarketHealth } from "@/lib/health";
+import { computeMarketHealth, sanitizeOnChainValue } from "@/lib/health";
 import { formatTokenAmount, formatSlotAge } from "@/lib/format";
 
 function formatNum(n: number): string {
@@ -40,10 +40,12 @@ export const EngineHealthCard: FC = () => {
 
   const health = computeMarketHealth(engine);
 
-  const cTot = engine.cTot ?? 0n;
-  const pnlPosTot = engine.pnlPosTot ?? 0n;
-  const netLpPos = engine.netLpPos ?? 0n;
-  const lpSumAbs = engine.lpSumAbs ?? 0n;
+  // Sanitize sentinel / corrupted on-chain values (u64::MAX or near-MAX garbage)
+  // before converting to display values. Matches the guard in SystemCapitalCard.tsx.
+  const cTot = sanitizeOnChainValue(engine.cTot ?? 0n);
+  const pnlPosTot = sanitizeOnChainValue(engine.pnlPosTot ?? 0n);
+  const netLpPos = sanitizeOnChainValue(engine.netLpPos ?? 0n);
+  const lpSumAbs = sanitizeOnChainValue(engine.lpSumAbs ?? 0n);
 
   const haircutDenom = cTot + pnlPosTot;
   const haircutPct = haircutDenom > 0n


### PR DESCRIPTION
## Problem
Health tab showed `Total Capital: 8216371213846743100.073967616` (raw u64 overflow) while Risk tab showed `0.00`. Same market, same field, different panels.

## Root Cause
`EngineHealthCard.tsx` read `engine.cTot`, `engine.pnlPosTot`, `engine.netLpPos`, `engine.lpSumAbs` directly as raw bigints without calling `sanitizeOnChainValue()`. `SystemCapitalCard.tsx` already had the correct guard.

## Fix
Import `sanitizeOnChainValue` from `@/lib/health` in `EngineHealthCard.tsx` and apply it to the four raw bigint reads before display. Matches the existing pattern in `SystemCapitalCard.tsx`.

## Test
- `pnpm tsc --noEmit`: clean
- All 74 tests pass

Fixes #1316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overall data integrity in the Trade Engine Health Card by adding enhanced validation to prevent potentially corrupted or sentinel on-chain values from being displayed to end users. This ensures accurate and reliable trading performance metrics, position information, and financial calculations are consistently shown throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->