### PR TITLE
fix: filter phantom OI history + blocklist bypass in /funding/global (GH#1458, GH#1459)

### DIFF
--- a/packages/api/src/middleware/validateSlab.ts
+++ b/packages/api/src/middleware/validateSlab.ts
@@ -38,8 +38,18 @@ const ENV_BLOCKED_SLABS: ReadonlySet<string> = new Set(
     .filter(Boolean),
 );
 
-function isBlocked(slab: string): boolean {
+/**
+ * Returns true if the slab is on the backend blocklist (hardcoded or env-var).
+ * Exported so other routes (e.g. /funding/global) can apply the same predicate
+ * without going through the Hono middleware (GH#1459).
+ */
+export function isBlockedSlab(slab: string): boolean {
   return HARDCODED_BLOCKED_SLABS.has(slab) || ENV_BLOCKED_SLABS.has(slab);
+}
+
+// Keep internal alias for the middleware below
+function isBlocked(slab: string): boolean {
+  return isBlockedSlab(slab);
 }
 
 /**

--- a/packages/api/src/routes/funding.ts
+++ b/packages/api/src/routes/funding.ts
@@ -19,6 +19,14 @@ import {
   truncateErrorMessage,
 } from "@percolator/shared";
 
+/**
+ * GH#1459: Import the backend blocklist predicate so /funding/global can
+ * filter blocked slabs. validateSlab middleware only runs on /:slab routes;
+ * the global endpoint bypasses it and must apply the same check inline.
+ * isBlockedSlab covers both HARDCODED_BLOCKED_SLABS and BLOCKED_MARKET_ADDRESSES env var.
+ */
+import { isBlockedSlab } from "../middleware/validateSlab.js";
+
 const logger = createLogger("api:funding");
 
 /**
@@ -52,16 +60,22 @@ export function fundingRoutes(): Hono {
       const SLOTS_PER_HOUR = 9000;
       const SLOTS_PER_DAY = 216000;
 
-      const markets = (allStats ?? []).map((stats) => {
-        const rateBps = sanitizeFundingRateBps(Number(stats.funding_rate ?? 0));
-        return {
-          slabAddress: stats.slab_address,
-          currentRateBpsPerSlot: rateBps,
-          hourlyRatePercent: Number(((rateBps / 10000.0) * SLOTS_PER_HOUR).toFixed(6)),
-          dailyRatePercent: Number(((rateBps / 10000.0) * SLOTS_PER_DAY).toFixed(4)),
-          netLpPosition: stats.net_lp_pos ?? "0",
-        };
-      });
+      // GH#1459: Filter blocked slabs from the global response.
+      // validateSlab middleware only runs on /:slab routes; the global endpoint
+      // queries all market_stats rows and previously exposed blocked slabs
+      // (8eFFEFBY, 3bmCyPee, 3YDqCJGz, 3ZKKwsK) with phantom netLpPosition values.
+      const markets = (allStats ?? [])
+        .filter((stats) => !isBlockedSlab(stats.slab_address))
+        .map((stats) => {
+          const rateBps = sanitizeFundingRateBps(Number(stats.funding_rate ?? 0));
+          return {
+            slabAddress: stats.slab_address,
+            currentRateBpsPerSlot: rateBps,
+            hourlyRatePercent: Number(((rateBps / 10000.0) * SLOTS_PER_HOUR).toFixed(6)),
+            dailyRatePercent: Number(((rateBps / 10000.0) * SLOTS_PER_DAY).toFixed(4)),
+            netLpPosition: stats.net_lp_pos ?? "0",
+          };
+        });
 
       return c.json({
         count: markets.length,

--- a/packages/api/src/routes/open-interest.ts
+++ b/packages/api/src/routes/open-interest.ts
@@ -12,6 +12,27 @@ import { validateSlab } from "../middleware/validateSlab.js";
 import { cacheMiddleware } from "../middleware/cache.js";
 import { getSupabase, createLogger } from "@percolator/shared";
 
+/**
+ * GH#1458: Phantom OI guard for history records.
+ *
+ * Pre-migration data in oi_history can contain astronomically large values
+ * (e.g. 9.87e+34) from uninitialized on-chain state. These corrupt OI charts
+ * for active markets (usdEkK5G, MOLTBOT). Filter them before returning history.
+ *
+ * Threshold: any total_oi or net_lp_pos value >= 1e18 (> max plausible micro-units
+ * for any real market at any token price) is considered phantom and excluded.
+ */
+const MAX_SANE_OI_RAW = 1e18;
+
+function isPhantomOiRecord(record: { total_oi: string | number | null; net_lp_pos: string | number | null }): boolean {
+  const oi = Number(record.total_oi);
+  const lp = Number(record.net_lp_pos);
+  return (
+    !Number.isFinite(oi) || Math.abs(oi) >= MAX_SANE_OI_RAW ||
+    !Number.isFinite(lp) || Math.abs(lp) >= MAX_SANE_OI_RAW
+  );
+}
+
 const logger = createLogger("api:open-interest");
 
 export function openInterestRoutes(): Hono {
@@ -68,17 +89,24 @@ export function openInterestRoutes(): Hono {
         throw historyError;
       }
 
+      // GH#1458: Filter phantom values from history before returning.
+      // Pre-migration oi_history rows can contain values like 9.87e+34 from
+      // uninitialized on-chain state — corrupts OI charts for active markets.
+      const filteredHistory = (history ?? [])
+        .filter((h) => !isPhantomOiRecord(h))
+        .map((h) => ({
+          timestamp: h.timestamp,
+          totalOi: h.total_oi,
+          netLpPos: h.net_lp_pos,
+        }));
+
       return c.json({
         slabAddress: slab,
         totalOpenInterest: stats.total_open_interest ?? "0",
         netLpPos: stats.net_lp_pos ?? "0",
         lpSumAbs: stats.lp_sum_abs ?? "0",
         lpMaxAbs: stats.lp_max_abs ?? "0",
-        history: (history ?? []).map((h) => ({
-          timestamp: h.timestamp,
-          totalOi: h.total_oi,
-          netLpPos: h.net_lp_pos,
-        })),
+        history: filteredHistory,
       });
     } catch (err) {
       logger.error("Error fetching OI data", { slab, error: err });

--- a/packages/api/tests/routes/funding.test.ts
+++ b/packages/api/tests/routes/funding.test.ts
@@ -294,5 +294,89 @@ describe("funding routes", () => {
       expect(data.count).toBe(0);
       expect(data.markets).toHaveLength(0);
     });
+
+    describe("GH#1459: blocklist bypass — blocked slabs must not appear in /funding/global", () => {
+      // These four addresses are on the backend HARDCODED_BLOCKED_SLABS list.
+      // Individual /funding/:slab 404s via validateSlab, but /funding/global was
+      // querying all market_stats rows without filtering, exposing phantom netLpPosition.
+      const BLOCKED_SLABS = [
+        "8eFFEFBY3HHbBgzxJJP5hyxdzMNMAumnYNhkWXErBM4c", // DfLoAzny/USD — GH#1413
+        "3bmCyPee8GWJR5aPGTyN5EyyQJLzYyD8Wkg9m1Afd1SD", // SEX/USD — migration 048
+        "3YDqCJGz88xGiPBiRvx4vrM51mWTiTZPZ95hxYDZqKpJ", // phantom-OI — migration 048
+        "3ZKKwsKoo5UP28cYmMpvGpwoFpWLVgEWLQJCejJnECQn", // phantom-OI — no liquidity
+      ];
+
+      it("filters out all 4 blocked slabs from /funding/global response", async () => {
+        const mockStats = [
+          // 1 real market
+          { slab_address: "11111111111111111111111111111111", funding_rate: 5, net_lp_pos: "1000000" },
+          // 4 blocked slabs with phantom netLpPosition
+          ...BLOCKED_SLABS.map((addr) => ({
+            slab_address: addr,
+            funding_rate: 0,
+            net_lp_pos: "987000000000000000000000000000000000", // phantom value
+          })),
+        ];
+
+        mockSupabase.from.mockReturnValue({
+          select: vi.fn().mockResolvedValue({ data: mockStats, error: null }),
+        });
+
+        const app = fundingRoutes();
+        const res = await app.request("/funding/global");
+
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        // Only the real market should appear
+        expect(data.count).toBe(1);
+        expect(data.markets).toHaveLength(1);
+        expect(data.markets[0].slabAddress).toBe("11111111111111111111111111111111");
+
+        // None of the blocked slabs should be in the response
+        const returnedAddrs = data.markets.map((m: { slabAddress: string }) => m.slabAddress);
+        for (const blocked of BLOCKED_SLABS) {
+          expect(returnedAddrs).not.toContain(blocked);
+        }
+      });
+
+      it("count in response reflects only unblocked markets", async () => {
+        const mockStats = BLOCKED_SLABS.map((addr) => ({
+          slab_address: addr,
+          funding_rate: 0,
+          net_lp_pos: "987000000000000000000000000000000000",
+        }));
+
+        mockSupabase.from.mockReturnValue({
+          select: vi.fn().mockResolvedValue({ data: mockStats, error: null }),
+        });
+
+        const app = fundingRoutes();
+        const res = await app.request("/funding/global");
+
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.count).toBe(0);
+        expect(data.markets).toHaveLength(0);
+      });
+
+      it("allows real (non-blocked) slabs through to the response", async () => {
+        const mockStats = [
+          { slab_address: "11111111111111111111111111111111", funding_rate: 10, net_lp_pos: "0" },
+          { slab_address: "22222222222222222222222222222222", funding_rate: -3, net_lp_pos: "500000" },
+        ];
+
+        mockSupabase.from.mockReturnValue({
+          select: vi.fn().mockResolvedValue({ data: mockStats, error: null }),
+        });
+
+        const app = fundingRoutes();
+        const res = await app.request("/funding/global");
+
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.count).toBe(2);
+        expect(data.markets).toHaveLength(2);
+      });
+    });
   });
 });

