### PR TITLE
fix: redirect /markets/[slab] to /trade/[slab] (GH#1552)

### DIFF
--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -46,6 +46,18 @@ const nextConfig: NextConfig = {
       buffer: "buffer",
     },
   },
+  async redirects() {
+    return [
+      // GH#1552: /markets/[slab] only works client-side (intercepting route).
+      // Direct navigation / refresh hits the server where no page exists → 404.
+      // Permanent redirect to the canonical /trade/[slab] route.
+      {
+        source: "/markets/:slab",
+        destination: "/trade/:slab",
+        permanent: true,
+      },
+    ];
+  },
   async rewrites() {
     return [
       // Data routes → API service


### PR DESCRIPTION
## Problem
`/markets/[slab]` returns 404 on direct navigation, refresh, or shared URLs. The route only works as a client-side intercepting route from the /markets list page.

## Fix
Add a permanent (301) redirect in `next.config.ts`: `/markets/:slab` → `/trade/:slab`.

The markets list page already links to `/trade/[slab]` (line 731), so this redirect only catches stale bookmarks, shared URLs, and direct navigation attempts.

## Testing
- Navigate directly to `/markets/<any-slab>` → should redirect to `/trade/<slab>`
- Existing `/trade/<slab>` routes unaffected
- Markets list page links still work (already point to `/trade/`)

Closes #1552

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved previously broken navigation paths that returned 404 errors. These URLs now properly redirect to their intended destinations, ensuring a seamless experience when refreshing pages or sharing links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->