### PR TITLE
fix(dashboard): guard account.pnl sentinel in PnlChart — GH#1352

### DIFF
--- a/app/components/dashboard/PnlChart.tsx
+++ b/app/components/dashboard/PnlChart.tsx
@@ -13,9 +13,12 @@ const ranges = ["24H", "7D", "30D", "ALL"] as const;
 
 export function PnlChart() {
   const [range, setRange] = useState<typeof ranges[number]>("7D");
-  const { totalPnl, positions, loading } = usePortfolio();
+  const { totalUnrealizedPnl, positions, loading } = usePortfolio();
 
-  const pnlFloat = Number(totalPnl) / 1e6;
+  // Use totalUnrealizedPnl (mark-to-market, already guarded against u64::MAX sentinels)
+  // rather than totalPnl (raw account.pnl sum) which can contain uninitialized sentinel
+  // values producing septillion-dollar overflow display (GH#1352).
+  const pnlFloat = Number(totalUnrealizedPnl) / 1e6;
   const isPositive = pnlFloat >= 0;
   const hasData = positions.length > 0;
 

--- a/app/hooks/usePortfolio.ts
+++ b/app/hooks/usePortfolio.ts
@@ -224,7 +224,10 @@ export function usePortfolio(): PortfolioData {
                   leverage,
                   maintenanceMarginBps,
                 });
-                pnlSum += account.pnl;
+                // Guard account.pnl against u64::MAX sentinel values before accumulating.
+                // Uninitialized / flat positions store u64::MAX as a sentinel — summing them
+                // raw produces septillion-dollar phantom totals (GH#1352 regression).
+                pnlSum += isSentinelValue(account.pnl) ? 0n : account.pnl;
                 depositSum += account.capital;
                 unrealizedPnlSum += unrealizedPnl;
               }


### PR DESCRIPTION
## Problem

**GH#1352 regression**: Dashboard Portfolio PnL widget shows `+$2,852,231,616,222,245,400,000,000.00` (septillion) on production. GH#1331/PR #1333 fixed `unrealizedPnl` computation but missed the separate code path feeding `totalPnl` → `PnlChart`.

## Root Cause

Two issues:

### 1. `usePortfolio.ts` — raw sentinel accumulation
```ts
pnlSum += account.pnl; // ← account.pnl can be u64::MAX for flat/uninitialized positions
```
This summed u64::MAX sentinel values directly into `totalPnl`.

### 2. `PnlChart.tsx` — reading the wrong field
```ts
const { totalPnl, positions, loading } = usePortfolio();
const pnlFloat = Number(totalPnl) / 1e6; // ← unsanitized raw sum
```
`totalUnrealizedPnl` (mark-to-market, already guarded) was available and used correctly by `DashboardHeader`. `PnlChart` used the wrong field.

## Fix

1. **`usePortfolio.ts`**: wrap `account.pnl` with `isSentinelValue` guard before accumulating — same guard already applied to `unrealizedPnl` in PR #1333
2. **`PnlChart.tsx`**: switch from `totalPnl` to `totalUnrealizedPnl`

## Testing

- Connect wallet `G7NGnUffoo2bKBY7nGjJmSZq7rSvG4bsJpK931rGQshD` (9 FLAT positions)
- Portfolio PnL widget should show $0.00 or a small value — not septillion
- Existing positions with real PnL should still display correctly

Closes GH#1352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated the PnL chart to display unrealized profit and loss values instead of total PnL, providing more accurate real-time tracking of your current position performance
  * Corrected portfolio calculations to properly handle uninitialized or flat positions, preventing phantom inflated totals from appearing in your overall portfolio summary

<!-- end of auto-generated comment: release notes by coderabbit.ai -->