### PR TITLE
fix(api): GH#1515 — align totalListedMarkets zombie check with /api/markets (off-by-one)

### DIFF
--- a/app/__tests__/api/stats-active-total-consistency.test.ts
+++ b/app/__tests__/api/stats-active-total-consistency.test.ts
@@ -304,3 +304,105 @@ describe("GH#1430 — fixed stats count aligns with /api/markets sanitizePrice l
     expect(countActive(phantomAwareDataFixed([row]))).toBe(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// GH#1515 — totalListedMarkets off-by-one: zombie check uses raw vs sanitized price
+// ---------------------------------------------------------------------------
+describe("GH#1515 — nonZombieListedMarkets must use price-sanitized data (phantomAwareData)", () => {
+  /**
+   * Simulates the isZombieMarket hasActivity check as in activeMarketFilter.ts.
+   * A market with vault=null, accounts=0, and no stats is zombie UNLESS hasActivity.
+   * hasActivity = isSaneMarketValue(last_price) || isSaneMarketValue(volume_24h) || accounts > 0
+   */
+  function isZombieMarket(row: {
+    vault_balance?: number | null;
+    c_tot?: number | null;
+    last_price?: number | null;
+    volume_24h?: number | null;
+    total_open_interest?: number | null;
+    total_accounts?: number | null;
+  }): boolean {
+    const vaultBal = row.vault_balance ?? null;
+    const cTot = row.c_tot ?? null;
+    const hasActivity =
+      isSaneMarketValue(row.last_price) ||
+      isSaneMarketValue(row.volume_24h) ||
+      (row.total_accounts ?? 0) > 0;
+    if (cTot !== null && cTot > 0 && hasActivity) return false;
+    if (vaultBal !== null && vaultBal === 0) return true;
+    if (vaultBal === null) {
+      const hasNoStats =
+        !isSaneMarketValue(row.last_price) &&
+        !isSaneMarketValue(row.volume_24h) &&
+        (row.total_accounts ?? 0) === 0;
+      if (hasNoStats) return true;
+    }
+    return false;
+  }
+
+  // A market whose raw DB price is > $1M (stale) but everything else is empty.
+  // vault=null, accounts=0, no volume, no OI — should be zombie.
+  const stalePriceMarket: StatsRow = {
+    slab_address: "stale-price-slab",
+    last_price: 7_900_000_000, // $7.9B stale oracle price (> $1M cap but < 1e18)
+    volume_24h: 0,
+    trade_count_24h: 0,
+    total_open_interest: 0,
+    open_interest_long: 0,
+    open_interest_short: 0,
+    vault_balance: null,
+    c_tot: null,
+    total_accounts: 0,
+    decimals: 6,
+    stats_updated_at: null,
+  };
+
+  it("BUG (was): raw last_price $7.9B passes isSaneMarketValue → hasActivity=true → NOT zombie", () => {
+    // Documents the bug: statsData (raw) → not zombie → counted in totalListedMarkets
+    expect(isSaneMarketValue(stalePriceMarket.last_price!)).toBe(true); // passes < 1e18 check
+    expect(isZombieMarket(stalePriceMarket as Parameters<typeof isZombieMarket>[0])).toBe(false);
+    // This caused the off-by-one: stats counted it, markets excluded it
+  });
+
+  it("FIX: after phantomAwareData price cap, $7.9B → zeroed → hasActivity=false → IS zombie", () => {
+    // Reproduces the fix: phantomAwareData zeroes all stats (incl. last_price) for phantom markets
+    // (vault=null, accounts=0 → isPhantom=true → last_price set to 0, not null).
+    // Key: isSaneMarketValue(0) = false → hasActivity=false → hasNoStats=true (vault=null) → zombie.
+    const processed = phantomAwareDataFixed([stalePriceMarket]);
+    const priceAfterSanitize = (processed[0] as StatsRow).last_price;
+    // Phantom path zeroes the field (0), not nulls it. 0 is also not sane.
+    expect(isSaneMarketValue(priceAfterSanitize ?? null)).toBe(false); // not a live price
+    expect(isZombieMarket(processed[0] as Parameters<typeof isZombieMarket>[0])).toBe(true);
+    // Correctly excluded from nonZombieListedMarkets → totalListedMarkets matches /api/markets
+  });
+
+  it("FIX: valid-price market (< $1M) remains non-zombie after sanitize", () => {
+    const validMarket: StatsRow = {
+      ...stalePriceMarket,
+      slab_address: "valid-slab",
+      last_price: 42.5,
+      vault_balance: 5_000_000,
+      total_accounts: 3,
+    };
+    const processed = phantomAwareDataFixed([validMarket]);
+    expect((processed[0] as StatsRow).last_price).toBe(42.5);
+    expect(isZombieMarket(processed[0] as Parameters<typeof isZombieMarket>[0])).toBe(false);
+  });
+
+  it("FIX: market with only stale price but no vault/accounts is correctly zombie after fix", () => {
+    // Ensures the broader set of stale-price-only markets all become zombie
+    const prices = [1_000_001, 5_000_000, 7_900_000_000, 999_999_999_999];
+    for (const last_price of prices) {
+      const row: StatsRow = {
+        ...stalePriceMarket,
+        slab_address: `slab-${last_price}`,
+        last_price,
+      };
+      const processed = phantomAwareDataFixed([row]);
+      expect(
+        isZombieMarket(processed[0] as Parameters<typeof isZombieMarket>[0]),
+        `price=${last_price} should be zombie after sanitize`,
+      ).toBe(true);
+    }
+  });
+});

--- a/app/app/api/stats/route.ts
+++ b/app/app/api/stats/route.ts
@@ -233,7 +233,16 @@ export async function GET(request: NextRequest) {
   // Previously statsData.length included zombies, causing totalListedMarkets (195) to
   // diverge from /api/markets total (122) by exactly zombieCount (73).
   // Uses shared isZombieMarket() helper (GH#1420 + GH#1427 predicate, CodeRabbit #1466).
-  const nonZombieListedMarkets = statsData.filter((m) => !isZombieMarket(m as {
+  //
+  // GH#1515: Use phantomAwareData (price-sanitized) instead of statsData (raw) here.
+  // /api/markets runs isZombieMarket with sanitizedPrice (capped at $1M via sanitizePrice).
+  // /api/stats was running isZombieMarket with raw last_price from statsData — a market
+  // with a stale DB price > $1M passes isSaneMarketValue() (< 1e18 ✓) → hasActivity=true
+  // → escapes zombie detection → counted in totalListedMarkets here, but /api/markets
+  // sanitizePrice() nulls that price → hasActivity=false → zombie → excluded from total.
+  // Fix: pass phantomAwareData (which already caps last_price at $1M via GH#1430 logic)
+  // so the zombie check uses the same effective price as /api/markets.
+  const nonZombieListedMarkets = phantomAwareData.filter((m) => !isZombieMarket(m as {
     vault_balance?: number | null;
     c_tot?: number | null;
     last_price?: number | null;


### PR DESCRIPTION
## Problem

`/api/stats` `totalListedMarkets=168` vs `/api/markets` `total=167` — off by one.

## Root Cause

`nonZombieListedMarkets` was calling `isZombieMarket()` with raw `statsData` (unsanitized `last_price`). A market with a stale DB price > $1M (e.g. $7.9B) passes `isSaneMarketValue()` (< 1e18 ✓) → `hasActivity=true` → escapes zombie detection → counted in `totalListedMarkets`.

Meanwhile `/api/markets` (GH#1506) runs the zombie check with `sanitizedPrice` (capped at $1M via `sanitizePrice()`). Same market: `sanitizePrice → null` → `isSaneMarketValue(null)=false` → `hasActivity=false` → is_zombie=true → excluded from `total`.

## Fix

Switch `nonZombieListedMarkets` from `statsData` → `phantomAwareData`. The `phantomAwareData` array already applies the $1M price cap (GH#1430) so the zombie predicate sees the same effective price as `/api/markets`.

## Testing

- Added 4 GH#1515 regression tests to `stats-active-total-consistency.test.ts`
- Covers: bug documentation, fix verification, valid-price preservation, and boundary sweep
- All 1292 tests passing

## How to Verify

```bash
curl https://percolatorlaunch.com/api/stats | jq .totalListedMarkets
curl 'https://percolatorlaunch.com/api/markets?limit=1' | jq .total
# Both should return same value
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved zombie market detection consistency by using sanitized pricing data instead of raw data, with proper price capping applied.

* **Tests**
  * Added comprehensive test suite covering zombie market detection with various stale price scenarios and phantom-aware data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->