### PR TITLE
fix(api): coerce NUMERIC string values before isZombieMarket() — GH#1494

### DIFF
--- a/app/__tests__/api/markets-zombie-string-coercion.test.ts
+++ b/app/__tests__/api/markets-zombie-string-coercion.test.ts
@@ -1,0 +1,167 @@
+/**
+ * GH#1494: is_zombie field always false in /api/markets array despite zombieCount=73.
+ *
+ * Root cause: Supabase returns NUMERIC columns (vault_balance, total_open_interest,
+ * volume_24h) as strings at runtime. TypeScript `as number | null` is compile-time only
+ * and does NOT coerce the value. The strict equality check `vaultBal === 0` in
+ * isZombieMarket() compares string "0" to number 0 → always false.
+ *
+ * Fix: coerce all NUMERIC fields via Number() before passing to isZombieMarket().
+ *
+ * These tests verify the numericOrNull coercion helper and the fixed route behaviour.
+ */
+
+import { describe, it, expect } from "vitest";
+import { isZombieMarket, isSaneMarketValue } from "@/lib/activeMarketFilter";
+import { isPhantomOpenInterest } from "@/lib/phantom-oi";
+
+// ---------------------------------------------------------------------------
+// numericOrNull helper (extracted from the fix in route.ts)
+// ---------------------------------------------------------------------------
+function numericOrNull(v: unknown): number | null {
+  if (v == null) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+// ---------------------------------------------------------------------------
+// Coercion helper tests
+// ---------------------------------------------------------------------------
+describe("numericOrNull coercion helper (GH#1494)", () => {
+  it("coerces string '0' to number 0", () => {
+    expect(numericOrNull("0")).toBe(0);
+  });
+
+  it("coerces string '1000000' to number 1000000", () => {
+    expect(numericOrNull("1000000")).toBe(1_000_000);
+  });
+
+  it("coerces string '5000000000' to number", () => {
+    expect(numericOrNull("5000000000")).toBe(5_000_000_000);
+  });
+
+  it("returns null for null input", () => {
+    expect(numericOrNull(null)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(numericOrNull(undefined)).toBeNull();
+  });
+
+  it("returns null for NaN-producing string", () => {
+    expect(numericOrNull("garbage")).toBeNull();
+  });
+
+  it("passes through number 0 as 0", () => {
+    expect(numericOrNull(0)).toBe(0);
+  });
+
+  it("passes through number 1000000 as 1000000", () => {
+    expect(numericOrNull(1_000_000)).toBe(1_000_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isZombieMarket with Supabase-style string vault_balance (GH#1494)
+// ---------------------------------------------------------------------------
+describe("isZombieMarket with Supabase NUMERIC string coercion (GH#1494)", () => {
+  it("is_zombie=true for string '0' vault_balance after coercion", () => {
+    // Without coercion: "0" === 0 → false (BUG)
+    // With coercion: numericOrNull("0") = 0, then 0 === 0 → true (FIXED)
+    expect(
+      isZombieMarket({
+        vault_balance: numericOrNull("0"),
+        last_price: null,
+        volume_24h: null,
+        total_open_interest: null,
+        total_accounts: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("is_zombie=false for string '1000000' vault_balance after coercion", () => {
+    expect(
+      isZombieMarket({
+        vault_balance: numericOrNull("1000000"),
+        last_price: 148,
+        volume_24h: null,
+        total_open_interest: null,
+        total_accounts: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it("is_zombie=true for string '0' vault_balance even with stale price (GH#1494 main case)", () => {
+    // This is the production case: vault=0, stale last_price still in DB
+    expect(
+      isZombieMarket({
+        vault_balance: numericOrNull("0"),
+        last_price: numericOrNull("148"),
+        volume_24h: numericOrNull("0"),
+        total_open_interest: numericOrNull("0"),
+        total_accounts: numericOrNull("0"),
+      }),
+    ).toBe(true);
+  });
+
+  it("is_zombie=false when vault > 0 as string", () => {
+    expect(
+      isZombieMarket({
+        vault_balance: numericOrNull("5000000000"),
+        last_price: numericOrNull("148"),
+        volume_24h: null,
+        total_open_interest: null,
+        total_accounts: numericOrNull("10"),
+      }),
+    ).toBe(false);
+  });
+
+  it("is_zombie=true for null vault + all string '0' stats (phantom market)", () => {
+    // GH#1427 phantom: vault=null, all zero stats as strings
+    expect(
+      isZombieMarket({
+        vault_balance: numericOrNull(null),
+        last_price: numericOrNull("0"),
+        volume_24h: numericOrNull("0"),
+        total_open_interest: numericOrNull("0"),
+        total_accounts: numericOrNull("0"),
+      }),
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isPhantomOpenInterest with Supabase string coercion (GH#1494)
+// ---------------------------------------------------------------------------
+describe("isPhantomOpenInterest with Number() coercion (GH#1494)", () => {
+  it("phantom when string accounts='0' and string vault='0'", () => {
+    // Before fix: vaultBal = "0" < 1_000_000 → NaN comparison → false (BUG)
+    // After fix: vaultBal = Number("0") = 0 < 1_000_000 → true (FIXED)
+    expect(isPhantomOpenInterest(Number("0"), Number("0"))).toBe(true);
+  });
+
+  it("phantom when accounts=0 and vault < 1M as string", () => {
+    expect(isPhantomOpenInterest(Number("0"), Number("500000"))).toBe(true);
+  });
+
+  it("not phantom when accounts > 0 and vault >= 1M", () => {
+    expect(isPhantomOpenInterest(Number("5"), Number("5000000000"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isSaneMarketValue with Supabase string values
+// ---------------------------------------------------------------------------
+describe("isSaneMarketValue with string inputs (defensive)", () => {
+  it("returns false for string '0' (not > 0)", () => {
+    // isSaneMarketValue compares v > 0 which does JS coercion, but let's confirm
+    // that the route explicitly coerces before calling isZombieMarket
+    expect(isSaneMarketValue("0" as unknown as number)).toBe(false);
+  });
+
+  it("note: === 0 does NOT coerce — this is why numericOrNull is required for isZombieMarket", () => {
+    // Demonstrate the root cause: strict equality does not coerce
+    expect(("0" as unknown as number) === 0).toBe(false);
+    expect(numericOrNull("0") === 0).toBe(true);
+  });
+});

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -186,8 +186,9 @@ export async function GET(request: NextRequest) {
       // computeMarketHealthFromStats and the markets page sort/filter.
       // GH#1438: Aligned to strict < via shared isPhantomOpenInterest() helper in lib/phantom-oi.ts
       // so /api/markets and /api/stats are guaranteed to use the same predicate (single source of truth).
-      const accountsCount = (m.total_accounts as number) ?? 0;
-      const vaultBal = (m.vault_balance as number) ?? 0;
+      // GH#1494: coerce NUMERIC (string from Supabase) to number before arithmetic comparisons.
+      const accountsCount = Number(m.total_accounts ?? 0);
+      const vaultBal = Number(m.vault_balance ?? 0);
       const isPhantomOI = isPhantomOpenInterest(accountsCount, vaultBal);
       const displayOiUsd = isPhantomOI ? null : total_open_interest_usd;
 
@@ -207,12 +208,24 @@ export async function GET(request: NextRequest) {
       // We tag them with is_zombie=true and exclude them from the default response
       // (opt-in via ?include_zombie=true). See isZombieMarket() in activeMarketFilter.ts
       // for the two conditions: vault=0 (drained) or vault=null+no-stats (phantom).
+      //
+      // GH#1494: Supabase returns NUMERIC columns (vault_balance, total_open_interest,
+      // volume_24h) as strings at runtime. TypeScript `as number | null` is compile-time
+      // only and does NOT coerce the value. Without Number() coercion, the strict equality
+      // check `vaultBal === 0` in isZombieMarket() compares string "0" to number 0 →
+      // always false → is_zombie is never set to true despite zombieCount=73.
+      // Fix: coerce all NUMERIC fields to number|null before passing to isZombieMarket().
+      const numericOrNull = (v: unknown): number | null => {
+        if (v == null) return null;
+        const n = Number(v);
+        return Number.isFinite(n) ? n : null;
+      };
       const is_zombie = isZombieMarket({
-        vault_balance: m.vault_balance as number | null,
-        last_price: m.last_price as number | null,
-        volume_24h: m.volume_24h as number | null,
-        total_open_interest: m.total_open_interest as number | null,
-        total_accounts: m.total_accounts as number | null,
+        vault_balance: numericOrNull(m.vault_balance),
+        last_price: numericOrNull(m.last_price),
+        volume_24h: numericOrNull(m.volume_24h),
+        total_open_interest: numericOrNull(m.total_open_interest),
+        total_accounts: numericOrNull(m.total_accounts),
       });
 
       return {


### PR DESCRIPTION
## Problem

**GH#1494**: `is_zombie` field always `false` in `/api/markets` array despite `zombieCount=73` in the response header.

## Root Cause

Supabase returns `NUMERIC` columns (`vault_balance`, `total_open_interest`, `volume_24h`) as **JavaScript strings** at runtime. TypeScript `as number | null` casts are compile-time only — they do not coerce the runtime string value.

`isZombieMarket()` uses strict equality `vaultBal === 0`. When `vault_balance` arrives as string `"0"`, the comparison `"0" === 0` is `false` → `is_zombie` is never set to `true`.

Result: all 73 zombie markets silently pass with `is_zombie: false`, while `zombieCount: 73` is correctly computed via a separate code path (which doesn't use `isZombieMarket()`).

## Fix

- Add a `numericOrNull(v)` coercion helper in the `.map()` body of `GET /api/markets`
- Apply `Number()` coercion to `accountsCount` and `vaultBal` before `isPhantomOpenInterest()`
- All `NUMERIC` fields passed to `isZombieMarket()` are now coerced via `numericOrNull()`

## Tests

New file: `__tests__/api/markets-zombie-string-coercion.test.ts` (18 tests)
- `numericOrNull` coercion helper
- `isZombieMarket()` with Supabase-style string inputs
- `isPhantomOpenInterest()` with `Number()` coercion

**1258/1258 tests pass.**

## Impact

After deploy: `is_zombie: true` will appear on all 73 zombie markets. `activeTotal + zombieCount` math will be consistent. No breaking changes — field was always present but always `false`.

Closes #1494

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed market classification logic to properly handle numeric values received as strings from the database, ensuring accurate detection of inactive and phantom markets.

* **Tests**
  * Added comprehensive test coverage for numeric string coercion behavior and market classification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->