### PR TITLE
test(api): blocklist coverage for /open-interest and /insurance (GH#1388)

### DIFF
--- a/packages/api/tests/routes/insurance.test.ts
+++ b/packages/api/tests/routes/insurance.test.ts
@@ -236,5 +236,63 @@ describe("insurance routes", () => {
 
       expect(limitCalled).toBe(true);
     });
+
+    describe("blocklist (GH#1388 / PR#1387)", () => {
+      // These three phantom-OI / empty-vault slabs must return 404 even when queried
+      // directly against the API, bypassing the Next.js proxy blocklist.
+      const BLOCKED = [
+        "3bmCyPee8GWJR5aPGTyN5EyyQJLzYyD8Wkg9m1Afd1SD",
+        "3YDqCJGz88xGiPBiRvx4vrM51mWTiTZPZ95hxYDZqKpJ",
+        "3ZKKwsKoo5UP28cYmMpvGpwoFpWLVgEWLQJCejJnECQn",
+      ];
+
+      for (const addr of BLOCKED) {
+        it(`returns 404 for blocked slab ${addr.slice(0, 8)}... on /insurance`, async () => {
+          const app = insuranceRoutes();
+          const res = await app.request(`/insurance/${addr}`);
+          expect(res.status).toBe(404);
+          const data = await res.json();
+          expect(data).toEqual({ error: "Market not found" });
+          // DB should never be queried for blocked slabs
+          expect(mockSupabase.from).not.toHaveBeenCalled();
+        });
+      }
+
+      it("allows valid non-blocked slabs through to DB layer", async () => {
+        mockSupabase.from.mockImplementation((table: string) => {
+          if (table === "market_stats") {
+            return {
+              select: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  single: vi.fn().mockResolvedValue({
+                    data: {
+                      insurance_balance: "1000000000",
+                      insurance_fee_revenue: "50000000",
+                      total_open_interest: "5000000000",
+                    },
+                    error: null,
+                  }),
+                })),
+              })),
+            };
+          } else if (table === "insurance_history") {
+            return {
+              select: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  order: vi.fn(() => ({
+                    limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+                  })),
+                })),
+              })),
+            };
+          }
+          return mockSupabase;
+        });
+
+        const app = insuranceRoutes();
+        const res = await app.request("/insurance/11111111111111111111111111111111");
+        expect(res.status).toBe(200);
+      });
+    });
   });
 });

--- a/packages/api/tests/routes/open-interest.test.ts
+++ b/packages/api/tests/routes/open-interest.test.ts
@@ -283,5 +283,64 @@ describe("open-interest routes", () => {
       const data = await res.json();
       expect(data.history).toHaveLength(0);
     });
+
+    describe("blocklist (GH#1388 / PR#1387)", () => {
+      // These three phantom-OI / empty-vault slabs must return 404 even when queried
+      // directly against the API, bypassing the Next.js proxy blocklist.
+      const BLOCKED = [
+        "3bmCyPee8GWJR5aPGTyN5EyyQJLzYyD8Wkg9m1Afd1SD",
+        "3YDqCJGz88xGiPBiRvx4vrM51mWTiTZPZ95hxYDZqKpJ",
+        "3ZKKwsKoo5UP28cYmMpvGpwoFpWLVgEWLQJCejJnECQn",
+      ];
+
+      for (const addr of BLOCKED) {
+        it(`returns 404 for blocked slab ${addr.slice(0, 8)}... on /open-interest`, async () => {
+          const app = openInterestRoutes();
+          const res = await app.request(`/open-interest/${addr}`);
+          expect(res.status).toBe(404);
+          const data = await res.json();
+          expect(data).toEqual({ error: "Market not found" });
+          // DB should never be queried for blocked slabs
+          expect(mockSupabase.from).not.toHaveBeenCalled();
+        });
+      }
+
+      it("allows valid non-blocked slabs through to DB layer", async () => {
+        mockSupabase.from.mockImplementation((table: string) => {
+          if (table === "market_stats") {
+            return {
+              select: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  single: vi.fn().mockResolvedValue({
+                    data: {
+                      total_open_interest: "1000",
+                      net_lp_pos: "100",
+                      lp_sum_abs: "200",
+                      lp_max_abs: "50",
+                    },
+                    error: null,
+                  }),
+                })),
+              })),
+            };
+          } else if (table === "oi_history") {
+            return {
+              select: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  order: vi.fn(() => ({
+                    limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+                  })),
+                })),
+              })),
+            };
+          }
+          return mockSupabase;
+        });
+
+        const app = openInterestRoutes();
+        const res = await app.request("/open-interest/11111111111111111111111111111111");
+        expect(res.status).toBe(200);
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
Adds blocklist test coverage for the two routes identified in GH#1388 as lacking it.

## What changed
- `tests/routes/open-interest.test.ts` — new `describe('blocklist')` block: 3 blocked slabs → 404, 1 valid pass-through test
- `tests/routes/insurance.test.ts` — same pattern

## Why
PR #1387 added `validateSlab` middleware to `/open-interest/:slab` and `/insurance/:slab` but only tested the middleware in isolation via `validateSlab.test.ts`. The route-level tests had no coverage of blocked addresses, leaving a gap that wouldn't catch regressions.

## Root cause of GH#1388
The underlying issue (Railway not redeployed) is a DevOps action — tagging `@devops` to trigger redeploy of `packages/api`.

## Tests
```
135 passed (14 test files)
```

Refs: GH#1388, PR#1387

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for blocklist validation across insurance and open-interest routes, verifying that blocked markets return 404 errors with appropriate messaging and that valid markets process successfully through the database layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->