### PR TITLE
feat(ux): PERC-1232 — DB last_price display fallback + oracle banner copy

### DIFF
--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -341,7 +341,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
           </p>
           <p className="mt-1 text-[9px] text-[var(--text-secondary)] leading-relaxed">
             {oracleUnavailable
-              ? "No oracle price feed is available for this market. Trading is disabled until the oracle is activated."
+              ? "Oracle not yet active — keeper has not cranked this market."
               : "The oracle price for this market has not been updated recently. Trading is temporarily disabled to prevent failed transactions."}
           </p>
         </div>

--- a/app/hooks/useLivePrice.ts
+++ b/app/hooks/useLivePrice.ts
@@ -201,6 +201,25 @@ export function useLivePrice(): PriceState {
           }
         })
         .catch(() => {});
+
+      // PERC-1232: DB last_price display-only fallback.
+      // When oracle is unavailable (on-chain price is 0, WS feed has no data),
+      // seed the display price from the Supabase markets_with_stats table so the
+      // chart shows e.g. $0.00083 instead of "—". Trading remains blocked via
+      // the oracleStale / oracleUnavailable gate in TradeForm — this only affects display.
+      fetch(`/api/markets/${slabAddr}`)
+        .then((r) => { if (!r.ok) throw new Error("not found"); return r.json(); })
+        .then((json: { market?: { last_price?: number | null } }) => {
+          const dbPrice = json.market?.last_price;
+          if (dbPrice != null && dbPrice > 0 && mountedRef.current) {
+            setState((prev) => {
+              // Only apply if we still have no live price (don't overwrite WS/on-chain data)
+              if (prev.price !== null) return prev;
+              return { ...prev, price: dbPrice, priceUsd: dbPrice, priceE6: BigInt(Math.round(dbPrice * 1_000_000)), loading: false };
+            });
+          }
+        })
+        .catch(() => {});
     }
 
     // M3: Capture slabAddr at subscription time for cleanup


### PR DESCRIPTION
## Summary

Fixes two UX issues for oracle-unavailable markets.

### Changes

**`useLivePrice.ts`**
- Added a secondary REST fetch to `/api/markets/[slab]` to retrieve `last_price` from Supabase
- When oracle is unavailable (on-chain price is 0, WS has no data), seeds `price`/`priceUsd`/`priceE6` from DB `last_price`
- Chart now shows historical price (e.g. $0.00083) instead of "—"
- Display-only: fallback only applied when `prev.price === null`, so live WS/on-chain data is never overwritten
- Trading remains fully blocked via `oracleStale`/`oracleUnavailable` gate in TradeForm

**`TradeForm.tsx`**
- Updated `oracleUnavailable` banner body copy from generic message to:
  > "Oracle not yet active — keeper has not cranked this market."

### Testing
- Markets with no oracle crank: chart should show DB last_price, trade button still disabled, oracle banner still shows
- Markets with live oracle: no change (DB fallback never fires when `prev.price !== null`)
- Stale oracle message unchanged