### PR TITLE
fix(GH#1508): skip admin-oracle markets with foreign oracleAuthority — stops OracleInvalid (0xc) spam

### DIFF
--- a/packages/keeper/src/services/crank.ts
+++ b/packages/keeper/src/services/crank.ts
@@ -42,6 +42,13 @@ interface MarketCrankState {
    * This field stores the original mainnet CA so Jupiter/DexScreener lookups use the right address.
    */
   mainnetCA?: string;
+  /**
+   * GH#1508: Admin-oracle market where the keeper is NOT the oracle authority.
+   * The market owner must push prices themselves — we can't crank without a valid oracle price.
+   * Cranking these causes OracleInvalid (0xc) errors. Skip until authority changes.
+   * Unlike permanentlySkipped (0x4), this is re-checked on each discovery cycle.
+   */
+  foreignOracleSkipped?: boolean;
 }
 
 /** Process items in batches with delay between batches.
@@ -147,6 +154,12 @@ export class CrankService {
         const state = this.markets.get(key)!;
         state.market = market;
         state.missingDiscoveryCount = 0;
+        // GH#1508: Reset foreignOracleSkipped on re-discovery — oracle authority may have changed.
+        // crankMarket() will re-check and re-set it if the keeper is still not the authority.
+        if (state.foreignOracleSkipped) {
+          state.foreignOracleSkipped = false;
+          logger.debug("Re-checking foreign oracle skip on rediscovery", { slabAddress: key });
+        }
         // PERC-381: Only re-enable permanently skipped (0x4) markets after a long cooldown
         // to avoid crank→skip→rediscover→re-enable→crank thrash loop on stale slabs.
         // Cooldown increases exponentially with skip count (1h, 2h, 4h, ... capped at 24h).
@@ -211,6 +224,23 @@ export class CrankService {
       const connection = getConnection();
       const keypair = loadKeypair(process.env.CRANK_KEYPAIR!);
       const programId = market.programId;
+
+      // GH#1508: Skip admin-oracle markets where we are NOT the oracle authority.
+      // Cranking without a valid oracle price causes OracleInvalid (0xc). The market
+      // owner must push prices themselves; the keeper has no authority here.
+      if (this.isAdminOracle(market) && !keypair.publicKey.equals(market.config.oracleAuthority)) {
+        if (!state.foreignOracleSkipped) {
+          state.foreignOracleSkipped = true;
+          logger.warn("Skipping admin-oracle market — keeper is not the oracle authority (would cause OracleInvalid 0xc). " +
+            "The market creator must push prices. Suppressing further crank attempts.", {
+            slabAddress,
+            oracleAuthority: market.config.oracleAuthority.toBase58(),
+            keeperKey: keypair.publicKey.toBase58(),
+            programId: programId.toBase58(),
+          });
+        }
+        return false;
+      }
 
       // PERC-204: Build all instructions into a single transaction bundle
       const instructions = [];
@@ -337,6 +367,7 @@ export class CrankService {
 
   // NEW: split skipped into categories
   let skippedPermanent = 0;
+  let skippedForeignOracle = 0;
   let skippedFailures = 0;
   let skippedNotDue = 0;
 
@@ -347,6 +378,11 @@ export class CrankService {
   for (const [slabAddress, state] of this.markets) {
     if (state.permanentlySkipped) {
       skippedPermanent++;
+      continue;
+    }
+    // GH#1508: Skip admin-oracle markets where keeper is not the oracle authority
+    if (state.foreignOracleSkipped) {
+      skippedForeignOracle++;
       continue;
     }
     if (state.consecutiveFailures > MAX_CONSECUTIVE_FAILURES) {
@@ -361,7 +397,7 @@ export class CrankService {
   }
 
   // NEW: meaningful accounting check
-  const skipped = skippedPermanent + skippedFailures + skippedNotDue;
+  const skipped = skippedPermanent + skippedForeignOracle + skippedFailures + skippedNotDue;
   const total = this.markets.size;
   const accounted = toCrank.length + skipped;
 
@@ -371,6 +407,7 @@ export class CrankService {
       toCrank: toCrank.length,
       skipped,
       skippedPermanent,
+      skippedForeignOracle,
       skippedFailures,
       skippedNotDue,
     });

--- a/packages/keeper/tests/services/crank.test.ts
+++ b/packages/keeper/tests/services/crank.test.ts
@@ -444,6 +444,164 @@ describe('CrankService', () => {
     });
   });
 
+  describe('GH#1508: foreign oracle skip (OracleInvalid 0xc prevention)', () => {
+    it('should skip admin-oracle market where keeper is not the oracle authority and set foreignOracleSkipped', async () => {
+      const slabAddress = 'MarketFO1111111111111111111111111111111';
+      const FOREIGN_AUTHORITY = 'ForeignAuth111111111111111111111111111111';
+      const mockMarket = {
+        slabAddress: { toBase58: () => slabAddress },
+        programId: { toBase58: () => '11111111111111111111111111111111' },
+        config: {
+          collateralMint: { toBase58: () => 'MintFO11111111111111111111111111111111' },
+          // Non-default oracleAuthority (admin oracle), but NOT equal to keeper key.
+          // isAdminOracle() checks !oracleAuthority.equals(PublicKey.default) → oracleAuthority.equals(default)=false → !false=true → isAdminOracle
+          // crankMarket() checks keypair.publicKey.equals(oracleAuthority) → we override loadKeypair below to return equals: () => false
+          oracleAuthority: {
+            toBase58: () => FOREIGN_AUTHORITY,
+            equals: (other: any) => false, // not equal to PublicKey.default OR keeper key
+          },
+          indexFeedId: { toBytes: () => new Uint8Array(32) },
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: { toBase58: () => 'AdminFO11111111111111111111111111111111' } },
+      };
+
+      // Override loadKeypair so keypair.publicKey.equals(oracleAuthority) returns false (foreign key)
+      vi.mocked(shared.loadKeypair).mockReturnValueOnce({
+        publicKey: {
+          toBase58: () => 'KeeperKey111111111111111111111111111111',
+          equals: (other: any) => false, // keeper key does NOT match the foreign oracle authority
+        },
+        secretKey: new Uint8Array(64),
+      } as any);
+
+      vi.mocked(core.discoverMarkets).mockResolvedValue([mockMarket] as any);
+      await crankService.discover();
+
+      const result = await crankService.crankMarket(slabAddress);
+
+      expect(result).toBe(false);
+      // Should NOT have submitted a transaction
+      expect(shared.sendWithRetryKeeper).not.toHaveBeenCalled();
+
+      const state = crankService.getMarkets().get(slabAddress)!;
+      expect(state.foreignOracleSkipped).toBe(true);
+      // Should not increment failure counters — this is an intentional skip, not a failure
+      expect(state.failureCount).toBe(0);
+      expect(state.consecutiveFailures).toBe(0);
+    });
+
+    it('should reset foreignOracleSkipped on rediscovery so oracle authority changes are picked up', async () => {
+      const slabAddress = 'MarketFO2111111111111111111111111111111';
+      const FOREIGN_AUTHORITY = 'ForeignAuth211111111111111111111111111111';
+      const mockMarket = {
+        slabAddress: { toBase58: () => slabAddress },
+        programId: { toBase58: () => '11111111111111111111111111111111' },
+        config: {
+          collateralMint: { toBase58: () => 'MintFO21111111111111111111111111111111' },
+          oracleAuthority: {
+            toBase58: () => FOREIGN_AUTHORITY,
+            equals: (other: any) => false,
+          },
+          indexFeedId: { toBytes: () => new Uint8Array(32) },
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: { toBase58: () => 'AdminFO21111111111111111111111111111111' } },
+      };
+
+      vi.mocked(core.discoverMarkets).mockResolvedValue([mockMarket] as any);
+      await crankService.discover();
+
+      // Override loadKeypair so keeper is NOT the oracle authority → foreignOracleSkipped set
+      vi.mocked(shared.loadKeypair).mockReturnValueOnce({
+        publicKey: { toBase58: () => 'KeeperKey211111111111111111111111111111', equals: () => false },
+        secretKey: new Uint8Array(64),
+      } as any);
+
+      await crankService.crankMarket(slabAddress);
+
+      const state = crankService.getMarkets().get(slabAddress)!;
+      expect(state.foreignOracleSkipped).toBe(true);
+
+      // Rediscovery should reset the flag so the next crankMarket call re-evaluates
+      await crankService.discover();
+      expect(state.foreignOracleSkipped).toBe(false);
+    });
+
+    it('should NOT skip admin-oracle market where keeper IS the oracle authority', async () => {
+      const slabAddress = 'MarketOwnOracle1111111111111111111111111';
+      const mockMarket = {
+        slabAddress: { toBase58: () => slabAddress },
+        programId: { toBase58: () => '11111111111111111111111111111111' },
+        config: {
+          collateralMint: { toBase58: () => 'MintOwn1111111111111111111111111111111' },
+          // Non-default oracleAuthority (admin oracle), equals keeper key
+          oracleAuthority: {
+            toBase58: () => '11111111111111111111111111111111',
+            equals: () => true, // keeper IS the oracle authority
+          },
+          indexFeedId: { toBytes: () => new Uint8Array(32) },
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: { toBase58: () => 'AdminOwn1111111111111111111111111111111' } },
+      };
+
+      vi.mocked(core.discoverMarkets).mockResolvedValue([mockMarket] as any);
+      await crankService.discover();
+
+      vi.mocked(shared.sendWithRetryKeeper).mockResolvedValue('sig-own-oracle');
+      const result = await crankService.crankMarket(slabAddress);
+
+      expect(result).toBe(true);
+      expect(shared.sendWithRetryKeeper).toHaveBeenCalled();
+
+      const state = crankService.getMarkets().get(slabAddress)!;
+      expect(state.foreignOracleSkipped).toBeUndefined();
+      expect(state.successCount).toBe(1);
+    });
+
+    it('crankAll should count foreignOracleSkipped markets in skipped total', async () => {
+      const slabForeign = 'MarketFO3111111111111111111111111111111';
+      const slabNormal = 'MarketNorm111111111111111111111111111111';
+      const mockForeignMarket = {
+        slabAddress: { toBase58: () => slabForeign },
+        programId: { toBase58: () => '11111111111111111111111111111111' },
+        config: {
+          collateralMint: { toBase58: () => 'MintFO31111111111111111111111111111111' },
+          oracleAuthority: { toBase58: () => 'ForeignAuth31111111111111111111111111111', equals: () => false },
+          indexFeedId: { toBytes: () => new Uint8Array(32) },
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: { toBase58: () => 'AdminFO31111111111111111111111111111111' } },
+      };
+      const mockNormalMarket = {
+        slabAddress: { toBase58: () => slabNormal },
+        programId: { toBase58: () => '11111111111111111111111111111111' },
+        config: {
+          collateralMint: { toBase58: () => 'MintNorm1111111111111111111111111111111' },
+          oracleAuthority: { toBase58: () => '11111111111111111111111111111111', equals: () => true },
+          indexFeedId: { toBytes: () => new Uint8Array(32) },
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: { toBase58: () => 'AdminNorm111111111111111111111111111111' } },
+      };
+
+      vi.mocked(core.discoverMarkets).mockResolvedValue([mockForeignMarket, mockNormalMarket] as any);
+      await crankService.discover();
+
+      // Pre-mark the foreign oracle market as skipped (as crankMarket would do)
+      const foreignState = crankService.getMarkets().get(slabForeign)!;
+      foreignState.foreignOracleSkipped = true;
+
+      vi.mocked(shared.sendWithRetryKeeper).mockResolvedValue('sig-normal');
+      const result = await crankService.crankAll();
+
+      // Normal market cranked; foreign oracle market skipped → skipped >= 1
+      expect(result.skipped).toBeGreaterThanOrEqual(1);
+      expect(result.success).toBe(1);
+    });
+  });
+
   describe('start and stop', () => {
     it('should start timer and perform initial discovery', async () => {
       vi.mocked(core.discoverMarkets).mockResolvedValue([]);


### PR DESCRIPTION
## Summary

Fixes #1508 — keeper:crank was throwing `[ERRO] Crank failed custom program error 0xc` (OracleInvalid) with `consecutiveFailures:8` on admin-oracle markets whose `oracleAuthority` is a third-party key (not the keeper's CRANK_KEYPAIR).

## Root Cause

`crankMarket()` correctly skipped the oracle *push* for foreign-authority markets, but **still submitted the crank instruction** — which the program rejects with `OracleInvalid` (error 12 = 0xc) because the admin oracle slab has no valid price data (only the market creator can push prices there).

Affected slabs confirmed via on-chain inspection:
- `3LzuDyhZzhSchxSqkBQCEaGAsXwu9vYZqSVH3MvNQB9k` (oracleAuthority: `3e9eB...`)
- `ykoRHvTmJRsCmN1guhBCWpdDhRhZb1oTutCZy5EgPEd` (oracleAuthority: `3PkUu...`)

Both are admin-oracle markets (oracleAuthority ≠ PublicKey.default) owned by third-party keys. Program `FwfBKZXbYr4vTK23bMFkbgKq3npJ3MSDxEaKmq9Aj4Qn` (Small 256-slot).

## Fix

In `crankMarket()`, detect admin-oracle markets where `keypair.publicKey !== oracleAuthority` before building any instructions. Set `state.foreignOracleSkipped = true` and return early.

Unlike `permanentlySkipped` (error 0x4 / InvalidSlabLen), this flag is **reset on each discovery cycle** so changes to oracle authority are picked up automatically.

`crankAll()` now also correctly counts `foreignOracleSkipped` markets in the skipped tally and accounting check.

## Testing

4 new regression tests:
1. Should skip and set `foreignOracleSkipped` when keeper ≠ oracle authority
2. Should reset `foreignOracleSkipped` on rediscovery (oracle authority change recovery)
3. Should NOT skip when keeper IS the oracle authority
4. `crankAll()` counts foreign-oracle-skipped markets in skipped total

**50/50 tests passing** (all existing + 4 new).

## Impact

- Stops 0xc error spam in keeper:crank logs immediately on deploy
- Reduces wasted transaction submissions + compute unit costs
- No user-facing impact: affected markets' prices can only be updated by their respective oracle authorities
- Operational: keeper:devops should redeploy keeper:crank after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Keeper now properly detects and skips admin-oracle markets where it lacks oracle authority, preventing invalid cranking attempts and transaction failures that impacted operations.

* **Tests**
  * Added comprehensive test coverage validating keeper behavior with admin-oracle markets and oracle authority scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->