### PR TITLE
fix(GH#1547): add pretest script to build @percolator/shared before test run

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "pnpm --filter @percolator/app dev",
     "build:app": "pnpm --filter @percolator/app build",
     "build:core": "pnpm --filter @percolator/sdk build",
+    "pretest": "pnpm --filter @percolator/shared build",
     "test": "pnpm -r test",
     "test:app": "cd app && pnpm test",
     "test:core": "cd packages/core && pnpm test",


### PR DESCRIPTION
## Summary

Fixes GH#1547: root `pnpm test` fails when `@percolator/shared` dist/ is stale or missing.

## Root Cause

`pnpm -r test` runs tests across all packages in parallel but `@percolator/shared` must be compiled (tsc) before any package that imports from it can be tested.

## Fix

Added `pretest` script to root `package.json`:
```json
"pretest": "pnpm --filter @percolator/shared build"
```

pnpm automatically runs `pretest` before `test`, so CI and local runs are both fixed.

## Impact
- Low priority (CI not affected, only local dev experience)
- No logic changes — build ordering only

Reported by QA (GH#1547)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test execution process to include an automatic build step, ensuring dependencies are properly prepared before running tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->