### PR TITLE
fix(GH#1583): auto-refill mint authority SOL before ATA creation

### DIFF
--- a/app/app/api/airdrop/route.ts
+++ b/app/app/api/airdrop/route.ts
@@ -11,6 +11,7 @@ import { NextRequest, NextResponse } from "next/server";
 import {
   Connection,
   Keypair,
+  LAMPORTS_PER_SOL,
   PublicKey,
   Transaction,
   sendAndConfirmTransaction,
@@ -156,6 +157,33 @@ export async function POST(req: NextRequest) {
 
     const cfg = getConfig();
     const connection = new Connection(cfg.rpcUrl, "confirmed");
+
+    // GH#1583: Ensure mint authority has enough SOL to create ATAs (~0.002 SOL each).
+    // Auto-request devnet airdrop if balance is below threshold.
+    // Threshold: 0.01 SOL (covers ~5 ATA creations with headroom for tx fees).
+    const MIN_SOL_THRESHOLD = 0.01 * LAMPORTS_PER_SOL;
+    const REFILL_SOL = 2; // lamports requested per airdrop call (devnet only)
+    try {
+      const mintAuthBalance = await connection.getBalance(mintAuthority.publicKey);
+      if (mintAuthBalance < MIN_SOL_THRESHOLD) {
+        console.warn(
+          `airdrop: mint authority balance low (${mintAuthBalance} lamports). Requesting devnet airdrop...`,
+        );
+        // requestAirdrop is fire-and-confirm; if rate-limited this throws but we continue anyway
+        const sig = await connection.requestAirdrop(
+          mintAuthority.publicKey,
+          REFILL_SOL * LAMPORTS_PER_SOL,
+        );
+        await connection.confirmTransaction(sig, "confirmed");
+        console.info(`airdrop: mint authority refilled. sig=${sig}`);
+      }
+    } catch (refillErr) {
+      // Non-fatal: devnet faucet may be rate-limited. Log and continue; the main tx will
+      // fail with a clear lamport error if balance truly insufficient.
+      console.warn(
+        `airdrop: could not auto-refill mint authority: ${refillErr instanceof Error ? refillErr.message : refillErr}`,
+      );
+    }
 
     // Calculate airdrop amount
     const decimals = 6; // Standard for devnet mirrors


### PR DESCRIPTION
## Problem
The `/api/airdrop` endpoint was failing with:
```
Transfer: insufficient lamports 974840, need 2039280
```
The server-side mint authority keypair (GRMMNsNPM1GbgxFh3S34f3jvUX6jPbPiH3oxopnDFiWM) had only ~0.001 SOL on devnet. Creating an ATA requires ~2,039,280 lamports (~0.002 SOL) and the balance was below that.

## Fix
- Before submitting the ATA-creation + mint transaction, check the mint authority's balance
- If below **0.01 SOL** threshold, automatically call `connection.requestAirdrop(2 SOL)` and confirm it
- Auto-refill is **non-fatal**: if the devnet faucet is rate-limited, we log a warning and continue (the original error will surface if balance is truly insufficient)
- Added `LAMPORTS_PER_SOL` import for clean arithmetic

## Testing
- All 1399 existing tests pass (112 test files, 0 failures)
- Manual: devnet airdrop CLI rate-limited, so this fix allows the endpoint to self-heal on the next request

## Notes
- DevOps can also transfer from crank wallet (2JaSzRYrf44fPpQBtRJfnCEgThwCmvpFd3FCXi45VXxm, 0.039 SOL) as belt-and-suspenders
- The `REFILL_SOL = 2` constant requests 2 SOL per refill, which covers ~1000 ATA creations before needing another refill

Closes #1583

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic balance verification and refill mechanism for the airdrop endpoint. If the designated wallet's balance falls below threshold, the system attempts automatic top-up on devnet. Refill failures are handled gracefully without interrupting transaction flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->