### PR TITLE
fix(GH#1568, GH#1571): portfolio LP value display consistency + airdrop env var alignment

### DIFF
--- a/app/app/api/airdrop/route.ts
+++ b/app/app/api/airdrop/route.ts
@@ -26,7 +26,10 @@ import * as Sentry from "@sentry/nextjs";
 
 export const dynamic = "force-dynamic";
 
-const NETWORK = process.env.NEXT_PUBLIC_SOLANA_NETWORK;
+// GH#1571: align with canonical env var (NEXT_PUBLIC_DEFAULT_NETWORK), fallback to legacy name
+const NETWORK =
+  process.env.NEXT_PUBLIC_DEFAULT_NETWORK?.trim() ??
+  process.env.NEXT_PUBLIC_SOLANA_NETWORK?.trim();
 const AIRDROP_USD_VALUE = 500;
 const RATE_LIMIT_HOURS = 24;
 

--- a/app/app/portfolio/page.tsx
+++ b/app/app/portfolio/page.tsx
@@ -155,7 +155,7 @@ export default function PortfolioPage() {
               },
               {
                 label: "LP Value",
-                value: !walletConnected ? "—" : lpPositions.loading ? "\u2026" : `$${lpPositions.totalRedeemable.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
+                value: !walletConnected ? "—" : lpPositions.loading ? "\u2026" : lpPositions.totalRedeemable.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 2 }),
                 color: !walletConnected ? "text-white/40" : lpPositions.totalRedeemable > 0 ? "text-[var(--cyan)]" : "text-[var(--text-dim)]",
                 sub: walletConnected && lpPositions.positions.length > 0
                   ? `${lpPositions.positions.length} pool${lpPositions.positions.length > 1 ? "s" : ""}`


### PR DESCRIPTION
## Summary
Two cosmetic/mainnet-readiness fixes bundled together.

### GH#1568 — Portfolio LP Value display inconsistency
**Problem:** LP Value stat showed `$0.00` (dollar sign + 2 decimals) while Portfolio Value and Total Deposited showed bare `0`. Inconsistent formatting confuses users.
**Fix:** Removed `$` prefix and changed `minimumFractionDigits: 2` → `minimumFractionDigits: 0` so all monetary stat cards render `0` when zero.

### GH#1571 — /api/airdrop uses legacy env var
**Problem:** `/api/airdrop` read `NEXT_PUBLIC_SOLANA_NETWORK` (legacy) instead of `NEXT_PUBLIC_DEFAULT_NETWORK` (canonical). All other devnet-guarded routes already migrated in GH#1380/PR#1379.
**Fix:** Align with same pattern: read `NEXT_PUBLIC_DEFAULT_NETWORK` first, fall back to legacy.

## Testing
- TypeScript: `pnpm tsc --noEmit` ✅ (no errors)
- Full test suite: 74 tests passing ✅
- Visual: zero-value wallet renders LP Value as `0` matching Portfolio Value / Total Deposited

## Files Changed
- `app/app/portfolio/page.tsx` — LP Value stat card value formatter
- `app/app/api/airdrop/route.ts` — NETWORK env var alignment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated decimal formatting in LP Value display for portfolio balances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->