### PR TITLE
security: remove silent RPC_URL fallback, enforce fail-fast validatio…

### DIFF
--- a/bots/oracle-keeper/index.ts
+++ b/bots/oracle-keeper/index.ts
@@ -92,7 +92,10 @@ const ORACLE_KEEPER_BLOCKED_MARKETS = new Set<string>([
 ]);
 const ADMIN_KP_PATH = process.env.ADMIN_KEYPAIR_PATH ??
   `${process.env.HOME}/.config/solana/percolator-upgrade-authority.json`;
-const RPC_URL = process.env.RPC_URL ?? "https://api.devnet.solana.com";
+// RPC_URL is required and validated at startup by validateEnvironmentConfig()
+// Removed silent fallback to prevent misconfigured production deployments from
+// accidentally connecting to public devnet (HIGH-002 security hardening)
+const RPC_URL = process.env.RPC_URL!;
 
 const conn = new Connection(RPC_URL, "confirmed");
 


### PR DESCRIPTION


Removes the dangerous default fallback to public devnet RPC endpoint. Misconfigured production deployments will now fail at startup with a clear error message instead of silently connecting to devnet.

This enforces the validation introduced in HIGH-001 (validateEnvironmentConfig) which now runs at startup and validates RPC_URL is set and valid.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * RPC configuration now fails at startup if not properly configured, preventing unintended connections to default networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->