### PR TITLE
fix(blocklist): add 11 remaining phantom oracle_authority=system-program slabs (GH#1398 follow-up)

### DIFF
--- a/app/__tests__/api/markets-post-leverage-guard.test.ts
+++ b/app/__tests__/api/markets-post-leverage-guard.test.ts
@@ -118,11 +118,30 @@ describe("POST /api/markets — max_leverage guard (GH#1398)", () => {
   });
 });
 
-describe("blocklist — CRJH9Gtk garbage market (GH#1398)", () => {
-  it("CRJH9Gtk7qQDdjzDufnAZdfa7AHisfvxCmVVvzpzQN9v is in BLOCKED_SLAB_ADDRESSES", async () => {
-    vi.resetModules();
-    const { BLOCKED_SLAB_ADDRESSES, isBlockedSlab } = await import("@/lib/blocklist");
-    expect(BLOCKED_SLAB_ADDRESSES.has("CRJH9Gtk7qQDdjzDufnAZdfa7AHisfvxCmVVvzpzQN9v")).toBe(true);
-    expect(isBlockedSlab("CRJH9Gtk7qQDdjzDufnAZdfa7AHisfvxCmVVvzpzQN9v")).toBe(true);
-  });
+describe("blocklist — GH#1398 garbage markets (system program oracle_authority)", () => {
+  const PHANTOM_SLABS = [
+    "CRJH9Gtk7qQDdjzDufnAZdfa7AHisfvxCmVVvzpzQN9v", // original (PR #1401)
+    // GH#1398 follow-up (PR #1404): remaining 11 phantom oracle_authority = system program slabs
+    "J6UU4VHbYXpCAACr5o5xjUVmquagiP2NGbbMp68VUCX9",
+    "8L47yqvQRLxZ6PzW3b9jawEM79CmokBvUzeLR7mvtyuU",
+    "8kkED3uZznGzSidr8kYJPd3VhzSh7LVngNUx2V1qnW9L",
+    "8pKtAV3z6iTKekieF9EenQ4tk1rkAVa9oYsqe7h1PGjx",
+    "Eekuz2TgXRPq3rsp5brRW5hofxLdwt6KUXbLUQCKHK9G",
+    "Av3zVrW5deLpLo1qZZ7yNJ5Lq5ja4Z9ixijVhV4MuRzE",
+    "CrbDmfiooBUTFfGyMhJ1hpToCrBLAXXKySBwEnLHV6kj",
+    "FhpPmmuh5UDAjvEjrYBPFwmj4CP4otvsYMxtTb46p1Ss",
+    "7xozYEbKhEdjQn5pCAV8bUDQGugZttqZTduPeHkoqRb8",
+    "3dp3e288oPjs5w92fg26cVYQMHGuUpsj8YbSFn6wrzp4",
+    "8nzjXMvdkC4fRF491QkpKE6aFTLmEcpXEnbh4wQT4iUA",
+  ];
+
+  it.each(PHANTOM_SLABS)(
+    "%s is in BLOCKED_SLAB_ADDRESSES and isBlockedSlab returns true",
+    async (slab) => {
+      vi.resetModules();
+      const { BLOCKED_SLAB_ADDRESSES, isBlockedSlab } = await import("@/lib/blocklist");
+      expect(BLOCKED_SLAB_ADDRESSES.has(slab)).toBe(true);
+      expect(isBlockedSlab(slab)).toBe(true);
+    }
+  );
 });

--- a/app/lib/blocklist.ts
+++ b/app/lib/blocklist.ts
@@ -33,6 +33,21 @@ export const BLOCKED_SLAB_ADDRESSES: ReadonlySet<string> = new Set([
   // oracle_authority = system program (11111111...), cannot receive price updates.
   // Deployer = DEVNET_MINT_AUTHORITY_KEYPAIR (accidental test deployment).
   "CRJH9Gtk7qQDdjzDufnAZdfa7AHisfvxCmVVvzpzQN9v",
+  // GH#1398 follow-up (PR #1404): Remaining 11 phantom slabs with oracle_authority =
+  // system program (11111111...). These cannot receive oracle price pushes, have no
+  // real liquidity, and cause /funding/[slab] → 500 errors via backend proxy.
+  // Addresses queried from markets_with_stats where oracle_authority = system program.
+  "J6UU4VHbYXpCAACr5o5xjUVmquagiP2NGbbMp68VUCX9",
+  "8L47yqvQRLxZ6PzW3b9jawEM79CmokBvUzeLR7mvtyuU",
+  "8kkED3uZznGzSidr8kYJPd3VhzSh7LVngNUx2V1qnW9L",
+  "8pKtAV3z6iTKekieF9EenQ4tk1rkAVa9oYsqe7h1PGjx",
+  "Eekuz2TgXRPq3rsp5brRW5hofxLdwt6KUXbLUQCKHK9G",
+  "Av3zVrW5deLpLo1qZZ7yNJ5Lq5ja4Z9ixijVhV4MuRzE",
+  "CrbDmfiooBUTFfGyMhJ1hpToCrBLAXXKySBwEnLHV6kj",
+  "FhpPmmuh5UDAjvEjrYBPFwmj4CP4otvsYMxtTb46p1Ss",
+  "7xozYEbKhEdjQn5pCAV8bUDQGugZttqZTduPeHkoqRb8",
+  "3dp3e288oPjs5w92fg26cVYQMHGuUpsj8YbSFn6wrzp4",
+  "8nzjXMvdkC4fRF491QkpKE6aFTLmEcpXEnbh4wQT4iUA",
 ]);
 
 /**


### PR DESCRIPTION
## Summary

GH#1398 follow-up. PR #1401 blocked only `CRJH9Gtk` (the 333x garbage market). QA confirmed 11 additional phantom slabs remain in the DB with `oracle_authority = 11111111111111111111111111111111` (system program), causing `/funding/[slab]` → 500 errors via backend proxy.

## Root Cause

These slabs were deployed with the system program as oracle authority — they can never receive oracle price pushes. The backend's `/funding/:slab` endpoint returns 500 for these. The frontend's `/api/funding/[slab]` route proxies through, propagating the 500.

The fix is to add them to `BLOCKED_SLAB_ADDRESSES` so the funding route guard returns 404 (not 500) and the slabs are hidden from all UI/API surfaces.

## Addresses Blocked (queried from Supabase `markets_with_stats`)

```
J6UU4VHbYXpCAACr5o5xjUVmquagiP2NGbbMp68VUCX9
8L47yqvQRLxZ6PzW3b9jawEM79CmokBvUzeLR7mvtyuU
8kkED3uZznGzSidr8kYJPd3VhzSh7LVngNUx2V1qnW9L
8pKtAV3z6iTKekieF9EenQ4tk1rkAVa9oYsqe7h1PGjx
Eekuz2TgXRPq3rsp5brRW5hofxLdwt6KUXbLUQCKHK9G
Av3zVrW5deLpLo1qZZ7yNJ5Lq5ja4Z9ixijVhV4MuRzE
CrbDmfiooBUTFfGyMhJ1hpToCrBLAXXKySBwEnLHV6kj
FhpPmmuh5UDAjvEjrYBPFwmj4CP4otvsYMxtTb46p1Ss
7xozYEbKhEdjQn5pCAV8bUDQGugZttqZTduPeHkoqRb8
3dp3e288oPjs5w92fg26cVYQMHGuUpsj8YbSFn6wrzp4
8nzjXMvdkC4fRF491QkpKE6aFTLmEcpXEnbh4wQT4iUA
```

## Changes

- `app/lib/blocklist.ts`: 11 addresses added to `BLOCKED_SLAB_ADDRESSES` with inline comment referencing this PR
- `app/__tests__/api/markets-post-leverage-guard.test.ts`: Expanded blocklist coverage from single `it()` to `it.each()` covering all 12 phantom oracle_authority slabs

## Test Plan

- All 1108 tests pass ✅
- `/api/funding/[slab]` for any of the 12 phantom slabs → 404 (not 500) after deploy
- Phantom slabs filtered from `GET /api/markets` and homepage via existing `isBlockedSlab()` guards

Closes #1398 (remaining phantom slabs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced blocklist verification tests with expanded coverage for phantom slab addresses
* **Security Updates**
  * Added 11 phantom slab addresses to the blocklist

<!-- end of auto-generated comment: release notes by coderabbit.ai -->