--- a/packages/api/tests/routes/open-interest.test.ts
+++ b/packages/api/tests/routes/open-interest.test.ts
@@ -342,5 +342,140 @@ describe("open-interest routes", () => {
         expect(res.status).toBe(200);
       });
     });
+
+    describe("GH#1458: phantom OI history filter — pre-migration values (9.87e+34) excluded", () => {
+      // usdEkK5G (11111111...) and MOLTBOT (22222222...) oi_history contained rows
+      // with total_oi = 9.87e+34 from uninitialized on-chain state. These must be
+      // stripped before the chart data is returned.
+
+      const PHANTOM_OI = "987000000000000000000000000000000000"; // ~9.87e+35
+      const VALID_OI_1 = "5000000000";
+      const VALID_OI_2 = "4800000000";
+
+      function mockSupabaseWithHistory(history: Array<{ timestamp: string; total_oi: string; net_lp_pos: string }>) {
+        return (table: string) => {
+          if (table === "market_stats") {
+            return {
+              select: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  single: vi.fn().mockResolvedValue({
+                    data: {
+                      total_open_interest: VALID_OI_1,
+                      net_lp_pos: "1500000",
+                      lp_sum_abs: "2000000",
+                      lp_max_abs: "500000",
+                    },
+                    error: null,
+                  }),
+                })),
+              })),
+            };
+          } else if (table === "oi_history") {
+            return {
+              select: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  order: vi.fn(() => ({
+                    limit: vi.fn().mockResolvedValue({ data: history, error: null }),
+                  })),
+                })),
+              })),
+            };
+          }
+          return mockSupabase;
+        };
+      }
+
+      it("strips phantom history records (total_oi >= 1e18) from response", async () => {
+        const history = [
+          { timestamp: "2026-01-01T00:00:00Z", total_oi: PHANTOM_OI, net_lp_pos: "0" },         // phantom — must be excluded
+          { timestamp: "2026-01-02T00:00:00Z", total_oi: VALID_OI_1, net_lp_pos: "1500000" },   // real — included
+          { timestamp: "2026-01-03T00:00:00Z", total_oi: VALID_OI_2, net_lp_pos: "1400000" },   // real — included
+        ];
+
+        mockSupabase.from.mockImplementation(mockSupabaseWithHistory(history));
+
+        const app = openInterestRoutes();
+        const res = await app.request("/open-interest/11111111111111111111111111111111");
+
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        // Only 2 valid records; phantom stripped
+        expect(data.history).toHaveLength(2);
+        expect(data.history.map((h: { totalOi: string }) => h.totalOi)).not.toContain(PHANTOM_OI);
+        expect(data.history[0].totalOi).toBe(VALID_OI_1);
+        expect(data.history[1].totalOi).toBe(VALID_OI_2);
+      });
+
+      it("strips records with phantom net_lp_pos (>= 1e18)", async () => {
+        const PHANTOM_LP = "12345678901234567890"; // > 1e18
+        const history = [
+          { timestamp: "2026-01-01T00:00:00Z", total_oi: VALID_OI_1, net_lp_pos: PHANTOM_LP }, // phantom LP — excluded
+          { timestamp: "2026-01-02T00:00:00Z", total_oi: VALID_OI_2, net_lp_pos: "1500000" },  // real — included
+        ];
+
+        mockSupabase.from.mockImplementation(mockSupabaseWithHistory(history));
+
+        const app = openInterestRoutes();
+        const res = await app.request("/open-interest/11111111111111111111111111111111");
+
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.history).toHaveLength(1);
+        expect(data.history[0].totalOi).toBe(VALID_OI_2);
+      });
+
+      it("returns all records when no phantom values present", async () => {
+        const history = [
+          { timestamp: "2026-01-01T00:00:00Z", total_oi: VALID_OI_1, net_lp_pos: "1500000" },
+          { timestamp: "2026-01-02T00:00:00Z", total_oi: VALID_OI_2, net_lp_pos: "1400000" },
+        ];
+
+        mockSupabase.from.mockImplementation(mockSupabaseWithHistory(history));
+
+        const app = openInterestRoutes();
+        const res = await app.request("/open-interest/11111111111111111111111111111111");
+
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.history).toHaveLength(2);
+      });
+
+      it("returns empty history if all records are phantom", async () => {
+        const history = [
+          { timestamp: "2026-01-01T00:00:00Z", total_oi: PHANTOM_OI, net_lp_pos: "0" },
+          { timestamp: "2026-01-02T00:00:00Z", total_oi: PHANTOM_OI, net_lp_pos: "0" },
+        ];
+
+        mockSupabase.from.mockImplementation(mockSupabaseWithHistory(history));
+
+        const app = openInterestRoutes();
+        const res = await app.request("/open-interest/11111111111111111111111111111111");
+
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.history).toHaveLength(0);
+        // Current OI data (from market_stats) should still be valid
+        expect(data.totalOpenInterest).toBe(VALID_OI_1);
+      });
+
+      it("GH#1458 regression: handles the specific 9.87e+34 value reported in the bug", async () => {
+        // Exact phantom value observed on usdEkK5G and MOLTBOT markets
+        const PHANTOM_9_87E34 = "98700000000000000000000000000000000"; // 9.87e+34
+        const history = [
+          { timestamp: "2026-01-01T00:00:00Z", total_oi: PHANTOM_9_87E34, net_lp_pos: "0" },
+          { timestamp: "2026-01-02T00:00:00Z", total_oi: VALID_OI_1, net_lp_pos: "1500000" },
+        ];
+
+        mockSupabase.from.mockImplementation(mockSupabaseWithHistory(history));
+
+        const app = openInterestRoutes();
+        const res = await app.request("/open-interest/11111111111111111111111111111111");
+
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.history).toHaveLength(1);
+        expect(data.history[0].totalOi).toBe(VALID_OI_1);
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes two P2 bugs found in QA regression.

### GH#1458 — Phantom OI in /api/open-interest history

**Problem:** `oi_history` contains pre-migration rows with values like `9.87e+34` (uninitialized on-chain state) for active markets (usdEkK5G, MOLTBOT). These were returned in the history array and corrupted OI charts.

**Fix:** Added `isPhantomOiRecord()` guard (threshold: `1e18`) in `open-interest.ts`. History records with `total_oi` or `net_lp_pos` >= `1e18` are filtered before the response is returned. Current `market_stats` OI data is unaffected.

### GH#1459 — Blocklist bypass in /api/funding/global

**Problem:** `validateSlab` middleware only runs on `/:slab` routes. `/funding/global` queries all `market_stats` rows without filtering, so blocked slabs (`8eFFEFBY`, `3bmCyPee`, `3YDqCJGz`, `3ZKKwsK`) appeared in the response with phantom `netLpPosition` values.

**Fix:** Exported `isBlockedSlab()` from `validateSlab.ts` (covers both `HARDCODED_BLOCKED_SLABS` and `BLOCKED_MARKET_ADDRESSES` env var). Applied filter in `/funding/global` before mapping markets.

## Files Changed
- `packages/api/src/routes/open-interest.ts` — phantom OI history filter
- `packages/api/src/routes/funding.ts` — blocklist filter in /funding/global
- `packages/api/src/middleware/validateSlab.ts` — export isBlockedSlab()
- `packages/api/tests/routes/open-interest.test.ts` — 5 new GH#1458 tests
- `packages/api/tests/routes/funding.test.ts` — 3 new GH#1459 tests

## Tests
144/144 pass. New tests cover:
- Phantom OI strip from history (total_oi, net_lp_pos, all-phantom → empty, regression for exact 9.87e+34 value)
- Blocklist filter in /funding/global (all 4 blocked slabs excluded, count correct, non-blocked pass through)

## How to Test
```bash
cd packages/api && pnpm test
```

Closes GH#1458, GH#1459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * The `/funding/global` endpoint now excludes blocked market slabs from results and accurately reflects the updated count.
  * The `/open-interest/:slab` endpoint now filters out invalid historical records containing anomalous data values.

* **Tests**
  * Added comprehensive test coverage for market slab blocklist filtering and open-interest data validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->