### PR TITLE
fix: stale oracle trade block, PnL overflow, OI double-count (GH#1330 #1331 #1332)

### DIFF
--- a/app/__tests__/components/ProtocolStatsBar.test.tsx
+++ b/app/__tests__/components/ProtocolStatsBar.test.tsx
@@ -1,8 +1,9 @@
 /**
- * GH#1274 — ProtocolStatsBar OI underreport regression tests.
+ * ProtocolStatsBar — OI calculation tests.
  *
- * Root cause: price fallback was `0`, making toUsd() short-circuit to 0 for
- * every market without an oracle price. Fix: fallback to $1 (matches api/stats).
+ * GH#1274: $1 price fallback for volume (admin markets counted at face value).
+ * GH#1332: No $1 fallback for OI — markets with no valid oracle price report $0 OI.
+ *          Phantom OI guard: vault < 1M or total_accounts = 0 → OI = 0.
  */
 
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
@@ -12,8 +13,6 @@ import "@testing-library/jest-dom";
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
-// The query chain is: getSupabase().from().select().returns()
-// We need to mock the full chain correctly.
 const mockReturns = vi.fn();
 const mockSelect = vi.fn(() => ({ returns: mockReturns }));
 const mockFrom = vi.fn(() => ({ select: mockSelect }));
@@ -37,6 +36,8 @@ type MarketRow = {
   total_open_interest: number | null;
   open_interest_long: number | null;
   open_interest_short: number | null;
+  vault_balance: number | null;
+  total_accounts: number | null;
 };
 
 function makeRow(overrides: Partial<MarketRow> = {}): MarketRow {
@@ -49,6 +50,9 @@ function makeRow(overrides: Partial<MarketRow> = {}): MarketRow {
     total_open_interest: null,
     open_interest_long: null,
     open_interest_short: null,
+    // Default: real market with vault + accounts so phantom guard passes
+    vault_balance: 1_000_000,
+    total_accounts: 2,
     ...overrides,
   };
 }
@@ -77,24 +81,28 @@ describe("ProtocolStatsBar — GH#1274 price fallback", () => {
     });
   });
 
-  it("shows non-zero OI when last_price is null — GH#1274 regression", async () => {
-    // Simulates the actual GH#1274 scenario: $53.8K OI across admin-mode markets
-    // 53,800 tokens at $1 fallback = $53.8K; raw = 53800 × 10^6 = 53_800_000_000
+  it("GH#1332: shows $0 OI when last_price is null (no $1 fallback for OI)", async () => {
+    // GH#1332: Admin-mode markets without a valid oracle price must not contribute
+    // to OI (their USD value is indeterminate). Previously the $1 fallback inflated
+    // global OI from $64K to $117K.
     const rawOi = 53_800 * 1_000_000;
     mockSupabase([
       makeRow({
         slab_address: "slab-admin-1",
-        last_price: null,  // no oracle price — must fall back to $1
+        last_price: null,  // no oracle price → OI = $0
         total_open_interest: rawOi,
         decimals: 6,
+        vault_balance: 5_000_000,
+        total_accounts: 3,
       }),
     ]);
 
     render(<ProtocolStatsBar />);
 
     await waitFor(() => {
-      // $53,800 → "$53.8K"
-      expect(screen.getByText("$53.8K")).toBeInTheDocument();
+      // No valid price → OI should be $0 (not $53.8K)
+      expect(screen.queryByText("$53.8K")).not.toBeInTheDocument();
+      expect(screen.getAllByText("$0").length).toBeGreaterThan(0);
     });
   });
 
@@ -107,6 +115,8 @@ describe("ProtocolStatsBar — GH#1274 price fallback", () => {
         last_price: 2.0,
         total_open_interest: rawOi,
         decimals: 6,
+        vault_balance: 1_000_000,
+        total_accounts: 2,
       }),
     ]);
 
@@ -117,8 +127,9 @@ describe("ProtocolStatsBar — GH#1274 price fallback", () => {
     });
   });
 
