### PR TITLE
fix(GH#1572,GH#1573,GH#1574): mainnet leaderboard copy/decimals + prices network guard

### DIFF
--- a/app/app/api/prices/route.ts
+++ b/app/app/api/prices/route.ts
@@ -25,10 +25,23 @@ export const dynamic = "force-dynamic";
  *     }
  *   }
  *
- * Security note: this route is BLOCKED from serving on mainnet.
- * The cluster guard sits in TraderFleetBot.start() upstream.
+ * Network: this route is restricted to devnet only.
+ * On mainnet, `market_stats` will contain mainnet oracle data — this guard
+ * prevents accidental serving of stale devnet prices on production.
  */
 export async function GET() {
+  // ── Network guard: devnet only (GH#1574) ───────────────────
+  const network =
+    process.env.NEXT_PUBLIC_DEFAULT_NETWORK?.trim() ??
+    process.env.NEXT_PUBLIC_SOLANA_NETWORK?.trim();
+  if (network === "mainnet-beta" || network === "mainnet") {
+    return NextResponse.json(
+      { error: "prices endpoint not available on mainnet" },
+      { status: 403 }
+    );
+  }
+
+
   try {
     // ── Primary: Supabase market_stats ─────────────────────────
     const db = getServiceClient();

--- a/app/app/leaderboard/page.tsx
+++ b/app/app/leaderboard/page.tsx
@@ -8,6 +8,13 @@ import { useWalletCompat } from "@/hooks/useWalletCompat";
 /** S2 devnet trading competition end: March 21, 2026 00:00 UTC */
 const COMPETITION_END = new Date("2026-03-21T00:00:00Z");
 
+/** True when deployed against mainnet-beta (GH#1572, GH#1573) */
+const IS_MAINNET =
+  process.env.NEXT_PUBLIC_DEFAULT_NETWORK?.trim() === "mainnet-beta" ||
+  process.env.NEXT_PUBLIC_DEFAULT_NETWORK?.trim() === "mainnet" ||
+  process.env.NEXT_PUBLIC_SOLANA_NETWORK?.trim() === "mainnet-beta" ||
+  process.env.NEXT_PUBLIC_SOLANA_NETWORK?.trim() === "mainnet";
+
 /* ── Types ────────────────────────────────────────────────── */
 interface LeaderboardEntry {
   rank: number;
@@ -61,10 +68,13 @@ function pad(n: number): string {
 }
 
 /** Format raw bigint volume as a compact human-readable string */
-/** Base-unit divisor: 9 decimal places matching devnet market collateral (PERC token).
- *  Previous value (10^6) was incorrect — caused volumes to display 1000x too high.
- *  TODO: fetch actual collateral decimals per-market for multi-collateral support. */
-const BASE_UNIT_DIVISOR = 1_000_000_000;
+/**
+ * Base-unit divisor for collateral decimals (GH#1573):
+ * - Mainnet: USDC (6 decimals) → 10^6
+ * - Devnet:  PERC token (9 decimals) → 10^9
+ * TODO: fetch actual collateral decimals per-market for multi-collateral support.
+ */
+const BASE_UNIT_DIVISOR = IS_MAINNET ? 1_000_000 : 1_000_000_000;
 
 function fmtVolume(raw: string): string {
   try {
@@ -246,17 +256,19 @@ function buildShareText(entry: LeaderboardEntry): string {
   const medal = RANK_MEDALS[entry.rank];
   const rankStr = medal ? `${medal} #${entry.rank}` : `#${entry.rank}`;
   const vol = fmtVolume(entry.totalVolume);
+  const network = IS_MAINNET ? "mainnet" : "devnet";
   return (
-    `I'm ${rankStr} on the @percolatorlaunch devnet leaderboard with ${vol} volume!\n\n` +
-    `S2 devnet competition ends Mar 21 — top traders get beta access 🚀\n\n` +
+    `I'm ${rankStr} on the @percolatorlaunch ${network} leaderboard with ${vol} volume!\n\n` +
+    `Permissionless perps on Solana — join the beta 🚀\n\n` +
     LEADERBOARD_URL
   );
 }
 
 function buildGenericShareText(): string {
+  const network = IS_MAINNET ? "mainnet" : "devnet";
   return (
-    `Check out the @percolatorlaunch devnet trading competition!\n\n` +
-    `Permissionless perps on Solana — top traders get beta access 🚀\n\n` +
+    `Check out the @percolatorlaunch ${network} trading leaderboard!\n\n` +
+    `Permissionless perps on Solana — join the beta 🚀\n\n` +
     LEADERBOARD_URL
   );
 }
@@ -476,24 +488,30 @@ export default function LeaderboardPage() {
             >
               Leaderboard
             </h1>
-            <span
-              className="text-xs font-mono px-2 py-0.5 rounded-sm border"
-              style={{
-                color: "var(--accent)",
-                borderColor: "var(--accent)",
-                background: "rgba(153,69,255,0.07)",
-              }}
-            >
-              DEVNET
-            </span>
+            {/* Network badge: hidden on mainnet (GH#1572) */}
+            {!IS_MAINNET && (
+              <span
+                className="text-xs font-mono px-2 py-0.5 rounded-sm border"
+                style={{
+                  color: "var(--accent)",
+                  borderColor: "var(--accent)",
+                  background: "rgba(153,69,255,0.07)",
+                }}
+              >
+                DEVNET
+              </span>
+            )}
           </div>
           <p style={{ color: "var(--text-secondary)" }} className="text-sm font-mono">
-            Top traders by trade volume on the Percolator devnet (trade count as tiebreaker)
+            {IS_MAINNET
+              ? "Top traders by volume on Percolator (trade count as tiebreaker)"
+              : "Top traders by trade volume on the Percolator devnet (trade count as tiebreaker)"}
           </p>
         </div>
 
         {/* ── Competition Banner ──────────────────────────────────── */}
-        <CompetitionBanner />
+        {/* S2 devnet competition banner: only shown on devnet (GH#1572) */}
+        {!IS_MAINNET && <CompetitionBanner />}
 
         {/* ── Period Switcher ─────────────────────────────────────── */}
         <div className="flex gap-1 mb-6">
@@ -704,7 +722,9 @@ export default function LeaderboardPage() {
                 Want to climb the board?
               </p>
               <p className="text-xs font-mono" style={{ color: "var(--text-secondary)" }}>
-                Get free devnet tokens and start trading across 126+ markets.
+                {IS_MAINNET
+                  ? "Start trading permissionless perps across 126+ markets."
+                  : "Get free devnet tokens and start trading across 126+ markets."}
               </p>
             </div>
             <div className="flex items-center gap-2 shrink-0">
@@ -728,8 +748,9 @@ export default function LeaderboardPage() {
                   SHARE 𝕏
                 </button>
               )}
+              {/* On mainnet link to trade; on devnet link to faucet (GH#1572) */}
               <Link
-                href="/devnet-mint"
+                href={IS_MAINNET ? "/trade" : "/devnet-mint"}
                 className="shrink-0 px-4 py-2 text-xs font-mono font-semibold tracking-wide transition-all"
                 style={{
                   background: "var(--accent)",
@@ -737,7 +758,7 @@ export default function LeaderboardPage() {
                   border: "1px solid var(--accent)",
                 }}
               >
-                GET TOKENS →
+                {IS_MAINNET ? "TRADE NOW →" : "GET TOKENS →"}
               </Link>
             </div>
           </div>


### PR DESCRIPTION
## Summary

Addresses three mainnet-readiness issues flagged by PM:

### GH#1574 — /api/prices network guard
- Adds a runtime guard: returns **403** when `NEXT_PUBLIC_DEFAULT_NETWORK` is `mainnet-beta` or `mainnet`
- Replaces the misleading comment claiming the guard existed in TraderFleetBot upstream
- Prevents stale devnet oracle prices from being served on production

### GH#1573 — Leaderboard collateral decimals
- `BASE_UNIT_DIVISOR` is now dynamic: **10^6** on mainnet (USDC), **10^9** on devnet (PERC)
- Eliminates the 1000x volume display error that would break the leaderboard on mainnet
- TODO comment preserved for future per-market collateral decimal fetching

### GH#1572 — Leaderboard stale devnet copy
- `DEVNET` badge hidden on mainnet
- Page subtitle updated for mainnet context
- S2 devnet competition banner suppressed on mainnet (competition ended Mar 21)
- Share text removes expired 'S2 devnet competition ends Mar 21' copy; network-aware text instead
- CTA on mainnet: links to `/trade` (not `/devnet-mint`), shows `TRADE NOW`

All changes gated on `IS_MAINNET` constant derived from existing `NEXT_PUBLIC_DEFAULT_NETWORK` env var — zero breaking changes on devnet.

## Testing
- 111 unit tests pass, 0 failures
- TypeScript: clean (no errors)

## Note on GH#1570 (matcher deploy)
This is DevOps infra — the program needs deployment to mainnet. Coder cannot unblock this alone. PM/DevOps action required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Network-specific experiences: leaderboard and navigation adapt for mainnet and devnet environments
  * Conditional display of badges, banners, and messaging based on active network
  * Updated call-to-action buttons and links with network-appropriate destinations

* **Chores**
  * Implemented environment detection for consistent cross-network behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->