### PR TITLE
fix(markets): GH#1526 oracle_mode filter + GH#1527 search by known token symbol

### DIFF
--- a/app/__tests__/api/markets-gh1526-gh1527.test.ts
+++ b/app/__tests__/api/markets-gh1526-gh1527.test.ts
@@ -1,0 +1,313 @@
+/**
+ * GH#1526: oracle_mode filter should map frontend values ("manual", "live_feed")
+ *          to DB-stored values ("admin", "hyperp") before filtering.
+ *
+ * GH#1527: search should match well-known token symbols (e.g. "SOL") even when
+ *          the DB stores truncated addresses (e.g. symbol="So111111").
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn(), captureMessage: vi.fn() }));
+
+vi.mock("@/lib/config", () => ({
+  getConfig: () => ({
+    rpcUrl: "https://api.devnet.solana.com",
+    network: "devnet",
+    programId: "11111111111111111111111111111111",
+  }),
+}));
+
+const SOL_MINT = "So11111111111111111111111111111111111111112";
+const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const BONK_MINT = "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263";
+
+function mkMarket(overrides: Record<string, unknown> = {}) {
+  return {
+    slab_address: `Slab${overrides.symbol ?? "X"}11111111111111111111111111111111`.slice(0, 44),
+    mint_address: "Mint111111111111111111111111111111111111111",
+    mainnet_ca: null,
+    symbol: "TEST",
+    name: "Test Market",
+    decimals: 6,
+    deployer: "11111111111111111111111111111111",
+    logo_url: null,
+    max_leverage: 10,
+    trading_fee_bps: 10,
+    last_price: 1.0,
+    mark_price: 1.0,
+    index_price: 1.0,
+    volume_24h: 1000,
+    open_interest_long: 500,
+    open_interest_short: 500,
+    total_open_interest: 1000,
+    insurance_fund: 1000,
+    insurance_balance: 1000,
+    total_accounts: 10,
+    funding_rate: 1,
+    net_lp_pos: 0,
+    lp_sum_abs: 0,
+    c_tot: 0,
+    vault_balance: 500_000_000,
+    created_at: "2026-01-01T00:00:00Z",
+    stats_updated_at: "2026-01-01T00:00:00Z",
+    oracle_mode: "admin",
+    dex_pool_address: null,
+    oracle_authority: "FF7KFfU5abBLnJoSLpPBEjxeJGCBFuWLvvqaJsH3fS5Y",
+    ...overrides,
+  };
+}
+
+let mockMarkets: unknown[] = [];
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceClient: () => ({
+    from: () => ({
+      select: () => Promise.resolve({ data: mockMarkets, error: null }),
+    }),
+  }),
+}));
+
+function makeRequest(params: Record<string, string> = {}) {
+  const url = new URL("http://localhost/api/markets");
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  const { NextRequest } = require("next/server");
+  return new NextRequest(url.toString());
+}
+
+// ─── GH#1526: oracle_mode filter mapping ────────────────────────────────────
+
+describe("GH#1526 — oracle_mode frontend→DB value mapping", () => {
+  beforeEach(() => {
+    mockMarkets = [];
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  it("oracle_mode=manual maps to DB value 'admin' and returns those markets", async () => {
+    mockMarkets = [
+      mkMarket({ symbol: "ADMIN1", oracle_mode: "admin", slab_address: "SlabADMIN111111111111111111111111111111111111" }),
+      mkMarket({ symbol: "HYPERP1", oracle_mode: "hyperp", slab_address: "SlabHYPERP11111111111111111111111111111111111" }),
+      mkMarket({ symbol: "PYTH1", oracle_mode: "pyth", slab_address: "SlabPYTH1111111111111111111111111111111111111" }),
+    ];
+
+    const { GET } = await import("@/app/api/markets/route");
+    const res = await GET(makeRequest({ oracle_mode: "manual" }));
+    const body = (await res.json()) as { markets: { symbol: string }[]; total: number };
+
+    expect(res.status).toBe(200);
+    // "manual" should resolve to "admin" and return only ADMIN1
+    expect(body.total).toBe(1);
+    expect(body.markets).toHaveLength(1);
+    expect(body.markets[0].symbol).toBe("ADMIN1");
+  });
+
+  it("oracle_mode=live_feed maps to DB value 'hyperp' and returns those markets", async () => {
+    mockMarkets = [
+      mkMarket({ symbol: "ADMIN1", oracle_mode: "admin", slab_address: "SlabADMIN111111111111111111111111111111111111" }),
+      mkMarket({ symbol: "HYPERP1", oracle_mode: "hyperp", slab_address: "SlabHYPERP11111111111111111111111111111111111" }),
+      mkMarket({ symbol: "HYPERP2", oracle_mode: "hyperp", slab_address: "SlabHYPERP21111111111111111111111111111111111" }),
+    ];
+
+    const { GET } = await import("@/app/api/markets/route");
+    const res = await GET(makeRequest({ oracle_mode: "live_feed" }));
+    const body = (await res.json()) as { markets: { symbol: string }[]; total: number };
+
+    expect(res.status).toBe(200);
+    // "live_feed" should resolve to "hyperp" and return 2 markets
+    expect(body.total).toBe(2);
+    expect(body.markets).toHaveLength(2);
+    expect(body.markets.map((m) => m.symbol).sort()).toEqual(["HYPERP1", "HYPERP2"]);
+  });
+
+  it("oracle_mode=admin (DB canonical value) still works as before", async () => {
+    mockMarkets = [
+      mkMarket({ symbol: "ADMIN1", oracle_mode: "admin", slab_address: "SlabADMIN111111111111111111111111111111111111" }),
+      mkMarket({ symbol: "HYPERP1", oracle_mode: "hyperp", slab_address: "SlabHYPERP11111111111111111111111111111111111" }),
+    ];
+
+    const { GET } = await import("@/app/api/markets/route");
+    const res = await GET(makeRequest({ oracle_mode: "admin" }));
+    const body = (await res.json()) as { markets: { symbol: string }[] };
+
+    expect(body.markets).toHaveLength(1);
+    expect(body.markets[0].symbol).toBe("ADMIN1");
+  });
+
+  it("oracle_mode=pyth still works", async () => {
+    mockMarkets = [
+      mkMarket({ symbol: "ADMIN1", oracle_mode: "admin", slab_address: "SlabADMIN111111111111111111111111111111111111" }),
+      mkMarket({ symbol: "PYTH1", oracle_mode: "pyth", slab_address: "SlabPYTH1111111111111111111111111111111111111" }),
+    ];
+
+    const { GET } = await import("@/app/api/markets/route");
+    const res = await GET(makeRequest({ oracle_mode: "pyth" }));
+    const body = (await res.json()) as { markets: { symbol: string }[] };
+
+    expect(body.markets).toHaveLength(1);
+    expect(body.markets[0].symbol).toBe("PYTH1");
+  });
+
+  it("regresses: oracle_mode=manual no longer returns 0 results when admin markets exist", async () => {
+    // This was the exact production failure: 168 admin markets, filter returns 0
+    mockMarkets = Array.from({ length: 5 }, (_, i) =>
+      mkMarket({
+        symbol: `MARKET${i}`,
+        oracle_mode: "admin",
+        slab_address: `SlabMARKET${i}1111111111111111111111111111111111`.slice(0, 44),
+      }),
+    );
+
+    const { GET } = await import("@/app/api/markets/route");
+    const res = await GET(makeRequest({ oracle_mode: "manual" }));
+    const body = (await res.json()) as { markets: unknown[]; total: number };
+
+    // Should return the 5 admin markets, not 0
+    expect(body.total).toBe(5);
+    expect(body.markets).toHaveLength(5);
+  });
+});
+
+// ─── GH#1527: search by well-known token symbol ─────────────────────────────
+
+describe("GH#1527 — search matches known token symbols via mint address", () => {
+  beforeEach(() => {
+    mockMarkets = [];
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  it("search=SOL matches market with SOL mint_address even when DB symbol is truncated", async () => {
+    mockMarkets = [
+      // SOL market — DB has truncated symbol from StatsCollector default
+      mkMarket({
+        symbol: "So111111",
+        name: "Market EkQty1Ls",
+        mint_address: SOL_MINT,
+        mainnet_ca: null,
+        slab_address: "SlabSOL11111111111111111111111111111111111111",
+      }),
+      // Unrelated market
+      mkMarket({
+        symbol: "WENDYS",
+        name: "Wendys Perp",
+        mint_address: "Mint111111111111111111111111111111111111111",
+        mainnet_ca: null,
+        slab_address: "SlabWENDYS1111111111111111111111111111111111",
+      }),
+    ];
+
+    const { GET } = await import("@/app/api/markets/route");
+    const res = await GET(makeRequest({ search: "SOL" }));
+    const body = (await res.json()) as { markets: { symbol: string }[]; total: number };
+
+    expect(res.status).toBe(200);
+    // Should find the SOL market via mint address lookup
+    expect(body.total).toBe(1);
+    expect(body.markets).toHaveLength(1);
+    expect(body.markets[0].mint_address).toBe(SOL_MINT);
+  });
+
+  it("search=sol (lowercase) matches SOL market case-insensitively", async () => {
+    mockMarkets = [
+      mkMarket({
+        symbol: "So111111",
+        name: "Market EkQty1Ls",
+        mint_address: SOL_MINT,
+        slab_address: "SlabSOL11111111111111111111111111111111111111",
+      }),
+    ];
+
+    const { GET } = await import("@/app/api/markets/route");
+    const res = await GET(makeRequest({ search: "sol" }));
+    const body = (await res.json()) as { markets: unknown[] };
+
+    expect(body.markets).toHaveLength(1);
+  });
+
+  it("search=BONK matches market with BONK mainnet_ca (fallback field)", async () => {
+    mockMarkets = [
+      mkMarket({
+        symbol: "DezXAZ8z",
+        name: "Market DezXAZ",
+        mint_address: "DevnetMint1111111111111111111111111111111111",
+        mainnet_ca: BONK_MINT, // mainnet CA is BONK
+        slab_address: "SlabBONK1111111111111111111111111111111111111",
+      }),
+    ];
+
+    const { GET } = await import("@/app/api/markets/route");
+    const res = await GET(makeRequest({ search: "BONK" }));
+    const body = (await res.json()) as { markets: unknown[] };
+
+    expect(body.markets).toHaveLength(1);
+  });
+
+  it("search=WENDYS still works via direct DB symbol match (regression)", async () => {
+    mockMarkets = [
+      mkMarket({
+        symbol: "WENDYS",
+        name: "Wendys Perp",
+        mint_address: "Mint111111111111111111111111111111111111111",
+        slab_address: "SlabWENDYS1111111111111111111111111111111111",
+      }),
+      mkMarket({
+        symbol: "So111111",
+        name: "Market EkQty1Ls",
+        mint_address: SOL_MINT,
+        slab_address: "SlabSOL11111111111111111111111111111111111111",
+      }),
+    ];
+
+    const { GET } = await import("@/app/api/markets/route");
+    const res = await GET(makeRequest({ search: "WENDYS" }));
+    const body = (await res.json()) as { markets: { symbol: string }[] };
+
+    expect(body.markets).toHaveLength(1);
+    expect(body.markets[0].symbol).toBe("WENDYS");
+  });
+
+  it("regresses: search=SOL no longer returns 0 when SOL market has truncated DB symbol", async () => {
+    // This was the exact production failure described in GH#1527
+    mockMarkets = [
+      mkMarket({
+        symbol: "So111111",
+        name: "Market EkQty1Ls",
+        mint_address: SOL_MINT,
+        slab_address: "SlabSOL11111111111111111111111111111111111111",
+      }),
+    ];
+
+    const { GET } = await import("@/app/api/markets/route");
+    const res = await GET(makeRequest({ search: "SOL" }));
+    const body = (await res.json()) as { markets: unknown[]; total: number };
+
+    // Previously returned 0 — now must return 1
+    expect(body.total).toBe(1);
+    expect(body.markets).toHaveLength(1);
+  });
+
+  it("search=USDC matches market with USDC mint address", async () => {
+    mockMarkets = [
+      mkMarket({
+        symbol: "EPjFWdd5",
+        name: "Market EPjFWdd",
+        mint_address: USDC_MINT,
+        slab_address: "SlabUSDC1111111111111111111111111111111111111",
+      }),
+      mkMarket({
+        symbol: "BONKMARKET",
+        name: "Bonk Market",
+        mint_address: BONK_MINT,
+        slab_address: "SlabBONK1111111111111111111111111111111111111",
+      }),
+    ];
+
+    const { GET } = await import("@/app/api/markets/route");
+    const res = await GET(makeRequest({ search: "USDC" }));
+    const body = (await res.json()) as { markets: unknown[]; total: number };
+
+    expect(body.total).toBe(1);
+    expect(body.markets).toHaveLength(1);
+  });
+});

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -9,6 +9,30 @@ import * as Sentry from "@sentry/nextjs";
 import { isSaneMarketValue, isActiveMarket, isZombieMarket } from "@/lib/activeMarketFilter";
 import { isPhantomOpenInterest } from "@/lib/phantom-oi";
 import { BLOCKED_SLAB_ADDRESSES as HARDCODED_BLOCKED_MARKETS } from "@/lib/blocklist";
+import { SLUG_ALIASES } from "@/lib/symbol-utils";
+
+/**
+ * GH#1526: Map frontend oracle_mode filter values to DB-stored values.
+ * The UI displays "manual" and "live feed" but the DB stores "admin" and "hyperp".
+ * Without this map the filter returns 0 results for any value except "admin".
+ */
+const ORACLE_MODE_FRONTEND_TO_DB: Record<string, string> = {
+  manual: "admin",
+  live_feed: "hyperp",
+  // Pass-through values (already DB canonical)
+  admin: "admin",
+  hyperp: "hyperp",
+  pyth: "pyth",
+};
+
+/**
+ * GH#1527: Build a reverse lookup from mint address → well-known ticker symbol.
+ * Used to make search match "SOL" even when DB stores symbol="So111111".
+ * Derived from SLUG_ALIASES (single source of truth).
+ */
+const MINT_TO_KNOWN_SYMBOL: Map<string, string> = new Map(
+  Object.entries(SLUG_ALIASES).map(([symbol, mint]) => [mint, symbol]),
+);
 
 /**
  * Maximum valid funding rate in bps/slot (matches on-chain guard).
@@ -290,23 +314,51 @@ export async function GET(request: NextRequest) {
     const activeTotal = nonZombieOnly.filter((m) => isActiveMarket(m as Parameters<typeof isActiveMarket>[0])).length;
 
     // GH#1512: Apply search filter — case-insensitive substring match on symbol or name.
+    // GH#1527: Also resolve the query against SLUG_ALIASES so searching "SOL" matches
+    // markets whose DB symbol is a truncated address (e.g. "So111111") but whose
+    // mint_address or mainnet_ca is the SOL mint. This bridges the gap between the
+    // human-readable token names shown in the UI (via token-metadata enrichment) and
+    // the raw DB values that the search runs against.
     const searchParam = request?.nextUrl?.searchParams?.get("search") ?? null;
     const searchTrimmed = searchParam ? searchParam.trim() : null;
     const searchFiltered = searchTrimmed
-      ? nonZombie.filter((m) => {
-          const sym = ((m as Record<string, unknown>).symbol as string | null) ?? "";
-          const name = ((m as Record<string, unknown>).name as string | null) ?? "";
+      ? (() => {
           const q = searchTrimmed.toLowerCase();
-          return sym.toLowerCase().includes(q) || name.toLowerCase().includes(q);
-        })
+          // Collect mint addresses whose well-known symbol matches the query
+          // (e.g. q="sol" matches MINT_TO_KNOWN_SYMBOL entry "SOL" → So111...112)
+          const matchingMints = new Set<string>();
+          for (const [mint, knownSymbol] of MINT_TO_KNOWN_SYMBOL) {
+            if (knownSymbol.toLowerCase().includes(q)) {
+              matchingMints.add(mint);
+            }
+          }
+          return nonZombie.filter((m) => {
+            const sym = ((m as Record<string, unknown>).symbol as string | null) ?? "";
+            const name = ((m as Record<string, unknown>).name as string | null) ?? "";
+            // Direct DB field match (existing behaviour — handles WENDYS, etc.)
+            if (sym.toLowerCase().includes(q) || name.toLowerCase().includes(q)) return true;
+            // GH#1527: Known-symbol match via mint_address or mainnet_ca
+            const mintAddress = ((m as Record<string, unknown>).mint_address as string | null) ?? "";
+            const mainnetCa = ((m as Record<string, unknown>).mainnet_ca as string | null) ?? "";
+            if (matchingMints.has(mintAddress) || matchingMints.has(mainnetCa)) return true;
+            return false;
+          });
+        })()
       : nonZombie;
 
     // GH#1512: Apply oracle_mode filter.
+    // GH#1526: Map frontend display values ("manual", "live_feed") to DB canonical
+    // values ("admin", "hyperp") before filtering. Previously the filter did an exact
+    // match, so passing "manual" or "live_feed" (the values the UI uses) always returned
+    // 0 results because the DB stores "admin" and "hyperp" respectively.
     const oracleModeParam = request?.nextUrl?.searchParams?.get("oracle_mode") ?? null;
     const oracleModeFiltered = oracleModeParam
-      ? searchFiltered.filter(
-          (m) => ((m as Record<string, unknown>).oracle_mode as string | null) === oracleModeParam,
-        )
+      ? (() => {
+          const dbValue = ORACLE_MODE_FRONTEND_TO_DB[oracleModeParam] ?? oracleModeParam;
+          return searchFiltered.filter(
+            (m) => ((m as Record<string, unknown>).oracle_mode as string | null) === dbValue,
+          );
+        })()
       : searchFiltered;
 
     // GH#1512: Apply sort + order. Supported sort keys: symbol, last_price, volume_24h,


### PR DESCRIPTION
## Summary

Fixes two P0 bugs reported by QA and PM on the /markets page filters.

---

## GH#1526 — oracle_mode filter returns 0 results for 'manual' / 'live_feed'

**Root cause:** The UI sends `oracle_mode=manual` and `oracle_mode=live_feed` but the DB stores `admin` and `hyperp`. The filter did an exact string match so it always returned 0 results.

**Fix:** Added `ORACLE_MODE_FRONTEND_TO_DB` map:
```
manual    → admin
live_feed → hyperp
admin     → admin  (pass-through)
hyperp    → hyperp (pass-through)
pyth      → pyth   (pass-through)
```
The filter now translates the frontend value before comparing against the DB field.

---

## GH#1527 — search=SOL returns 0 results

**Root cause:** The DB stores `symbol='So111111'` and `name='Market EkQty1Ls'` for SOL markets (auto-generated defaults). The UI enriches these with token metadata but search runs against the raw DB fields only.

**Fix:** Added `MINT_TO_KNOWN_SYMBOL` (derived from existing `SLUG_ALIASES`) so searching 'SOL' also checks whether the market's `mint_address` or `mainnet_ca` corresponds to a known ticker. No external calls — pure in-memory lookup from existing constants.

---

## Testing

- 11 new unit tests in `__tests__/api/markets-gh1526-gh1527.test.ts` — all pass
- Existing 57 markets tests all pass (markets-search-filter, markets-sort, markets-active-total-zombie, markets-zombie-filter)

## DevOps Note

The 3 Sentry 500s on `GET /funding/<address>` (Mar 4–5, Feb 27) appear to be uninitialized market slabs. The `GH#1602` guard in `/api/funding/[slab]/route.ts` already converts backend 500s to 404s — those are pre-existing and resolved by that guard.

## How to Test

```bash
# GH#1526: should now return markets (was 0)
curl 'https://percolatorlaunch.com/api/markets?oracle_mode=manual&limit=10'
curl 'https://percolatorlaunch.com/api/markets?oracle_mode=live_feed&limit=10'

# GH#1527: should now return SOL markets (was 0)
curl 'https://percolatorlaunch.com/api/markets?search=SOL'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Market search now matches well-known token symbols (such as SOL, USDC, BONK) even when the stored symbol is truncated, improving search discoverability.
  * Oracle mode filtering now correctly translates user selections to appropriate database values for more accurate market filtering results.

* **Tests**
  * Added comprehensive test coverage for market search and filtering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->