### PR TITLE
fix(api): GH#1499 — c_tot>0 zombie exemption requires corroborating activity

### DIFF
--- a/app/__tests__/api/markets-zombie-filter.test.ts
+++ b/app/__tests__/api/markets-zombie-filter.test.ts
@@ -18,16 +18,31 @@ function isSaneMarketValue(v: number | null | undefined): boolean {
 
 type MarketRow = {
   vault_balance?: number | null;
+  c_tot?: number | null;
   last_price?: number | null;
   volume_24h?: number | null;
   total_open_interest?: number | null;
   total_accounts?: number | null;
 };
 
-/** GH#1427: mirrors the route.ts is_zombie logic */
+/** GH#1427 + GH#1499: mirrors the activeMarketFilter.ts isZombieMarket logic */
 function isZombie(m: MarketRow): boolean {
-  if (m.vault_balance != null && m.vault_balance === 0) return true;
-  if (m.vault_balance == null) {
+  const vaultBal = m.vault_balance ?? null;
+  const cTot = m.c_tot ?? null;
+
+  // GH#1499: c_tot > 0 only exempts when there is corroborating activity.
+  // FF7K markets: vault=0, c_tot>0, has price → hasActivity=true → not zombie.
+  // NNOB: vault=0, c_tot>0, no price, no accounts → hasActivity=false → zombie.
+  const hasActivity =
+    isSaneMarketValue(m.last_price) ||
+    isSaneMarketValue(m.volume_24h) ||
+    isSaneMarketValue(m.total_open_interest) ||
+    (m.total_accounts ?? 0) > 0;
+
+  if (cTot !== null && cTot > 0 && hasActivity) return false;
+
+  if (vaultBal !== null && vaultBal === 0) return true;
+  if (vaultBal === null) {
     const hasNoStats =
       !isSaneMarketValue(m.last_price) &&
       !isSaneMarketValue(m.volume_24h) &&
@@ -192,6 +207,67 @@ describe("GH#1427 null vault_balance + no-stats zombie", () => {
       "PHANTOM1",
       "PHANTOM2",
     ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GH#1499 — NNOB edge case: c_tot > 0 but no activity (vault=0, accounts=0, no price)
+// ---------------------------------------------------------------------------
+
+describe("GH#1499 c_tot>0 with no activity still zombie", () => {
+  it("NNOB case: c_tot=100B, vault=0, accounts=0, no price → zombie", () => {
+    // Before fix: c_tot > 0 short-circuited → is_zombie=false (BUG: NNOB showed in default response with null price)
+    // After fix: c_tot > 0 only exempts when hasActivity is also true
+    expect(
+      isZombie({
+        vault_balance: 0,
+        // c_tot not in the local type — but the API/lib now checks for activity
+        last_price: null,
+        volume_24h: null,
+        total_open_interest: null,
+        total_accounts: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("FF7K healthy case: c_tot>0, vault=0, has price → NOT zombie", () => {
+    // The 33 working FF7K markets: vault=0 (stores collateral in slab), c_tot>0,
+    // and keeper is actively pushing prices. c_tot+activity exemption applies.
+    expect(
+      isZombie({
+        vault_balance: 0,
+        c_tot: 1_000_000_000,
+        last_price: 1.0, // keeper cranks this → hasActivity=true
+        volume_24h: null,
+        total_open_interest: null,
+        total_accounts: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it("FF7K with accounts case: c_tot>0, vault=0, has accounts → NOT zombie", () => {
+    expect(
+      isZombie({
+        vault_balance: 0,
+        c_tot: 5_000_000_000,
+        last_price: null,
+        volume_24h: null,
+        total_open_interest: null,
+        total_accounts: 3, // users have positions → hasActivity=true
+      }),
+    ).toBe(false);
+  });
+
+  it("dead slab: vault=0, no price, no accounts, no volume → zombie", () => {
+    expect(
+      isZombie({
+        vault_balance: 0,
+        last_price: null,
+        volume_24h: null,
+        total_open_interest: null,
+        total_accounts: 0,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/app/__tests__/api/markets-zombie-string-coercion.test.ts
+++ b/app/__tests__/api/markets-zombie-string-coercion.test.ts
@@ -150,6 +150,93 @@ describe("isPhantomOpenInterest with Number() coercion (GH#1494)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// GH#1499 — c_tot > 0 only exempts when market has corroborating activity
+// ---------------------------------------------------------------------------
+describe("GH#1499 isZombieMarket c_tot + activity check", () => {
+  it("NNOB case: c_tot>0, vault=0, no price, no accounts → zombie (was bug: returned false)", () => {
+    // Before fix: c_tot > 0 short-circuited → return false (NNOB showed in response w/ null prices)
+    // After fix: c_tot > 0 only exempts if hasActivity (price or accounts) is truthy
+    expect(
+      isZombieMarket({
+        vault_balance: 0,
+        c_tot: 100_000_000_000,
+        last_price: null,
+        volume_24h: null,
+        total_open_interest: null,
+        total_accounts: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("FF7K healthy: c_tot>0, vault=0, has price → NOT zombie (keeper cranking)", () => {
+    // The 33 working FF7K markets: keeper pushes prices → hasActivity=true → exemption holds
+    expect(
+      isZombieMarket({
+        vault_balance: 0,
+        c_tot: 1_000_000_000,
+        last_price: 1.0,
+        volume_24h: null,
+        total_open_interest: null,
+        total_accounts: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it("FF7K with accounts: c_tot>0, vault=0, has accounts → NOT zombie", () => {
+    expect(
+      isZombieMarket({
+        vault_balance: 0,
+        c_tot: 5_000_000_000,
+        last_price: null,
+        volume_24h: null,
+        total_open_interest: null,
+        total_accounts: 5,
+      }),
+    ).toBe(false);
+  });
+
+  it("no c_tot, vault=0, no activity → zombie", () => {
+    expect(
+      isZombieMarket({
+        vault_balance: 0,
+        c_tot: null,
+        last_price: null,
+        volume_24h: null,
+        total_open_interest: null,
+        total_accounts: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("c_tot=0, vault=0, no activity → zombie (c_tot=0 not exempt)", () => {
+    expect(
+      isZombieMarket({
+        vault_balance: 0,
+        c_tot: 0,
+        last_price: null,
+        volume_24h: null,
+        total_open_interest: null,
+        total_accounts: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("c_tot>0, vault>0 (normal market with price) → NOT zombie", () => {
+    // Standard healthy market: both c_tot and vault > 0, has price
+    expect(
+      isZombieMarket({
+        vault_balance: 5_000_000_000,
+        c_tot: 1_000_000_000_000,
+        last_price: 150,
+        volume_24h: null,
+        total_open_interest: null,
+        total_accounts: 10,
+      }),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // isSaneMarketValue with Supabase string values
 // ---------------------------------------------------------------------------
 describe("isSaneMarketValue with string inputs (defensive)", () => {

--- a/app/lib/activeMarketFilter.ts
+++ b/app/lib/activeMarketFilter.ts
@@ -38,10 +38,24 @@ export function isActiveMarket(row: {
 /**
  * Determine if a market row is a "zombie" — has no LP liquidity and no real activity.
  *
- * Two zombie conditions (GH#1420 + GH#1427):
- *   1. vault_balance === 0  → explicitly drained vault, no liquidity.
+ * Three zombie conditions (GH#1420 + GH#1427 + GH#1499):
+ *   1. vault_balance === 0 AND no sane stats AND total_accounts === 0
+ *      → drained/dead market with no activity (even if c_tot > 0 from stale slab data).
  *   2. vault_balance === null AND no sane stats AND total_accounts === 0
  *      → phantom market that was never indexed or funded.
+ *   3. (Legacy) vault_balance === 0 with no c_tot and no activity
+ *      → explicitly drained vault.
+ *
+ * GH#1499 edge case — "c_tot > 0 → not zombie" is too broad:
+ * NNOB has c_tot=100B but vault=0, zero accounts, and null price because no oracle
+ * keeper cranks it. After PR#1496 (c_tot > 0 → short-circuit return false), NNOB
+ * escaped the zombie filter and appeared in the default response with null prices.
+ * Fix: c_tot > 0 only exempts a market from zombie status when there is corroborating
+ * activity — a live price (keeper is cranking) OR real accounts (users have positions).
+ * Without either, c_tot is legacy collateral in a dead slab and should be zombie.
+ *
+ * FF7K keeper markets (33 of 34): vault=0, c_tot>0, have prices → hasActivity=true → not zombie ✓
+ * NNOB (the outlier): vault=0, c_tot>0, no price, no accounts → hasActivity=false → zombie ✓
  *
  * SINGLE SOURCE OF TRUTH: used by /api/markets and /api/stats to ensure
  * consistent zombie exclusion across the platform. Previously duplicated
@@ -58,11 +72,22 @@ export function isZombieMarket(row: {
   const vaultBal = row.vault_balance ?? null;
   const cTot = row.c_tot ?? null;
 
-  // If on-chain collateral total (c_tot) is positive, market has real funds
-  // even if vault_balance reads 0. This happens because c_tot tracks collateral
-  // inside the slab data, while vault_balance reads the separate vault ATA.
-  // FF7K keeper markets store collateral in the slab, not the vault ATA.
-  if (cTot !== null && cTot > 0) return false;
+  // Compute whether this market has any live activity — price, volume, OI, or
+  // real user accounts. Used to validate the c_tot exemption (GH#1499).
+  const hasActivity =
+    isSaneMarketValue(row.last_price) ||
+    isSaneMarketValue(row.volume_24h) ||
+    isSaneMarketValue(row.total_open_interest) ||
+    (row.total_accounts ?? 0) > 0;
+
+  // If on-chain collateral total (c_tot) is positive AND there is corroborating activity,
+  // the market has real funds and a live oracle — not a zombie.
+  // FF7K keeper markets: vault=0 (stores collateral in slab), c_tot>0, prices present → active.
+  //
+  // GH#1499: Do NOT exempt when c_tot>0 but vault=0, accounts=0, and no price.
+  // That pattern means the slab has legacy collateral but no active keeper or positions.
+  // In that case, fall through to the vault_balance=0 zombie check below.
+  if (cTot !== null && cTot > 0 && hasActivity) return false;
 
   if (vaultBal !== null && vaultBal === 0) return true;
   if (vaultBal === null) {


### PR DESCRIPTION
## Problem

NNOB market regression from PR#1496: `isZombieMarket()` short-circuited on `c_tot > 0` before checking `vault_balance=0`, leaving NNOB visible in the default `/api/markets` response with null prices.

**NNOB stats:** `c_tot=100B, vault=0, total_accounts=0, last_price=null`

The exemption was designed for the 33 FF7K keeper markets (`vault=0`, `c_tot>0`, keeper actively pushing prices). NNOB is the 1 outlier: same slab pattern but no oracle keeper cranks it — zero accounts, no price, no volume.

## Root Cause

```ts
// Before (PR#1496):
if (cTot !== null && cTot > 0) return false; // too broad — NNOB escapes
```

NNOB: `c_tot=100B > 0` → unconditional early return → `is_zombie=false` → shows in default response with null prices.

## Fix

`c_tot > 0` only exempts a market from zombie status when there is corroborating **activity** — a live price (keeper is cranking), real accounts (users have positions), or sane volume/OI.

```ts
// After:
const hasActivity =
  isSaneMarketValue(row.last_price) ||
  isSaneMarketValue(row.volume_24h) ||
  isSaneMarketValue(row.total_open_interest) ||
  (row.total_accounts ?? 0) > 0;

if (cTot !== null && cTot > 0 && hasActivity) return false;
```

**NNOB (c_tot=100B, vault=0, accounts=0, no price):** `hasActivity=false` → falls through → `vault=0 → is_zombie=true` ✅  
**FF7K healthy markets (c_tot>0, price present):** `hasActivity=true` → exemption applies → `is_zombie=false` ✅

## GH#1500 (68 markets, no price)

Investigated — **NOT a zombie regression.** These 67 markets (`vault=1M+`, `c_tot>0`, `accounts=2-3`) are user-created admin-oracle markets with no oracle keeper pushing prices. `is_zombie=false` is **correct** — they have real collateral and accounts. Prices are null because no keeper is deployed for their oracle_authority keys (`HoibauLv7E...`, `Af5bTkfT...`, etc.). This is an operational/keeper coverage issue, not an API code bug. Closed as expected behavior.

## Tests

- 10 new test cases covering NNOB pattern, FF7K exemption, dead-slab variants
- Updated local test mirror in `markets-zombie-filter.test.ts` to match new lib semantics
- 1268/1268 passing ✅

## Files Changed

- `app/lib/activeMarketFilter.ts` — core fix in `isZombieMarket()`
- `app/__tests__/api/markets-zombie-filter.test.ts` — added GH#1499 suite, updated local mirror
- `app/__tests__/api/markets-zombie-string-coercion.test.ts` — added GH#1499 suite using `isZombieMarket()` directly

Fixes #1499

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined market classification logic to ensure markets with active trading activity (price movements, volume, or account engagement) are not incorrectly flagged as inactive.

* **Tests**
  * Added comprehensive test coverage for updated market activity detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->