### PR TITLE
fix: faucet button shows helpful link for non-mirror devnet tokens (GH#1367)

### DIFF
--- a/app/components/trade/DepositWithdrawCard.tsx
+++ b/app/components/trade/DepositWithdrawCard.tsx
@@ -84,20 +84,14 @@ export const DepositWithdrawCard: FC<DepositWithdrawCardProps> = ({ slabAddress,
             <p className="text-[10px] text-[var(--warning)]">
               You need {symbol} tokens to trade this market.
             </p>
-            {/* Show devnet faucet button for all devnet markets */}
-            {mktConfig?.collateralMint ? (
+            {/* GH#1367: Show faucet button for all devnet markets.
+                DevnetTokenFaucetButton self-corrects to a faucet link for non-mirror mints. */}
+            {mktConfig?.collateralMint && (
               <DevnetTokenFaucetButton
                 mintAddress={mktConfig.collateralMint.toBase58()}
                 symbol={symbol}
               />
-            ) : mktConfig?.collateralMint ? (
-              <a
-                href={`/devnet-mint?mint=${mktConfig.collateralMint.toBase58()}&symbol=${encodeURIComponent(symbol)}`}
-                className="text-[10px] text-[var(--warning)] underline underline-offset-2 hover:text-[var(--warning)]/80"
-              >
-                Mint some from the faucet →
-              </a>
-            ) : null}
+            )}
           </div>
         )}
         {hasTokens ? (

--- a/app/components/trade/DevnetTokenFaucetButton.tsx
+++ b/app/components/trade/DevnetTokenFaucetButton.tsx
@@ -27,6 +27,8 @@ export function DevnetTokenFaucetButton({ mintAddress, symbol }: DevnetTokenFauc
   const [claimed, setClaimed] = useState<{ amount: number; sig: string } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [rateLimited, setRateLimited] = useState<{ nextClaimAt: string } | null>(null);
+  // GH#1367: set true when API confirms this mint is not a devnet mirror
+  const [isNonMirrorMint, setIsNonMirrorMint] = useState(false);
 
   const isDevnet = getNetwork() === "devnet";
 
@@ -50,8 +52,8 @@ export function DevnetTokenFaucetButton({ mintAddress, symbol }: DevnetTokenFauc
       if (resp.status === 429) {
         setRateLimited({ nextClaimAt: data.nextClaimAt });
       } else if (resp.status === 400 && data.error?.includes("not a known devnet mirror mint")) {
-        // Silently hide — this market isn't a devnet mirror, button shouldn't render
-        // (parent should have guarded, but handle gracefully)
+        // GH#1367: Token is not a devnet mirror mint — switch to faucet link UI
+        setIsNonMirrorMint(true);
         setError(null);
       } else if (!resp.ok) {
         setError(data.error ?? "Faucet failed");
@@ -70,6 +72,21 @@ export function DevnetTokenFaucetButton({ mintAddress, symbol }: DevnetTokenFauc
 
   // Don't render without wallet
   if (!connected || !publicKey) return null;
+
+  // GH#1367: Not a devnet mirror mint — show faucet page link instead of airdrop button
+  if (isNonMirrorMint) {
+    return (
+      <div className="flex items-center gap-1.5 text-[10px]">
+        <span className="text-[var(--text-secondary)]">Get {symbol} →</span>
+        <a
+          href={`/devnet-mint?mint=${encodeURIComponent(mintAddress)}&symbol=${encodeURIComponent(symbol)}`}
+          className="text-[var(--accent)] hover:underline underline-offset-2 font-medium"
+        >
+          Devnet Faucet
+        </a>
+      </div>
+    );
+  }
 
   // Rate limited — show countdown info
   if (rateLimited) {


### PR DESCRIPTION
## Problem
The 💧 'Get [TOKEN]' faucet button on the trade page showed an inline API error for native devnet tokens like WENDYS that aren't in the devnet_mints table. The button was calling `/api/devnet-airdrop` which correctly rejects with `400 mintAddress is not a known devnet mirror mint`, but the component silently swallowed this and left the button visible.

## Root Causes
1. **`DevnetTokenFaucetButton`**: The 400 non-mirror case called `setError(null)` but left the button rendered. No state transition to a useful fallback.
2. **`DepositWithdrawCard`**: Dead ternary in the 'no account / no tokens' block — both branches checked `mktConfig?.collateralMint`, so the fallback faucet link was unreachable dead code.

## Fix
**`DevnetTokenFaucetButton`**: Added `isNonMirrorMint` state. On 400 non-mirror response, sets flag and renders a 'Get {symbol} → Devnet Faucet' link pointing to `/devnet-mint?mint=...&symbol=...` where users can self-service mint test tokens.

**`DepositWithdrawCard`**: Removed dead ternary. Renders `DevnetTokenFaucetButton` unconditionally when `collateralMint` is present — button self-corrects via Fix 1.

## Testing
- All 1057 tests pass
- On first click for non-mirror mints, button transitions to a 'Get {symbol} → Devnet Faucet' link

Closes #1367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced visibility of devnet token faucet options by displaying an accessible faucet link for non-mirror mints instead of silently hiding the option.

* **Refactor**
  * Simplified the deposit/withdraw card rendering logic for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->