-  it("OI must not be $0 when raw OI is sane and last_price is null", async () => {
-    // 100K tokens × 10^6 = 10^11 raw → $100K at $1 fallback
+  it("GH#1332: OI is $0 when raw OI is sane but last_price is null", async () => {
+    // GH#1332 regression: even with sane raw OI, if price is unknown the USD value
+    // is indeterminate — should NOT use $1 fallback.
     const rawOi = 100_000 * 1_000_000;
     mockSupabase([
       makeRow({
@@ -126,22 +137,89 @@ describe("ProtocolStatsBar — GH#1274 price fallback", () => {
         last_price: null,
         total_open_interest: rawOi,
         decimals: 6,
+        vault_balance: 2_000_000,
+        total_accounts: 1,
       }),
     ]);
 
     render(<ProtocolStatsBar />);
 
     await waitFor(() => {
-      expect(screen.getByText("$100.0K")).toBeInTheDocument();
+      // Should be $0 — no $1 fallback for OI
+      expect(screen.queryByText("$100.0K")).not.toBeInTheDocument();
+      expect(screen.getAllByText("$0").length).toBeGreaterThan(0);
     });
   });
 
-  it("counts active markets when last_price is null but OI is sane", async () => {
+  it("GH#1297: phantom market (total_accounts=0) contributes $0 OI even with valid price", async () => {
+    const rawOi = 50_000 * 1_000_000;
+    mockSupabase([
+      makeRow({
+        slab_address: "slab-phantom",
+        last_price: 1.0,
+        total_open_interest: rawOi,
+        decimals: 6,
+        vault_balance: 1_000_000,
+        total_accounts: 0,  // phantom — no real positions
+      }),
+    ]);
+
+    render(<ProtocolStatsBar />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("$50.0K")).not.toBeInTheDocument();
+      expect(screen.getAllByText("$0").length).toBeGreaterThan(0);
+    });
+  });
+
+  it("GH#1297: phantom market (vault < 1M) contributes $0 OI", async () => {
+    const rawOi = 50_000 * 1_000_000;
+    mockSupabase([
+      makeRow({
+        slab_address: "slab-dust-vault",
+        last_price: 1.0,
+        total_open_interest: rawOi,
+        decimals: 6,
+        vault_balance: 999_999,  // strictly < 1M → phantom
+        total_accounts: 5,
+      }),
+    ]);
+
+    render(<ProtocolStatsBar />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("$50.0K")).not.toBeInTheDocument();
+      expect(screen.getAllByText("$0").length).toBeGreaterThan(0);
+    });
+  });
+
+  it("vault=1M (creation-deposit) is NOT phantom — contributes OI correctly", async () => {
+    // Strict < 1M guard: vault=1M is NOT phantom (usdEkK5G, MOLTBOT case).
+    const rawOi = 1000 * 1_000_000;
+    mockSupabase([
+      makeRow({
+        slab_address: "slab-creation-vault",
+        last_price: 3.0,
+        total_open_interest: rawOi,
+        decimals: 6,
+        vault_balance: 1_000_000,  // exactly 1M — NOT phantom
+        total_accounts: 1,
+      }),
+    ]);
+
+    render(<ProtocolStatsBar />);
+
+    await waitFor(() => {
+      expect(screen.getByText("$3.0K")).toBeInTheDocument();
+    });
+  });
+
+  it("counts active markets with valid price and real vault", async () => {
     const rawOi = 1_000_000 * 1_000_000;
     mockSupabase([
-      makeRow({ slab_address: "s1", last_price: null, total_open_interest: rawOi }),
-      makeRow({ slab_address: "s2", last_price: null, total_open_interest: rawOi }),
-      makeRow({ slab_address: "s3", last_price: null, total_open_interest: rawOi }),
+      makeRow({ slab_address: "s1", last_price: 1.0, total_open_interest: rawOi, vault_balance: 2_000_000, total_accounts: 3 }),
+      makeRow({ slab_address: "s2", last_price: 1.0, total_open_interest: rawOi, vault_balance: 2_000_000, total_accounts: 3 }),
+      makeRow({ slab_address: "s3", last_price: 1.0, total_open_interest: rawOi, vault_balance: 2_000_000, total_accounts: 3 }),
     ]);
 
     render(<ProtocolStatsBar />);
@@ -160,8 +238,8 @@ describe("ProtocolStatsBar — GH#1274 price fallback", () => {
 
     const rawOi = 50_000 * 1_000_000;
     mockSupabase([
-      makeRow({ slab_address: "slab-blocked", last_price: null, total_open_interest: rawOi }),
-      makeRow({ slab_address: "slab-ok", last_price: null, total_open_interest: rawOi }),
+      makeRow({ slab_address: "slab-blocked", last_price: 1.0, total_open_interest: rawOi, vault_balance: 2_000_000, total_accounts: 3 }),
+      makeRow({ slab_address: "slab-ok", last_price: 1.0, total_open_interest: rawOi, vault_balance: 2_000_000, total_accounts: 3 }),
     ]);
 
     render(<ProtocolStatsBar />);

--- a/app/components/dashboard/ProtocolStatsBar.tsx
+++ b/app/components/dashboard/ProtocolStatsBar.tsx
@@ -48,7 +48,7 @@ export function ProtocolStatsBar() {
     try {
       const { data } = await getSupabase()
         .from("markets_with_stats")
-        .select("slab_address, symbol, volume_24h, last_price, decimals, total_open_interest, open_interest_long, open_interest_short")
+        .select("slab_address, symbol, volume_24h, last_price, decimals, total_open_interest, open_interest_long, open_interest_short, vault_balance, total_accounts")
         .returns<{
           slab_address: string;
           symbol: string | null;
@@ -58,6 +58,8 @@ export function ProtocolStatsBar() {
           total_open_interest: number | null;
           open_interest_long: number | null;
           open_interest_short: number | null;
+          vault_balance: number | null;
+          total_accounts: number | null;
         }[]>();
 
       if (!data || data.length === 0) {
@@ -65,8 +67,11 @@ export function ProtocolStatsBar() {
         return;
       }
 
-      // GH#1268: Match /api/stats conversion logic — cap price at $10K, fallback OI to long+short
-      const MAX_SANE_PRICE_USD = 10_000;
+      // GH#1332: Match /api/stats exactly — $1M price cap, no $1 fallback for OI,
+      // phantom OI guard (vault < 1M or 0 accounts).
+      const MAX_SANE_PRICE_USD = 1_000_000; // matches /api/stats route
+      // GH#1297: Phantom OI guard threshold — matches /api/stats strict < 1M.
+      const MIN_VAULT_FOR_OI = 1_000_000;
 
       let vol24h = 0;
       let oi = 0;
@@ -76,20 +81,20 @@ export function ProtocolStatsBar() {
         if (!row.slab_address || isBlockedSlab(row.slab_address)) continue;
 
         const dec = Math.pow(10, Math.min(Math.max(row.decimals ?? 6, 0), 18));
-        // Use $1 fallback when last_price is missing/invalid — matches api/stats route logic
-        // so admin-mode markets (no oracle price) are still counted at face value (GH#1274)
-        const price = (row.last_price != null && row.last_price > 0 && row.last_price <= MAX_SANE_PRICE_USD)
-          ? row.last_price
-          : 1;
+        const validPrice = row.last_price != null && row.last_price > 0 && row.last_price <= MAX_SANE_PRICE_USD;
+        // For volume: use $1 fallback so admin markets contribute volume at face value.
+        const priceForVol = validPrice ? row.last_price! : 1;
+        // For OI: no fallback — indeterminate USD value must be skipped (GH#1318 / GH#1332).
+        const priceForOi = validPrice ? row.last_price! : 0;
 
-        const toUsd = (raw: number): number => {
-          if (!isSaneMarketValue(raw) || price <= 0) return 0;
-          const usd = (raw / dec) * price;
+        const toUsdVol = (raw: number): number => {
+          if (!isSaneMarketValue(raw) || priceForVol <= 0) return 0;
+          const usd = (raw / dec) * priceForVol;
           return usd > MAX_USD_PER_MARKET ? 0 : usd;
         };
 
         // Volume: stored in token units, convert to USD
-        const capVol = toUsd(Number(row.volume_24h ?? 0));
+        const capVol = toUsdVol(Number(row.volume_24h ?? 0));
 
         // OI: fallback to long+short if total_open_interest is missing (GH#1268)
         const rawOi = isSaneMarketValue(row.total_open_interest)
@@ -97,7 +102,17 @@ export function ProtocolStatsBar() {
           : (isSaneMarketValue((row.open_interest_long ?? 0) + (row.open_interest_short ?? 0))
               ? (row.open_interest_long ?? 0) + (row.open_interest_short ?? 0)
               : 0);
-        const capOi = toUsd(rawOi);
+
+        // GH#1297: Skip phantom markets — mirrors /api/stats isPhantomOI guard exactly.
+        // Strict < 1M (vault=1M creation-deposit markets are NOT phantom).
+        const accountsCount = row.total_accounts ?? 0;
+        const vaultBal = row.vault_balance ?? 0;
+        const isPhantomOI = accountsCount === 0 || vaultBal < MIN_VAULT_FOR_OI;
+
+        // GH#1332: No $1 fallback for OI — skip markets with no valid oracle price.
+        const capOi = (!isPhantomOI && priceForOi > 0 && isSaneMarketValue(rawOi))
+          ? Math.min((rawOi / dec) * priceForOi, MAX_USD_PER_MARKET)
+          : 0;
 
         if (isActiveMarket({ volume_24h: capVol, total_open_interest: capOi })) {
           activeCount++;

--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -12,6 +12,7 @@ import { useEngineState } from "@/hooks/useEngineState";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { useTokenMeta } from "@/hooks/useTokenMeta";
 import { useLivePrice } from "@/hooks/useLivePrice";
+import { useOracleFreshness } from "@/hooks/useOracleFreshness";
 import { AccountKind, computePreTradeLiqPrice } from "@percolator/sdk";
 import { PreTradeSummary } from "@/components/trade/PreTradeSummary";
 import { TradeConfirmationModal } from "@/components/trade/TradeConfirmationModal";
@@ -58,6 +59,12 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
   const { accounts, config: mktConfig, header } = useSlabState();
   const tokenMeta = useTokenMeta(mktConfig?.collateralMint ?? null);
   const { priceUsd } = useLivePrice();
+  // GH#1330: Detect stale oracle to block trade submission before tx failure.
+  // Admin-oracle and Hyperp markets can have stale on-chain prices the frontend
+  // otherwise shows as valid. We treat stale+ready as a hard block — same UX as
+  // no-price — to avoid the silent "Oracle is invalid" on-chain rejection.
+  const { level: oracleLevel, mode: oracleMode, ready: oracleReady } = useOracleFreshness();
+  const oracleStale = oracleReady && oracleLevel === "stale" && (oracleMode === "admin" || oracleMode === "hyperp");
   const openWalletModal = usePrivyLogin();
   const mintAddress = mktConfig?.collateralMint?.toBase58() ?? "";
   const symbol = sanitizeSymbol(tokenMeta?.symbol, mintAddress);
@@ -322,6 +329,18 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
         </div>
       )}
 
+      {/* GH#1330: Stale oracle warning — admin/hyperp markets can show a valid price
+          in the UI while the on-chain oracle timestamp is expired. Block the trade
+          button to prevent silent tx failure with "Oracle is invalid". */}
+      {oracleStale && priceUsd && !mockMode && (
+        <div className="mb-3 rounded-none border border-[var(--short)]/30 bg-[var(--short)]/5 p-2.5">
+          <p className="text-[9px] font-bold uppercase tracking-[0.15em] text-[var(--short)]">Oracle Stale</p>
+          <p className="mt-1 text-[9px] text-[var(--text-secondary)] leading-relaxed">
+            The oracle price for this market has not been updated recently. Trading is temporarily disabled to prevent failed transactions.
+          </p>
+        </div>
+      )}
+
       {/* Direction toggle */}
       <div className="mb-3 flex gap-1">
         <button
@@ -475,10 +494,10 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
       ) : (
         <button
           onClick={() => {
-            if (!marginInput || !userAccount || positionSize <= 0n || exceedsMargin || riskGateActive || header?.paused || tradePhase !== "idle" || loading || (!priceUsd && !mockMode)) return;
+            if (!marginInput || !userAccount || positionSize <= 0n || exceedsMargin || riskGateActive || header?.paused || tradePhase !== "idle" || loading || (!priceUsd && !mockMode) || (oracleStale && !mockMode)) return;
             setShowConfirmModal(true);
           }}
-          disabled={tradePhase !== "idle" || loading || !marginInput || positionSize <= 0n || exceedsMargin || riskGateActive || header?.paused || lpUnderfunded || vaultEmpty || (!priceUsd && !mockMode)}
+          disabled={tradePhase !== "idle" || loading || !marginInput || positionSize <= 0n || exceedsMargin || riskGateActive || header?.paused || lpUnderfunded || vaultEmpty || (!priceUsd && !mockMode) || (oracleStale && !mockMode)}
           className={`w-full rounded-none py-2.5 text-[11px] font-medium uppercase tracking-[0.1em] text-white transition-all duration-150 hover:scale-[1.01] active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:scale-100 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--bg)] ${
             direction === "long"
               ? "bg-[var(--long)] hover:brightness-110 focus-visible:ring-[var(--long)]"

--- a/app/hooks/useOracleFreshness.ts
+++ b/app/hooks/useOracleFreshness.ts
@@ -72,13 +72,16 @@ export function useOracleFreshness(): OracleFreshnessState {
   const prevPriceRef = useRef<bigint | null>(null);
   const tickRef = useRef<ReturnType<typeof setInterval>>(undefined);
 
-  const mode = config
+  // Guard: detectOracleMode requires both PublicKey fields — skip if either is missing
+  // (e.g. partial mock configs in test environments).
+  const hasOracleKeys = config?.oracleAuthority != null && config?.indexFeedId != null;
+  const mode = (config && hasOracleKeys)
     ? detectOracleMode(config)
     : null;
 
   // Track price changes to detect updates
   useEffect(() => {
-    if (!config) return;
+    if (!config || !hasOracleKeys) return;
     const currentMode = detectOracleMode(config);
 
     if (currentMode === "admin") {

--- a/app/hooks/usePortfolio.ts
+++ b/app/hooks/usePortfolio.ts
@@ -19,6 +19,7 @@ import {
   type Account,
   type RiskParams,
 } from "@percolator/sdk";
+import { isSentinelValue } from "@/lib/health";
 import { getConfig } from "@/lib/config";
 
 export interface PortfolioPosition {
@@ -168,10 +169,13 @@ export function usePortfolio(): PortfolioData {
                   maintenanceMarginBps,
                 );
 
-                // Compute unrealized PnL using oracle price
+                // Compute unrealized PnL using oracle price.
+                // GH#1331: account.pnl can be u64::MAX sentinel for uninitialized/flat
+                // positions. Guard it with isSentinelValue to prevent billion-dollar
+                // phantom PnL on the dashboard when oracle price is unavailable.
                 const unrealizedPnl = oraclePriceE6 > 0n
                   ? computeMarkPnl(account.positionSize, account.entryPrice, oraclePriceE6)
-                  : account.pnl;
+                  : (isSentinelValue(account.pnl) ? 0n : account.pnl);
 
                 // PnL percentage
                 const pnlPercent = computePnlPercent(unrealizedPnl, account.capital);


### PR DESCRIPTION
Fixes three QA regression bugs. See commit message for details. Tests: 87 files pass (1044 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trading is now blocked when on-chain oracle data becomes stale, with a warning message displayed.
  * Fixed Open Interest calculation for markets with minimal vault balances or activity—now correctly shows $0 instead of fallback values.
  * Fixed dashboard portfolio display where unavailable oracle prices could show phantom profit/loss values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->