### PR TITLE
fix(auto-fund): set recentBlockhash+feePayer before sendRawTransaction

### DIFF
--- a/app/app/api/auto-fund/route.ts
+++ b/app/app/api/auto-fund/route.ts
@@ -157,10 +157,15 @@ export async function POST(req: NextRequest) {
               ),
             );
 
+            // Set recentBlockhash + feePayer before signing (required for sendRawTransaction)
+            const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash();
+            tx.recentBlockhash = blockhash;
+            tx.feePayer = mintAuthPk;
+
             // Sign and send transaction using sealed signer
             const signed = mintSigner.signTransaction(tx);
             const sig = await connection.sendRawTransaction((signed as Transaction).serialize());
-            await connection.confirmTransaction(sig, "confirmed");
+            await connection.confirmTransaction({ signature: sig, blockhash, lastValidBlockHeight }, "confirmed");
 
             results.usdc_minted = true;
             results.usdc_amount = USDC_MINT_AMOUNT / 1_000_000;


### PR DESCRIPTION
## Problem

`auto-fund/route.ts` calls `sendRawTransaction` without first setting `recentBlockhash` and `feePayer` on the Transaction. This causes:
```
Transaction recentBlockhash field is required → serialize() throws → 500
```

Identical bug to what was fixed in PR #1373 for `devnet-airdrop/route.ts`. Caught by CodeRabbit's review of #1373.

## Fix

- Call `connection.getLatestBlockhash()` before signing
- Assign `tx.recentBlockhash = blockhash` and `tx.feePayer = mintAuthPk`
- Use blockhash-aware `confirmTransaction({ signature, blockhash, lastValidBlockHeight })` overload for proper expiration handling

## Testing

- 1058 tests passing (87 test files, 2 skipped)
- TypeScript clean (no new errors)

## Related
- PR #1373 — same fix in devnet-airdrop/route.ts
- CodeRabbit review comment on PR #1373

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction confirmation handling in the auto-fund process for enhanced reliability and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->