### PR TITLE
fix(deposit): skip stale-slab InitUser re-check when account already exists (P0 race)

### DIFF
--- a/app/components/trade/DepositWithdrawCard.tsx
+++ b/app/components/trade/DepositWithdrawCard.tsx
@@ -176,7 +176,10 @@ export const DepositWithdrawCard: FC<DepositWithdrawCardProps> = ({ slabAddress,
       if (amtNative <= 0n) return;
       let sig: string | undefined;
       if (mode === "deposit") {
-        sig = await deposit({ userIdx: userAccount.idx, amount: amtNative });
+        // accountExists=true: DepositWithdrawCard only renders when userAccount !== null,
+        // so the account is confirmed by SlabProvider. Skips the stale-slab re-check in
+        // useDeposit that would incorrectly prepend a duplicate InitUser. (P0 race fix)
+        sig = await deposit({ userIdx: userAccount.idx, amount: amtNative, accountExists: true });
       } else {
         sig = await withdraw({ userIdx: userAccount.idx, amount: amtNative });
       }

--- a/app/hooks/useDeposit.ts
+++ b/app/hooks/useDeposit.ts
@@ -31,7 +31,7 @@ export function useDeposit(slabAddress: string) {
   const inflightRef = useRef(false);
 
   const deposit = useCallback(
-    async (params: { userIdx: number; amount: bigint }) => {
+    async (params: { userIdx: number; amount: bigint; accountExists?: boolean }) => {
       if (inflightRef.current) throw new Error("Deposit already in progress");
       inflightRef.current = true;
       setLoading(true);
@@ -53,6 +53,14 @@ export function useDeposit(slabAddress: string) {
         //      If not, prepend InitUser (tag 1) before DepositCollateral (tag 3).
         //      This prevents the silent on-chain failure that occurs when
         //      deposit is called for a user who has never traded this market.
+        //
+        // RACE CONDITION GUARD: If the caller sets accountExists=true (meaning
+        // useUserAccount() confirmed the account in SlabProvider's state), we
+        // skip the auto-init path entirely. This prevents a stale RPC response
+        // from incorrectly treating an existing account as absent and prepending
+        // a duplicate InitUser — which would fail on-chain and block all deposits
+        // made immediately after account creation. See GH P0 bug: "Account created
+        // but deposit fails after creation."
         //
         // If the RPC call itself throws (timeout, 429 etc.), we fall through
         // best-effort and let the chain surface any error naturally.
@@ -76,7 +84,11 @@ export function useDeposit(slabAddress: string) {
         let resolvedUserIdx = params.userIdx;
         const instructions: TransactionInstruction[] = [];
 
-        if (slabData) {
+        // Only run auto-init check if the caller hasn't confirmed the account exists.
+        // When accountExists=true, the caller (DepositWithdrawCard) already verified
+        // the account via useUserAccount() — skip the stale-slab re-check that would
+        // incorrectly try to InitUser a second time.
+        if (slabData && !params.accountExists) {
           try {
             const slabAccounts = parseAllAccounts(slabData);
             const pkStr = wallet.publicKey.toBase58();


### PR DESCRIPTION
## Problem

**P0 bug: Account created but deposit fails after creation.**

### Root Cause

`useDeposit` fetches fresh slab data on every call to guard against missing sub-accounts (auto-init added in #1038). The race:

1. User creates account via `initUser` → account confirmed on-chain
2. `refreshSlab()` fires in SlabProvider → `useUserAccount()` returns valid account → deposit form renders
3. User clicks deposit → `useDeposit` calls `getAccountInfo(slabPk)` for fresh slab data
4. **RPC returns stale data** (different node or cache miss) — user account not present
5. `parseAllAccounts` finds no account → `resolvedUserIdx = slabAccounts.length`, prepends **second `InitUser`**
6. TX fails because the account slot is already occupied → deposit blocked

### Fix

Added `accountExists?: boolean` to `deposit()` params.

- `DepositWithdrawCard` passes `accountExists: true` — it only renders the deposit form when `useUserAccount()` is non-null, meaning SlabProvider has confirmed the account. This skips the stale-slab re-check entirely.
- All other callers that omit the flag preserve the existing auto-init behavior.

## Testing

- 1044 tests pass (87 test files)
- Manually traced the race condition path — `accountExists: true` bypasses `if (slabData && !params.accountExists)` block entirely

## Related

- Reported by PM message 2026-03-16 21:54 UTC
- Root: stale-RPC double-InitUser race