### PR TITLE
fix(oracle): show unavailable banner when oracle never cranked (GH#1341)

### DIFF
--- a/app/components/oracle/OracleFreshnessIndicator.tsx
+++ b/app/components/oracle/OracleFreshnessIndicator.tsx
@@ -37,8 +37,30 @@ export const OracleFreshnessIndicator: FC = () => {
     setPanelOpen(true);
   }, []);
 
-  // GH#1338: Still render for unavailable markets (mode detected, no price)
-  if (!ready && level !== 'unavailable') return null;
+  // GH#1341: If no oracle mode detected at all, nothing to show
+  if (!mode) return null;
+
+  // GH#1341: Oracle mode detected but price never cranked — show unavailable banner
+  if (!ready) {
+    return (
+      <>
+        <div
+          className="flex items-center gap-1.5 px-2 py-1 text-[10px]"
+          style={{
+            backgroundColor: "rgba(239,68,68,0.10)",
+            color: "#ef4444",
+            fontFamily: "var(--font-mono)",
+          }}
+        >
+          <span>⚠</span>
+          <span>Oracle unavailable — market not yet cranked</span>
+        </div>
+        {panelOpen && (
+          <OracleDetailsPanel onClose={() => setPanelOpen(false)} />
+        )}
+      </>
+    );
+  }
 
   const elapsedText =
     elapsedSecs < 60


### PR DESCRIPTION
## What
One-line fix: the early-return `if (!ready) return null` in `OracleFreshnessIndicator` suppressed the red 'Oracle Unavailable' banner for uncranked HYPERP markets.

## Why
`ready` requires `lastUpdateMs !== null`, which is always false for never-cranked oracles. The component bailed before reaching the unavailable banner render path.

## Fix
```diff
-  if (!ready) return null;
+  if (!ready && level !== 'unavailable') return null;
```

## Impact
Display-only fix — trading was already correctly blocked by `TradeForm`.

Closes #1341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering for unavailable markets in the freshness indicator: when a market mode is detected but data isn’t ready, an “unavailable” banner is shown while still allowing the details panel and other status info (elapsed time, publisher) to be displayed. This ensures better visibility during data loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->