### PR TITLE
fix(GH1486): MHH leverage slider stuck at 1x — prefer max(on-chain, supabase)

### DIFF
--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -131,12 +131,18 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
   const tradingFeeBps = params?.tradingFeeBps ?? 30n;
   // Clamp to minimum 1 — if initialMarginBps > 10000 (>100% margin), integer division yields
   // 0 which breaks the slider (min=1 > max=0) and causes the "1x and 0x simultaneously" bug.
-  // GH#1480: When initialMarginBps is 0 (Bug #845 uninitialised slab), fall back to
-  // Supabase max_leverage which is set correctly at market creation time.
+  // GH#1480: When initialMarginBps is 0 (Bug #845 uninitialised slab), on-chain gives 0 — use Supabase.
+  // GH#1486: When on-chain is lower than Supabase (e.g. MHH: on-chain=1x, Supabase=20x), use Supabase.
   const maxLeverageFromOnChain = initialMarginBps > 0n ? Math.max(1, Number(10000n / initialMarginBps)) : 0;
-  const rawMaxLeverage = maxLeverageFromOnChain > 0
-    ? maxLeverageFromOnChain
-    : (marketInfo?.max_leverage != null && marketInfo.max_leverage > 0 ? marketInfo.max_leverage : 1);
+  // GH#1486: Prefer Supabase max_leverage when it exceeds on-chain value.
+  // MHH market has initialMarginBps=10000 (100% margin) giving 1x on-chain, but
+  // Supabase correctly records max_leverage=20. Always use max(on-chain, supabase)
+  // so neither source silently under-caps the slider.
+  const supabaseLeverage = marketInfo?.max_leverage != null && marketInfo.max_leverage > 0 ? marketInfo.max_leverage : 0;
+  const rawMaxLeverage = Math.max(
+    maxLeverageFromOnChain > 0 ? maxLeverageFromOnChain : 0,
+    supabaseLeverage,
+  ) || 1;
   // GH#1483: Clamp to MAX_DISPLAY_LEVERAGE — protects against corrupt DB values.
   // Program enforces real margin requirements at execution time.
   const maxLeverage = Math.min(MAX_DISPLAY_LEVERAGE, rawMaxLeverage);


### PR DESCRIPTION
## Problem
GH#1486: MHH market leverage slider shows 1x instead of 20x on the trade page.

PR #1482 fixed the `initialMarginBps=0` regression (uninitialised slab), but introduced a new regression for markets like MHH where `initialMarginBps=10000` (100% margin). Integer division gives 1x on-chain which is a valid value (>0), so the Supabase fallback was never reached — even though Supabase correctly stores `max_leverage=20`.

## Fix
Compute `max(on-chain, supabase)` so the higher (correct) value always wins:

```ts
const supabaseLeverage = marketInfo?.max_leverage ?? 0;
const rawMaxLeverage = Math.max(
  maxLeverageFromOnChain > 0 ? maxLeverageFromOnChain : 0,
  supabaseLeverage,
) || 1;
```

This handles all three cases:
- `initialMarginBps=0` (uninitialised): on-chain=0, supabase wins ✅
- `initialMarginBps=10000` (MHH, 100% margin): on-chain=1, supabase=20, supabase wins ✅
- Normal markets: on-chain=20, supabase=20 (or 0 if missing), on-chain wins ✅

## Testing
- Build passes ✅
- MHH trade page: verify slider shows 20x not 1x
- SOL/USD, BTC/USD: verify leverage unchanged

Fixes GH#1486. Regression introduced by PR #1482.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved leverage limit calculations for the trading slider. The system now better prioritizes and combines multiple available data sources to determine more accurate maximum leverage values, with improved fallback behavior when some data sources are unavailable or invalid. This ensures consistent and reliable leverage constraints are applied across all trading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->