### PR TITLE
fix(indexer): null max_leverage guard + Helius 429 backoff

### DIFF
--- a/packages/indexer/src/services/MarketDiscovery.ts
+++ b/packages/indexer/src/services/MarketDiscovery.ts
@@ -6,6 +6,27 @@ const logger = createLogger("indexer:market-discovery");
 
 const INITIAL_RETRY_DELAYS = [5_000, 15_000, 30_000, 60_000]; // escalating backoff
 
+/**
+ * Exponential backoff delays for Helius 429 rate-limit responses during discovery.
+ * Helius free/starter plans cap getProgramAccounts at ~40 req/s. When discovery
+ * iterates multiple programs in quick succession each call internally batches
+ * several RPC calls and can exhaust the limit. These delays give the rate limiter
+ * time to recover before the next program is attempted.
+ */
+const HELIUS_429_BACKOFF_MS = [2_000, 5_000, 15_000, 30_000]; // per-program retry
+
+/** Jitter: add up to 25% random delay to avoid thundering-herd on retry. */
+function withJitter(delayMs: number): number {
+  return delayMs + Math.floor(Math.random() * delayMs * 0.25);
+}
+
+/** Return true if the error looks like an HTTP 429 / rate-limit response. */
+function isRateLimitError(err: unknown): boolean {
+  if (!err) return false;
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.includes("429") || msg.toLowerCase().includes("rate limit") || msg.toLowerCase().includes("too many requests");
+}
+
 export class MarketDiscovery {
   private markets = new Map<string, { market: DiscoveredMarket }>();
   private timer: ReturnType<typeof setInterval> | null = null;
@@ -18,13 +39,31 @@ export class MarketDiscovery {
     let failedPrograms = 0;
     
     for (const id of programIds) {
-      try {
-        const found = await discoverMarkets(conn, new PublicKey(id));
-        all.push(...found);
-      } catch (e) {
-        failedPrograms++;
-        logger.warn("Failed to discover on program", { programId: id, error: e });
+      let discovered = false;
+      for (let attempt = 0; attempt <= HELIUS_429_BACKOFF_MS.length; attempt++) {
+        try {
+          const found = await discoverMarkets(conn, new PublicKey(id));
+          all.push(...found);
+          discovered = true;
+          break;
+        } catch (e) {
+          if (isRateLimitError(e) && attempt < HELIUS_429_BACKOFF_MS.length) {
+            const delay = withJitter(HELIUS_429_BACKOFF_MS[attempt]);
+            logger.warn("Helius 429 on discoverMarkets — backing off", {
+              programId: id,
+              attempt: attempt + 1,
+              delayMs: delay,
+            });
+            await new Promise(r => setTimeout(r, delay));
+            continue;
+          }
+          // Non-429 error or exhausted retries
+          failedPrograms++;
+          logger.warn("Failed to discover on program", { programId: id, error: e, attempt: attempt + 1 });
+          break;
+        }
       }
+      // Inter-program spacing: 2s base, helps avoid consecutive 429s on multi-program configs
       await new Promise(r => setTimeout(r, 2000));
     }
     

--- a/packages/indexer/src/services/StatsCollector.ts
+++ b/packages/indexer/src/services/StatsCollector.ts
@@ -242,6 +242,19 @@ export class StatsCollector {
           }
 
           const maxLeverage = Math.floor(10000 / initialMarginBps);
+
+          // Guard: ensure computed maxLeverage is a valid positive integer.
+          // Math.floor(Infinity) = Infinity, NaN can propagate via type coercion, and
+          // JSON serialisation converts Infinity/NaN to null — violating the DB NOT NULL
+          // constraint (error code 23502). Slab 7dVewVxW triggers this path.
+          if (!Number.isFinite(maxLeverage) || maxLeverage <= 0 || !Number.isInteger(maxLeverage)) {
+            logger.warn("Skipping market registration — computed maxLeverage is invalid", {
+              slabAddress,
+              initialMarginBps,
+              maxLeverage,
+            });
+            continue;
+          }
           
           // Try to resolve token metadata from on-chain (Helius DAS / Metaplex)
           let symbol = mintAddress.substring(0, 8); // fallback


### PR DESCRIPTION
## Problem

Two recurring indexer errors:

1. **DB error every ~2 min** — `null value in column max_leverage` for slab `7dVewVxWcVGRdLCiPgyeeKYDaSBq31J9YKjtMs9WQeem`. `Math.floor(Infinity)` = `Infinity`, which JSON serialises to `null`, violating the `NOT NULL` constraint (23502). Root cause: `initialMarginBps` passes the existing guards (positive, finite) but the computed `maxLeverage` is not separately validated before insert.

2. **Helius 429s on `discoverMarkets`** — rate-limit hits when multiple programs are discovered in sequence. Each call makes several RPC round trips; no retry on 429 meant permanent failure counts.

## Fix

**`StatsCollector.syncMarkets`** — post-computation guard after `Math.floor(10000 / initialMarginBps)`:
- Skips insert if `maxLeverage` is non-finite, ≤ 0, or non-integer (catches Infinity/NaN before JSON serialisation converts to null)

**`MarketDiscovery.discover`** — 429-aware per-program retry:
- Exponential backoff: 2s → 5s → 15s → 30s + 25% jitter
- Non-429 errors fail fast (no change to existing behaviour)
- Inter-program 2s spacing preserved

## Tests
`pnpm --filter @percolator/indexer test` — **74/74 pass ✅**