### PR TITLE
fix: defense-in-depth OI proxy + sync backend blocklist (GH#1461, GH#1462)

### DIFF
--- a/app/app/api/open-interest/[slab]/route.ts
+++ b/app/app/api/open-interest/[slab]/route.ts
@@ -1,0 +1,80 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { proxyToApi } from "@/lib/api-proxy";
+import { isBlockedSlab } from "@/lib/blocklist";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Phantom OI threshold: values at or above this are corrupted pre-migration data
+ * from uninitialized on-chain state (e.g. 9.87e+34). Matches the backend guard
+ * in packages/api/src/routes/open-interest.ts (GH#1458).
+ */
+const MAX_SANE_OI_RAW = 1e18;
+
+function isPhantomOiRecord(record: {
+  totalOi?: string | number | null;
+  netLpPos?: string | number | null;
+}): boolean {
+  const oi = Number(record.totalOi ?? 0);
+  const lp = Number(record.netLpPos ?? 0);
+  return (
+    !Number.isFinite(oi) ||
+    Math.abs(oi) >= MAX_SANE_OI_RAW ||
+    !Number.isFinite(lp) ||
+    Math.abs(lp) >= MAX_SANE_OI_RAW
+  );
+}
+
+/**
+ * GET /api/open-interest/[slab]
+ *
+ * Defense-in-depth proxy: proxies to Railway percolator-api, then:
+ * 1. Returns 404 for blocked slabs (GH#1462)
+ * 2. Strips phantom OI records from history (GH#1458)
+ *
+ * Previously this was a next.config.js rewrite with no server-side filtering,
+ * so phantom data from Railway (if it hadn't redeployed) passed straight through.
+ */
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ slab: string }> },
+) {
+  const { slab } = await params;
+
+  // Blocklist check — short-circuit before hitting Railway.
+  if (isBlockedSlab(slab)) {
+    return NextResponse.json({ error: "Market not found" }, { status: 404 });
+  }
+
+  const upstream = await proxyToApi(req, `/open-interest/${slab}`);
+
+  if (!upstream.ok) return upstream;
+
+  let data: Record<string, unknown>;
+  try {
+    data = await upstream.clone().json();
+  } catch {
+    return upstream;
+  }
+
+  // GH#1462: Strip phantom OI records from history array.
+  if (Array.isArray(data.history)) {
+    data = {
+      ...data,
+      history: (
+        data.history as Array<{
+          totalOi?: string | number | null;
+          netLpPos?: string | number | null;
+        }>
+      ).filter((h) => !isPhantomOiRecord(h)),
+    };
+  }
+
+  const upstreamCacheControl =
+    upstream.headers.get("Cache-Control") ?? "no-store, max-age=0";
+
+  return NextResponse.json(data, {
+    status: upstream.status,
+    headers: { "Cache-Control": upstreamCacheControl },
+  });
+}

