### PR TITLE
fix(stats): remove unused MIN_VAULT_FOR_OI import (CodeRabbit nitpick #1440)

### DIFF
--- a/app/app/api/stats/route.ts
+++ b/app/app/api/stats/route.ts
@@ -6,7 +6,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServiceClient } from "@/lib/supabase";
 import { isActiveMarket, isSaneMarketValue } from "@/lib/activeMarketFilter";
-import { MIN_VAULT_FOR_OI, isPhantomOpenInterest } from "@/lib/phantom-oi";
+import { isPhantomOpenInterest } from "@/lib/phantom-oi";
 import { BLOCKED_SLAB_ADDRESSES } from "@/lib/blocklist";
 import type { Database } from "@/lib/database.types";
 export const dynamic = "force-dynamic";


### PR DESCRIPTION
## Summary
Removes unused `MIN_VAULT_FOR_OI` import from `/api/stats/route.ts`.

CodeRabbit flagged this in PR #1440 — the file only calls `isPhantomOpenInterest()` and never references the constant directly.

## Change
```diff
-import { MIN_VAULT_FOR_OI, isPhantomOpenInterest } from "@/lib/phantom-oi";
+import { isPhantomOpenInterest } from "@/lib/phantom-oi";
```

## Testing
- TypeScript: only pre-existing bs58/tweetnacl module errors (unrelated, present on main)
- No logic changes — import-only cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up unused imports in the backend API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->