### PR TITLE
fix(api/markets): sort=oi/volume/health named aliases not applied (GH#1566)

### DIFF
--- a/app/__tests__/api/markets-sort-named-aliases.test.ts
+++ b/app/__tests__/api/markets-sort-named-aliases.test.ts
@@ -1,0 +1,246 @@
+/**
+ * GH#1566: /api/markets sort=oi / sort=volume / sort=health return markets in random order.
+ *
+ * Root cause: "oi", "volume", and "health" are named SortKey aliases used by the frontend,
+ * but the API's SORTABLE_FIELDS set did not include them. They fell through to no-sort,
+ * returning DB insertion order. sort=recent had the same bug (fixed in PR#1557).
+ *
+ * Fix (this PR): NAMED_SORT_ALIASES map handles:
+ *   - "oi"     → total_open_interest DESC
+ *   - "volume" → volume_24h DESC
+ *   - "health" → computeMarketHealthFromStats rank ASC (healthy=0, caution=1, warning=2, empty=3)
+ *
+ * This test validates the sort logic inline (same pattern as markets-sort.test.ts).
+ */
+import { describe, it, expect } from "vitest";
+import { computeMarketHealthFromStats } from "@/lib/health";
+
+// ---- Inline reproduction of the GH#1566 fix logic ----
+
+const SORTABLE_FIELDS = new Set([
+  "symbol",
+  "last_price",
+  "mark_price",
+  "index_price",
+  "volume_24h",
+  "volume_24h_usd",
+  "total_open_interest",
+  "total_open_interest_usd",
+  "funding_rate",
+  "created_at",
+  "stats_updated_at",
+  "trade_count_24h",
+  "insurance_fund",
+  "insurance_balance",
+  "total_accounts",
+]);
+
+const NAMED_SORT_ALIASES: Record<string, { field: string; dir: number } | "health"> = {
+  recent: { field: "created_at", dir: -1 },
+  oi: { field: "total_open_interest", dir: -1 },
+  volume: { field: "volume_24h", dir: -1 },
+  health: "health",
+};
+
+const HEALTH_ORDER: Record<string, number> = { healthy: 0, caution: 1, warning: 2, empty: 3 };
+const healthRank = (m: Record<string, unknown>): number => {
+  const h = computeMarketHealthFromStats({
+    total_open_interest: m.total_open_interest as number | null,
+    open_interest_long: m.open_interest_long as number | null,
+    open_interest_short: m.open_interest_short as number | null,
+    insurance_balance: m.insurance_balance as number | null,
+    insurance_fund: m.insurance_fund as number | null,
+    c_tot: m.c_tot as number | null,
+    vault_balance: m.vault_balance as number | null,
+    total_accounts: m.total_accounts as number | null,
+  });
+  return HEALTH_ORDER[h.level] ?? 5;
+};
+
+function applySort(
+  markets: Record<string, unknown>[],
+  sortParam: string | null,
+  orderParam = "asc",
+): Record<string, unknown>[] {
+  const sortDir = orderParam === "desc" ? -1 : 1;
+  const namedAlias = sortParam ? NAMED_SORT_ALIASES[sortParam] : undefined;
+  const effectiveSortParam =
+    namedAlias && namedAlias !== "health"
+      ? namedAlias.field
+      : sortParam === "recent" ? "created_at" : sortParam;
+  const effectiveSortDir =
+    namedAlias && namedAlias !== "health"
+      ? namedAlias.dir
+      : sortParam === "recent" ? -1 : sortDir;
+
+  if (namedAlias === "health") {
+    return [...markets].sort((a, b) => sortDir * (healthRank(a) - healthRank(b)));
+  }
+  if (effectiveSortParam && SORTABLE_FIELDS.has(effectiveSortParam)) {
+    return [...markets].sort((a, b) => {
+      const av = a[effectiveSortParam] ?? null;
+      const bv = b[effectiveSortParam] ?? null;
+      if (av === null && bv === null) return 0;
+      if (av === null) return 1;
+      if (bv === null) return -1;
+      if (typeof av === "string" && typeof bv === "string") return effectiveSortDir * av.localeCompare(bv);
+      return effectiveSortDir * ((av as number) - (bv as number));
+    });
+  }
+  return markets;
+}
+
+// ---- Fixtures ----
+
+const MARKETS: Record<string, unknown>[] = [
+  {
+    symbol: "AAA",
+    total_open_interest: 2_660_054_000_000, // highest OI
+    volume_24h: 1_000,
+    vault_balance: 5_000_000,
+    total_accounts: 3,
+    c_tot: 100,
+    insurance_balance: 100,
+    open_interest_long: 1_330_027_000_000,
+    open_interest_short: 1_330_027_000_000,
+  },
+  {
+    symbol: "BBB",
+    total_open_interest: 0,
+    volume_24h: 999_999_999,  // highest volume
+    vault_balance: 0,          // empty (zombie)
+    total_accounts: 0,
+    c_tot: 0,
+    insurance_balance: 0,
+    open_interest_long: 0,
+    open_interest_short: 0,
+  },
+  {
+    symbol: "CCC",
+    total_open_interest: 9_000_000,
+    volume_24h: 500,
+    vault_balance: 5_000_000,
+    total_accounts: 2,
+    c_tot: 0,              // no capital → warning
+    insurance_balance: 0,
+    open_interest_long: 4_500_000,
+    open_interest_short: 4_500_000,
+  },
+  {
+    symbol: "DDD",
+    total_open_interest: 0,
+    volume_24h: 0,
+    vault_balance: 5_000_000,
+    total_accounts: 1,
+    c_tot: 100,
+    insurance_balance: 100,
+    open_interest_long: 0,
+    open_interest_short: 0,
+  },
+];
+
+// ---- Tests ----
+
+describe("GH#1566 sort=oi", () => {
+  it("sorts by total_open_interest DESC (highest OI first)", () => {
+    const result = applySort(MARKETS, "oi");
+    const ois = result.map((m) => m.total_open_interest);
+    expect(ois[0]).toBe(2_660_054_000_000);
+    expect(ois[1]).toBe(9_000_000);
+    // 0 values last
+    expect(ois[ois.length - 1]).toBe(0);
+  });
+
+  it("sort=oi result differs from DB order (regression guard)", () => {
+    const original = MARKETS.map((m) => m.symbol);
+    const sorted = applySort(MARKETS, "oi").map((m) => m.symbol);
+    expect(sorted).not.toEqual(original);
+  });
+
+  it("sort=oi is always DESC regardless of ?order= param", () => {
+    const asc = applySort(MARKETS, "oi", "asc");
+    const desc = applySort(MARKETS, "oi", "desc");
+    // Named alias forces DESC; ?order= param ignored for named aliases
+    expect(asc.map((m) => m.total_open_interest)).toEqual(desc.map((m) => m.total_open_interest));
+    expect(asc[0].total_open_interest).toBe(2_660_054_000_000);
+  });
+});
+
+describe("GH#1566 sort=volume", () => {
+  it("sorts by volume_24h DESC (highest volume first)", () => {
+    const result = applySort(MARKETS, "volume");
+    const vols = result.map((m) => m.volume_24h);
+    expect(vols[0]).toBe(999_999_999);
+    expect(vols[1]).toBe(1_000);
+    expect(vols[2]).toBe(500);
+    expect(vols[3]).toBe(0);
+  });
+
+  it("sort=volume result differs from DB order (regression guard)", () => {
+    const original = MARKETS.map((m) => m.symbol);
+    const sorted = applySort(MARKETS, "volume").map((m) => m.symbol);
+    expect(sorted).not.toEqual(original);
+  });
+});
+
+describe("GH#1566 sort=health", () => {
+  it("sorts by health level ascending: healthy < caution < warning < empty", () => {
+    const result = applySort(MARKETS, "health");
+    const levels = result.map((m) => {
+      const h = computeMarketHealthFromStats({
+        total_open_interest: m.total_open_interest as number | null,
+        open_interest_long: m.open_interest_long as number | null,
+        open_interest_short: m.open_interest_short as number | null,
+        insurance_balance: m.insurance_balance as number | null,
+        c_tot: m.c_tot as number | null,
+        vault_balance: m.vault_balance as number | null,
+        total_accounts: m.total_accounts as number | null,
+      });
+      return h.level;
+    });
+    // DDD: oi=0, capital>0 → healthy; AAA: oi>0, capital>0 → healthy
+    // CCC: oi>0, capital=0 → warning; BBB: all 0 → empty
+    const rankOrdered = levels.map((l) => HEALTH_ORDER[l] ?? 5);
+    for (let i = 0; i < rankOrdered.length - 1; i++) {
+      expect(rankOrdered[i]).toBeLessThanOrEqual(rankOrdered[i + 1]);
+    }
+  });
+
+  it("sort=health DESC reverses order (worst health first)", () => {
+    const asc = applySort(MARKETS, "health", "asc");
+    const desc = applySort(MARKETS, "health", "desc");
+    expect(asc.map((m) => m.symbol)).not.toEqual(desc.map((m) => m.symbol));
+    // Last in asc == first in desc
+    const ascSymbols = asc.map((m) => m.symbol);
+    const descSymbols = desc.map((m) => m.symbol);
+    expect(descSymbols[0]).toBe(ascSymbols[ascSymbols.length - 1]);
+  });
+});
+
+describe("GH#1566 sort=recent (regression guard — was fixed in PR#1557)", () => {
+  const DATED = [
+    { symbol: "OLD", total_open_interest: 0, volume_24h: 0, vault_balance: 0, total_accounts: 0, c_tot: 0, insurance_balance: 0, created_at: "2026-01-01T00:00:00Z" },
+    { symbol: "MID", total_open_interest: 0, volume_24h: 0, vault_balance: 0, total_accounts: 0, c_tot: 0, insurance_balance: 0, created_at: "2026-02-15T00:00:00Z" },
+    { symbol: "NEW", total_open_interest: 0, volume_24h: 0, vault_balance: 0, total_accounts: 0, c_tot: 0, insurance_balance: 0, created_at: "2026-03-22T00:00:00Z" },
+  ] as Record<string, unknown>[];
+
+  it("sort=recent still returns newest-first", () => {
+    const result = applySort(DATED, "recent");
+    expect(result[0].symbol).toBe("NEW");
+    expect(result[result.length - 1].symbol).toBe("OLD");
+  });
+});
+
+describe("GH#1566 bogus sort param (no regression)", () => {
+  it("unknown sort param returns original order unchanged", () => {
+    const original = MARKETS.map((m) => m.symbol);
+    const result = applySort(MARKETS, "bogus_field");
+    expect(result.map((m) => m.symbol)).toEqual(original);
+  });
+
+  it("null sort param returns original order unchanged", () => {
+    const original = MARKETS.map((m) => m.symbol);
+    const result = applySort(MARKETS, null);
+    expect(result.map((m) => m.symbol)).toEqual(original);
+  });
+});

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -8,6 +8,7 @@ import { getConfig } from "@/lib/config";
 import * as Sentry from "@sentry/nextjs";
 import { isSaneMarketValue, isActiveMarket, isZombieMarket } from "@/lib/activeMarketFilter";
 import { isPhantomOpenInterest } from "@/lib/phantom-oi";
+import { computeMarketHealthFromStats } from "@/lib/health";
 import { BLOCKED_SLAB_ADDRESSES } from "@/lib/blocklist";
 import { SLUG_ALIASES } from "@/lib/symbol-utils";
 
@@ -415,23 +416,66 @@ export async function GET(request: NextRequest) {
     // the "recent" value (not in SORTABLE_FIELDS), returning unsorted DB order.
     // Map "recent" → created_at with forced DESC direction so API consumers and the
     // frontend server-side path both return newest-first.
-    const effectiveSortParam = sortParam === "recent" ? "created_at" : sortParam;
-    const effectiveSortDir = sortParam === "recent" ? -1 : sortDir; // recent always DESC
+    //
+    // GH#1566: sort=oi and sort=volume are named aliases matching the frontend SortKey enum.
+    // Previously these fell through to no-sort (not in SORTABLE_FIELDS), returning DB order.
+    // - "oi"     → total_open_interest DESC (raw atom count; USD not reliable on devnet)
+    // - "volume" → volume_24h DESC
+    // - "health" → computed health level numeric sort via computeMarketHealthFromStats
+    //              (healthy=0 < caution=1 < warning=2 < empty=3), ascending by default
+    const NAMED_SORT_ALIASES: Record<string, { field: string; dir: number } | "health"> = {
+      recent: { field: "created_at", dir: -1 },
+      oi: { field: "total_open_interest", dir: -1 },
+      volume: { field: "volume_24h", dir: -1 },
+      health: "health",
+    };
+    const namedAlias = sortParam ? NAMED_SORT_ALIASES[sortParam] : undefined;
+    const effectiveSortParam =
+      namedAlias && namedAlias !== "health"
+        ? namedAlias.field
+        : sortParam === "recent" ? "created_at" : sortParam; // backward-compat fallback
+    const effectiveSortDir =
+      namedAlias && namedAlias !== "health"
+        ? namedAlias.dir
+        : sortParam === "recent" ? -1 : sortDir;
+
+    // Health sort uses a computed level rank, not a raw field value.
+    const HEALTH_ORDER: Record<string, number> = { healthy: 0, caution: 1, warning: 2, empty: 3 };
+    const healthRank = (m: Record<string, unknown>): number => {
+      const h = computeMarketHealthFromStats({
+        total_open_interest: m.total_open_interest as number | null,
+        open_interest_long: m.open_interest_long as number | null,
+        open_interest_short: m.open_interest_short as number | null,
+        insurance_balance: m.insurance_balance as number | null,
+        insurance_fund: m.insurance_fund as number | null,
+        c_tot: m.c_tot as number | null,
+        vault_balance: m.vault_balance as number | null,
+        total_accounts: m.total_accounts as number | null,
+      });
+      return HEALTH_ORDER[h.level] ?? 5;
+    };
+
     const sorted =
-      effectiveSortParam && SORTABLE_FIELDS.has(effectiveSortParam)
+      namedAlias === "health"
         ? [...oracleModeFiltered].sort((a, b) => {
-            const av = (a as Record<string, unknown>)[effectiveSortParam] ?? null;
-            const bv = (b as Record<string, unknown>)[effectiveSortParam] ?? null;
-            // Nulls last regardless of order direction.
-            if (av === null && bv === null) return 0;
-            if (av === null) return 1;
-            if (bv === null) return -1;
-            if (typeof av === "string" && typeof bv === "string") {
-              return effectiveSortDir * av.localeCompare(bv);
-            }
-            return effectiveSortDir * ((av as number) - (bv as number));
+            const ra = healthRank(a as Record<string, unknown>);
+            const rb = healthRank(b as Record<string, unknown>);
+            return sortDir * (ra - rb);
           })
-        : oracleModeFiltered;
+        : effectiveSortParam && SORTABLE_FIELDS.has(effectiveSortParam)
+          ? [...oracleModeFiltered].sort((a, b) => {
+              const av = (a as Record<string, unknown>)[effectiveSortParam] ?? null;
+              const bv = (b as Record<string, unknown>)[effectiveSortParam] ?? null;
+              // Nulls last regardless of order direction.
+              if (av === null && bv === null) return 0;
+              if (av === null) return 1;
+              if (bv === null) return -1;
+              if (typeof av === "string" && typeof bv === "string") {
+                return effectiveSortDir * av.localeCompare(bv);
+              }
+              return effectiveSortDir * ((av as number) - (bv as number));
+            })
+          : oracleModeFiltered;
 
     // GH#1348: Respect ?limit= query param to avoid returning 100+ markets
     // GH#1490: Validate limit (must be 1–500) and offset (must be >= 0) using


### PR DESCRIPTION
## Problem

`sort=oi`, `sort=volume`, and `sort=health` in `/api/markets` returned markets in arbitrary DB insertion order. The frontend markets page uses these exact sort keys (defined in `SortKey` type), so sorting via the API was silently broken.

Example from QA: market `2VqYNj8G` (OI=2.66T, highest) was appearing at position 84/168 with `sort=oi`.

## Root Cause

These named keys weren't in `SORTABLE_FIELDS` and had no alias mapping, so they fell through to the `oracleModeFiltered` no-sort branch. Same bug as `sort=recent` (fixed in PR #1557 via the `recent → created_at` alias).

## Fix

Introduce `NAMED_SORT_ALIASES` map following the same pattern as the `sort=recent` fix:

| sort param | maps to | direction |
|---|---|---|
| `oi` | `total_open_interest` | DESC |
| `volume` | `volume_24h` | DESC |
| `health` | `computeMarketHealthFromStats` rank | ASC (healthy=0, caution=1, warning=2, empty=3) |
| `recent` | `created_at` | DESC (now unified under alias map) |

Named aliases always use their forced direction (DESC for oi/volume/recent, rank ASC for health) — the `?order=` param is ignored for these aliases, matching frontend behaviour.

Health sort uses `computeMarketHealthFromStats` — same function the frontend uses client-side — ensuring API and UI ordering are consistent.

## Tests

10 new tests in `markets-sort-named-aliases.test.ts`:
- `sort=oi` → highest OI first, differs from DB order
- `sort=volume` → highest volume first, differs from DB order  
- `sort=health` → healthy < caution < warning < empty; DESC reverses
- `sort=recent` regression guard (was fixed in PR#1557)
- bogus/null sort param → original order unchanged

**1392 tests pass** (10 new added from 1382).

Fixes #1566

Filed by: QA Sieve

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Markets API now supports sorting by health status (with ascending/descending options), open interest (OI), and 24-hour trading volume. Open interest and volume sorting default to descending order.

* **Tests**
  * Added comprehensive test coverage for market sort alias handling and sorting behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->