### PR TITLE
fix(api): backend blocklist for phantom-OI slabs — Sentry 500 -> 404

### DIFF
--- a/packages/api/src/middleware/validateSlab.ts
+++ b/packages/api/src/middleware/validateSlab.ts
@@ -3,8 +3,42 @@ import type { Context, Next } from "hono";
 import { sanitizeSlabAddress } from "@percolator/shared";
 
 /**
+ * Known-bad slab addresses that cause backend 500 errors (empty vault / phantom OI).
+ *
+ * These are the same addresses hardcoded in the Next.js app's BLOCKED_SLAB_ADDRESSES
+ * (app/lib/blocklist.ts). They are repeated here so the backend API returns 404
+ * even when called directly (bypassing the Next.js proxy layer).
+ *
+ * GH#1357 / PR#1377 / Sentry follow-up (devops 2026-03-17).
+ * Extend via BLOCKED_MARKET_ADDRESSES env var (comma-separated pubkeys).
+ */
+const HARDCODED_BLOCKED_SLABS: ReadonlySet<string> = new Set([
+  // SEX/USD — devnet-only token, empty vault, phantom OI (migration 048)
+  "3bmCyPee8GWJR5aPGTyN5EyyQJLzYyD8Wkg9m1Afd1SD",
+  // Empty-vault phantom-OI slab (migration 048)
+  "3YDqCJGz88xGiPBiRvx4vrM51mWTiTZPZ95hxYDZqKpJ",
+  // Empty-vault phantom-OI slab (no on-chain liquidity)
+  "3ZKKwsKoo5UP28cYmMpvGpwoFpWLVgEWLQJCejJnECQn",
+]);
+
+/**
+ * Runtime-configurable blocklist loaded once at startup from BLOCKED_MARKET_ADDRESSES.
+ * Allows ops to block new addresses without a code deploy.
+ */
+const ENV_BLOCKED_SLABS: ReadonlySet<string> = new Set(
+  (process.env.BLOCKED_MARKET_ADDRESSES ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean),
+);
+
+function isBlocked(slab: string): boolean {
+  return HARDCODED_BLOCKED_SLABS.has(slab) || ENV_BLOCKED_SLABS.has(slab);
+}
+
+/**
  * Hono middleware that validates the `:slab` route param is a valid Solana public key.
- * Returns 400 if invalid.
+ * Returns 400 if invalid, 404 if the address is on the backend blocklist.
  */
 export async function validateSlab(c: Context, next: Next) {
   const slab = c.req.param("slab");
@@ -21,6 +55,12 @@ export async function validateSlab(c: Context, next: Next) {
     new PublicKey(sanitized);
   } catch {
     return c.json({ error: "Invalid slab address" }, 400);
+  }
+
+  // Blocklist check — return 404 for known-bad/empty slabs instead of proxying
+  // to DB queries that return 500 (phantom OI / no market_stats rows).
+  if (isBlocked(sanitized)) {
+    return c.json({ error: "Market not found" }, 404);
   }
 
   return next();

--- a/packages/api/tests/middleware/validateSlab.test.ts
+++ b/packages/api/tests/middleware/validateSlab.test.ts
@@ -104,4 +104,30 @@ describe("validateSlab middleware", () => {
     const data = await res.json();
     expect(data).toEqual({ error: "Invalid slab address" });
   });
+
+  describe("blocklist (GH#1357 / Sentry 2026-03-17)", () => {
+    // These three addresses are phantom-OI / empty-vault slabs that cause backend
+    // 500s when queried. They are hardcoded so the API returns 404 even when called
+    // directly, bypassing the Next.js proxy blocklist.
+    const BLOCKED = [
+      "3bmCyPee8GWJR5aPGTyN5EyyQJLzYyD8Wkg9m1Afd1SD",
+      "3YDqCJGz88xGiPBiRvx4vrM51mWTiTZPZ95hxYDZqKpJ",
+      "3ZKKwsKoo5UP28cYmMpvGpwoFpWLVgEWLQJCejJnECQn",
+    ];
+
+    for (const addr of BLOCKED) {
+      it(`returns 404 for blocked slab ${addr.slice(0, 8)}...`, async () => {
+        const res = await app.request(`/markets/${addr}`);
+        expect(res.status).toBe(404);
+        const data = await res.json();
+        expect(data).toEqual({ error: "Market not found" });
+      });
+    }
+
+    it("still allows valid non-blocked slabs through", async () => {
+      const valid = "11111111111111111111111111111111";
+      const res = await app.request(`/markets/${valid}`);
+      expect(res.status).toBe(200);
+    });
+  });
 });


### PR DESCRIPTION
## Problem
Devops Sentry alert (2026-03-17): three slab addresses returning HTTP 500 from the backend API:
- `3bmCyPee...` (SEX/USD, empty vault, migration 048)
- `3YDqCJGz...` (phantom OI, migration 048)
- `3ZKKwsK...` (no on-chain liquidity)

These are already in `BLOCKED_SLAB_ADDRESSES` (app/lib/blocklist.ts) which blocks them at the Next.js proxy layer. But calls reaching the backend API directly bypass that guard and hit the DB, causing 500s.

## Fix
Add a hardcoded blocklist and `BLOCKED_MARKET_ADDRESSES` env-var support to `validateSlab` middleware in packages/api. Blocked addresses now return `404 { error: 'Market not found' }` before any DB query — matching the proxy layer behaviour and eliminating Sentry noise.

New addresses can be blocked at runtime via `BLOCKED_MARKET_ADDRESSES=addr1,addr2` env var without a code deploy.

## Tests
4 new test cases in validateSlab.test.ts:
- One per blocked address (verifies 404)
- Non-blocked valid address still returns 200

All 127 api package tests passing.

Refs: GH#1357, Sentry devops report 2026-03-17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Market blocklist support: blocked markets now return 404 "Market not found" 
  * Blocklist configurable via environment variables

* **Tests**
  * Added test coverage for market blocklist validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->