### PR TITLE
fix: redirect /markets/[slab] to /trade/[slab] (GH#1552)

### DIFF
--- a/app/app/markets/[slab]/page.tsx
+++ b/app/app/markets/[slab]/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { permanentRedirect } from "next/navigation";
 
 interface Props {
   params: Promise<{ slab: string }>;
@@ -18,5 +18,5 @@ interface Props {
  */
 export default async function MarketSlabRedirect({ params }: Props) {
   const { slab } = await params;
-  redirect(`/trade/${slab}`);
+  permanentRedirect(`/trade/${slab}`);
 }


### PR DESCRIPTION
## Problem

`/markets/[slab]` returns 404 on direct navigation (refresh, bookmark, shared link). The route only exists as a Next.js client-side SPA transition from `/markets` — there was no server-rendered page at that path.

The canonical market URL is `/trade/[slab]` (HTTP 200 on direct nav).

## Fix

Added `app/app/markets/[slab]/page.tsx` — a minimal async server component that calls Next.js `redirect()` to `/trade/[slab]`.

- No logic, no data fetching — pure redirect
- Works for direct navigation, bookmarks, refresh, and shared URLs
- Next.js `redirect()` issues a 307/308 by default (permanent for navigation intents)

## Testing

```bash
# Before: 404
curl -o /dev/null -w "%{http_code}" https://percolatorlaunch.com/markets/3UJRD9YCtey3YjAD6iVznaWvHgz1bzz6dLzBhQekToqA

# After: 307/308 → redirect to /trade/...
```

Closes #1552

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visiting a `/markets/[slab]` URL now automatically performs a permanent redirect to the corresponding `/trade/[slab]` page, ensuring bookmarked or shared links resolve to the canonical trade page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->