### PR TITLE
fix(GH#1455): activeTotal independent of include_zombie flag

### DIFF
--- a/app/__tests__/api/markets-zombie-count.test.ts
+++ b/app/__tests__/api/markets-zombie-count.test.ts
@@ -212,3 +212,66 @@ describe("GH#1445 zombie market frontend count fix", () => {
     expect(isSaneMarketValue(100)).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// GH#1455: activeTotal must be zombie-independent (same with or without include_zombie)
+// ---------------------------------------------------------------------------
+
+describe("GH#1455 — activeTotal is independent of include_zombie flag", () => {
+  function isSaneVal(v: number | null | undefined): boolean {
+    if (v == null) return false;
+    return v > 0 && v < 1e18 && Number.isFinite(v);
+  }
+
+  type MarketRow = {
+    slab_address: string;
+    is_zombie: boolean;
+    last_price?: number | null;
+    volume_24h?: number | null;
+    total_open_interest?: number | null;
+    open_interest_long?: number | null;
+    open_interest_short?: number | null;
+  };
+
+  function computeActiveTotal(sanitized: MarketRow[]): number {
+    // Fixed: always use non-zombie subset only
+    const nonZombieOnly = sanitized.filter((m) => !m.is_zombie);
+    return nonZombieOnly.filter((m) => isActiveMarket(m)).length;
+  }
+
+  it("returns same activeTotal regardless of include_zombie flag", () => {
+    const sanitized: MarketRow[] = [
+      // 2 active non-zombie markets
+      { slab_address: "A1", is_zombie: false, last_price: 150, volume_24h: 1_000_000 },
+      { slab_address: "A2", is_zombie: false, last_price: 50, volume_24h: 500_000 },
+      // 2 zombie markets with stale volume that would pass isActiveMarket
+      { slab_address: "Z1", is_zombie: true, last_price: null, volume_24h: 800_000_000 },
+      { slab_address: "Z2", is_zombie: true, last_price: null, volume_24h: 500_000_000 },
+    ];
+
+    // activeTotal should be 2 regardless of include_zombie
+    expect(computeActiveTotal(sanitized)).toBe(2);
+    // Verify zombies WOULD have inflated the count if we used nonZombie (the bug)
+    // When include_zombie=true, nonZombie = sanitized (all 4 markets)
+    const buggyCount = sanitized.filter((m) => isActiveMarket(m)).length;
+    expect(buggyCount).toBe(4); // demonstrates the inflation
+  });
+
+  it("activeTotal === 69 even when include_zombie returns 71 total non-zombie (simulated production)", () => {
+    // Simulate the production scenario: 69 active non-zombies, 2 zombie with stale volume
+    const actives: MarketRow[] = Array.from({ length: 69 }, (_, i) => ({
+      slab_address: `active-${i}`,
+      is_zombie: false,
+      last_price: 100 + i,
+      volume_24h: 1_000_000,
+    }));
+    const staleZombies: MarketRow[] = [
+      { slab_address: "zombie-btc", is_zombie: true, last_price: null, volume_24h: 500_000_000 },
+      { slab_address: "zombie-sol", is_zombie: true, last_price: null, volume_24h: 300_000_000 },
+    ];
+    const sanitized = [...actives, ...staleZombies];
+
+    // Fixed behavior: activeTotal = 69 (zombie-independent)
+    expect(computeActiveTotal(sanitized)).toBe(69);
+  });
+});

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -269,7 +269,13 @@ export async function GET(request: NextRequest) {
     // fetching all records. Reflects post-filter count (blocked markets excluded).
     // #1172: Add activeTotal — markets with at least one sane stat (price/volume/OI).
     // This matches the count shown by /api/stats totalMarkets.
-    const activeTotal = nonZombie.filter((m) => isActiveMarket(m as Parameters<typeof isActiveMarket>[0])).length;
+    // GH#1455: activeTotal must always be computed from the non-zombie subset only,
+    // regardless of include_zombie. When include_zombie=true, nonZombie includes all
+    // markets (zombies + non-zombies). Computing activeTotal from nonZombie would
+    // count zombie markets that have stale volume/OI stats, inflating the count
+    // (e.g. 71 vs 69). Fix: filter out is_zombie before applying isActiveMarket.
+    const nonZombieOnly = sanitized.filter((m) => !(m as Record<string, unknown>).is_zombie);
+    const activeTotal = nonZombieOnly.filter((m) => isActiveMarket(m as Parameters<typeof isActiveMarket>[0])).length;
 
     // GH#1348: Respect ?limit= query param to avoid returning 100+ markets
     const limitParam = request?.nextUrl?.searchParams?.get("limit") ?? null;


### PR DESCRIPTION
## Problem

`/api/markets` returns `activeTotal=69` normally but `activeTotal=71` when `?include_zombie=true`. [GH#1455]

**Root cause:** `activeTotal` was computed from the `nonZombie` array, which is used as the response payload. When `include_zombie=true`, `nonZombie` includes **all** markets (zombies + non-zombies). Some zombie markets have stale historical `volume_24h` that passes `isActiveMarket()`, inflating the count by 2.

## Fix

Introduce a dedicated `nonZombieOnly` array (always filtered, regardless of flag) and compute `activeTotal` from that instead of from `nonZombie`.

```ts
// Before (bug): activeTotal computed from response set — includes zombies when include_zombie=true
const activeTotal = nonZombie.filter(isActiveMarket).length; // 71 with include_zombie

// After (fix): always from non-zombie subset only
const nonZombieOnly = sanitized.filter((m) => !m.is_zombie);
const activeTotal = nonZombieOnly.filter(isActiveMarket).length; // 69 always
```

## Tests

- 2 new regression tests in `markets-zombie-count.test.ts` (GH#1455 block)
- 1209 tests passing ✅, tsc clean ✅

## Checklist

- [x] Fixes GH#1455
- [x] `activeTotal` now equals 69 regardless of `include_zombie` flag
- [x] `zombieCount` already uses the correct pattern (from tagged `is_zombie` field)
- [x] No breaking changes — response shape unchanged
- [x] Regression tests added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where inactive zombie market data could incorrectly inflate the active market count in the markets endpoint.

* **Tests**
  * Added test coverage to verify active market counts are computed accurately regardless of zombie market presence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->