### PR TITLE
fix(faucet): never return empty error string on catch (GH#1474)

### DIFF
--- a/app/__tests__/api/faucet-route.test.ts
+++ b/app/__tests__/api/faucet-route.test.ts
@@ -8,6 +8,7 @@
  * - USDC amount constant
  * - SOL airdrop path dispatching
  * - USDC sealed-signer path: on-chain authority check returns 400 (not 500)
+ * - GH#1474: error field is never empty string (fallback to toString/generic)
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -240,6 +241,44 @@ describe("/api/faucet route", () => {
       const rateLimited = isRateLimit(errMsg);
       const statusCode = rateLimited ? 429 : 500;
       expect(statusCode).toBe(429);
+    });
+  });
+
+  describe("GH#1474: error response is never empty string", () => {
+    // Mirrors the error serialisation logic in the catch handler and SOL airdrop catch.
+    const serializeError = (error: unknown): string => {
+      if (error instanceof Error) {
+        return error.message || error.toString() || "Internal server error";
+      }
+      return String(error) || "Internal server error";
+    };
+
+    it("returns message when Error has non-empty message", () => {
+      const e = new Error("something went wrong");
+      expect(serializeError(e)).toBe("something went wrong");
+    });
+
+    it("falls back to toString() when Error.message is empty string", () => {
+      const e = new Error("");
+      // Error.toString() returns "Error" when message is empty
+      expect(serializeError(e)).toBe("Error");
+    });
+
+    it("returns generic message when Error.message and toString both empty", () => {
+      const e = new Error("");
+      // Override toString to simulate degenerate case
+      e.toString = () => "";
+      expect(serializeError(e)).toBe("Internal server error");
+    });
+
+    it("stringifies non-Error throws (e.g. string literal throws)", () => {
+      const thrown = "authority_mismatch";
+      expect(serializeError(thrown)).toBe("authority_mismatch");
+    });
+
+    it("handles null/undefined thrown values without returning empty", () => {
+      expect(serializeError(null)).toBe("null");
+      expect(serializeError(undefined)).toBe("undefined");
     });
   });
 });

--- a/app/app/api/faucet/route.ts
+++ b/app/app/api/faucet/route.ts
@@ -130,8 +130,11 @@ export async function POST(req: NextRequest) {
         sig = await pubConn.requestAirdrop(walletPk, SOL_AIRDROP_AMOUNT);
         await pubConn.confirmTransaction(sig, "confirmed");
       } catch (airdropErr) {
+        // GH#1474: fall back to toString() when .message is empty
         const msg =
-          airdropErr instanceof Error ? airdropErr.message : "Airdrop failed";
+          airdropErr instanceof Error
+            ? airdropErr.message || airdropErr.toString() || "Airdrop failed"
+            : String(airdropErr) || "Airdrop failed";
         // Detect Solana devnet RPC rate-limit responses.
         // The public devnet faucet returns "429 Too Many Requests", "airdrop request limit",
         // or similar strings when the wallet or IP has exceeded the daily drip.
@@ -341,12 +344,11 @@ export async function POST(req: NextRequest) {
     Sentry.captureException(error, {
       tags: { endpoint: "/api/faucet", method: "POST" },
     });
-    return NextResponse.json(
-      {
-        error:
-          error instanceof Error ? error.message : "Internal server error",
-      },
-      { status: 500 },
-    );
+    // GH#1474: ensure error is never empty string — fall back to toString() or generic message
+    const errorMsg =
+      error instanceof Error
+        ? error.message || error.toString() || "Internal server error"
+        : String(error) || "Internal server error";
+    return NextResponse.json({ error: errorMsg }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary

Fixes #1474 — `POST /api/faucet` was returning `{"error":""}` (HTTP 500) when a thrown `Error` had an empty `.message` property (e.g. the `authority_mismatch` path before GH#1477 fix, or any other degenerate throw).

## Changes

**`app/app/api/faucet/route.ts`**
- Outer catch: `error.message || error.toString() || 'Internal server error'`
- SOL airdrop catch: same pattern for `airdropErr`

**`app/__tests__/api/faucet-route.test.ts`**
- 5 new regression tests for GH#1474 error serialisation:
  - Non-empty message → returned as-is
  - Empty message → falls back to `toString()` (`"Error"`)
  - Both empty → returns `"Internal server error"`
  - String literal throw → stringified
  - null/undefined throw → stringified (not empty)

## Test Results
27/27 tests pass.

## How to Test
```bash
cd app && pnpm vitest run __tests__/api/faucet-route.test.ts
```