### PR TITLE
fix: GH#1417 — add blocklist guard to /api/markets/[slab] endpoint

### DIFF
--- a/app/app/api/markets/[slab]/route.ts
+++ b/app/app/api/markets/[slab]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { PublicKey } from "@solana/web3.js";
 import { getServiceClient } from "@/lib/supabase";
 import { SLUG_ALIASES } from "@/lib/symbol-utils";
+import { isBlockedSlab } from "@/lib/blocklist";
 import * as Sentry from "@sentry/nextjs";
 
 /**
@@ -38,6 +39,15 @@ export async function GET(
   { params }: { params: Promise<{ slab: string }> }
 ) {
   const { slab } = await params;
+
+  // GH#1417: Blocked slabs must return 404 even when addressed directly.
+  // The bulk /api/markets endpoint already filters via BLOCKED_SLAB_ADDRESSES but
+  // this individual endpoint had no guard, allowing blocked addresses (e.g. 8eFFEFBY)
+  // to return HTTP 200 with phantom data.
+  if (isBlockedSlab(slab)) {
+    return NextResponse.json({ error: "Market not found" }, { status: 404 });
+  }
+
   try {
     const supabase = getServiceClient();
     let data: Record<string, unknown> | null = null;


### PR DESCRIPTION
## Summary
Fixes GH#1417 filed by QA.

The individual `/api/markets/[slab]` route had no check against `BLOCKED_SLAB_ADDRESSES`, allowing blocked addresses (e.g. `8eFFEFBY3HHbBgzxJJP5hyxdzMNMAumnYNhkWXErBM4c`) to return HTTP 200 with phantom market data.

## Change
- Import `isBlockedSlab` from `@/lib/blocklist`
- Return 404 immediately before any DB query when the slab is on the blocklist
- Mirrors the guard already in the bulk `/api/markets` endpoint (which imports `BLOCKED_SLAB_ADDRESSES` and filters via `.filter()`)

## Testing
- All 136 tests pass locally
- TypeScript compiles clean (`tsc --noEmit`)

## How to verify
```bash
curl /api/markets/8eFFEFBY3HHbBgzxJJP5hyxdzMNMAumnYNhkWXErBM4c
# Before: 200 with phantom market data
# After:  404 {"error":"Market not found"}
```

Related: GH#1413, PR #1415, PR #1416

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where blocked markets could be accessed directly through the API. These markets now properly return an access denied error instead of allowing data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->