### PR TITLE
fix(GH#1506): use sanitizedPrice in zombie check — stale DB price > $1M escaping hasActivity guard

### DIFF
--- a/app/__tests__/api/markets-zombie-string-coercion.test.ts
+++ b/app/__tests__/api/markets-zombie-string-coercion.test.ts
@@ -252,3 +252,94 @@ describe("isSaneMarketValue with string inputs (defensive)", () => {
     expect(numericOrNull("0") === 0).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// GH#1506 — stale raw DB price > MAX_SANE_PRICE_USD must not prevent zombie classification
+// ---------------------------------------------------------------------------
+/**
+ * Simulate the sanitizePrice display cap: any price > $1M is nulled for output.
+ * The route passes sanitizedPrice (already nulled) to isZombieMarket — not the
+ * raw DB value. Before the fix, numericOrNull(m.last_price) was used, which kept
+ * the stale large price as a "sane" value, causing hasActivity=true.
+ */
+function sanitizePrice(v: number | null | undefined): number | null {
+  const MAX_SANE_PRICE_USD = 1_000_000;
+  if (v == null) return null;
+  if (!Number.isFinite(v) || v <= 0 || v > MAX_SANE_PRICE_USD) return null;
+  return v;
+}
+
+describe("GH#1506 zombie check uses sanitizedPrice, not raw DB price", () => {
+  it("NNOB: raw DB price > $1M → sanitized=null → is_zombie=true", () => {
+    // NNOB has a stale admin-oracle raw price e.g. 12_000_000 (> $1M cap).
+    // sanitizePrice nulls it for display. The zombie check must use the sanitized
+    // value so that hasActivity=false and the c_tot>0 exemption does NOT fire.
+    const rawLastPrice = 12_000_000; // garbage stale DB value
+    const sanitizedLastPrice = sanitizePrice(rawLastPrice); // → null
+    expect(sanitizedLastPrice).toBeNull();
+
+    expect(
+      isZombieMarket({
+        vault_balance: 0,
+        c_tot: 100_000_000_000,
+        last_price: sanitizedLastPrice, // null (display-layer capped)
+        volume_24h: 0,
+        total_open_interest: 0,
+        total_accounts: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("NNOB: passing raw DB price instead of sanitized causes is_zombie=false (documents the bug)", () => {
+    // This test documents WHY the fix is needed — raw price passes isSaneMarketValue
+    // even though it will be nulled for display. Do NOT regress to this behaviour.
+    const rawLastPrice = 12_000_000;
+    expect(isSaneMarketValue(rawLastPrice)).toBe(true); // raw value looks "sane" (< 1e18)
+
+    expect(
+      isZombieMarket({
+        vault_balance: 0,
+        c_tot: 100_000_000_000,
+        last_price: rawLastPrice, // BUG: raw value → hasActivity=true → not zombie
+        volume_24h: 0,
+        total_open_interest: 0,
+        total_accounts: 0,
+      }),
+    ).toBe(false); // confirms the bug that GH#1506 fixed
+  });
+
+  it("FF7K healthy market: sanitizedPrice valid → hasActivity=true → NOT zombie", () => {
+    // Normal FF7K market with a good keeper price (< $1M) — should never be zombie.
+    const rawLastPrice = 1.05; // $1.05 USDC-based market
+    const sanitizedLastPrice = sanitizePrice(rawLastPrice); // → 1.05
+    expect(sanitizedLastPrice).toBe(1.05);
+
+    expect(
+      isZombieMarket({
+        vault_balance: 0,
+        c_tot: 1_000_000_000,
+        last_price: sanitizedLastPrice,
+        volume_24h: 0,
+        total_open_interest: 0,
+        total_accounts: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it("market with stale $2M price but vault>0 — not zombie (vault drives it)", () => {
+    // Vault > 0 means LP liquidity exists regardless of price. Not zombie.
+    const sanitizedLastPrice = sanitizePrice(2_000_000); // → null (> $1M)
+    expect(sanitizedLastPrice).toBeNull();
+
+    expect(
+      isZombieMarket({
+        vault_balance: 5_000_000_000, // vault > 0
+        c_tot: 1_000_000_000,
+        last_price: sanitizedLastPrice, // null
+        volume_24h: 0,
+        total_open_interest: 0,
+        total_accounts: 0,
+      }),
+    ).toBe(false);
+  });
+});

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -220,10 +220,17 @@ export async function GET(request: NextRequest) {
         const n = Number(v);
         return Number.isFinite(n) ? n : null;
       };
+      // GH#1506: Use sanitizedPrice (already capped at MAX_SANE_PRICE_USD=$1M) for the
+      // zombie check instead of numericOrNull(m.last_price). Raw DB prices can be stale
+      // garbage values that pass isSaneMarketValue (< 1e18) but exceed the display cap.
+      // NNOB had a stale raw last_price > $1M in DB — sanitizePrice nulled it for output,
+      // but passing numericOrNull(m.last_price) to isZombieMarket() made hasActivity=true
+      // → c_tot>0 exemption fired → is_zombie=false, even though the API returned null.
+      // Using sanitizedPrice keeps the zombie check consistent with what consumers receive.
       const is_zombie = isZombieMarket({
         vault_balance: numericOrNull(m.vault_balance),
         c_tot: numericOrNull(m.c_tot),
-        last_price: numericOrNull(m.last_price),
+        last_price: sanitizedPrice,
         volume_24h: numericOrNull(m.volume_24h),
         total_open_interest: numericOrNull(m.total_open_interest),
         total_accounts: numericOrNull(m.total_accounts),


### PR DESCRIPTION
## Summary

NNOB market (`3K66...`) remains `is_zombie=false` despite vault=0, accounts=0, OI=0, and `last_price=null` in the API response.

## Root Cause

`isZombieMarket()` was called with `numericOrNull(m.last_price)` — the **raw DB value**. NNOB has a stale admin-oracle raw `last_price` in the DB that exceeds `MAX_SANE_PRICE_USD` ($1M).

`sanitizePrice()` correctly nulls it for display (consumers see `last_price: null`), but passing `numericOrNull(m.last_price)` to `isZombieMarket()` returned the large raw value, which:
- Passed `isSaneMarketValue()` (raw value is < 1e18) → `hasActivity = true`
- `c_tot > 0 && hasActivity` → early return `false` (not zombie)
- Result: `is_zombie=false` even though the API returned `last_price=null`

This is a data consistency bug — the zombie classification disagreed with the displayed data.

## Fix

Pass `sanitizedPrice` (already computed above, display-capped at $1M) to `isZombieMarket()` instead of `numericOrNull(m.last_price)`. One-line change in route.ts.

```diff
- last_price: numericOrNull(m.last_price),
+ last_price: sanitizedPrice,
```

## Why `sanitizedPrice` is the right value

The zombie check should be consistent with what API consumers receive. If the display layer has already determined a price is corrupt/stale and nulled it, the zombie logic must agree. Using a raw DB value that differs from the output creates exactly this inconsistency.

## All previous zombie fixes remain intact
- GH#1494: numericOrNull coercion for vault_balance, volume_24h, OI, accounts ✓
- GH#1499: c_tot>0 only exempts with corroborating activity ✓
- GH#1502: phantom OI excluded from hasActivity ✓
- GH#1506 (this PR): price used in hasActivity matches display price ✓

## Tests

4 new regression cases in `markets-zombie-string-coercion.test.ts`:
- NNOB: raw DB price > $1M → sanitized=null → `is_zombie=true` ✓
- Documents the pre-fix bug (raw price → `is_zombie=false`) ✓
- FF7K healthy: good price ($1.05) → `is_zombie=false` ✓
- vault>0 with stale price: not zombie (vault drives classification) ✓

**1274/1274 tests passing**

Closes #1506

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed zombie market detection to evaluate prices after sanitization, ensuring consistency between `is_zombie` classification and the actual `last_price` returned to API consumers.
  * Stale or oversized price values no longer incorrectly exempt markets from zombie status.

* **Tests**
  * Added test suite validating zombie market detection behavior with price sanitization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->