### PR TITLE
fix(markets): strict phantom OI threshold + slab endpoint price sanitize (GH#1405 Part 2)

### DIFF
--- a/app/__tests__/api/markets-price-sanitize.test.ts
+++ b/app/__tests__/api/markets-price-sanitize.test.ts
@@ -296,26 +296,31 @@ describe("GET /api/markets — price sanitization (#856)", () => {
       expect(m?.total_open_interest_usd).toBeNull();
     });
 
-    it("suppresses total_open_interest_usd when vault_balance is dust (< 1,000,000)", async () => {
+    it("suppresses total_open_interest_usd when vault_balance is dust (<= 1,000,000) — GH#1405 Part 2", async () => {
       mockMarkets = [
         mkMarket({ symbol: "DUST_1", vault_balance: 1, total_open_interest: 2_000_000_000_000, last_price: 1.0 }),
         mkMarket({ symbol: "DUST_100", vault_balance: 100, total_open_interest: 2_000_000_000_000, last_price: 1.0 }),
         mkMarket({ symbol: "DUST_999999", vault_balance: 999_999, total_open_interest: 2_000_000_000_000, last_price: 1.0 }),
+        // GH#1405 Part 2: exactly at threshold (1M) is now also phantom (was previously allowed through)
+        mkMarket({ symbol: "DUST_1M", vault_balance: 1_000_000, total_open_interest: 2_000_000_000_000, last_price: 1.0 }),
       ];
       vi.resetModules();
       const { GET } = await import("@/app/api/markets/route");
       const res = await GET();
       const body = (await res.json()) as { markets: { symbol: string; total_open_interest_usd: number | null }[] };
-      for (const sym of ["DUST_1", "DUST_100", "DUST_999999"]) {
+      for (const sym of ["DUST_1", "DUST_100", "DUST_999999", "DUST_1M"]) {
         const m = body.markets.find((m) => m.symbol === sym);
         expect(m?.total_open_interest_usd).toBeNull(); // dust vault → phantom OI suppressed
       }
     });
 
-    it("passes through total_open_interest_usd when vault_balance >= 1,000,000 (real liquidity)", async () => {
+    it("passes through total_open_interest_usd when vault_balance > 1,000,000 (real liquidity)", async () => {
       mockMarkets = [
-        // exactly at threshold boundary — real liquidity starts here
+        // GH#1405 Part 2: exactly at threshold (1M) is now treated as phantom (<=).
+        // Real liquidity requires vault_balance > 1_000_000.
         mkMarket({ symbol: "AT_THRESHOLD", vault_balance: 1_000_000, total_open_interest: 1_000, decimals: 6, last_price: 1.0 }),
+        // one above threshold — real liquidity
+        mkMarket({ symbol: "ABOVE_THRESHOLD", vault_balance: 1_000_001, total_open_interest: 1_000, decimals: 6, last_price: 1.0 }),
         // well above threshold — typical LP deposit
         mkMarket({ symbol: "REAL_VAULT", vault_balance: 500_000_000, total_open_interest: 1_000, decimals: 6, last_price: 1.0 }),
       ];
@@ -324,8 +329,12 @@ describe("GET /api/markets — price sanitization (#856)", () => {
       const res = await GET();
       const body = (await res.json()) as { markets: { symbol: string; total_open_interest_usd: number | null }[] };
       const atThreshold = body.markets.find((m) => m.symbol === "AT_THRESHOLD");
+      const aboveThreshold = body.markets.find((m) => m.symbol === "ABOVE_THRESHOLD");
       const realVault = body.markets.find((m) => m.symbol === "REAL_VAULT");
-      expect(atThreshold?.total_open_interest_usd).toBeCloseTo(0.001, 6); // 1000 / 1e6 * 1.0
+      // exactly at threshold → phantom (GH#1405 Part 2: <= guard)
+      expect(atThreshold?.total_open_interest_usd).toBeNull();
+      // one above threshold → real liquidity, OI passes through
+      expect(aboveThreshold?.total_open_interest_usd).toBeCloseTo(0.001, 6); // 1000 / 1e6 * 1.0
       expect(realVault?.total_open_interest_usd).toBeCloseTo(0.001, 6);
     });
 

--- a/app/app/api/markets/[slab]/route.ts
+++ b/app/app/api/markets/[slab]/route.ts
@@ -3,6 +3,19 @@ import { PublicKey } from "@solana/web3.js";
 import { getServiceClient } from "@/lib/supabase";
 import { SLUG_ALIASES } from "@/lib/symbol-utils";
 import * as Sentry from "@sentry/nextjs";
+
+/**
+ * GH#1405: Sanitize price fields from the DB. Returns null for corrupt/garbage values.
+ * Matches the MAX_SANE_PRICE_USD guard in /api/markets route.ts ($1M ceiling).
+ * Prevents raw unscaled admin oracle values (e.g. 10001100011 for DfLoAzny) from
+ * being returned to callers of the individual slab endpoint.
+ */
+const MAX_SANE_PRICE_USD = 1_000_000; // $1M — matches bulk /api/markets guard
+function sanitizePrice(v: unknown): number | null {
+  if (v == null || typeof v !== "number") return null;
+  if (!Number.isFinite(v) || v <= 0 || v > MAX_SANE_PRICE_USD) return null;
+  return v;
+}
 export const dynamic = "force-dynamic";
 
 function isValidPublicKey(s: string): boolean {
@@ -96,7 +109,17 @@ export async function GET(
       return NextResponse.json({ error: "Market not found" }, { status: 404 });
     }
 
-    return NextResponse.json({ market: data });
+    // GH#1405: Sanitize price fields before returning — raw DB values from admin-mode
+    // markets may be unscaled u64 authorityPriceE6 values (e.g. DfLoAzny: 10001100011).
+    // Matches the sanitizePrice guard in the bulk /api/markets endpoint.
+    const sanitized = {
+      ...data,
+      last_price: sanitizePrice(data.last_price),
+      mark_price: sanitizePrice(data.mark_price),
+      index_price: sanitizePrice(data.index_price),
+    };
+
+    return NextResponse.json({ market: sanitized });
   } catch (error) {
     Sentry.captureException(error, {
       tags: { endpoint: "/api/markets/[slab]", method: "GET", slab },

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -172,7 +172,10 @@ export async function GET(request: NextRequest) {
       // GH#1271: Also suppress when vault_balance = 0 (no LP liquidity → no real positions).
       // PERC-816: Extend to suppress for dust vault_balance (0 < vault < 1,000,000 micro-units).
       // Mirrors the invariant enforced by StatsCollector and migration 049.
-      const MIN_VAULT_FOR_OI = 1_000_000; // < 1 USDC at 6 decimals; dust at 9 decimals
+      // GH#1405 Part 2: use strict GTE (<=) so vault_balance == MIN_VAULT_FOR_OI is
+      // also treated as phantom — markets at exactly the threshold have no real LP
+      // liquidity. Consistent with homepage phantomAwareData guard.
+      const MIN_VAULT_FOR_OI = 1_000_000; // <= 1 USDC at 6 decimals; dust at 9 decimals
       const accountsCount = (m.total_accounts as number) ?? 0;
       const vaultBal = (m.vault_balance as number) ?? 0;
       // GH#1290 / PERC-570: Phantom OI guard — suppress all OI fields (USD and raw atoms)
@@ -180,7 +183,7 @@ export async function GET(request: NextRequest) {
       // and migration 051. Suppressing only total_open_interest_usd left the raw
       // total_open_interest atom value in the response, which fed phantom OI into
       // computeMarketHealthFromStats and the markets page sort/filter.
-      const isPhantomOI = accountsCount === 0 || vaultBal < MIN_VAULT_FOR_OI;
+      const isPhantomOI = accountsCount === 0 || vaultBal <= MIN_VAULT_FOR_OI;
       const displayOiUsd = isPhantomOI ? null : total_open_interest_usd;
 
       // GH#1270: Pre-compute volume_24h in USD so consumers (e.g. Watchlist) don't need

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -168,12 +168,15 @@ export default function Home() {
           // stale non-zero OI in the DB (the indexer syncs from on-chain, where the
           // value hasn't been zeroed). Without this guard, those phantom markets pass
           // isActiveMarket (via total_open_interest > 0) and inflate the homepage count.
-          // threshold matches /api/markets + /api/stats: vault < 1M = dust/empty.
+          // threshold matches /api/markets + /api/stats: vault <= 1M = dust/empty.
+          // GH#1405 Part 2: use strict GTE (<=) so vault_balance == MIN_VAULT_FOR_ACTIVE
+          // is also treated as phantom — markets at exactly the threshold have no real LP
+          // liquidity backing and carry stale/corrupt OI (e.g. DfLoAzny).
           const MIN_VAULT_FOR_ACTIVE = 1_000_000;
           const phantomAwareData = data.map((m) => {
             const accountsCount = m.total_accounts ?? 0;
             const vaultBal = m.vault_balance ?? 0;
-            const isPhantom = accountsCount === 0 || vaultBal < MIN_VAULT_FOR_ACTIVE;
+            const isPhantom = accountsCount === 0 || vaultBal <= MIN_VAULT_FOR_ACTIVE;
             if (!isPhantom) return m;
             // Zero OI so isActiveMarket won't count stale phantom OI as "active"
             return { ...m, total_open_interest: 0, open_interest_long: 0, open_interest_short: 0 };


### PR DESCRIPTION
## Summary

Part 2 of GH#1405 — two fixes following PR #1406 (merged).

### Fix 1: Strict vault threshold (<=)

Changed phantom OI guard from `vaultBal < MIN_VAULT_FOR_OI` → `vaultBal <= MIN_VAULT_FOR_OI` in:
- `app/app/api/markets/route.ts`
- `app/app/page.tsx` (homepage `phantomAwareData`)

**Root cause:** DfLoAzny has `vault_balance: 1000000` (exactly at the 1M threshold). The old `<` guard let it pass through, carrying corrupt `total_open_interest: 2000000000000` and stale/admin price data. After PR #1406 the price renders as '—', but the market still appeared in Active Markets sorted by OI. Strict `<=` excludes it cleanly.

### Fix 2: Individual slab endpoint price sanitization

`/api/markets/[slab]/route.ts` now applies `sanitizePrice()` (MAX_SANE_PRICE_USD = $1M) to `last_price`, `mark_price`, `index_price` before returning.

The bulk `/api/markets` endpoint already sanitized these fields, but the individual slab endpoint returned raw DB values. Callers of `GET /api/markets/DfLoAzny...` still received `last_price: 10001100011`.

## Testing

- Updated `PERC-816` dust vault suite: added `DUST_1M` case (`vault == 1M` now suppressed)
- Added `ABOVE_THRESHOLD` case (`vault == 1_000_001` passes through correctly)
- 1115/1115 tests pass (34 bigint-binding skips — pre-existing)

## How to Test

1. DfLoAzny should no longer appear in Active Markets on homepage
2. `GET /api/markets/8eFFEFBY3HHbBgzxJJP5hyxdzMNMAumnYNhkWXErBM4c` should return `last_price: null`

Closes GH#1405 Part 2.