### PR TITLE
fix(faucet): use NEXT_PUBLIC_DEFAULT_NETWORK env var (GH#1380)

### DIFF
--- a/app/__tests__/api/faucet-route.test.ts
+++ b/app/__tests__/api/faucet-route.test.ts
@@ -36,10 +36,12 @@ vi.mock("@sentry/nextjs", () => ({
 describe("/api/faucet route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_DEFAULT_NETWORK = "devnet";
     process.env.NEXT_PUBLIC_SOLANA_NETWORK = "devnet";
   });
 
   it("should reject requests on mainnet", async () => {
+    process.env.NEXT_PUBLIC_DEFAULT_NETWORK = "mainnet";
     process.env.NEXT_PUBLIC_SOLANA_NETWORK = "mainnet";
 
     // We'd need to import the route handler and mock NextRequest

--- a/app/app/api/faucet/route.ts
+++ b/app/app/api/faucet/route.ts
@@ -30,7 +30,10 @@ import * as Sentry from "@sentry/nextjs";
 
 export const dynamic = "force-dynamic";
 
-const NETWORK = process.env.NEXT_PUBLIC_SOLANA_NETWORK;
+// Use NEXT_PUBLIC_DEFAULT_NETWORK — canonical network env var (GH#1380, aligned with auto-fund fix in PR #1379)
+const NETWORK =
+  process.env.NEXT_PUBLIC_DEFAULT_NETWORK?.trim() ??
+  process.env.NEXT_PUBLIC_SOLANA_NETWORK;
 const USDC_MINT_AMOUNT = 10_000_000_000; // 10,000 USDC (6 decimals)
 const RATE_LIMIT_HOURS = 24;
 


### PR DESCRIPTION
## What
Fixes #1380 — `/api/faucet` returns *Faucet only available on devnet* on the production devnet deployment.

## Why
The faucet route was checking `NEXT_PUBLIC_SOLANA_NETWORK` which is not set in Vercel. PR #1379 fixed the same issue in `/api/auto-fund` by switching to `NEXT_PUBLIC_DEFAULT_NETWORK`. This PR aligns faucet with that fix.

## Changes
- `app/app/api/faucet/route.ts`: Use `NEXT_PUBLIC_DEFAULT_NETWORK` (trimmed) as primary, fall back to `NEXT_PUBLIC_SOLANA_NETWORK`
- Updated faucet test to set both env vars

## How to Test
```bash
curl -X POST https://percolatorlaunch.com/api/faucet -H 'Content-Type: application/json' -d '{"wallet":"...","type":"sol"}'
```
Should no longer return the devnet guard error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced network configuration handling for the faucet service with improved environment variable precedence logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->