### PR TITLE
fix(GH1483): clamp UI max_leverage display to MAX_DISPLAY_LEVERAGE=200

### DIFF
--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -31,6 +31,12 @@ import { formatStatValue } from "@/lib/format";
  *  exceed this and are nulled/excluded. */
 const MAX_SANE_PRICE_USD = 1_000_000;
 
+/** GH#1483: Upper bound for UI leverage display. The Solana program enforces margin
+ *  requirements at execution time, so this is display-only protection against corrupt
+ *  DB values (keeper bug, row injection, data corruption). 200x is well above any
+ *  legitimate max leverage on Percolator devnet (current max: 20x). */
+const MAX_DISPLAY_LEVERAGE = 200;
+
 function formatNum(n: number | null | undefined): string {
   if (n === null || n === undefined) return "\u2014";
   if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(1)}M`;
@@ -164,7 +170,8 @@ function MarketsPageInner() {
       // when no Supabase record exists (new market not yet indexed).
       const stats = statsMap.get(addr) || null;
       const onChainMaxLev = d.params.initialMarginBps > 0n ? Math.floor(10000 / Number(d.params.initialMarginBps)) : 0;
-      const maxLev = (stats?.max_leverage != null && stats.max_leverage > 0) ? stats.max_leverage : onChainMaxLev;
+      const rawLev = (stats?.max_leverage != null && stats.max_leverage > 0) ? stats.max_leverage : onChainMaxLev;
+      const maxLev = Math.min(MAX_DISPLAY_LEVERAGE, rawLev);
       const oracleMode = detectOracleMode(d.config);
       const isAdminOracle = oracleMode === "hyperp" || oracleMode === "admin";
       seenSlabs.add(addr);
@@ -176,7 +183,7 @@ function MarketsPageInner() {
       if (seenSlabs.has(slabAddr)) continue;
       // Use Supabase fields for display
       const mint = stats.mint_address ?? "";
-      const maxLev = stats.max_leverage ?? 10;
+      const maxLev = Math.min(MAX_DISPLAY_LEVERAGE, stats.max_leverage ?? 10);
       // Without on-chain data, we can't detect oracle mode — use Supabase oracle_authority hint
       const isAdminOracle = stats.oracle_authority != null && stats.oracle_authority !== "";
       result.push({

--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -27,6 +27,11 @@ import { useMarketInfo } from "@/hooks/useMarketInfo";
 const LEVERAGE_PRESETS = [1, 2, 3, 5, 10];
 const MARGIN_PRESETS = [25, 50, 75, 100];
 
+/** GH#1483: Upper bound for UI leverage display. Clamps Supabase-sourced max_leverage
+ *  to protect against DB corruption/keeper bugs. The Solana program enforces margin
+ *  requirements at execution time regardless of what the UI slider shows. */
+const MAX_DISPLAY_LEVERAGE = 200;
+
 function formatPerc(native: bigint, decimals = 6): string {
   const abs = native < 0n ? -native : native;
   const base = 10n ** BigInt(decimals);
@@ -129,9 +134,12 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
   // GH#1480: When initialMarginBps is 0 (Bug #845 uninitialised slab), fall back to
   // Supabase max_leverage which is set correctly at market creation time.
   const maxLeverageFromOnChain = initialMarginBps > 0n ? Math.max(1, Number(10000n / initialMarginBps)) : 0;
-  const maxLeverage = maxLeverageFromOnChain > 0
+  const rawMaxLeverage = maxLeverageFromOnChain > 0
     ? maxLeverageFromOnChain
     : (marketInfo?.max_leverage != null && marketInfo.max_leverage > 0 ? marketInfo.max_leverage : 1);
+  // GH#1483: Clamp to MAX_DISPLAY_LEVERAGE — protects against corrupt DB values.
+  // Program enforces real margin requirements at execution time.
+  const maxLeverage = Math.min(MAX_DISPLAY_LEVERAGE, rawMaxLeverage);
 
   const availableLeverage = useMemo(() => {
     const arr = LEVERAGE_PRESETS.filter((l) => l <= maxLeverage);


### PR DESCRIPTION
## Summary

Fixes GH#1483 (LOW severity): Supabase `max_leverage` had no upper bound cap in UI display.

## Root Cause

PR #1482 introduced Supabase as the source for `max_leverage` in the markets page and trade form. If `markets_with_stats` returns an abnormally high value (e.g. 9999x) due to DB corruption, keeper bug, or row injection, the leverage slider would display 9999x — confusing traders into attempting trades the Solana program will reject.

## Changes

### `MAX_DISPLAY_LEVERAGE = 200` constant (both files)
Well above any legitimate max leverage on Percolator devnet (current max: 20x). Provides headroom for future markets without false-positive clamping.

### `app/app/markets/page.tsx`
- On-chain-enriched branch: `Math.min(MAX_DISPLAY_LEVERAGE, rawLev)`
- Supabase-only branch: `Math.min(MAX_DISPLAY_LEVERAGE, stats.max_leverage ?? 10)`

### `app/components/trade/TradeForm.tsx`
- Post-resolution clamp: `Math.min(MAX_DISPLAY_LEVERAGE, rawMaxLeverage)`

## Severity / Safety

**No funds at risk.** The Solana program enforces margin requirements at execution time regardless of UI slider values. This is display-only hardening.

## Testing

- ✅ All 1227 tests pass (98 test files)
- Manual: set `max_leverage = 9999` in Supabase → slider now caps at 200x instead of 9999x

Closes #1483

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Capped maximum leverage display at 200x across the markets and trading interface to ensure consistent UI presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->