### PR TITLE
fix(blocklist): hardcode 3 NL no-liquidity slabs causing /funding/ 500 errors (GH#1357)

### DIFF
--- a/app/__tests__/lib/blocklist.test.ts
+++ b/app/__tests__/lib/blocklist.test.ts
@@ -9,6 +9,19 @@ describe("blocklist", () => {
     expect(isBlockedSlab("BxJPaMaCfEGTBsjZ8wfj3Yfzf4wpasmxKAEvqZZRcGPP")).toBe(true);
   });
 
+  // GH#1357 / PR#1377: NL no-liquidity slabs hardcoded into blocklist
+  it("blocks 3bmCyPee SEX/USD slab (PR #1377)", () => {
+    expect(isBlockedSlab("3bmCyPee8GWJR5aPGTyN5EyyQJLzYyD8Wkg9m1Afd1SD")).toBe(true);
+  });
+
+  it("blocks 3YDqCJGz phantom-OI slab (PR #1377)", () => {
+    expect(isBlockedSlab("3YDqCJGz88xGiPBiRvx4vrM51mWTiTZPZ95hxYDZqKpJ")).toBe(true);
+  });
+
+  it("blocks 3ZKKwsKoo empty-vault slab (PR #1377)", () => {
+    expect(isBlockedSlab("3ZKKwsKoo5UP28cYmMpvGpwoFpWLVgEWLQJCejJnECQn")).toBe(true);
+  });
+
   it("isBlockedSlab returns false for a valid market address", () => {
     expect(isBlockedSlab("SomeValidMarketAddressNotInBlocklist1234567")).toBe(false);
   });

--- a/app/lib/blocklist.ts
+++ b/app/lib/blocklist.ts
@@ -20,6 +20,15 @@ export const BLOCKED_SLAB_ADDRESSES: ReadonlySet<string> = new Set([
   // false total OI). Migration 045 zeroed the DB but the indexer re-synced from on-chain.
   // Blocked permanently until on-chain state is corrected. PR #1219.
   "H5Vunzd2yAMygnpFiGUASDSx2s8P3bfPTzjCfrRsPeph",
+  // GH#1357 / PR#1362: no-liquidity slabs causing /funding/ 500 errors (Sentry).
+  // Previously expected in BLOCKED_MARKET_ADDRESSES env var; hardcoded here so the
+  // middleware guard (pre-rewrite) blocks them even in fresh deployments without env config.
+  // SEX/USD — devnet-only token, empty vault, phantom OI (migration 048). PR #1377.
+  "3bmCyPee8GWJR5aPGTyN5EyyQJLzYyD8Wkg9m1Afd1SD",
+  // Empty-vault phantom-OI slab (migration 048). PR #1377.
+  "3YDqCJGz88xGiPBiRvx4vrM51mWTiTZPZ95hxYDZqKpJ",
+  // Empty-vault phantom-OI slab (no on-chain liquidity). PR #1377.
+  "3ZKKwsKoo5UP28cYmMpvGpwoFpWLVgEWLQJCejJnECQn",
 ]);
 
 /**


### PR DESCRIPTION
## Problem

PR #1362 added the middleware slab blocklist guard but never hardcoded the 3 NL/no-liquidity slabs that triggered the fix. They were expected in `BLOCKED_MARKET_ADDRESSES` env var, but that's not set on all deployments — Sentry is still reporting 3 new 500 errors:

- `3bmCyPee8GWJR5aPGTyN5EyyQJLzYyD8Wkg9m1Afd1SD` (SEX/USD — devnet-only token, empty vault, migration 048)
- `3YDqCJGz88xGiPBiRvx4vrM51mWTiTZPZ95hxYDZqKpJ` (empty-vault phantom OI, migration 048)
- `3ZKKwsKoo5UP28cYmMpvGpwoFpWLVgEWLQJCejJnECQn` (empty-vault, no on-chain liquidity)

## Fix

Add all 3 full slab addresses to `BLOCKED_SLAB_ADDRESSES` in `app/lib/blocklist.ts`. The middleware guard reads this set pre-rewrite, so this ensures `/api/funding/:slab` and `/api/funding/:slab/history` return 404 without requiring env var config.

## Testing

- 9/9 blocklist tests pass (3 new assertions added)
- `isBlockedSlab('3bmCyPee8GWJR5aPGTyN5EyyQJLzYyD8Wkg9m1Afd1SD')` → `true` ✅
- `isBlockedSlab('3YDqCJGz88xGiPBiRvx4vrM51mWTiTZPZ95hxYDZqKpJ')` → `true` ✅  
- `isBlockedSlab('3ZKKwsKoo5UP28cYmMpvGpwoFpWLVgEWLQJCejJnECQn')` → `true` ✅
- All other existing tests pass (1061 total)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added three slab addresses to the blocklist to address identified issues. The core blocking mechanism remains unchanged.

* **Tests**
  * Expanded test coverage with three new test cases verifying that the newly blocked addresses are correctly identified and handled by the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->