### PR TITLE
fix(oracle-accuracy-test): address CodeRabbit review on PR #1560

### DIFF
--- a/scripts/hyperp-pyth-accuracy-test.mjs
+++ b/scripts/hyperp-pyth-accuracy-test.mjs
@@ -32,7 +32,7 @@ const MINTS = {
 const HERMES_URL = process.env.HERMES_URL ?? "https://hermes.pyth.network";
 
 // Canonical mainnet USDC mint — used to reliably filter quote tokens instead of symbol matching
-const USDC_MINT = "EPjFWaJrgqAfIsZ2uG9Kqh28rtzuwMvzA98Fwp34d82w";
+const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 
 // Minimum liquidity (USD) required for a DexScreener pool to be used as the price source.
 // Pools below this threshold are considered stale/thin and we fall through to Jupiter price API.


### PR DESCRIPTION
## Summary

Follow-up to PR #1560 — addresses 2 actionable + 1 nitpick from CodeRabbit review.

## Changes

### 1. `HERMES_URL` env var support (nitpick → fixed)
`fetchPythPrice` was hardcoding `https://hermes.pyth.network`. Now reads `process.env.HERMES_URL` with the same fallback used in `oracle-keeper.ts:64-66`. If the keeper is pointed at a mirror or failover Hermes, the test now validates the same backend.

### 2. USDC filter pinned to canonical mint (actionable → fixed)
The DexScreener pairs filter was matching `p.quoteToken?.symbol === "USDC"` — brittle, since multiple tokens share that symbol on Solana. Now checks `p.quoteToken?.address === "EPjFWdd..."` (mainnet USDC mint).

### 3. Removed Pyth-from-Pyth fallback in `fetchJupiterPrice` (actionable → fixed, most impactful)
`fetchJupiterPrice` was calling `fetchPythPrice` as its primary "fallback", which caused Pyth-vs-Pyth comparisons for BTC and ETH (thin DEX liquidity → fell back → both sides read Pyth → always 0.00% deviation). This made the test appear to pass for BTC/ETH even if the push pipeline had a real deviation. Now `fetchJupiterPrice` only tries Jupiter; if Jupiter is also unavailable, it throws and the sample is correctly recorded as an error.

## Test Impact
- SOL: no change (deep Raydium pool, DexScreener path)
- BTC/ETH: previously showed 0.00% (Pyth-vs-Pyth). Now shows error if no JUPITER_API_KEY, or true Jupiter-vs-Pyth deviation if key is set.

Closes CodeRabbit findings on PR #1560.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable Hermes endpoint via environment variable.

* **Bug Fixes**
  * Improved USDC pair accuracy by filtering based on token address instead of symbol name.
  * Simplified price source fallback behavior for more reliable pricing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->