### PR TITLE
fix(GH#1251): live oracle authority check in crankAll — prevent foreign-oracle markets counting as failed after discover() resets flag

### DIFF
--- a/packages/keeper/src/services/crank.ts
+++ b/packages/keeper/src/services/crank.ts
@@ -373,6 +373,13 @@ export class CrankService {
 
   const MAX_CONSECUTIVE_FAILURES = 10;
 
+  // GH#1251: Load the keeper key once here so we can check authority live.
+  // We re-evaluate foreign oracle authority at crankAll time rather than relying on
+  // state.foreignOracleSkipped.  After discover() resets the flag, crankMarket() would
+  // return false (and set failed++) instead of skipped.  Checking here means those markets
+  // are categorised as skipped before they even enter the crank queue.
+  const keeperKey = loadKeypair(process.env.CRANK_KEYPAIR!).publicKey;
+
   const toCrank: string[] = [];
 
   for (const [slabAddress, state] of this.markets) {
@@ -380,8 +387,18 @@ export class CrankService {
       skippedPermanent++;
       continue;
     }
-    // GH#1508: Skip admin-oracle markets where keeper is not the oracle authority
-    if (state.foreignOracleSkipped) {
+    // GH#1251: Live authority check — covers both the steady-state case (flag already set)
+    // and the post-discover() window where the flag was just reset.
+    // Any admin-oracle market where the keeper is NOT the oracle authority is always skipped.
+    if (
+      this.isAdminOracle(state.market) &&
+      !keeperKey.equals(state.market.config.oracleAuthority)
+    ) {
+      // Keep the flag in sync so crankMarket() also fast-paths correctly.
+      if (!state.foreignOracleSkipped) {
+        state.foreignOracleSkipped = true;
+        logger.debug("crankAll: re-skipping foreign oracle market (flag was reset by discover)", { slabAddress });
+      }
       skippedForeignOracle++;
       continue;
     }

--- a/packages/keeper/tests/services/crank.test.ts
+++ b/packages/keeper/tests/services/crank.test.ts
@@ -563,12 +563,17 @@ describe('CrankService', () => {
     it('crankAll should count foreignOracleSkipped markets in skipped total', async () => {
       const slabForeign = 'MarketFO3111111111111111111111111111111';
       const slabNormal = 'MarketNorm111111111111111111111111111111';
+      const FOREIGN_AUTH = 'ForeignAuth31111111111111111111111111111';
       const mockForeignMarket = {
         slabAddress: { toBase58: () => slabForeign },
         programId: { toBase58: () => '11111111111111111111111111111111' },
         config: {
           collateralMint: { toBase58: () => 'MintFO31111111111111111111111111111111' },
-          oracleAuthority: { toBase58: () => 'ForeignAuth31111111111111111111111111111', equals: () => false },
+          // Non-default, non-keeper oracle authority → isAdminOracle=true, keeper≠authority
+          oracleAuthority: {
+            toBase58: () => FOREIGN_AUTH,
+            equals: (_other: any) => false, // not PublicKey.default AND not keeper key
+          },
           indexFeedId: { toBytes: () => new Uint8Array(32) },
         },
         params: { maintenanceMarginBps: 500n },
@@ -586,10 +591,20 @@ describe('CrankService', () => {
         header: { admin: { toBase58: () => 'AdminNorm111111111111111111111111111111' } },
       };
 
+      // GH#1251: crankAll now calls loadKeypair() for a live authority check.
+      // Keeper key must NOT match oracleAuthority so the foreign market is skipped.
+      vi.mocked(shared.loadKeypair).mockReturnValue({
+        publicKey: {
+          toBase58: () => 'KeeperKey311111111111111111111111111111',
+          equals: (_other: any) => false, // keeper ≠ foreign oracle authority
+        },
+        secretKey: new Uint8Array(64),
+      } as any);
+
       vi.mocked(core.discoverMarkets).mockResolvedValue([mockForeignMarket, mockNormalMarket] as any);
       await crankService.discover();
 
-      // Pre-mark the foreign oracle market as skipped (as crankMarket would do)
+      // Pre-mark the foreign oracle market as skipped (as crankMarket would do in steady state)
       const foreignState = crankService.getMarkets().get(slabForeign)!;
       foreignState.foreignOracleSkipped = true;
 
@@ -599,6 +614,74 @@ describe('CrankService', () => {
       // Normal market cranked; foreign oracle market skipped → skipped >= 1
       expect(result.skipped).toBeGreaterThanOrEqual(1);
       expect(result.success).toBe(1);
+    });
+
+    it('GH#1251: crankAll should count foreign-oracle market as skipped (not failed) even after discover() resets the flag', async () => {
+      // Regression test: after discover() resets foreignOracleSkipped=false, crankAll used to
+      // enqueue the market, call crankMarket() which returned false → failed++ instead of skipped++.
+      // Fix: live authority check in crankAll before enqueue.
+      const slabForeign = 'MarketFO4111111111111111111111111111111';
+      const slabNormal  = 'MarketNorm2111111111111111111111111111111';
+
+      const FOREIGN_AUTHORITY = 'ForeignAuth41111111111111111111111111111';
+
+      const mockForeignMarket = {
+        slabAddress: { toBase58: () => slabForeign },
+        programId:   { toBase58: () => '11111111111111111111111111111111' },
+        config: {
+          collateralMint: { toBase58: () => 'MintFO41111111111111111111111111111111' },
+          // Non-default, non-keeper oracle authority
+          oracleAuthority: {
+            toBase58: () => FOREIGN_AUTHORITY,
+            equals: (_other: any) => false, // not PublicKey.default → isAdminOracle=true; not keeper → should skip
+          },
+          indexFeedId: { toBytes: () => new Uint8Array(32) },
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: { toBase58: () => 'AdminFO41111111111111111111111111111111' } },
+      };
+      const mockNormalMarket = {
+        slabAddress: { toBase58: () => slabNormal },
+        programId:   { toBase58: () => '11111111111111111111111111111111' },
+        config: {
+          collateralMint: { toBase58: () => 'MintNorm2111111111111111111111111111111' },
+          oracleAuthority: { toBase58: () => '11111111111111111111111111111111', equals: () => true },
+          indexFeedId: { toBytes: () => new Uint8Array(32) },
+        },
+        params: { maintenanceMarginBps: 500n },
+        header: { admin: { toBase58: () => 'AdminNorm2111111111111111111111111111111' } },
+      };
+
+      // Keeper key does NOT match FOREIGN_AUTHORITY
+      vi.mocked(shared.loadKeypair).mockReturnValue({
+        publicKey: {
+          toBase58: () => 'KeeperKey411111111111111111111111111111',
+          equals: (_other: any) => false,
+        },
+        secretKey: new Uint8Array(64),
+      } as any);
+
+      vi.mocked(core.discoverMarkets).mockResolvedValue([mockForeignMarket, mockNormalMarket] as any);
+      await crankService.discover();
+
+      // Simulate what crankMarket() does: set foreignOracleSkipped=true
+      const foreignState = crankService.getMarkets().get(slabForeign)!;
+      foreignState.foreignOracleSkipped = true;
+
+      // Now simulate discover() resetting the flag (as it does on each cycle)
+      foreignState.foreignOracleSkipped = false;
+
+      vi.mocked(shared.sendWithRetryKeeper).mockResolvedValue('sig-norm2');
+      const result = await crankService.crankAll();
+
+      // The foreign oracle market should be SKIPPED, not failed
+      expect(result.failed).toBe(0);
+      expect(result.skipped).toBeGreaterThanOrEqual(1);
+      expect(result.success).toBe(1);
+
+      // Confirm the flag was re-set by crankAll's live check
+      const stateAfter = crankService.getMarkets().get(slabForeign)!;
+      expect(stateAfter.foreignOracleSkipped).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #1509 (foreign oracle skip). CodeRabbit identified that after `discover()` resets `foreignOracleSkipped = false`, the next `crankAll()` cycle would enqueue those markets, call `crankMarket()` which returns `false`, and increment `failed++` instead of `skipped++`.

## Root Cause

`crankAll()` relied on `state.foreignOracleSkipped` to gate foreign-oracle markets. But `discover()` intentionally resets this flag on every cycle so authority changes are picked up. In the window between reset and next `crankMarket()` call, those markets slipped through into `toCrank` and were counted as failures.

## Fix

Load `keeperKey` once at the top of `crankAll()`, then do a **live** `isAdminOracle + !keypair.equals(oracleAuthority)` check before enqueuing. Markets that fail this check:
- Are categorised as `skippedForeignOracle++` immediately
- Have their `foreignOracleSkipped` flag kept in sync (for the `crankMarket` fast-path)
- Never enter `toCrank`, so they can't pollute `failed` count

The `discover()` reset behaviour is preserved — authority changes will still be detected on the next cycle.

## Testing

1 new regression test: `GH#1251: crankAll should count foreign-oracle market as skipped (not failed) even after discover() resets the flag`

**51/51 tests passing.**

## Impact

- Eliminates false `failed` increments in keeper:crank cycle logs for foreign-oracle markets
- No behaviour change for markets with Pyth oracle or keeper-owned admin oracle
- Operational: keeper:crank should be redeployed after merge to clear residual counts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced oracle authority validation to properly detect and handle foreign oracle market mismatches, ensuring correct re-synchronization during operation cycles instead of marking them as failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->