### PR TITLE
refactor: extract isZombieMarket() shared helper (CodeRabbit #1466)

### DIFF
--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -5,7 +5,7 @@ import { parseHeader } from "@percolator/sdk";
 import { getServiceClient } from "@/lib/supabase";
 import { getConfig } from "@/lib/config";
 import * as Sentry from "@sentry/nextjs";
-import { isSaneMarketValue, isActiveMarket } from "@/lib/activeMarketFilter";
+import { isSaneMarketValue, isActiveMarket, isZombieMarket } from "@/lib/activeMarketFilter";
 import { isPhantomOpenInterest } from "@/lib/phantom-oi";
 import { BLOCKED_SLAB_ADDRESSES as HARDCODED_BLOCKED_MARKETS } from "@/lib/blocklist";
 
@@ -199,30 +199,20 @@ export async function GET(request: NextRequest) {
         sanitizedPrice,
       );
 
-      // GH#1420: Mark zombie markets (vault_balance == 0) so they can be filtered.
+      // GH#1420 + GH#1427: Mark zombie markets using shared isZombieMarket() helper.
+      // (CodeRabbit #1466: extracted from inline predicate in stats route to avoid drift.)
       // Zombie markets have no LP liquidity; their prices are stale/garbage from
       // when the vault drained (e.g. BTC@$148, SOL@$0.60 — prices from months ago).
       // We tag them with is_zombie=true and exclude them from the default response
-      // (opt-in via ?include_zombie=true). vault_balance=0 is strictly zero (fully drained).
-      // Only mark zombie when vault_balance is explicitly 0 — do not treat null/missing
-      // stats rows as drained (CodeRabbit: null-coalesce to 0 misclassifies stats-less markets).
-      //
-      // GH#1427: Also mark as zombie when vault_balance IS null AND all key stats are null
-      // (no last_price, no volume_24h, no total_open_interest, no accounts). These are
-      // phantom markets that have never received data from the indexer — they have explicitly
-      // is_zombie=false from the DB but no evidence of ever being active or having LP capital.
-      // Condition: vault_balance == null AND !isSaneMarketValue on all three price/volume/OI
-      // fields AND total_accounts == 0. This is more conservative than null-coalescing to 0
-      // (which would misclassify markets still being indexed), while still catching the 6
-      // phantom markets reported in GH#1427.
-      const hasNoStats =
-        !isSaneMarketValue(m.last_price as number | null) &&
-        !isSaneMarketValue(m.volume_24h as number | null) &&
-        !isSaneMarketValue(m.total_open_interest as number | null) &&
-        ((m.total_accounts as number) ?? 0) === 0;
-      const is_zombie =
-        (m.vault_balance != null && (m.vault_balance as number) === 0) ||
-        (m.vault_balance == null && hasNoStats);
+      // (opt-in via ?include_zombie=true). See isZombieMarket() in activeMarketFilter.ts
+      // for the two conditions: vault=0 (drained) or vault=null+no-stats (phantom).
+      const is_zombie = isZombieMarket({
+        vault_balance: m.vault_balance as number | null,
+        last_price: m.last_price as number | null,
+        volume_24h: m.volume_24h as number | null,
+        total_open_interest: m.total_open_interest as number | null,
+        total_accounts: m.total_accounts as number | null,
+      });
 
       return {
         ...m,

--- a/app/app/api/stats/route.ts
+++ b/app/app/api/stats/route.ts
@@ -5,7 +5,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { getServiceClient } from "@/lib/supabase";
-import { isActiveMarket, isSaneMarketValue } from "@/lib/activeMarketFilter";
+import { isActiveMarket, isSaneMarketValue, isZombieMarket } from "@/lib/activeMarketFilter";
 import { isPhantomOpenInterest } from "@/lib/phantom-oi";
 import { BLOCKED_SLAB_ADDRESSES } from "@/lib/blocklist";
 import type { Database } from "@/lib/database.types";
@@ -232,21 +232,14 @@ export async function GET(request: NextRequest) {
   // /api/markets excludes zombies (vault=0 or null+no-stats) from its `total` field.
   // Previously statsData.length included zombies, causing totalListedMarkets (195) to
   // diverge from /api/markets total (122) by exactly zombieCount (73).
-  // Apply the same zombie predicate used in /api/markets (GH#1420 + GH#1427):
-  //   - vault_balance == 0 (explicitly drained)
-  //   - vault_balance == null AND no sane stats AND total_accounts == 0 (never indexed)
-  const nonZombieListedMarkets = statsData.filter((m) => {
-    const vaultBal = (m as Record<string, unknown>).vault_balance as number | null;
-    const hasNoStats =
-      !isSaneMarketValue(m.last_price) &&
-      !isSaneMarketValue(m.volume_24h) &&
-      !isSaneMarketValue(m.total_open_interest) &&
-      ((m as Record<string, unknown>).total_accounts as number ?? 0) === 0;
-    const isZombie =
-      (vaultBal != null && vaultBal === 0) ||
-      (vaultBal == null && hasNoStats);
-    return !isZombie;
-  });
+  // Uses shared isZombieMarket() helper (GH#1420 + GH#1427 predicate, CodeRabbit #1466).
+  const nonZombieListedMarkets = statsData.filter((m) => !isZombieMarket(m as {
+    vault_balance?: number | null;
+    last_price?: number | null;
+    volume_24h?: number | null;
+    total_open_interest?: number | null;
+    total_accounts?: number | null;
+  }));
 
   return NextResponse.json({
     totalMarkets,

--- a/app/lib/activeMarketFilter.ts
+++ b/app/lib/activeMarketFilter.ts
@@ -34,3 +34,35 @@ export function isActiveMarket(row: {
   if (isSaneMarketValue(combinedOI)) return true;
   return false;
 }
+
+/**
+ * Determine if a market row is a "zombie" — has no LP liquidity and no real activity.
+ *
+ * Two zombie conditions (GH#1420 + GH#1427):
+ *   1. vault_balance === 0  → explicitly drained vault, no liquidity.
+ *   2. vault_balance === null AND no sane stats AND total_accounts === 0
+ *      → phantom market that was never indexed or funded.
+ *
+ * SINGLE SOURCE OF TRUTH: used by /api/markets and /api/stats to ensure
+ * consistent zombie exclusion across the platform. Previously duplicated
+ * inline in both routes (CodeRabbit PR #1466 nitpick).
+ */
+export function isZombieMarket(row: {
+  vault_balance?: number | null;
+  last_price?: number | null;
+  volume_24h?: number | null;
+  total_open_interest?: number | null;
+  total_accounts?: number | null;
+}): boolean {
+  const vaultBal = row.vault_balance ?? null;
+  if (vaultBal !== null && vaultBal === 0) return true;
+  if (vaultBal === null) {
+    const hasNoStats =
+      !isSaneMarketValue(row.last_price) &&
+      !isSaneMarketValue(row.volume_24h) &&
+      !isSaneMarketValue(row.total_open_interest) &&
+      (row.total_accounts ?? 0) === 0;
+    if (hasNoStats) return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

Addresses the CodeRabbit nitpick from PR #1466: the inline zombie-detection predicate was duplicated in both `/api/stats` and `/api/markets` routes. This refactor extracts it into a shared `isZombieMarket()` function in `app/lib/activeMarketFilter.ts` — the existing SINGLE SOURCE OF TRUTH for market filter logic.

## Changes
- **`app/lib/activeMarketFilter.ts`**: Added `isZombieMarket()` export with JSDoc and full zombie predicate (GH#1420 + GH#1427 conditions)
- **`app/app/api/stats/route.ts`**: Replace 10-line inline predicate with `!isZombieMarket(m)`
- **`app/app/api/markets/route.ts`**: Replace 10-line inline predicate with `isZombieMarket({...})`

## Behaviour
No functional change. The predicate is identical to what was already merged in PR #1466. Both routes now share the same implementation — future changes only need to happen in one place.

## Tests
- TypeScript: clean (no errors)
- 1213/1213 unit + integration + E2E tests pass

## Related
- Closes CodeRabbit nitpick on PR #1466
- GH#1420, GH#1427 (original zombie filter logic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored and consolidated zombie market detection logic from multiple API endpoints into a centralized, reusable utility function. This consolidation improves overall code organization, reduces code duplication, and ensures consistent and uniform market filtering behavior across the platform while maintaining identical functionality and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->