### PR TITLE
fix(GH1480): max leverage shows 0x/1x — prefer Supabase max_leverage over on-chain initialMarginBps

### DIFF
--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -156,10 +156,17 @@ function MarketsPageInner() {
       // GH#1106: deduplicate — same slab can appear from multiple program scans
       if (seenSlabs.has(addr)) continue;
       const mint = d.config.collateralMint.toBase58();
-      const maxLev = d.params.initialMarginBps > 0n ? Math.floor(10000 / Number(d.params.initialMarginBps)) : 0;
+      // GH#1480: Prefer Supabase max_leverage (indexed by keeper, always correct) over
+      // on-chain initialMarginBps computation. The on-chain bps → leverage conversion can
+      // give 0 when initialMarginBps is misread (e.g. layout mismatch on V1D slabs reads
+      // warmup_period_slots instead). Supabase is set at market creation and updated by
+      // the indexer, matching what /api/markets returns. Fall back to bps derivation only
+      // when no Supabase record exists (new market not yet indexed).
+      const stats = statsMap.get(addr) || null;
+      const onChainMaxLev = d.params.initialMarginBps > 0n ? Math.floor(10000 / Number(d.params.initialMarginBps)) : 0;
+      const maxLev = (stats?.max_leverage != null && stats.max_leverage > 0) ? stats.max_leverage : onChainMaxLev;
       const oracleMode = detectOracleMode(d.config);
       const isAdminOracle = oracleMode === "hyperp" || oracleMode === "admin";
-      const stats = statsMap.get(addr) || null;
       seenSlabs.add(addr);
       result.push({ slabAddress: addr, mintAddress: mint, symbol: null, name: null, maxLeverage: maxLev, isAdminOracle, onChain: d, supabase: stats });
     }

--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -22,6 +22,7 @@ import { usePrivyLogin } from "@/hooks/usePrivySafe";
 import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab, getMockUserAccountIdle } from "@/lib/mock-trade-data";
 import { sanitizeSymbol } from "@/lib/symbol-utils";
+import { useMarketInfo } from "@/hooks/useMarketInfo";
 
 const LEVERAGE_PRESETS = [1, 2, 3, 5, 10];
 const MARGIN_PRESETS = [25, 50, 75, 100];
@@ -117,12 +118,20 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
   // program will reject trades with Custom(14) Undercollateralized on the LP side.
   const lpUnderfunded = hasValidLP && lpEntry!.account.capital === 0n;
 
+  // GH#1480: Bug #845 — many devnet slabs have initialMarginBps=0 due to init bug.
+  // Use Supabase max_leverage as fallback when on-chain value is 0.
+  const { market: marketInfo } = useMarketInfo(slabAddress);
   const initialMarginBps = params?.initialMarginBps ?? 1000n;
   const maintenanceMarginBps = params?.maintenanceMarginBps ?? 500n;
   const tradingFeeBps = params?.tradingFeeBps ?? 30n;
   // Clamp to minimum 1 — if initialMarginBps > 10000 (>100% margin), integer division yields
   // 0 which breaks the slider (min=1 > max=0) and causes the "1x and 0x simultaneously" bug.
