### PR TITLE
fix(GH#1438): align /api/markets isPhantomOI to strict < (matches /api/stats)

### DIFF
--- a/app/__tests__/api/markets-price-sanitize.test.ts
+++ b/app/__tests__/api/markets-price-sanitize.test.ts
@@ -297,28 +297,33 @@ describe("GET /api/markets — price sanitization (#856)", () => {
       expect(body.markets.find((m) => m.symbol === "HEALTHY")).toBeDefined();
     });
 
-    it("suppresses total_open_interest_usd when vault_balance is dust (<= 1,000,000) — GH#1405 Part 2", async () => {
+    it("suppresses total_open_interest_usd when vault_balance is dust (< 1,000,000) — GH#1438 alignment", async () => {
       mockMarkets = [
         mkMarket({ symbol: "DUST_1", vault_balance: 1, total_open_interest: 2_000_000_000_000, last_price: 1.0 }),
         mkMarket({ symbol: "DUST_100", vault_balance: 100, total_open_interest: 2_000_000_000_000, last_price: 1.0 }),
         mkMarket({ symbol: "DUST_999999", vault_balance: 999_999, total_open_interest: 2_000_000_000_000, last_price: 1.0 }),
-        // GH#1405 Part 2: exactly at threshold (1M) is now also phantom (was previously allowed through)
-        mkMarket({ symbol: "DUST_1M", vault_balance: 1_000_000, total_open_interest: 2_000_000_000_000, last_price: 1.0 }),
+        // GH#1438: vault=1M is the creation-deposit amount; strict < means it is NOT phantom.
+        // OI should pass through for vault=1M (aligns /api/markets with /api/stats).
+        mkMarket({ symbol: "CREATION_DEPOSIT_1M", vault_balance: 1_000_000, total_open_interest: 2_000_000_000_000, last_price: 1.0 }),
       ];
       vi.resetModules();
       const { GET } = await import("@/app/api/markets/route");
       const res = await GET();
       const body = (await res.json()) as { markets: { symbol: string; total_open_interest_usd: number | null }[] };
-      for (const sym of ["DUST_1", "DUST_100", "DUST_999999", "DUST_1M"]) {
+      // vault < 1M → phantom OI suppressed
+      for (const sym of ["DUST_1", "DUST_100", "DUST_999999"]) {
         const m = body.markets.find((m) => m.symbol === sym);
         expect(m?.total_open_interest_usd).toBeNull(); // dust vault → phantom OI suppressed
       }
+      // vault=1M → NOT phantom (strict <), OI passes through
+      const creation1M = body.markets.find((m) => m.symbol === "CREATION_DEPOSIT_1M");
+      expect(creation1M?.total_open_interest_usd).toBeGreaterThan(0); // real OI for creation-deposit vault
     });
 
-    it("passes through total_open_interest_usd when vault_balance > 1,000,000 (real liquidity)", async () => {
+    it("passes through total_open_interest_usd when vault_balance >= 1,000,000 (real liquidity)", async () => {
       mockMarkets = [
-        // GH#1405 Part 2: exactly at threshold (1M) is now treated as phantom (<=).
-        // Real liquidity requires vault_balance > 1_000_000.
+        // GH#1438: vault=1M is the creation-deposit amount; strict < means it is NOT phantom.
+        // Aligned with /api/stats which also uses strict < for the same boundary.
         mkMarket({ symbol: "AT_THRESHOLD", vault_balance: 1_000_000, total_open_interest: 1_000, decimals: 6, last_price: 1.0 }),
         // one above threshold — real liquidity
         mkMarket({ symbol: "ABOVE_THRESHOLD", vault_balance: 1_000_001, total_open_interest: 1_000, decimals: 6, last_price: 1.0 }),
@@ -332,8 +337,8 @@ describe("GET /api/markets — price sanitization (#856)", () => {
       const atThreshold = body.markets.find((m) => m.symbol === "AT_THRESHOLD");
       const aboveThreshold = body.markets.find((m) => m.symbol === "ABOVE_THRESHOLD");
       const realVault = body.markets.find((m) => m.symbol === "REAL_VAULT");
-      // exactly at threshold → phantom (GH#1405 Part 2: <= guard)
-      expect(atThreshold?.total_open_interest_usd).toBeNull();
+      // exactly at threshold (vault=1M) → NOT phantom (GH#1438: strict < aligns with /api/stats)
+      expect(atThreshold?.total_open_interest_usd).toBeCloseTo(0.001, 6); // 1000 / 1e6 * 1.0
       // one above threshold → real liquidity, OI passes through
       expect(aboveThreshold?.total_open_interest_usd).toBeCloseTo(0.001, 6); // 1000 / 1e6 * 1.0
       expect(realVault?.total_open_interest_usd).toBeCloseTo(0.001, 6);

--- a/app/__tests__/api/stats-active-total-consistency.test.ts
+++ b/app/__tests__/api/stats-active-total-consistency.test.ts
@@ -13,8 +13,10 @@
  * deposit minimum). Using <= classifies all of them as phantom.
  *
  * GH#1435 correct fix: use strict < for vault phantom check in /api/stats so that
- * vault=1M markets are correctly counted as active. The mismatch with /api/markets
- * isPhantomOI (which uses <=) must be addressed by fixing /api/markets, not stats.
+ * vault=1M markets are correctly counted as active.
+ *
+ * GH#1438: /api/markets isPhantomOI also changed to strict < to align with /api/stats.
+ * Both endpoints now agree: vault=1_000_000 (creation-deposit) is NOT phantom.
  *
  * Fix: (1) apply the $1M cap to last_price in phantomAwareData before
  * isActiveMarket() in /api/stats, mirroring /api/markets sanitizePrice.

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -177,10 +177,13 @@ export async function GET(request: NextRequest) {
       // GH#1271: Also suppress when vault_balance = 0 (no LP liquidity → no real positions).
       // PERC-816: Extend to suppress for dust vault_balance (0 < vault < 1,000,000 micro-units).
       // Mirrors the invariant enforced by StatsCollector and migration 049.
-      // GH#1405 Part 2: use strict GTE (<=) so vault_balance == MIN_VAULT_FOR_OI is
-      // also treated as phantom — markets at exactly the threshold have no real LP
-      // liquidity. Consistent with homepage phantomAwareData guard.
-      const MIN_VAULT_FOR_OI = 1_000_000; // <= 1 USDC at 6 decimals; dust at 9 decimals
+      // GH#1438: Align with /api/stats strict < so vault=1_000_000 (creation-deposit amount)
+      // is NOT treated as phantom OI. All active devnet markets have vault=1M exactly;
+      // using <= caused /api/markets to suppress their OI while /api/stats counted them,
+      // producing a visible totalOpenInterest mismatch between the two endpoints.
+      // Proper zombie threshold is vault=0 (strictly zero) — markets with any real LP deposit
+      // above dust are not phantom. See GH#1432 original intent + GH#1435 hotfix context.
+      const MIN_VAULT_FOR_OI = 1_000_000; // strict <: vault=1M is NOT phantom (creation-deposit)
       const accountsCount = (m.total_accounts as number) ?? 0;
       const vaultBal = (m.vault_balance as number) ?? 0;
       // GH#1290 / PERC-570: Phantom OI guard — suppress all OI fields (USD and raw atoms)
@@ -188,7 +191,8 @@ export async function GET(request: NextRequest) {
       // and migration 051. Suppressing only total_open_interest_usd left the raw
       // total_open_interest atom value in the response, which fed phantom OI into
       // computeMarketHealthFromStats and the markets page sort/filter.
-      const isPhantomOI = accountsCount === 0 || vaultBal <= MIN_VAULT_FOR_OI;
+      // GH#1438: Changed <= to < to align with /api/stats phantom OI guard.
+      const isPhantomOI = accountsCount === 0 || vaultBal < MIN_VAULT_FOR_OI;
       const displayOiUsd = isPhantomOI ? null : total_open_interest_usd;
 
       // GH#1270: Pre-compute volume_24h in USD so consumers (e.g. Watchlist) don't need


### PR DESCRIPTION
## Summary

Aligns `/api/markets` phantom OI guard with `/api/stats` by changing `<=` to strict `<`.

## Root Cause

After the GH#1435 hotfix (PR #1437), `/api/stats` uses strict `< 1_000_000` for `isPhantom` (vault=1M is NOT phantom — it's the creation-deposit amount). However, `/api/markets` still used `<= 1_000_000` for `isPhantomOI`, meaning vault=1M markets had their OI suppressed to null in `/api/markets` while being counted as real OI in `/api/stats`.

This produced an OI mismatch between the two endpoints for all active devnet markets (which have vault=1_000_000 exactly).

## Changes

- **`app/app/api/markets/route.ts`**: `isPhantomOI = accountsCount === 0 || vaultBal <= MIN_VAULT_FOR_OI` → `vaultBal < MIN_VAULT_FOR_OI`
- **`app/__tests__/api/markets-price-sanitize.test.ts`**: Updated vault threshold tests — vault=1M now expects OI to pass through (not null); vault < 1M still suppressed
- **`app/__tests__/api/stats-active-total-consistency.test.ts`**: Removed stale comment saying /api/markets still uses `<=`

## Zombie vs Phantom

The zombie filter (vault=0 markets excluded from the list) is **unchanged**. The change only affects OI suppression for vault=1M markets. Boundary summary:
- vault=0 → zombie (excluded from list)  
- vault=1 to 999_999 → phantom OI (suppressed)
- vault=1_000_000 → real OI (was phantom with `<=`, now active with `<`)
- vault > 1_000_000 → real OI (unchanged)

## Tests

75/75 pass on affected test files:
- `markets-price-sanitize.test.ts` ✅
- `stats-active-total-consistency.test.ts` ✅  
- `stats-phantom-oi-guard.test.ts` ✅
- `markets-zombie-filter.test.ts` ✅

Closes #1438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Updated dust suppression threshold for market open interest: vault balances exactly equal to 1,000,000 USD now display open interest data instead of being suppressed, bringing consistency across API endpoints.

## Tests
* Updated test cases to reflect the revised dust threshold boundary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->