### PR TITLE
fix: filter out garbage markets with system program oracle_authority (GH#1398)

### DIFF
--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -139,6 +139,13 @@ export async function GET(request: NextRequest) {
     const ZERO_PUBKEY = "11111111111111111111111111111111";
     const sanitized = ((data ?? []) as unknown as Record<string, unknown>[])
       .filter((m) => !BLOCKED_MARKET_ADDRESSES.has(m.slab_address as string))
+      // GH#1398: Filter out garbage markets with system program as oracle_authority.
+      // These markets cannot receive valid oracle price updates and are likely
+      // accidental deployments (e.g. symbol '11111111', 333x leverage).
+      .filter((m) => {
+        const auth = m.oracle_authority as string | null;
+        return auth !== ZERO_PUBKEY;
+      })
       .map((m) => {
       let oracle_mode = m.oracle_mode as string | null;
       if (!oracle_mode) {

--- a/app/app/api/stats/route.ts
+++ b/app/app/api/stats/route.ts
@@ -67,7 +67,7 @@ export async function GET(request: NextRequest) {
     // GH#1218: include slab_address so we can filter blocked markets (same as /api/markets)
     // GH#1265: also fetch trade_count_24h so we can sum it directly (replaces buggy trades table count query)
     // GH#1297: include vault_balance + total_accounts to apply phantom OI guard (consistent with /api/markets)
-    supabase.from("markets_with_stats").select("slab_address, volume_24h, trade_count_24h, open_interest_long, open_interest_short, total_open_interest, last_price, decimals, vault_balance, total_accounts").limit(500),
+    supabase.from("markets_with_stats").select("slab_address, volume_24h, trade_count_24h, open_interest_long, open_interest_short, total_open_interest, last_price, decimals, vault_balance, total_accounts, oracle_authority").limit(500),
     supabase.from("trades").select("trader").limit(5000),
   ]);
 
@@ -81,8 +81,12 @@ export async function GET(request: NextRequest) {
       .map((s) => s.trim())
       .filter(Boolean),
   ]);
+  // GH#1398: Filter out garbage markets with system program oracle_authority
+  const ZERO_PUBKEY = "11111111111111111111111111111111";
   const statsData = (statsRes.data ?? []).filter(
     (m) => !BLOCKED_MARKET_ADDRESSES.has((m as Record<string, unknown>).slab_address as string ?? ""),
+  ).filter(
+    (m) => (m as Record<string, unknown>).oracle_authority !== ZERO_PUBKEY,
   );
 
   // GH#1337: Suppress phantom OI before counting active markets.

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -129,7 +129,7 @@ export default function Home() {
       }
 
       try {
-        const { data, error: dbError } = await getSupabase().from("markets_with_stats").select("slab_address, symbol, volume_24h, insurance_balance, insurance_fund, last_price, total_open_interest, open_interest_long, open_interest_short, decimals") as { data: { slab_address: string; symbol: string | null; volume_24h: number | null; insurance_balance: number | null; insurance_fund: number | null; last_price: number | null; total_open_interest: number | null; open_interest_long: number | null; open_interest_short: number | null; decimals: number | null }[] | null; error: { message: string } | null };
+        const { data, error: dbError } = await getSupabase().from("markets_with_stats").select("slab_address, symbol, volume_24h, insurance_balance, insurance_fund, last_price, total_open_interest, open_interest_long, open_interest_short, decimals, oracle_authority") as { data: { slab_address: string; symbol: string | null; volume_24h: number | null; insurance_balance: number | null; insurance_fund: number | null; last_price: number | null; total_open_interest: number | null; open_interest_long: number | null; open_interest_short: number | null; decimals: number | null; oracle_authority: string | null }[] | null; error: { message: string } | null };
         if (dbError) {
           console.error("Failed to query markets_with_stats:", dbError.message);
           throw new Error(dbError.message);
@@ -167,8 +167,11 @@ export default function Home() {
           // (consistent with /api/stats and markets page). Also exclude blocked/stale
           // slab addresses — these pass isActiveMarket (last_price > 0) but are bad
           // on-chain data that corrupt insurance and volume aggregates (GH#1181).
+          const ZERO_PUBKEY = "11111111111111111111111111111111";
           const activeData = data
             .filter((m) => !isBlockedSlab(m.slab_address))
+            // GH#1398: Filter out garbage markets with system program oracle_authority
+            .filter((m) => m.oracle_authority !== ZERO_PUBKEY)
             .filter(isActiveMarket);
           setStats({
             markets: activeData.length,
@@ -199,6 +202,7 @@ export default function Home() {
           // GH#1224: exclude blocked slab addresses (same filter as activeData/stats)
           const converted = data
             .filter((m) => !isBlockedSlab(m.slab_address))
+            .filter((m) => m.oracle_authority !== ZERO_PUBKEY)
             .map((m) => ({
             slab_address: m.slab_address,
             symbol: m.symbol,


### PR DESCRIPTION
## What
Filter out markets where `oracle_authority` is the system program (`11111111...1`) from all API endpoints and the homepage. These are garbage/test deployments that cannot receive valid oracle price updates.

## Why
- **GH#1398**: A garbage market (CRJH9Gtk) with 333x leverage, symbol `11111111`, and system program oracle_authority is visible in the API. 11 other markets share this invalid oracle_authority.
- **GH#1397**: Homepage market count (171) doesn't match API data (208 total / 134 active). Root cause: inconsistent filtering — this PR applies the same oracle_authority filter everywhere.

## Changes
- `/api/markets`: Filter out system-program oracle_authority markets before sanitization
- `/api/stats`: Add `oracle_authority` to query select; filter before aggregation
- `app/page.tsx`: Add `oracle_authority` to homepage query; filter in activeData + featured pipelines

## Testing
- All 1089 existing tests pass
- Manual: `curl /api/markets | jq '[.markets[] | select(.oracle_authority == "11111111111111111111111111111111")] | length'` → should return 0

Closes #1397, closes #1398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed invalid and corrupted market entries from all API endpoints and user-facing displays.
  * Enhanced data quality by filtering out phantom markets across market listings, statistics, and dashboard views.
  * Improved overall platform reliability and data accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->