### PR TITLE
fix(api): strict integer validation for limit/offset params (GH#1490 follow-up)

### DIFF
--- a/app/__tests__/lib/route-validators.test.ts
+++ b/app/__tests__/lib/route-validators.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for validateNumericParam — strict integer enforcement (GH#1490 follow-up).
+ * Ensures floats, trailing-garbage strings, and out-of-range values are rejected.
+ */
+import { validateNumericParam } from "@/lib/route-validators";
+
+describe("validateNumericParam", () => {
+  describe("strict integer check", () => {
+    it("accepts a valid positive integer string", () => {
+      const result = validateNumericParam("10", { min: 1, max: 500 });
+      expect(result.valid).toBe(true);
+      if (result.valid) expect(result.value).toBe(10);
+    });
+
+    it("accepts zero when min is 0", () => {
+      const result = validateNumericParam("0", { min: 0 });
+      expect(result.valid).toBe(true);
+      if (result.valid) expect(result.value).toBe(0);
+    });
+
+    it("rejects float string '1.5'", () => {
+      const result = validateNumericParam("1.5", { min: 1, max: 500 });
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects trailing-garbage string '20abc'", () => {
+      const result = validateNumericParam("20abc", { min: 1, max: 500 });
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects empty string", () => {
+      const result = validateNumericParam("", { min: 0 });
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects null", () => {
+      const result = validateNumericParam(null, { min: 0 });
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects undefined", () => {
+      const result = validateNumericParam(undefined, { min: 0 });
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects NaN string", () => {
+      const result = validateNumericParam("NaN", { min: 0 });
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects leading-space string ' 10'", () => {
+      const result = validateNumericParam(" 10", { min: 0 });
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe("range enforcement", () => {
+    it("rejects value below min", () => {
+      const result = validateNumericParam("0", { min: 1, max: 500 });
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects value above max", () => {
+      const result = validateNumericParam("501", { min: 1, max: 500 });
+      expect(result.valid).toBe(false);
+    });
+
+    it("accepts value at exactly min", () => {
+      const result = validateNumericParam("1", { min: 1, max: 500 });
+      expect(result.valid).toBe(true);
+      if (result.valid) expect(result.value).toBe(1);
+    });
+
+    it("accepts value at exactly max", () => {
+      const result = validateNumericParam("500", { min: 1, max: 500 });
+      expect(result.valid).toBe(true);
+      if (result.valid) expect(result.value).toBe(500);
+    });
+  });
+});

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -272,20 +272,23 @@ export async function GET(request: NextRequest) {
     // GH#1490: Validate limit (must be 1–500) and offset (must be >= 0) using
     // validateNumericParam() from route-validators.ts. Previously limit=-1/0/999999
     // all returned the full dataset and non-numeric offset was silently ignored.
+    // Follow-up: use validated .value directly (not re-parsed) to reject "1.5"/"20abc".
     const MAX_LIMIT = 500;
     const limitParam = request?.nextUrl?.searchParams?.get("limit") ?? null;
+    let limitNum = 0;
     if (limitParam !== null) {
       const limitValidation = validateNumericParam(limitParam, { min: 1, max: MAX_LIMIT });
       if (!limitValidation.valid) return limitValidation.response;
+      limitNum = limitValidation.value;
     }
-    const limitNum = limitParam ? parseInt(limitParam, 10) : 0;
 
     const offsetParam = request?.nextUrl?.searchParams?.get("offset") ?? null;
+    let offsetNum = 0;
     if (offsetParam !== null) {
       const offsetValidation = validateNumericParam(offsetParam, { min: 0 });
       if (!offsetValidation.valid) return offsetValidation.response;
+      offsetNum = offsetValidation.value;
     }
-    const offsetNum = offsetParam ? parseInt(offsetParam, 10) : 0;
 
     const paged = offsetNum > 0 ? nonZombie.slice(offsetNum) : nonZombie;
     const limited = limitNum > 0 ? paged.slice(0, limitNum) : paged;

--- a/app/lib/route-validators.ts
+++ b/app/lib/route-validators.ts
@@ -59,6 +59,15 @@ export function validateNumericParam(
     };
   }
 
+  // Strict integer check: reject floats ("1.5"), trailing garbage ("20abc"), and negatives
+  // expressed as non-integer strings. parseInt alone would silently accept these.
+  if (!/^-?\d+$/.test(value)) {
+    return {
+      valid: false,
+      response: NextResponse.json({ error: "Invalid numeric parameter" }, { status: 400 }),
+    };
+  }
+
   const num = parseInt(value, 10);
   if (isNaN(num)) {
     return {


### PR DESCRIPTION
## Summary

CodeRabbit review on PR #1491 flagged two issues:

1. `validateNumericParam` uses `parseInt` which silently accepts floats (`"1.5"" → 1`) and trailing-garbage strings (`"20abc"" → 20`)
2. `markets/route.ts` re-parsed with `parseInt` after validation instead of using `.value` from the result

## Changes

- **`app/lib/route-validators.ts`**: Add `/^-?\d+$/` regex guard before `parseInt` to reject non-integer strings
- **`app/app/api/markets/route.ts`**: Use `limitValidation.value` / `offsetValidation.value` directly (no re-parse)
- **`app/__tests__/lib/route-validators.test.ts`**: 13 new tests covering strict integer enforcement and range checks

## Test

```
vitest run __tests__/lib/route-validators.test.ts
✓ 13 tests pass
```

Closes: CodeRabbit review comment on PR #1491

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite validating strict integer format checking and range boundary handling.

* **Bug Fixes**
  * Enhanced numeric parameter validation to strictly reject invalid formats—including decimal numbers, strings with trailing characters, and leading whitespace—for improved API consistency and data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->