### PR TITLE
fix(devnet-airdrop): set recentBlockhash+feePayer before sendRawTransaction (P0 — BONK 500)

### DIFF
--- a/app/app/api/devnet-airdrop/route.ts
+++ b/app/app/api/devnet-airdrop/route.ts
@@ -391,6 +391,14 @@ export async function POST(req: NextRequest) {
       }
       tx.add(createMintToInstruction(mintPk, ata, mintAuthPk, rawAmount));
 
+      // Set recentBlockhash and feePayer before signing.
+      // sendRawTransaction requires both fields to be set — unlike sendAndConfirmTransaction
+      // which fetches the blockhash internally. Without this, serialize() throws
+      // "Transaction recentBlockhash field is required", causing a 500.
+      const { blockhash } = await connection.getLatestBlockhash();
+      tx.recentBlockhash = blockhash;
+      tx.feePayer = mintAuthPk;
+
       // Sign using sealed signer and send raw.
       // sendAndConfirmTransaction() calls tx.sign(signers) internally which wipes all existing
       // signatures — including the one the sealed signer just applied. Use sendRawTransaction +

--- a/app/app/api/devnet-mint-token/route.ts
+++ b/app/app/api/devnet-mint-token/route.ts
@@ -220,6 +220,11 @@ export async function POST(req: NextRequest) {
           ),
         );
 
+        // Set recentBlockhash and feePayer before signing (required for sendRawTransaction).
+        const { blockhash: airdropBlockhash } = await connection.getLatestBlockhash();
+        airdropTx.recentBlockhash = airdropBlockhash;
+        airdropTx.feePayer = mintAuthPk;
+
         // Sign and send raw — sendAndConfirmTransaction wipes the sealed signer's signature
         // by calling tx.sign(signers) internally. Use sendRawTransaction instead.
         const signedAirdropTx = mintSigner.signTransaction(airdropTx);


### PR DESCRIPTION
## Problem
POST `/api/devnet-airdrop` returns `500 Internal Server Error` for BONK and any new mirror mint.

## Root Cause
PR #1356 (`fix(S-1): use sendRawTransaction`) switched from `sendAndConfirmTransaction` to `sendRawTransaction` to preserve the sealed signer's signature. However it forgot to add the `getLatestBlockhash` + set `recentBlockhash` + `feePayer` step that `devnet-mirror-mint` already has.

`sendAndConfirmTransaction` fetches the blockhash internally before serialising. `sendRawTransaction` does not — so `Transaction.serialize()` throws:
```
Transaction recentBlockhash field is required
```
This exception falls through the `mintErr` catch (not an authority error), re-throws, and hits the outer catch → generic 500.

PR #1370 (the BONK authority-mismatch fix) didn't catch this because the old BONK mint failed earlier (authority check), masking the blockhash bug. The new re-keyed BONK mint (`CCPHprPU6RsT4KbwVRC5Gk21L3B7VFsPUZFxEjZS4SeC`) has the correct authority, so it reaches `serialize()` and hits the bug.

## Fix
Mirror `devnet-mirror-mint`'s working pattern: fetch latest blockhash and set both fields before signing.

**`devnet-airdrop/route.ts`** — fetch blockhash before `mintSigner.signTransaction(tx)`
**`devnet-mint-token/route.ts`** — same fix for the `already_exists` airdrop path

## Testing
- BONK airdrop `POST /api/devnet-airdrop` with `mintAddress=CCPHprPU6RsT4KbwVRC5Gk21L3B7VFsPUZFxEjZS4SeC` should return 200 + signature
- JUP airdrop path unchanged
- `devnet-mint-token` already_exists flow now also gets blockhash set
- TypeScript: `pnpm tsc --noEmit` clean ✓

## Fixes
GH#1371 (BONK 500 post-rekeying)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transaction failures in devnet airdrop and token minting operations that previously caused server errors during transaction processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->