### PR TITLE
fix(dashboard): constrain Funding Rates list with scroll container (GH#1350)

### DIFF
--- a/app/components/dashboard/FundingRates.tsx
+++ b/app/components/dashboard/FundingRates.tsx
@@ -78,8 +78,9 @@ export function FundingRates() {
           </p>
         </div>
       ) : (
+        <div className="max-h-[280px] overflow-y-auto">
         <ul className="divide-y divide-[rgba(255,255,255,0.04)]">
-          {active.map((m) => {
+          {active.slice(0, 15).map((m) => {
             const isPositive = m.rateBpsPerSlot > 0;
             const rateStr =
               (isPositive ? "+" : "") +
@@ -118,6 +119,7 @@ export function FundingRates() {
             );
           })}
         </ul>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## What

Adds a scroll container with `max-h-[280px] overflow-y-auto` around the Funding Rates `<ul>` on the dashboard, and caps rendered items to 15 via `.slice(0, 15)`.

## Why

GH#1350: Without this fix the panel renders all ~172 markets, making the dashboard page body **9,423px tall**. Identical UX regression to the Watchlist overflow fixed in PR #1349.

## How to test

1. Open `/dashboard`
2. Scroll to Funding Rates panel — list should be bounded (~280px) with internal scroll
3. Page should no longer be thousands of pixels tall

Fixes #1350

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The active funding rates list now includes a scrollable container, allowing users to easily browse through available rates without occupying excessive screen space.
  * The display is limited to show the first 15 active funding rates, optimizing performance and providing faster initial load times for the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->