### PR TITLE
fix(markets): sort 'recent' by created_at instead of slab address

### DIFF
--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -362,9 +362,15 @@ function MarketsPageInner() {
           const order: Record<string, number> = { healthy: 0, caution: 1, warning: 2, empty: 3 };
           return (order[ha.level] ?? 5) - (order[hb.level] ?? 5);
         }
-        case "recent":
-          // Sort by most recently added (slab address is sequential-ish)
+        case "recent": {
+          // Sort by created_at descending; fall back to slab address if missing
+          const aTime = a.supabase?.created_at;
+          const bTime = b.supabase?.created_at;
+          if (aTime && bTime) return bTime.localeCompare(aTime);
+          if (bTime) return 1;  // b has time, a doesn't → b first
+          if (aTime) return -1; // a has time, b doesn't → a first
           return b.slabAddress.localeCompare(a.slabAddress);
+        }
         default: return 0;
       }
     });


### PR DESCRIPTION
## Summary
Fixes #1549

The `recent` sort on /markets was using `slabAddress.localeCompare()` which gives lexicographic order, not chronological. Markets with slab addresses starting with 'z' appeared first regardless of creation date.

## Changes
- Use `supabase.created_at` descending for the `recent` sort
- Fall back to slab address comparison only when `created_at` is unavailable

## Testing
- Click 'recent' sort on /markets → newest markets (by creation date) should appear first
- WAR2 (created 2026-03-21) should sort above older markets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sorting for recently created markets to provide more consistent and reliable ordering with enhanced fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->