--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -58,7 +58,8 @@ const nextConfig: NextConfig = {
       { source: "/api/funding/:slab/history", destination: `${API_URL}/funding/:slab/history` },
       { source: "/api/funding/:slab", destination: `${API_URL}/funding/:slab` },
       { source: "/api/insurance/:slab", destination: `${API_URL}/insurance/:slab` },
-      { source: "/api/open-interest/:slab", destination: `${API_URL}/open-interest/:slab` },
+      // GH#1462: Moved to app/api/open-interest/[slab]/route.ts for defense-in-depth phantom OI filtering.
+      // { source: "/api/open-interest/:slab", destination: `${API_URL}/open-interest/:slab` },
       { source: "/api/prices/:path*", destination: `${API_URL}/prices/:path*` },
       { source: "/api/crank/status", destination: `${API_URL}/crank/status` },
       { source: "/api/trades/recent", destination: `${API_URL}/trades/recent` },

--- a/packages/api/src/middleware/validateSlab.ts
+++ b/packages/api/src/middleware/validateSlab.ts
@@ -13,18 +13,28 @@ import { sanitizeSlabAddress } from "@percolator/shared";
  * Extend via BLOCKED_MARKET_ADDRESSES env var (comma-separated pubkeys).
  */
 const HARDCODED_BLOCKED_SLABS: ReadonlySet<string> = new Set([
-  // SEX/USD — devnet-only token, empty vault, phantom OI (migration 048)
-  "3bmCyPee8GWJR5aPGTyN5EyyQJLzYyD8Wkg9m1Afd1SD",
-  // Empty-vault phantom-OI slab (migration 048)
-  "3YDqCJGz88xGiPBiRvx4vrM51mWTiTZPZ95hxYDZqKpJ",
-  // Empty-vault phantom-OI slab (no on-chain liquidity)
-  "3ZKKwsKoo5UP28cYmMpvGpwoFpWLVgEWLQJCejJnECQn",
-  // GH#1413: DfLoAzny/USD slab — phantom market with vault_balance=1M (at threshold),
-  // stale on-chain OI (2T micro-units ≈ 2,000,000 tokens). Added to frontend blocklist
-  // (app/lib/blocklist.ts) via PR #1415 but missing from backend validateSlab middleware.
-  // /api/open-interest/8eFFEFBY returns 200 with phantom data without this entry.
-  // Also covers /api/funding/8eFFEFBY returning stale zero-rate data.
-  "8eFFEFBY3HHbBgzxJJP5hyxdzMNMAumnYNhkWXErBM4c",
+  // Synced with app/lib/blocklist.ts — keep both in sync (GH#1461/1462).
+  "BxJPaMaCfEGTBsjZ8wfj3Yfzf4wpasmxKAEvqZZRcGPP", // Stale SOL/USD slab (PR #1179)
+  "HjBePQZnoZVftg9B52gyeuHGjBvt2f8FNCVP4FeoP3YT", // GH#837: wrong oracle_authority
+  "H5Vunzd2yAMygnpFiGUASDSx2s8P3bfPTzjCfrRsPeph", // GH#1218: NL/USD corrupt OI
+  "3bmCyPee8GWJR5aPGTyN5EyyQJLzYyD8Wkg9m1Afd1SD", // SEX/USD — empty vault (PR #1377)
+  "3YDqCJGz88xGiPBiRvx4vrM51mWTiTZPZ95hxYDZqKpJ", // Empty-vault phantom-OI (PR #1377)
+  "3ZKKwsKoo5UP28cYmMpvGpwoFpWLVgEWLQJCejJnECQn", // Empty-vault phantom-OI (PR #1377)
+  "CRJH9Gtk7qQDdjzDufnAZdfa7AHisfvxCmVVvzpzQN9v", // GH#1398: garbage test market
+  // GH#1398 follow-up: phantom slabs with oracle_authority = system program
+  "J6UU4VHbYXpCAACr5o5xjUVmquagiP2NGbbMp68VUCX9",
+  "8L47yqvQRLxZ6PzW3b9jawEM79CmokBvUzeLR7mvtyuU",
+  "8kkED3uZznGzSidr8kYJPd3VhzSh7LVngNUx2V1qnW9L",
+  "8pKtAV3z6iTKekieF9EenQ4tk1rkAVa9oYsqe7h1PGjx",
+  "Eekuz2TgXRPq3rsp5brRW5hofxLdwt6KUXbLUQCKHK9G",
+  "Av3zVrW5deLpLo1qZZ7yNJ5Lq5ja4Z9ixijVhV4MuRzE",
+  "CrbDmfiooBUTFfGyMhJ1hpToCrBLAXXKySBwEnLHV6kj",
+  "FhpPmmuh5UDAjvEjrYBPFwmj4CP4otvsYMxtTb46p1Ss",
+  "7xozYEbKhEdjQn5pCAV8bUDQGugZttqZTduPeHkoqRb8",
+  "3dp3e288oPjs5w92fg26cVYQMHGuUpsj8YbSFn6wrzp4",
+  "8nzjXMvdkC4fRF491QkpKE6aFTLmEcpXEnbh4wQT4iUA",
+  "3bmCyPeeDwAfLbhfnRpYJHkWVqAf3Q5JaWXGfZjbmjNp", // GH#1410: phantom SEX/USD
+  "8eFFEFBY3HHbBgzxJJP5hyxdzMNMAumnYNhkWXErBM4c", // GH#1413: DfLoAzny/USD phantom
 ]);
 
 /**


### PR DESCRIPTION
## What

Fixes two regressions from PR #1460 where phantom OI records and blocked slabs still appeared on production.

### Root Cause

1. **GH#1462 (phantom OI)**: `/api/open-interest/[slab]` was a raw `next.config.ts` rewrite to Railway with **no Vercel-layer filtering**. If Railway hadn't redeployed (or env-var was misconfigured), phantom values (9.87e+34) passed straight through.

2. **GH#1461 (blocked slabs in /funding/global)**: The Vercel defense-in-depth filter was added by #1460 but the backend `HARDCODED_BLOCKED_SLABS` was missing 15 entries vs the frontend blocklist, so Railway's response included blocked slabs.

### Changes

- **New `app/api/open-interest/[slab]/route.ts`**: Vercel-layer proxy that:
  - Returns 404 for blocked slabs (short-circuits before hitting Railway)
  - Strips phantom OI records (totalOi or netLpPos >= 1e18) from history
  - Mirrors the defense-in-depth pattern from `/api/funding/global`

- **Synced backend blocklist**: `packages/api/src/middleware/validateSlab.ts` now has all 20 entries matching `app/lib/blocklist.ts` (was missing 15)

- **Commented out** `next.config.ts` rewrite for `/api/open-interest/:slab` (route.ts takes precedence)

### Testing

- Verify `curl /api/open-interest/Bc7A4yCa2SpaBCLCMpphwFE45YPFnJF4Hk1hPfZMKgvK` returns 0 phantom records
- Verify `curl /api/funding/global` returns 0 blocked slabs (8eFFEFBY, 3bmCyPee, 3YDqCJGz, 3ZKKwsK)
- Verify `curl /api/open-interest/8eFFEFBY3HHbBgzxJJP5hyxdzMNMAumnYNhkWXErBM4c` returns 404

Fixes #1461, Fixes #1462

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced open-interest API endpoint to filter out invalid/phantom order book records based on numerical sanity checks, improving data accuracy.
  * Blocked market slabs now return proper error responses instead of proxying requests.

* **Refactor**
  * Migrated open-interest API routing from configuration to dedicated route handler for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->