-  const maxLeverage = initialMarginBps > 0n ? Math.max(1, Number(10000n / initialMarginBps)) : 1;
+  // GH#1480: When initialMarginBps is 0 (Bug #845 uninitialised slab), fall back to
+  // Supabase max_leverage which is set correctly at market creation time.
+  const maxLeverageFromOnChain = initialMarginBps > 0n ? Math.max(1, Number(10000n / initialMarginBps)) : 0;
+  const maxLeverage = maxLeverageFromOnChain > 0
+    ? maxLeverageFromOnChain
+    : (marketInfo?.max_leverage != null && marketInfo.max_leverage > 0 ? marketInfo.max_leverage : 1);
 
   const availableLeverage = useMemo(() => {
     const arr = LEVERAGE_PRESETS.filter((l) => l <= maxLeverage);

--- a/app/hooks/useMarketInfo.ts
+++ b/app/hooks/useMarketInfo.ts
@@ -5,6 +5,7 @@ import { getSupabase } from "@/lib/supabase";
 import type { Database } from "@/lib/database.types";
 
 type MarketWithStats = Database['public']['Views']['markets_with_stats']['Row'];
+type SupabaseClient = ReturnType<typeof getSupabase>;
 
 export function useMarketInfo(slabAddress: string) {
   const [market, setMarket] = useState<MarketWithStats | null>(null);
@@ -14,10 +15,22 @@ export function useMarketInfo(slabAddress: string) {
   useEffect(() => {
     setLoading(true);
     setError(null);
-    const supabase = getSupabase();
+
+    let supabase: SupabaseClient;
+    try {
+      supabase = getSupabase();
+    } catch {
+      // Supabase client creation can fail if env vars missing (e.g. in test env)
+      setError("Database unavailable");
+      setLoading(false);
+      return;
+    }
+
+    const sb = supabase;
+
     async function load() {
       try {
-        const { data, error: dbError } = await supabase
+        const { data, error: dbError } = await sb
           .from("markets_with_stats")
           .select("*")
           .eq("slab_address", slabAddress)
@@ -40,7 +53,7 @@ export function useMarketInfo(slabAddress: string) {
     load();
 
     // Subscribe to stat updates
-    const channel = supabase
+    const channel = sb
       .channel(`market-${slabAddress}`)
       .on("postgres_changes", {
         event: "UPDATE",
@@ -52,7 +65,7 @@ export function useMarketInfo(slabAddress: string) {
       })
       .subscribe();
 
-    return () => { supabase.removeChannel(channel); };
+    return () => { sb.removeChannel(channel); };
   }, [slabAddress]);
 
   return { market, loading, error };


### PR DESCRIPTION
## Summary

Fixes GH#1480: /markets page shows '0x' for ALL markets in max leverage column, and trade page leverage slider for MHH maxes at 1x instead of 20x.

## Root Cause

Bug #845 — many V1D devnet slabs have `initialMarginBps=0` (uninitialised field at market creation time). When `initialMarginBps=0`:
- **markets page**: `10000/0` guard gives `maxLev=0` → renders `0x` for ALL markets
- **trade page**: `Math.max(1, 10000n/0n)` fallback gives `maxLeverage=1` → slider caps at 1x

## Changes

### 1. `app/app/markets/page.tsx`
For on-chain discovered markets, prefer `stats.max_leverage` from Supabase (set correctly at market creation, indexed by keeper) over on-chain computation. Falls back to bps derivation only when no Supabase record exists. This matches what `/api/markets` already returns.

### 2. `app/components/trade/TradeForm.tsx`  
Add `useMarketInfo(slabAddress)` and use `marketInfo.max_leverage` as fallback when on-chain `initialMarginBps` gives 0. Existing `Math.max(1,...)` guard becomes the ultimate safety net.

### 3. `app/hooks/useMarketInfo.ts`
Wrap `getSupabase()` in try/catch (same pattern as `useAllMarketStats`) so missing env vars in test environments don't throw. Fixes 9 TradeForm test failures.

## Testing

- ✅ All 1227 tests pass (98 test files)
- ✅ Markets page will now show correct leverage (5x, 10x, 20x etc.) from Supabase
- ✅ Trade page leverage slider will respect actual max_leverage from DB

## How to Test

1. Visit /markets — all markets should show their correct max leverage (not 0x)
2. Visit /trade/HAXvtHameEn3C5URDSs26qq9m7cYo742xf95Spn7zMGB (MHH) — slider should max at 20x

Closes #1480

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected leverage limit calculations for trading by prioritizing market statistics when available.
  * Fixed leverage limits for certain markets that were previously restricted to 1x.
  * Enhanced reliability of market data synchronization with improved error handling for database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->