### PR TITLE
fix(GH#1594): total_open_interest_usd null for 63 zero-OI markets

### DIFF
--- a/app/__tests__/api/gh1578-zero-oi-volume-usd.test.ts
+++ b/app/__tests__/api/gh1578-zero-oi-volume-usd.test.ts
@@ -139,6 +139,23 @@ describe("GH#1578: zero OI/volume → USD should be 0, not null", () => {
     expect(market.volume_24h_usd).toBe(0);
   });
 
+  it("GH#1594: returns 0 OI when total_open_interest is null but long+short are both 0", async () => {
+    // 63 markets had null total_open_interest_usd because the combined fallback
+    // path returned null for combined=0 (isSaneMarketValue(0) === false)
+    mockRows = [makeZeroOiMarket({
+      total_open_interest: null,  // not indexed yet
+      open_interest_long: "0",
+      open_interest_short: "0",
+      total_accounts: "5",
+      vault_balance: "5000000",
+    })];
+    const res = await GET(makeRequest());
+    const body = await res.json();
+    const market = body.markets?.[0];
+    expect(market).toBeDefined();
+    expect(market.total_open_interest_usd).toBe(0);
+  });
+
   it("preserves non-zero USD values for active markets", async () => {
     mockRows = [makeZeroOiMarket({
       total_open_interest: "1000000",

--- a/app/__tests__/api/markets-price-sanitize.test.ts
+++ b/app/__tests__/api/markets-price-sanitize.test.ts
@@ -217,7 +217,7 @@ describe("GET /api/markets — price sanitization (#856)", () => {
     const fallback = body.markets.find((m) => m.symbol === "FALLBACK");
 
     expect(norm?.total_open_interest_usd).toBeCloseTo(0.001, 6);   // 1000 / 1e6 * 1.0
-    expect(sentinel?.total_open_interest_usd).toBeNull();           // sentinel rejected
+    expect(sentinel?.total_open_interest_usd).toBe(0);              // GH#1594: sentinel primary rejected, but long=0+short=0 → valid zero OI
     expect(noprice?.total_open_interest_usd).toBeNull();            // no price
     expect(fallback?.total_open_interest_usd).toBeCloseTo(0.001, 6); // (600+400) / 1e6 * 1.0
   });

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -229,7 +229,8 @@ export async function GET(request: NextRequest) {
         : (() => {
             // total_open_interest was null or garbage → try long+short fallback
             const combined = (n_open_interest_long ?? 0) + (n_open_interest_short ?? 0);
-            return isSaneMarketValue(combined) ? combined : null;
+            // GH#1594: combined === 0 is valid (zero OI), same as primary path's n_total_open_interest === 0 guard
+            return combined === 0 || isSaneMarketValue(combined) ? combined : null;
           })();
       const total_open_interest_usd = rawToUsd(rawOi, n_decimals, sanitizedPrice);
 


### PR DESCRIPTION
## Problem
63 markets with zero OI show total_open_interest_usd: null instead of 0. Breaks sort=oi.

## Root Cause
Fallback path (long+short) missing combined===0 guard that primary path has.

## Fix
One-line: add combined === 0 || before isSaneMarketValue(combined) in fallback.

## Tests
- Added GH#1594 regression test
- Updated SENTINEL expectation (0 not null when long=0+short=0)
- 425/425 tests pass

Closes #1594

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved open interest data handling. The API now correctly calculates and displays zero open interest values in USD when combined long and short open interest positions equal zero, showing 0 instead of null. This ensures more accurate market data representation and better consistency in handling zero-value scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->