### PR TITLE
fix(api): add 8eFFEFBY to backend validateSlab blocklist (GH#1413 follow-up, PR #1415)

### DIFF
--- a/packages/api/src/middleware/validateSlab.ts
+++ b/packages/api/src/middleware/validateSlab.ts
@@ -19,6 +19,12 @@ const HARDCODED_BLOCKED_SLABS: ReadonlySet<string> = new Set([
   "3YDqCJGz88xGiPBiRvx4vrM51mWTiTZPZ95hxYDZqKpJ",
   // Empty-vault phantom-OI slab (no on-chain liquidity)
   "3ZKKwsKoo5UP28cYmMpvGpwoFpWLVgEWLQJCejJnECQn",
+  // GH#1413: DfLoAzny/USD slab — phantom market with vault_balance=1M (at threshold),
+  // stale on-chain OI (2T micro-units ≈ 2,000,000 tokens). Added to frontend blocklist
+  // (app/lib/blocklist.ts) via PR #1415 but missing from backend validateSlab middleware.
+  // /api/open-interest/8eFFEFBY returns 200 with phantom data without this entry.
+  // Also covers /api/funding/8eFFEFBY returning stale zero-rate data.
+  "8eFFEFBY3HHbBgzxJJP5hyxdzMNMAumnYNhkWXErBM4c",
 ]);
 
 /**

--- a/packages/api/tests/middleware/validateSlab.test.ts
+++ b/packages/api/tests/middleware/validateSlab.test.ts
@@ -106,13 +106,17 @@ describe("validateSlab middleware", () => {
   });
 
   describe("blocklist (GH#1357 / Sentry 2026-03-17)", () => {
-    // These three addresses are phantom-OI / empty-vault slabs that cause backend
+    // These addresses are phantom-OI / empty-vault slabs that cause backend
     // 500s when queried. They are hardcoded so the API returns 404 even when called
     // directly, bypassing the Next.js proxy blocklist.
     const BLOCKED = [
       "3bmCyPee8GWJR5aPGTyN5EyyQJLzYyD8Wkg9m1Afd1SD",
       "3YDqCJGz88xGiPBiRvx4vrM51mWTiTZPZ95hxYDZqKpJ",
       "3ZKKwsKoo5UP28cYmMpvGpwoFpWLVgEWLQJCejJnECQn",
+      // GH#1413: DfLoAzny/USD slab — was blocked in frontend blocklist.ts (PR #1415)
+      // but missing from backend validateSlab; /api/open-interest/8eFFEFBY was returning
+      // 200 with phantom 2T micro-unit OI data. Fixed by PR #1416.
+      "8eFFEFBY3HHbBgzxJJP5hyxdzMNMAumnYNhkWXErBM4c",
     ];
 
     for (const addr of BLOCKED) {


### PR DESCRIPTION
## Summary

CodeRabbit flagged in PR #1415 post-merge: `8eFFEFBY3HHbBgzxJJP5hyxdzMNMAumnYNhkWXErBM4c` (DfLoAzny/USD slab) was added to the **frontend** `app/lib/blocklist.ts` but was **missing** from the **backend** `packages/api/src/middleware/validateSlab.ts`.

### Root Cause

Without this entry in `HARDCODED_BLOCKED_SLABS`, calling the API directly bypasses the Next.js layer and:
- `/api/open-interest/8eFFEFBY3HHbBgzxJJP5hyxdzMNMAumnYNhkWXErBM4c` → returns HTTP 200 with phantom \~2T micro-unit OI data
- `/api/funding/8eFFEFBY3HHbBgzxJJP5hyxdzMNMAumnYNhkWXErBM4c` → returns stale zero-rate data

### Fix

Add `8eFFEFBY3HHbBgzxJJP5hyxdzMNMAumnYNhkWXErBM4c` to `HARDCODED_BLOCKED_SLABS` in `validateSlab.ts` so the middleware returns 404 for both routes.

### Testing

Extended the blocklist describe block in `validateSlab.test.ts` — all 14 tests pass (136 total).

```bash
# Verify after deploy: should return 404
curl https://percolatorlaunch.com/api/open-interest/8eFFEFBY3HHbBgzxJJP5hyxdzMNMAumnYNhkWXErBM4c
curl https://percolatorlaunch.com/api/funding/8eFFEFBY3HHbBgzxJJP5hyxdzMNMAumnYNhkWXErBM4c
```

Closes #1413 (follow-up to #1415)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Blocked access to a specific Solana market address, which now returns HTTP 404 "Market not found" when accessed.

* **Tests**
  * Updated validation tests to verify blocklist behavior for the newly blocked market address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->