### PR TITLE
fix(api): validate limit/offset query params on GET /api/markets (GH#1490)

### DIFF
--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 // requireAuth removed from POST — on-chain admin verification is sufficient
 import { Connection, PublicKey } from "@solana/web3.js";
+import { validateNumericParam } from "@/lib/route-validators";
 import { parseHeader } from "@percolator/sdk";
 import { getServiceClient } from "@/lib/supabase";
 import { getConfig } from "@/lib/config";
@@ -268,9 +269,26 @@ export async function GET(request: NextRequest) {
     const activeTotal = nonZombieOnly.filter((m) => isActiveMarket(m as Parameters<typeof isActiveMarket>[0])).length;
 
     // GH#1348: Respect ?limit= query param to avoid returning 100+ markets
+    // GH#1490: Validate limit (must be 1–500) and offset (must be >= 0) using
+    // validateNumericParam() from route-validators.ts. Previously limit=-1/0/999999
+    // all returned the full dataset and non-numeric offset was silently ignored.
+    const MAX_LIMIT = 500;
     const limitParam = request?.nextUrl?.searchParams?.get("limit") ?? null;
+    if (limitParam !== null) {
+      const limitValidation = validateNumericParam(limitParam, { min: 1, max: MAX_LIMIT });
+      if (!limitValidation.valid) return limitValidation.response;
+    }
     const limitNum = limitParam ? parseInt(limitParam, 10) : 0;
-    const limited = limitNum > 0 ? nonZombie.slice(0, limitNum) : nonZombie;
+
+    const offsetParam = request?.nextUrl?.searchParams?.get("offset") ?? null;
+    if (offsetParam !== null) {
+      const offsetValidation = validateNumericParam(offsetParam, { min: 0 });
+      if (!offsetValidation.valid) return offsetValidation.response;
+    }
+    const offsetNum = offsetParam ? parseInt(offsetParam, 10) : 0;
+
+    const paged = offsetNum > 0 ? nonZombie.slice(offsetNum) : nonZombie;
+    const limited = limitNum > 0 ? paged.slice(0, limitNum) : paged;
 
     return NextResponse.json({ total: nonZombie.length, activeTotal, zombieCount, markets: limited }, {
       headers: {


### PR DESCRIPTION
## Summary

Fixes GH#1490 — `/api/markets` was accepting invalid `limit` and `offset` query params without validation.

## What changed

- Import `validateNumericParam()` from the already-existing `app/lib/route-validators.ts` (no new utility code)
- **`limit`**: must be 1–500 (inclusive). `limit<=0`, `limit>500`, and non-numeric strings now return **400 Bad Request**. Omitting `limit` continues to return all markets.
- **`offset`**: must be ≥0. Negative or non-numeric values now return **400 Bad Request**. Omitting `offset` returns from the start.
- Offset is now correctly applied as a slice before limit, enabling proper pagination.

## Behaviour after fix

| Request | Before | After |
|---|---|---|
| `?limit=-1` | 200 + all markets | 400 |
| `?limit=0` | 200 + all markets | 400 |
| `?limit=999999` | 200 + all markets | 400 (> MAX_LIMIT=500) |
| `?offset=INVALID` | 200 (silently ignored) | 400 |
| `?limit=20&offset=40` | 200 (offset ignored) | 200 + correct page |
| `?limit=20` | 200 + first 20 | unchanged ✅ |
| (no params) | 200 + all markets | unchanged ✅ |

## How to test

```bash
# Should return 400
curl -s 'https://percolatorlaunch.com/api/markets?limit=-1' | jq .error
curl -s 'https://percolatorlaunch.com/api/markets?limit=0' | jq .error
curl -s 'https://percolatorlaunch.com/api/markets?limit=999999' | jq .error
curl -s 'https://percolatorlaunch.com/api/markets?offset=INVALID' | jq .error

# Should return 200
curl -s 'https://percolatorlaunch.com/api/markets?limit=20&offset=0' | jq .total
```

Closes #1490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed API pagination to properly validate `limit` and `offset` parameters, now returning errors for invalid values instead of silently applying defaults that could return unintended results.

## New Features
* Added support for offset-based pagination in the markets API, enabling more flexible result navigation alongside limit-based pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->