### PR TITLE
fix(markets): sort OI by USD value in USD mode (GH-1327)

### DIFF
--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -274,6 +274,22 @@ function MarketsPageInner() {
           return volB > volA ? 1 : volB < volA ? -1 : 0;
         }
         case "oi": {
+          if (showUsd) {
+            // GH-1327: In USD mode, sort by USD-equivalent OI.
+            // Markets without a valid price get USD OI = 0 (sort to bottom).
+            const usdOI = (m: MergedMarket): number => {
+              const raw = getOI(m);
+              if (raw === 0n) return 0;
+              const price = m.supabase?.last_price ?? null;
+              if (price == null || price <= 0 || price > MAX_SANE_PRICE_USD) return 0;
+              const meta = tokenMetaMap.get(m.mintAddress);
+              const decimals = Math.min(Math.max(meta?.decimals ?? 6, 0), 18);
+              return Number(raw) / (10 ** decimals) * price;
+            };
+            const oiA = usdOI(a);
+            const oiB = usdOI(b);
+            return oiB - oiA;
+          }
           const oiA = getOI(a);
           const oiB = getOI(b);
           return oiB > oiA ? 1 : oiB < oiA ? -1 : 0;
@@ -295,7 +311,7 @@ function MarketsPageInner() {
       }
     });
     return list;
-  }, [effectiveMarkets, debouncedSearch, sortBy, leverageFilter, oracleFilter, tokenMetaMap]);
+  }, [effectiveMarkets, debouncedSearch, sortBy, leverageFilter, oracleFilter, tokenMetaMap, showUsd]);
 
   // P-MED-3: Progressive reveal + intersection observer backup
   // Auto-load items in batches via requestAnimationFrame for instant display.


### PR DESCRIPTION
## What
In USD display mode on `/markets`, OI sort now uses USD-equivalent values instead of raw token amounts.

## Why
Markets without an oracle price but with large raw token OI (e.g. billions of lamports) were sorting above legitimately high-USD-OI markets like usdEkK5G ($60K) and MOLTBOT ($4.6K). This made the OI ranking misleading.

## How
- Added USD-aware OI comparator in the `oi` sort case: computes `(rawOI / 10^decimals) × price`
- Markets with null/invalid price get USD OI = 0, sorting to the bottom
- Added `showUsd` to the `useMemo` dependency array so the sort recomputes on toggle
- Token-mode sort is unchanged (raw bigint comparison)

## Testing
- TypeScript compiles clean (`tsc --noEmit`)
- Existing test suite passes

Closes #1327

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced open interest sorting to correctly calculate and display USD-equivalent values when in USD display mode. Markets now re-sort properly when switching between USD and token display modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->