### PR TITLE
fix(homepage): use shared isPhantomOpenInterest() for consistent market count (GH#1448)

### DIFF
--- a/app/__tests__/unit/homepage-markets-count.test.ts
+++ b/app/__tests__/unit/homepage-markets-count.test.ts
@@ -1,0 +1,51 @@
+/**
+ * GH#1448: Homepage markets count must use shared isPhantomOpenInterest()
+ * (strict < on vault_balance) instead of local <= check.
+ *
+ * The bug: homepage used `vaultBal <= 1_000_000` to detect phantom markets,
+ * while /api/stats used isPhantomOpenInterest() with `vaultBal < 1_000_000`.
+ * Since most devnet markets have vault_balance == 1_000_000 (creation deposit),
+ * the homepage zeroed their stats → only 2 of 69 survived isActiveMarket().
+ */
+
+import { describe, it, expect } from "vitest";
+import { isPhantomOpenInterest, MIN_VAULT_FOR_OI } from "@/lib/phantom-oi";
+import { isActiveMarket } from "@/lib/activeMarketFilter";
+
+describe("GH#1448: Homepage phantom OI alignment with /api/stats", () => {
+  it("vault_balance == MIN_VAULT_FOR_OI (1_000_000) is NOT phantom", () => {
+    // This is the standard creation deposit — must NOT be treated as phantom
+    expect(isPhantomOpenInterest(1, MIN_VAULT_FOR_OI)).toBe(false);
+  });
+
+  it("vault_balance < MIN_VAULT_FOR_OI IS phantom", () => {
+    expect(isPhantomOpenInterest(1, MIN_VAULT_FOR_OI - 1)).toBe(true);
+    expect(isPhantomOpenInterest(1, 0)).toBe(true);
+  });
+
+  it("market with vault=1M, last_price>0 passes isActiveMarket (not zeroed)", () => {
+    // Simulates what happens when isPhantomOpenInterest returns false:
+    // the market's stats are preserved, and isActiveMarket sees real values
+    const market = {
+      last_price: 1111,
+      volume_24h: 0,
+      total_open_interest: 54000000,
+    };
+    const isPhantom = isPhantomOpenInterest(1, 1_000_000);
+    expect(isPhantom).toBe(false);
+    expect(isActiveMarket(market)).toBe(true);
+  });
+
+  it("market with vault=1M would fail if using <= (the old bug)", () => {
+    // Demonstrates the bug: with <=, vault=1M is phantom → stats zeroed → not active
+    const oldBugIsPhantom = (accounts: number, vault: number) =>
+      accounts === 0 || vault <= 1_000_000; // OLD broken logic
+    
+    expect(oldBugIsPhantom(1, 1_000_000)).toBe(true); // BUG: wrongly phantom
+    expect(isPhantomOpenInterest(1, 1_000_000)).toBe(false); // CORRECT: not phantom
+  });
+
+  it("accounts=0 is always phantom regardless of vault", () => {
+    expect(isPhantomOpenInterest(0, 10_000_000)).toBe(true);
+  });
+});

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -8,6 +8,7 @@ import { isMockMode } from "@/lib/mock-mode";
 import { MOCK_SLAB_ADDRESSES, getMockMarketData } from "@/lib/mock-trade-data";
 import { isActiveMarket, isSaneMarketValue } from "@/lib/activeMarketFilter";
 import { isBlockedSlab } from "@/lib/blocklist";
+import { isPhantomOpenInterest } from "@/lib/phantom-oi";
 import { ScrollReveal } from "@/components/ui/ScrollReveal";
 import { GradientText } from "@/components/ui/GradientText";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
@@ -168,15 +169,15 @@ export default function Home() {
           // stale non-zero OI in the DB (the indexer syncs from on-chain, where the
           // value hasn't been zeroed). Without this guard, those phantom markets pass
           // isActiveMarket (via total_open_interest > 0) and inflate the homepage count.
-          // threshold matches /api/markets + /api/stats: vault <= 1M = dust/empty.
-          // GH#1405 Part 2: use strict GTE (<=) so vault_balance == MIN_VAULT_FOR_ACTIVE
-          // is also treated as phantom — markets at exactly the threshold have no real LP
-          // liquidity backing and carry stale/corrupt OI (e.g. DfLoAzny).
-          const MIN_VAULT_FOR_ACTIVE = 1_000_000;
+          // GH#1448: Use shared isPhantomOpenInterest() from lib/phantom-oi.ts (strict <)
+          // instead of local MIN_VAULT_FOR_ACTIVE with <=. The <= operator treated
+          // vault_balance == 1_000_000 (standard creation deposit) as phantom, which
+          // zeroed stats for ~67 of 69 active devnet markets → homepage showed "2".
+          // /api/stats already uses isPhantomOpenInterest (strict <), so this aligns both.
           const phantomAwareData = data.map((m) => {
             const accountsCount = m.total_accounts ?? 0;
             const vaultBal = m.vault_balance ?? 0;
-            const isPhantom = accountsCount === 0 || vaultBal <= MIN_VAULT_FOR_ACTIVE;
+            const isPhantom = isPhantomOpenInterest(accountsCount, vaultBal);
             if (!isPhantom) return m;
             // Zero OI AND last_price so isActiveMarket won't count stale phantom OI or
             // corrupt raw last_price (e.g. DfLoAzny: last_price=10001100011 ≈$10B from


### PR DESCRIPTION
## Problem
Homepage shows **Markets 2** instead of **69** (the count from `/api/stats.totalMarkets`).

## Root Cause
Homepage (`page.tsx`) used a local phantom detection with `vault_balance <= 1_000_000`, while `/api/stats` uses the shared `isPhantomOpenInterest()` with strict `< 1_000_000`.

Most devnet markets have `vault_balance == 1_000_000` (the standard creation deposit). The `<=` operator treated ~67 of 69 active markets as phantom, zeroing their stats so `isActiveMarket()` rejected them — leaving only 2.

## Fix
- Import and use `isPhantomOpenInterest()` from `lib/phantom-oi.ts` (strict `<`) instead of local `MIN_VAULT_FOR_ACTIVE` constant with `<=`
- This aligns homepage with `/api/stats` and `/api/markets` (single source of truth)
- Added 5 unit tests in `__tests__/unit/homepage-markets-count.test.ts`

## Tests
All 1192 tests passing ✅

Closes #1448

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive unit tests validating phantom open-interest detection logic, covering various vault balance thresholds, account counts, and edge cases.

* **Refactor**
  * Consolidated phantom market detection implementation to align homepage behavior with API endpoints. Markets classified as phantom now consistently zero all open-interest metrics and set price data to null, ensuring uniform handling across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->