### PR TITLE
refactor: extract phantom-OI predicate to shared lib/phantom-oi.ts (PERC-1242)

### DIFF
--- a/app/__tests__/api/markets-price-sanitize.test.ts
+++ b/app/__tests__/api/markets-price-sanitize.test.ts
@@ -305,6 +305,11 @@ describe("GET /api/markets — price sanitization (#856)", () => {
         // GH#1438: vault=1M is the creation-deposit amount; strict < means it is NOT phantom.
         // OI should pass through for vault=1M (aligns /api/markets with /api/stats).
         mkMarket({ symbol: "CREATION_DEPOSIT_1M", vault_balance: 1_000_000, total_open_interest: 2_000_000_000_000, last_price: 1.0 }),
+        // GH#1438 pure-OI boundary: vault=1M market with no last_price and no volume_24h.
+        // This is the exact regression vector — a market at the threshold that has OI
+        // but no price data. The phantom guard must NOT suppress its OI; activeTotal
+        // should reflect it (though USD value will be 0/null without a price).
+        mkMarket({ symbol: "PURE_OI_1M", vault_balance: 1_000_000, total_open_interest: 5_000_000_000, last_price: null, volume_24h: null }),
       ];
       vi.resetModules();
       const { GET } = await import("@/app/api/markets/route");
@@ -318,6 +323,13 @@ describe("GET /api/markets — price sanitization (#856)", () => {
       // vault=1M → NOT phantom (strict <), OI passes through
       const creation1M = body.markets.find((m) => m.symbol === "CREATION_DEPOSIT_1M");
       expect(creation1M?.total_open_interest_usd).toBeGreaterThan(0); // real OI for creation-deposit vault
+      // Pure-OI boundary (GH#1438 regression vector): vault=1M, no last_price, no volume_24h.
+      // The phantom guard must NOT suppress the raw OI atoms. USD is null (no price) but the
+      // market still appears in the response and its raw total_open_interest is non-zero.
+      const pureOi1M = body.markets.find((m) => m.symbol === "PURE_OI_1M");
+      expect(pureOi1M).toBeDefined(); // market is included (vault=1M is not phantom)
+      expect(pureOi1M?.total_open_interest_usd).toBeNull(); // no price → USD is null, not phantom-suppressed
+      expect((pureOi1M as Record<string, unknown>)?.total_open_interest).toBe(5_000_000_000); // raw OI passes through
     });
 
     it("passes through total_open_interest_usd when vault_balance >= 1,000,000 (real liquidity)", async () => {

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -6,6 +6,7 @@ import { getServiceClient } from "@/lib/supabase";
 import { getConfig } from "@/lib/config";
 import * as Sentry from "@sentry/nextjs";
 import { isSaneMarketValue, isActiveMarket } from "@/lib/activeMarketFilter";
+import { isPhantomOpenInterest } from "@/lib/phantom-oi";
 import { BLOCKED_SLAB_ADDRESSES as HARDCODED_BLOCKED_MARKETS } from "@/lib/blocklist";
 
 /**
@@ -177,22 +178,16 @@ export async function GET(request: NextRequest) {
       // GH#1271: Also suppress when vault_balance = 0 (no LP liquidity → no real positions).
       // PERC-816: Extend to suppress for dust vault_balance (0 < vault < 1,000,000 micro-units).
       // Mirrors the invariant enforced by StatsCollector and migration 049.
-      // GH#1438: Align with /api/stats strict < so vault=1_000_000 (creation-deposit amount)
-      // is NOT treated as phantom OI. All active devnet markets have vault=1M exactly;
-      // using <= caused /api/markets to suppress their OI while /api/stats counted them,
-      // producing a visible totalOpenInterest mismatch between the two endpoints.
-      // Proper zombie threshold is vault=0 (strictly zero) — markets with any real LP deposit
-      // above dust are not phantom. See GH#1432 original intent + GH#1435 hotfix context.
-      const MIN_VAULT_FOR_OI = 1_000_000; // strict <: vault=1M is NOT phantom (creation-deposit)
-      const accountsCount = (m.total_accounts as number) ?? 0;
-      const vaultBal = (m.vault_balance as number) ?? 0;
       // GH#1290 / PERC-570: Phantom OI guard — suppress all OI fields (USD and raw atoms)
       // when vault is dust/empty or no accounts exist. Matches StatsCollector invariant
       // and migration 051. Suppressing only total_open_interest_usd left the raw
       // total_open_interest atom value in the response, which fed phantom OI into
       // computeMarketHealthFromStats and the markets page sort/filter.
-      // GH#1438: Changed <= to < to align with /api/stats phantom OI guard.
-      const isPhantomOI = accountsCount === 0 || vaultBal < MIN_VAULT_FOR_OI;
+      // GH#1438: Aligned to strict < via shared isPhantomOpenInterest() helper in lib/phantom-oi.ts
+      // so /api/markets and /api/stats are guaranteed to use the same predicate (single source of truth).
+      const accountsCount = (m.total_accounts as number) ?? 0;
+      const vaultBal = (m.vault_balance as number) ?? 0;
+      const isPhantomOI = isPhantomOpenInterest(accountsCount, vaultBal);
       const displayOiUsd = isPhantomOI ? null : total_open_interest_usd;
 
       // GH#1270: Pre-compute volume_24h in USD so consumers (e.g. Watchlist) don't need

--- a/app/app/api/stats/route.ts
+++ b/app/app/api/stats/route.ts
@@ -6,6 +6,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServiceClient } from "@/lib/supabase";
 import { isActiveMarket, isSaneMarketValue } from "@/lib/activeMarketFilter";
+import { MIN_VAULT_FOR_OI, isPhantomOpenInterest } from "@/lib/phantom-oi";
 import { BLOCKED_SLAB_ADDRESSES } from "@/lib/blocklist";
 import type { Database } from "@/lib/database.types";
 export const dynamic = "force-dynamic";
@@ -92,7 +93,6 @@ export async function GET(request: NextRequest) {
   // count as "active" here but not in /api/markets (which zeros OI post-sanitization).
   // This produced a 172 vs 135 mismatch. Now we zero phantom OI first, so both
   // endpoints agree on what counts as "active".
-  const MIN_VAULT_FOR_ACTIVE = 1_000_000;
   // GH#1430: Match /api/markets sanitizePrice cap — null out last_price > $1M before
   // isActiveMarket() so markets with corrupt oracle prices (e.g. $7.9T) don't count
   // as "active" in stats while being nulled in /api/markets. Previously this cap was
@@ -102,14 +102,11 @@ export async function GET(request: NextRequest) {
   const phantomAwareData = statsData.map((m) => {
     const accountsCount = (m as Record<string, unknown>).total_accounts as number ?? 0;
     const vaultBal = (m as Record<string, unknown>).vault_balance as number ?? 0;
-    // GH#1435 HOTFIX: Revert <= back to strict <.
-    // PR #1433 changed this to <= to match /api/markets isPhantomOI, but all active devnet
-    // markets have vault_balance=1_000_000 exactly (the creation-deposit amount). Using <=
-    // caused every market to be treated as phantom → totalMarkets=0 on production since 09:38 UTC.
-    // Correct discriminant: use strict < so vault=1M markets are NOT phantom.
-    // The mismatch with /api/markets (GH#1432) must be fixed by aligning /api/markets to
-    // use strict < instead — not by changing stats to <=.
-    const isPhantom = accountsCount === 0 || vaultBal < MIN_VAULT_FOR_ACTIVE;
+    // GH#1435/GH#1438: Use shared isPhantomOpenInterest() from lib/phantom-oi.ts (strict <).
+    // Previously this route had its own copy of the predicate (MIN_VAULT_FOR_ACTIVE).
+    // Now both /api/markets and /api/stats derive the phantom determination from the same
+    // function, eliminating the drift that caused GH#1432, GH#1435, and GH#1438.
+    const isPhantom = isPhantomOpenInterest(accountsCount, vaultBal);
     if (!isPhantom) {
       // GH#1430: Null out corrupt prices before isActiveMarket() check so the active-market
       // count matches /api/markets which applies sanitizePrice (> $1M → null) before filtering.
@@ -180,31 +177,19 @@ export async function GET(request: NextRequest) {
   // Markets with accounts_count=0 or vault<1M are stale/orphaned; their raw OI atoms
   // are not backed by real positions. Without this filter, the $1 fallback (GH#1265)
   // inflated /api/stats totalOpenInterest to $117K vs /api/markets sum of $64K.
-  const MIN_VAULT_FOR_OI_STATS = 1_000_000;
   const totalOpenInterest = activeData.reduce(
     (sum, m) => {
-      // GH#1297: Skip phantom markets (no accounts or dust/empty vault) — same guard as /api/markets
+      // GH#1297: Skip phantom markets (no accounts or dust/empty vault) — same guard as /api/markets.
+      // GH#1438: Now uses shared isPhantomOpenInterest() from lib/phantom-oi.ts (MIN_VAULT_FOR_OI = 1_000_000, strict <).
       const accountsCount = (m as Record<string, unknown>).total_accounts as number ?? 0;
       const vaultBal = (m as Record<string, unknown>).vault_balance as number ?? 0;
-      // GH#1314→GH#1432: /api/markets now uses <= 1M for phantom OI (PR #1405).
-      // Keeping strict < here for the OI sum to preserve existing OI accounting.
-      // The active-market count fix (GH#1432) uses <= above in phantomAwareData.
-      // OI sum was already accurate; only totalMarkets count needed aligning.
-      // PR #1303 used <= which incorrectly filtered vault=1M markets;
-      // /api/markets isPhantomOI is the single source of truth for OI filtering.
       const rawOi = isSaneMarketValue(m.total_open_interest)
         ? m.total_open_interest!
         : (isSaneMarketValue((m.open_interest_long ?? 0) + (m.open_interest_short ?? 0))
             ? (m.open_interest_long ?? 0) + (m.open_interest_short ?? 0)
             : 0);
       if (!isSaneMarketValue(rawOi)) return sum;
-      // Skip phantom markets: no accounts, OR vault below creation-deposit threshold.
-      // Intentional divergence from /api/markets: strict < here means vault=1M is NOT phantom
-      // (so it contributes to OI sum), whereas /api/markets uses <= (vault=1M IS phantom for
-      // active-market counting). The two operators serve different purposes: OI sum accounting
-      // vs active-market count — they are not required to match.
-      const isPhantomOI = accountsCount === 0 || vaultBal < MIN_VAULT_FOR_OI_STATS;
-      if (isPhantomOI) return sum;
+      if (isPhantomOpenInterest(accountsCount, vaultBal)) return sum;
       // GH#1318: No $1 fallback — markets without a valid oracle price have indeterminate
       // USD OI and must NOT contribute to totalOpenInterest.
       // Previously (GH#1265) a $1/token fallback was used for admin-mode devnet markets

--- a/app/lib/phantom-oi.ts
+++ b/app/lib/phantom-oi.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared phantom-OI helpers.
+ *
+ * "Phantom OI" = open interest that is NOT backed by real positions:
+ *   - markets with no accounts (vault was never seeded with traders), OR
+ *   - markets whose vault_balance is below the creation-deposit threshold (1 USDC = 1_000_000 micro-units).
+ *
+ * This is the single source of truth used by both /api/markets and /api/stats.
+ * Previously each route maintained its own copy of the constant and predicate,
+ * which led to drift (GH#1432, GH#1435, GH#1438).
+ *
+ * Rule: vault_balance < MIN_VAULT_FOR_OI  →  phantom (strict <).
+ *   vault=0       → phantom  (no LP deposit)
+ *   vault=1–999_999 → phantom  (dust / creation not finalised)
+ *   vault=1_000_000 → NOT phantom  (standard creation-deposit; all active devnet markets)
+ *   vault>1_000_000 → NOT phantom  (real LP liquidity)
+ */
+
+/** Minimum vault_balance (micro-units) for a market to be considered non-phantom. */
+export const MIN_VAULT_FOR_OI = 1_000_000;
+
+/**
+ * Returns true when a market's open interest should be treated as phantom
+ * (suppressed / excluded from aggregates).
+ *
+ * @param accountsCount  Value of `total_accounts` from the market row (0 when null).
+ * @param vaultBalance   Value of `vault_balance`   from the market row (0 when null).
+ */
+export function isPhantomOpenInterest(
+  accountsCount: number,
+  vaultBalance: number,
+): boolean {
+  return accountsCount === 0 || vaultBalance < MIN_VAULT_FOR_OI;
+}


### PR DESCRIPTION
## Summary

Addresses CodeRabbit nitpicks from PR #1439.

Both `/api/markets` and `/api/stats` now use `isPhantomOpenInterest()` from a single shared module (`app/lib/phantom-oi.ts`) instead of maintaining their own inline copies of `MIN_VAULT_FOR_OI` and the predicate.

## Why

The drift between these two copies caused three consecutive production incidents:
- **GH#1432**: routes diverged → OI mismatch
- **GH#1435**: hotfix changed one route, broke the other
- **GH#1438**: follow-up to re-align the two routes

With a shared helper, any future change to the phantom threshold touches exactly one place.

## Changes

- `app/lib/phantom-oi.ts` — new shared helper with `MIN_VAULT_FOR_OI` and `isPhantomOpenInterest()`
- `/api/markets/route.ts` — replace inline const+predicate with import
- `/api/stats/route.ts` — replace `MIN_VAULT_FOR_ACTIVE` / `MIN_VAULT_FOR_OI_STATS` with `isPhantomOpenInterest()` in both `phantomAwareData` map and OI reduce
- `markets-price-sanitize.test.ts` — add `PURE_OI_1M` boundary fixture: vault=1M with no `last_price`/`volume_24h`, asserts raw OI passes through (not phantom-suppressed) and `total_open_interest_usd` is null (no price). Covers GH#1438 regression end-to-end.

## Tests

249/249 API tests pass locally.

## Related

- Closes CodeRabbit nitpicks on PR #1439
- GH#1438, GH#1435, GH#1432

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test for edge case handling of vault balances at the creation deposit boundary.

* **Refactor**
  * Consolidated phantom open interest detection logic into a reusable shared module, eliminating duplicate threshold definitions across API routes and ensuring consistent phantom detection behavior throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->