### PR TITLE
fix(AirdropButton): show faucet link on 400 non-mirror-mint response (GH#1371)

### DIFF
--- a/app/__tests__/components/AirdropButton.test.tsx
+++ b/app/__tests__/components/AirdropButton.test.tsx
@@ -137,6 +137,21 @@ describe("AirdropButton", () => {
     });
   });
 
+  it("shows faucet link when API returns 400 non-mirror-mint error (GH#1371)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch(400, { error: "mintAddress is not a known devnet mirror mint" })
+    );
+
+    render(<AirdropButton mintAddress={MINT} symbol="WENDYS" />);
+    fireEvent.click(screen.getByRole("button", { name: /get wendys/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Devnet Faucet →/i)).toBeDefined();
+      expect(screen.getByText(/Get WENDYS:/i)).toBeDefined();
+    });
+  });
+
   it("shows countdown on 429 rate-limit response", async () => {
     vi.stubGlobal(
       "fetch",

--- a/app/components/trade/AirdropButton.tsx
+++ b/app/components/trade/AirdropButton.tsx
@@ -37,6 +37,7 @@ export function AirdropButton({ mintAddress, symbol, isUserCreated = true, isDev
   const [error, setError] = useState<string | null>(null);
   const [countdown, setCountdown] = useState<string | null>(null);
   const [nextClaimAt, setNextClaimAt] = useState<string | null>(null);
+  const [isNonMirrorMint, setIsNonMirrorMint] = useState(false);
 
   const isDevnet = getNetwork() === "devnet";
 
@@ -83,6 +84,9 @@ export function AirdropButton({ mintAddress, symbol, isUserCreated = true, isDev
       if (resp.status === 429) {
         setNextClaimAt(data.nextClaimAt);
         setError(`Next claim in ${Math.floor((data.retryAfterSecs ?? 86400) / 3600)}h`);
+      } else if (resp.status === 400 && data.error?.includes("not a known devnet mirror mint")) {
+        setIsNonMirrorMint(true);
+        setError(null);
       } else if (!resp.ok) {
         setError(data.error ?? "Airdrop failed");
       } else {
@@ -104,7 +108,7 @@ export function AirdropButton({ mintAddress, symbol, isUserCreated = true, isDev
   // endpoint will reject with "not a known devnet mirror mint". Instead of showing
   // the button and a confusing inline error, show a clear message with a link to
   // /devnet-mint where users can mint test tokens for any market.
-  if (!isDevnetMirror) {
+  if (!isDevnetMirror || isNonMirrorMint) {
     return (
       <div className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md bg-[var(--bg-elevated)] border border-[var(--border)] text-[10px]">
         <span className="text-[var(--text-muted)]">Get {symbol}:</span>


### PR DESCRIPTION
## What
AirdropButton (💧 Get [TOKEN] header button) now catches the 400 'not a known devnet mirror mint' response and dynamically switches to a 'Get {symbol}: Devnet Faucet →' link instead of showing a confusing inline error.

## Why
PR #1368 fixed DevnetTokenFaucetButton but missed AirdropButton. When `isDevnetMirror` defaults to `true` (most call sites), clicking the button for non-mirror tokens showed a raw error with no actionable path.

## Changes
- **AirdropButton.tsx**: Added `isNonMirrorMint` state. On 400 with 'not a known devnet mirror mint', sets state to render the faucet link (same UI as the existing `!isDevnetMirror` guard).
- **AirdropButton.test.tsx**: Added test verifying faucet link appears after 400 non-mirror response.

## Testing
- All 10 unit tests pass
- Repro: navigate to WENDYS/USD → click 💧 Get WENDYS → now shows faucet link

Closes #1371

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of non-mirror mint tokens in the airdrop functionality. Users will now see a Devnet Faucet link as an alternative when applicable, providing better access to tokens on devnet.

* **Tests**
  * Added test coverage for airdrop button behavior with non-mirror mint tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->