### PR TITLE
fix: OI sort in USD mode ignores price for no-price markets (#1327)

### DIFF
--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -265,6 +265,18 @@ function MarketsPageInner() {
         ?? ((m.supabase?.open_interest_long ?? 0) + (m.supabase?.open_interest_short ?? 0));
       return BigInt(isSentinelNum(supaOI) ? 0 : Math.max(0, supaOI));
     };
+    // USD-aware OI sort key: converts raw token OI → USD using market price.
+    // Markets with no valid price return 0 so they sort to the bottom in USD mode.
+    // Fixes #1327: no-price markets with huge raw token OI were floating above real USD markets.
+    const getOIUsdSortKey = (m: MergedMarket): number => {
+      const onChainPriceE6 = m.onChain ? resolveMarketPriceE6(m.onChain.config) : 0n;
+      const rawPrice = m.supabase?.last_price ?? priceE6ToUsd(onChainPriceE6);
+      const price = rawPrice != null && rawPrice > 0 && rawPrice <= MAX_SANE_PRICE_USD ? rawPrice : null;
+      if (price == null) return 0; // no price → sort to bottom
+      const rawDecimals = tokenMetaMap.get(m.mintAddress)?.decimals ?? (m.supabase?.decimals ?? 6);
+      const mintDecimals = Math.min(Math.max(rawDecimals, 0), 18);
+      return (Number(getOI(m)) / 10 ** mintDecimals) * price;
+    };
     list = [...list].sort((a, b) => {
       switch (sortBy) {
         case "volume": {
@@ -274,6 +286,11 @@ function MarketsPageInner() {
           return volB > volA ? 1 : volB < volA ? -1 : 0;
         }
         case "oi": {
+          // In USD mode: sort by USD-equivalent OI; no-price markets → 0 → bottom (fix #1327)
+          // In token mode: sort by raw token amount as before
+          if (showUsd) {
+            return getOIUsdSortKey(b) - getOIUsdSortKey(a);
+          }
           const oiA = getOI(a);
           const oiB = getOI(b);
           return oiB > oiA ? 1 : oiB < oiA ? -1 : 0;
@@ -295,7 +312,7 @@ function MarketsPageInner() {
       }
     });
     return list;
-  }, [effectiveMarkets, debouncedSearch, sortBy, leverageFilter, oracleFilter, tokenMetaMap]);
+  }, [effectiveMarkets, debouncedSearch, sortBy, leverageFilter, oracleFilter, showUsd, tokenMetaMap]);
 
   // P-MED-3: Progressive reveal + intersection observer backup
   // Auto-load items in batches via requestAnimationFrame for instant display.


### PR DESCRIPTION
## Problem
In USD display mode on `/markets`, sorting by OI was comparing raw token amounts from `total_open_interest` across all markets. No-price markets with billions of raw tokens (e.g. BdzV at 2.66T) floated above markets with real USD open interest (e.g. usdEkK5G at $60K).

## Root Cause
The `getOI()` helper returns raw bigint token amounts regardless of whether a price exists. The `case "oi"` sort used this directly — no USD conversion, no price check.

## Fix
- Add `getOIUsdSortKey()` that converts token OI → USD using market price
- No-price markets (price = null or 0) return `0`, sorting them to the bottom in USD mode
- Raw token sort (USD mode off) is unchanged
- **Bonus:** Add `showUsd` to the `filtered` useMemo dep array — it was missing, which meant the OI sort wouldn't recompute when toggling between USD/token display

## How to Test
1. Go to `/markets?usd=true`
2. Click "Sort by OI"
3. Priced markets with USD OI should appear first; no-price markets sort to bottom
4. Toggle to token mode — no-price markets with high raw OI return to their natural position

Closes #1327

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Open Interest column sorting to properly respect the selected currency display mode (USD or token-based).
  * Improved handling for markets without available pricing data to ensure consistent sorting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->