### PR TITLE
fix: clarify isPhantomOI comment in /api/stats (CodeRabbit #1433 feedback)

### DIFF
--- a/app/app/api/stats/route.ts
+++ b/app/app/api/stats/route.ts
@@ -196,7 +196,10 @@ export async function GET(request: NextRequest) {
             : 0);
       if (!isSaneMarketValue(rawOi)) return sum;
       // Skip phantom markets: no accounts, OR vault below creation-deposit threshold.
-      // Strict < mirrors /api/markets isPhantomOI exactly (vault=1M is NOT phantom).
+      // Intentional divergence from /api/markets: strict < here means vault=1M is NOT phantom
+      // (so it contributes to OI sum), whereas /api/markets uses <= (vault=1M IS phantom for
+      // active-market counting). The two operators serve different purposes: OI sum accounting
+      // vs active-market count — they are not required to match.
       const isPhantomOI = accountsCount === 0 || vaultBal < MIN_VAULT_FOR_OI_STATS;
       if (isPhantomOI) return sum;
       // GH#1318: No $1 fallback — markets without a valid oracle price have indeterminate


### PR DESCRIPTION
## Summary
Addresses CodeRabbit feedback on PR #1433.

The comment at stats/route.ts line 199 incorrectly claimed:
> "Strict `<` mirrors /api/markets isPhantomOI exactly (vault=1M is NOT phantom)"

This was inaccurate — /api/markets uses `<=` while stats uses strict `<`. The divergence is **intentional** (different purposes: OI sum accounting vs active-market counting), but the comment misrepresented it as identical behaviour.

## Change
- Updated comment to clearly explain the intentional divergence between the two operators and why they differ

## Testing
- No logic change — comment only
- All existing tests continue to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation to clarify statistics API behavior regarding market handling in open interest calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->