### PR TITLE
fix(api): GH#1429 zombieCount=0 with include_zombie=true + GH#1430 stats/markets activeTotal mismatch

### DIFF
--- a/app/__tests__/api/markets-zombie-count.test.ts
+++ b/app/__tests__/api/markets-zombie-count.test.ts
@@ -1,0 +1,123 @@
+/**
+ * GH#1429: zombieCount must be non-zero even when include_zombie=true.
+ *
+ * Regression test for the bug where zombieCount was computed as
+ * `sanitized.length - nonZombie.length`. When include_zombie=true, nonZombie
+ * includes all markets, making the difference always 0.
+ *
+ * Fix: compute zombieCount directly from the is_zombie flag on sanitized
+ * markets, independent of the include_zombie filter.
+ */
+import { describe, it, expect } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Minimal reproduction of the zombieCount computation in /api/markets/route.ts
+// ---------------------------------------------------------------------------
+
+type Market = { slab_address: string; is_zombie: boolean };
+
+/**
+ * Buggy implementation (before fix):
+ * zombieCount = sanitized.length - nonZombie.length
+ * When includeZombie=true, nonZombie === sanitized, so count is always 0.
+ */
+function zombieCountBuggy(sanitized: Market[], includeZombie: boolean): number {
+  const nonZombie = sanitized.filter((m) => includeZombie || !m.is_zombie);
+  return sanitized.length - nonZombie.length;
+}
+
+/**
+ * Fixed implementation (after fix):
+ * zombieCount = sanitized.filter(is_zombie).length
+ * Independent of the includeZombie filter flag.
+ */
+function zombieCountFixed(sanitized: Market[], _includeZombie: boolean): number {
+  return sanitized.filter((m) => m.is_zombie === true).length;
+}
+
+const ALIVE: Market = { slab_address: "alive1", is_zombie: false };
+const ZOMBIE: Market = { slab_address: "zombie1", is_zombie: true };
+const ZOMBIE2: Market = { slab_address: "zombie2", is_zombie: true };
+
+describe("GH#1429 — zombieCount bug regression", () => {
+  describe("buggy implementation (documents the pre-fix behaviour)", () => {
+    it("returns 0 when include_zombie=false (works by accident)", () => {
+      // include_zombie=false: nonZombie excludes zombie, so diff is correct
+      expect(zombieCountBuggy([ALIVE, ZOMBIE], false)).toBe(1);
+    });
+
+    it("returns 0 (wrong!) when include_zombie=true", () => {
+      // BUG: nonZombie === sanitized when includeZombie=true → diff = 0
+      expect(zombieCountBuggy([ALIVE, ZOMBIE], true)).toBe(0);
+    });
+  });
+
+  describe("fixed implementation", () => {
+    it("returns correct count when include_zombie=false", () => {
+      expect(zombieCountFixed([ALIVE, ZOMBIE], false)).toBe(1);
+    });
+
+    it("returns correct count when include_zombie=true", () => {
+      // FIX: counts from is_zombie flag, ignoring the include flag
+      expect(zombieCountFixed([ALIVE, ZOMBIE], true)).toBe(1);
+    });
+
+    it("returns 0 when there are no zombies (include_zombie=true)", () => {
+      expect(zombieCountFixed([ALIVE], true)).toBe(0);
+    });
+
+    it("counts multiple zombies correctly with include_zombie=true", () => {
+      expect(zombieCountFixed([ALIVE, ZOMBIE, ZOMBIE2], true)).toBe(2);
+    });
+
+    it("counts multiple zombies correctly with include_zombie=false", () => {
+      expect(zombieCountFixed([ALIVE, ZOMBIE, ZOMBIE2], false)).toBe(2);
+    });
+
+    it("returns sanitized.length when all are zombies", () => {
+      expect(zombieCountFixed([ZOMBIE, ZOMBIE2], true)).toBe(2);
+    });
+
+    it("returns 0 when sanitized is empty", () => {
+      expect(zombieCountFixed([], true)).toBe(0);
+      expect(zombieCountFixed([], false)).toBe(0);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Response shape assertion: zombieCount present and consistent
+// ---------------------------------------------------------------------------
+describe("GH#1429 — response shape with fixed zombieCount", () => {
+  function buildResponse(
+    sanitized: Market[],
+    includeZombie: boolean,
+  ): { total: number; zombieCount: number; markets: Market[] } {
+    const nonZombie = sanitized.filter((m) => includeZombie || !m.is_zombie);
+    // FIXED: compute from tag, not from difference
+    const zombieCount = sanitized.filter((m) => m.is_zombie === true).length;
+    return { total: nonZombie.length, zombieCount, markets: nonZombie };
+  }
+
+  it("include_zombie=true: total=2, zombieCount=1, markets has both", () => {
+    const res = buildResponse([ALIVE, ZOMBIE], true);
+    expect(res.total).toBe(2);
+    expect(res.zombieCount).toBe(1);
+    expect(res.markets).toHaveLength(2);
+  });
+
+  it("include_zombie=false: total=1, zombieCount=1, markets has only alive", () => {
+    const res = buildResponse([ALIVE, ZOMBIE], false);
+    expect(res.total).toBe(1);
+    expect(res.zombieCount).toBe(1);
+    expect(res.markets).toHaveLength(1);
+    expect(res.markets[0].slab_address).toBe("alive1");
+  });
+
+  it("no zombies: zombieCount=0 regardless of flag", () => {
+    const resTrue = buildResponse([ALIVE], true);
+    const resFalse = buildResponse([ALIVE], false);
+    expect(resTrue.zombieCount).toBe(0);
+    expect(resFalse.zombieCount).toBe(0);
+  });
+});

--- a/app/__tests__/api/stats-active-total-consistency.test.ts
+++ b/app/__tests__/api/stats-active-total-consistency.test.ts
@@ -1,0 +1,272 @@
+/**
+ * GH#1430: /api/stats totalMarkets must not count corrupt-price markets as active.
+ *
+ * Root cause: /api/stats used isSaneMarketValue (< 1e18) for last_price
+ * before counting active markets, while /api/markets applies sanitizePrice
+ * (nulls last_price > $1M) first. Markets with $1M < last_price < 1e18
+ * counted as active in stats but not in markets.
+ *
+ * Fix: apply the $1M cap to last_price in phantomAwareData before
+ * isActiveMarket() in /api/stats, mirroring /api/markets sanitizePrice.
+ */
+import { describe, it, expect } from "vitest";
+import { isActiveMarket, isSaneMarketValue } from "@/lib/activeMarketFilter";
+
+// ---------------------------------------------------------------------------
+// Constants — must match /api/stats and /api/markets
+// ---------------------------------------------------------------------------
+const MAX_SANE_PRICE_USD = 1_000_000;  // $1M — /api/markets sanitizePrice cap
+const MIN_VAULT_FOR_ACTIVE = 1_000_000;
+
+// ---------------------------------------------------------------------------
+// Reproduce the phantomAwareData mapping from /api/stats (fixed version)
+// ---------------------------------------------------------------------------
+type StatsRow = {
+  slab_address?: string;
+  last_price?: number | null;
+  volume_24h?: number | null;
+  trade_count_24h?: number | null;
+  open_interest_long?: number | null;
+  open_interest_short?: number | null;
+  total_open_interest?: number | null;
+  vault_balance?: number | null;
+  total_accounts?: number | null;
+  stats_updated_at?: string | null;
+  decimals?: number | null;
+};
+
+/** Reproduces the buggy phantomAwareData (before fix): no price cap for non-phantoms */
+function phantomAwareDataBuggy(statsData: StatsRow[]): StatsRow[] {
+  return statsData.map((m) => {
+    const accountsCount = (m.total_accounts ?? 0);
+    const vaultBal = (m.vault_balance ?? 0);
+    const isPhantom = accountsCount === 0 || vaultBal < MIN_VAULT_FOR_ACTIVE;
+    if (!isPhantom) return m;  // BUG: returns raw m with possibly corrupt price
+    return {
+      ...m,
+      last_price: 0,
+      volume_24h: 0,
+      trade_count_24h: 0,
+      total_open_interest: 0,
+      open_interest_long: 0,
+      open_interest_short: 0,
+    };
+  });
+}
+
+/** Reproduces the fixed phantomAwareData: applies $1M price cap for non-phantoms */
+function phantomAwareDataFixed(statsData: StatsRow[]): StatsRow[] {
+  return statsData.map((m) => {
+    const accountsCount = (m.total_accounts ?? 0);
+    const vaultBal = (m.vault_balance ?? 0);
+    const isPhantom = accountsCount === 0 || vaultBal < MIN_VAULT_FOR_ACTIVE;
+    if (!isPhantom) {
+      // GH#1430: Apply sanitizePrice cap before isActiveMarket
+      const rawPrice = m.last_price;
+      const sanitizedPrice =
+        rawPrice != null && rawPrice > 0 && rawPrice <= MAX_SANE_PRICE_USD
+          ? rawPrice
+          : null;
+      if (sanitizedPrice !== rawPrice) {
+        return { ...m, last_price: sanitizedPrice };
+      }
+      return m;
+    }
+    return {
+      ...m,
+      last_price: 0,
+      volume_24h: 0,
+      trade_count_24h: 0,
+      total_open_interest: 0,
+      open_interest_long: 0,
+      open_interest_short: 0,
+    };
+  });
+}
+
+function countActive(data: StatsRow[]): number {
+  return data.filter(isActiveMarket).length;
+}
+
+// ---------------------------------------------------------------------------
+// Market factories
+// ---------------------------------------------------------------------------
+function market(overrides: Partial<StatsRow> = {}): StatsRow {
+  return {
+    slab_address: "slab1",
+    last_price: 1.5,
+    volume_24h: 1000,
+    trade_count_24h: 5,
+    total_open_interest: 200,
+    open_interest_long: 100,
+    open_interest_short: 100,
+    vault_balance: 5_000_000,
+    total_accounts: 3,
+    decimals: 6,
+    stats_updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests — isSaneMarketValue (shared utility, unchanged)
+// ---------------------------------------------------------------------------
+describe("isSaneMarketValue — price boundary checks", () => {
+  it("accepts $1 (valid)", () => expect(isSaneMarketValue(1)).toBe(true));
+  it("accepts $1M exactly (valid)", () => expect(isSaneMarketValue(1_000_000)).toBe(true));
+  it("accepts $5M (valid per isSaneMarket — < 1e18)", () => expect(isSaneMarketValue(5_000_000)).toBe(true));
+  it("rejects null", () => expect(isSaneMarketValue(null)).toBe(false));
+  it("rejects 0", () => expect(isSaneMarketValue(0)).toBe(false));
+  it("rejects negative", () => expect(isSaneMarketValue(-1)).toBe(false));
+  it("rejects sentinel 1e18", () => expect(isSaneMarketValue(1e18)).toBe(false));
+});
+
+// ---------------------------------------------------------------------------
+// Tests — buggy implementation (documents that $5M passes as active — WRONG)
+// ---------------------------------------------------------------------------
+describe("buggy phantomAwareData — shows the inconsistency", () => {
+  it("incorrectly counts market with $5M corrupt price as active", () => {
+    const row = market({
+      last_price: 5_000_000, // corrupt, nulled in /api/markets but not in stats (bug)
+      volume_24h: 0,
+      total_open_interest: 0,
+      open_interest_long: 0,
+      open_interest_short: 0,
+    });
+    const processed = phantomAwareDataBuggy([row]);
+    // BUG: last_price $5M passes isSaneMarketValue → counted as active
+    expect(countActive(processed)).toBe(1); // ← wrong (mismatches /api/markets)
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — fixed implementation
+// ---------------------------------------------------------------------------
+describe("GH#1430 — fixed phantomAwareData applies $1M cap before isActiveMarket", () => {
+  it("correctly rejects corrupt price $5M (> $1M cap)", () => {
+    const row = market({
+      last_price: 5_000_000,
+      volume_24h: 0,
+      total_open_interest: 0,
+      open_interest_long: 0,
+      open_interest_short: 0,
+    });
+    const processed = phantomAwareDataFixed([row]);
+    // FIX: $5M > $1M is nulled, not sane → market NOT counted as active
+    expect(countActive(processed)).toBe(0);
+  });
+
+  it("accepts valid $1M price as active", () => {
+    const row = market({
+      last_price: 1_000_000,
+      volume_24h: 0,
+      total_open_interest: 0,
+    });
+    const processed = phantomAwareDataFixed([row]);
+    expect(countActive(processed)).toBe(1);
+  });
+
+  it("rejects price just above cap ($1M + $1)", () => {
+    const row = market({
+      last_price: 1_000_001,
+      volume_24h: 0,
+      total_open_interest: 0,
+      open_interest_long: 0,
+      open_interest_short: 0,
+    });
+    const processed = phantomAwareDataFixed([row]);
+    expect(countActive(processed)).toBe(0);
+  });
+
+  it("still counts active via volume_24h when price is corrupt", () => {
+    const row = market({
+      last_price: 9_000_000, // corrupt
+      volume_24h: 50_000,    // valid
+      total_open_interest: 0,
+    });
+    const processed = phantomAwareDataFixed([row]);
+    // Active via volume_24h even though price is bad
+    expect(countActive(processed)).toBe(1);
+  });
+
+  it("still counts active via total_open_interest when price is corrupt", () => {
+    const row = market({
+      last_price: 9_000_000, // corrupt
+      volume_24h: 0,
+      total_open_interest: 500,
+    });
+    const processed = phantomAwareDataFixed([row]);
+    expect(countActive(processed)).toBe(1);
+  });
+
+  it("phantom market (vault < 1M) is zeroed out and not counted", () => {
+    const row = market({ vault_balance: 500_000, total_accounts: 5 });
+    const processed = phantomAwareDataFixed([row]);
+    expect(countActive(processed)).toBe(0);
+  });
+
+  it("mixed: 2 valid + 1 corrupt price + 1 phantom = 2 active", () => {
+    const rows = [
+      market({ slab_address: "a", last_price: 50 }),
+      market({ slab_address: "b", last_price: 120 }),
+      market({
+        slab_address: "c",
+        last_price: 9_000_000,  // corrupt
+        volume_24h: 0,
+        total_open_interest: 0,
+        open_interest_long: 0,
+        open_interest_short: 0,
+      }),
+      market({ slab_address: "d", vault_balance: 0, total_accounts: 0 }),
+    ];
+    const processed = phantomAwareDataFixed(rows);
+    expect(countActive(processed)).toBe(2);
+  });
+
+  it("does not modify non-corrupt prices unnecessarily", () => {
+    const row = market({ last_price: 42.5 });
+    const processed = phantomAwareDataFixed([row]);
+    expect((processed[0] as StatsRow).last_price).toBe(42.5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Alignment check: fixed stats count === /api/markets activeTotal logic
+// ---------------------------------------------------------------------------
+describe("GH#1430 — fixed stats count aligns with /api/markets sanitizePrice logic", () => {
+  const MAX_SANE = 1_000_000;
+
+  // Simulate what /api/markets does: sanitizePrice → null if > $1M
+  function sanitizePrice(v: number | null): number | null {
+    if (v == null) return null;
+    if (!Number.isFinite(v) || v <= 0 || v > MAX_SANE) return null;
+    return v;
+  }
+
+  it("both treat $1M price as valid active", () => {
+    const raw = 1_000_000;
+    expect(sanitizePrice(raw)).not.toBeNull(); // /api/markets: valid
+    const row = market({ last_price: raw, volume_24h: 0, total_open_interest: 0 });
+    expect(countActive(phantomAwareDataFixed([row]))).toBe(1); // stats: active
+  });
+
+  it("both treat $1M + 1 price as invalid", () => {
+    const raw = 1_000_001;
+    expect(sanitizePrice(raw)).toBeNull(); // /api/markets: nulled
+    const row = market({
+      last_price: raw,
+      volume_24h: 0,
+      total_open_interest: 0,
+      open_interest_long: 0,
+      open_interest_short: 0,
+    });
+    expect(countActive(phantomAwareDataFixed([row]))).toBe(0); // stats: inactive
+  });
+
+  it("both treat $500K price as valid", () => {
+    const raw = 500_000;
+    expect(sanitizePrice(raw)).not.toBeNull();
+    const row = market({ last_price: raw, volume_24h: 0, total_open_interest: 0 });
+    expect(countActive(phantomAwareDataFixed([row]))).toBe(1);
+  });
+});

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -260,7 +260,11 @@ export async function GET(request: NextRequest) {
 
     // GH#1420: Filter zombie markets (vault_balance=0) unless ?include_zombie=true
     const nonZombie = sanitized.filter((m) => includeZombie || !(m as Record<string, unknown>).is_zombie);
-    const zombieCount = sanitized.length - nonZombie.length;
+    // GH#1429: Compute zombieCount from sanitized array BEFORE the zombie filter, not from
+    // the difference sanitized.length - nonZombie.length. When include_zombie=true, nonZombie
+    // includes all markets (including zombies), making the difference always 0. Computing
+    // directly from the tagged is_zombie field gives the correct count regardless of the flag.
+    const zombieCount = sanitized.filter((m) => (m as Record<string, unknown>).is_zombie === true).length;
 
     // #1168: Include total count so API consumers can get market count without
     // fetching all records. Reflects post-filter count (blocked markets excluded).

--- a/app/app/api/stats/route.ts
+++ b/app/app/api/stats/route.ts
@@ -93,11 +93,28 @@ export async function GET(request: NextRequest) {
   // This produced a 172 vs 135 mismatch. Now we zero phantom OI first, so both
   // endpoints agree on what counts as "active".
   const MIN_VAULT_FOR_ACTIVE = 1_000_000;
+  // GH#1430: Match /api/markets sanitizePrice cap — null out last_price > $1M before
+  // isActiveMarket() so markets with corrupt oracle prices (e.g. $7.9T) don't count
+  // as "active" in stats while being nulled in /api/markets. Previously this cap was
+  // only applied during USD conversion (toUsd), not before the isActiveMarket check,
+  // causing 65 corrupt-price markets to be counted in totalMarkets but not activeTotal.
+  const MAX_SANE_PRICE_FOR_ACTIVE = 1_000_000; // $1M — mirrors /api/markets sanitizePrice
   const phantomAwareData = statsData.map((m) => {
     const accountsCount = (m as Record<string, unknown>).total_accounts as number ?? 0;
     const vaultBal = (m as Record<string, unknown>).vault_balance as number ?? 0;
     const isPhantom = accountsCount === 0 || vaultBal < MIN_VAULT_FOR_ACTIVE;
-    if (!isPhantom) return m;
+    if (!isPhantom) {
+      // GH#1430: Null out corrupt prices before isActiveMarket() check so the active-market
+      // count matches /api/markets which applies sanitizePrice (> $1M → null) before filtering.
+      const rawPrice = (m as Record<string, unknown>).last_price as number | null;
+      const sanitizedPrice = (rawPrice != null && rawPrice > 0 && rawPrice <= MAX_SANE_PRICE_FOR_ACTIVE)
+        ? rawPrice
+        : null;
+      if (sanitizedPrice !== rawPrice) {
+        return { ...m, last_price: sanitizedPrice };
+      }
+      return m;
+    }
     // GH#1425: Zero out ALL stat fields (including last_price and volume_24h) so
     // isActiveMarket() won't consider stale values as "active" for zombie markets.
     // Previously only OI fields were zeroed; vault_balance=0 zombies still passed


### PR DESCRIPTION
## Summary

Fixes two bugs filed by QA after PR #1426 + #1428 merge.

---

### GH#1429 — zombieCount always 0 when include_zombie=true (P3)

**Root cause:** `zombieCount` was computed as `sanitized.length - nonZombie.length`. When `include_zombie=true`, `nonZombie` includes all markets (including zombies), so the difference is always 0.

**Fix:** Compute `zombieCount` directly from the `is_zombie` tag on the sanitized array, independent of the `includeZombie` flag.

```diff
- const zombieCount = sanitized.length - nonZombie.length;
+ const zombieCount = sanitized.filter((m) => m.is_zombie === true).length;
```

---

### GH#1430 — /api/stats totalMarkets=105 vs /api/markets activeTotal=40 (P2)

**Root cause:** `/api/stats` counted markets with corrupt oracle prices ($1M < price < 1e18) as active because `isSaneMarketValue` only caps at `1e18`. Meanwhile `/api/markets` applies `sanitizePrice` which nulls any price > $1M. The 65-market gap consisted of markets whose only sane stat was a corrupt last_price that passed stats but was nulled in markets.

**Fix:** Apply the $1M cap to `last_price` in `phantomAwareData` before `isActiveMarket()` in `/api/stats`, mirroring the `sanitizePrice` guard already used in `/api/markets`.

Markets that are active via `volume_24h` or `total_open_interest` (regardless of corrupt price) are still counted correctly.

---

### Tests

31 new unit tests across 2 new test files:
- `__tests__/api/markets-zombie-count.test.ts` — documents the bug and verifies the fix
- `__tests__/api/stats-active-total-consistency.test.ts` — verifies price cap alignment between stats and markets

All 1175 tests pass.

## How to Test

```bash
# Verify zombieCount > 0 with include_zombie=true
curl 'https://app.percolator.trade/api/markets?include_zombie=true' | jq .zombieCount
# Should be > 0 (was always 0 before fix)

# Verify totalMarkets ≈ activeTotal
curl 'https://app.percolator.trade/api/stats' | jq .totalMarkets
curl 'https://app.percolator.trade/api/markets' | jq .activeTotal
# Should be equal or very close (was 105 vs 40 before fix)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed zombie market count calculations that incorrectly returned zero when including zombie markets
  * Improved active market statistics accuracy by validating price data against a maximum price threshold

* **Tests**
  * Added regression test coverage for zombie market counting edge cases and statistics consistency verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->