### PR TITLE
fix(GH#1595): TOCTOU race in faucet/auto-fund rate limiting

### DIFF
--- a/app/app/api/auto-fund/route.ts
+++ b/app/app/api/auto-fund/route.ts
@@ -21,6 +21,7 @@ import {
 import { getConfig } from "@/lib/config";
 import { getServiceClient } from "@/lib/supabase";
 import { getDevnetMintSigner } from "@/lib/devnet-signer";
+import { tryFaucetGate, releaseFaucetClaim } from "@/lib/faucet-rate-gate";
 import * as Sentry from "@sentry/nextjs";
 
 export const dynamic = "force-dynamic";
@@ -70,20 +71,13 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // Rate limit check via Supabase
+    // GH#1595: INSERT-as-gate rate limit — eliminates SELECT→INSERT TOCTOU window.
     const supabase = getServiceClient();
-    const cutoff = new Date(Date.now() - RATE_LIMIT_HOURS * 60 * 60 * 1000).toISOString();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { data: recent } = await (supabase as any)
-      .from("auto_fund_log")
-      .select("id")
-      .eq("wallet", walletAddress)
-      .gte("created_at", cutoff)
-      .limit(1);
+    const gate = await tryFaucetGate(supabase, walletAddress, "auto-fund");
 
-    if (recent && recent.length > 0) {
+    if (!gate.allowed) {
       return NextResponse.json(
-        { error: "Already funded in the last 24 hours", funded: false },
+        { error: "Already funded in the last 24 hours", funded: false, nextClaimAt: gate.nextClaimAt },
         { status: 429 },
       );
     }
@@ -181,7 +175,7 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    // Log the funding event
+    // Log the funding event (analytics — gate handles rate limiting)
     if (results.sol_airdropped || results.usdc_minted) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await (supabase as any).from("auto_fund_log").insert({
@@ -189,6 +183,9 @@ export async function POST(req: NextRequest) {
         sol_airdropped: results.sol_airdropped,
         usdc_minted: results.usdc_minted,
       });
+    } else {
+      // Nothing funded (already had sufficient balance) — release gate so user can retry
+      if (gate.claimId) await releaseFaucetClaim(supabase, gate.claimId);
     }
 
     return NextResponse.json({

--- a/app/app/api/faucet/route.ts
+++ b/app/app/api/faucet/route.ts
@@ -31,6 +31,7 @@ import {
 import { getConfig } from "@/lib/config";
 import { getServiceClient } from "@/lib/supabase";
 import { getDevnetMintSigner } from "@/lib/devnet-signer";
+import { tryFaucetGate, releaseFaucetClaim } from "@/lib/faucet-rate-gate";
 import * as Sentry from "@sentry/nextjs";
 
 export const dynamic = "force-dynamic";
@@ -87,35 +88,17 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // Rate limit check via Supabase — per wallet per type
+    // GH#1595: INSERT-as-gate rate limit — eliminates SELECT→INSERT TOCTOU window.
+    // Uses faucet_claims table with UNIQUE(wallet, fund_type).
     const supabase = getServiceClient();
-    const cutoff = new Date(
-      Date.now() - RATE_LIMIT_HOURS * 60 * 60 * 1000,
-    ).toISOString();
+    const gate = await tryFaucetGate(supabase, walletAddress, type);
 
-    const rateField = type === "sol" ? "sol_airdropped" : "usdc_minted";
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { data: recent } = await (supabase as any)
-      .from("auto_fund_log")
-      .select("id, created_at")
-      .eq("wallet", walletAddress)
-      .eq(rateField, true)
-      .gte("created_at", cutoff)
-      .order("created_at", { ascending: false })
-      .limit(1);
-
-    if (recent && recent.length > 0) {
-      const lastClaim = new Date(recent[0].created_at);
-      const nextClaimAt = new Date(
-        lastClaim.getTime() + RATE_LIMIT_HOURS * 60 * 60 * 1000,
-      ).toISOString();
-
+    if (!gate.allowed) {
       return NextResponse.json(
         {
           error: "Already claimed in the last 24 hours",
           funded: false,
-          nextClaimAt,
+          nextClaimAt: gate.nextClaimAt,
         },
         { status: 429 },
       );
@@ -141,7 +124,8 @@ export async function POST(req: NextRequest) {
         const isRateLimit =
           /429|too many requests|rate.?limit|airdrop.*limit|limit.*airdrop/i.test(msg);
         if (isRateLimit) {
-          // Do NOT capture rate-limit hits as Sentry exceptions — they're expected.
+          // GH#1595: release gate so user can retry after RPC rate limit clears
+          if (gate.claimId) await releaseFaucetClaim(supabase, gate.claimId);
           return NextResponse.json(
             {
               error:
@@ -152,10 +136,10 @@ export async function POST(req: NextRequest) {
           );
         }
         // GH#1392: Solana devnet returns "Internal error" for transient failures
-        // (throttling, recent airdrop, RPC overload). Return 503 so clients can retry.
         const isRetryable =
           /internal error|service unavailable|timeout|ECONNREFUSED/i.test(msg);
         if (isRetryable) {
+          if (gate.claimId) await releaseFaucetClaim(supabase, gate.claimId);
           return NextResponse.json(
             {
               error:
@@ -165,6 +149,7 @@ export async function POST(req: NextRequest) {
             { status: 503 },
           );
         }
+        if (gate.claimId) await releaseFaucetClaim(supabase, gate.claimId);
         Sentry.captureException(airdropErr, {
           tags: { endpoint: "/api/faucet", type: "sol" },
           extra: { walletAddress },
@@ -172,6 +157,7 @@ export async function POST(req: NextRequest) {
         return NextResponse.json({ error: msg }, { status: 500 });
       }
 
+      // GH#1595: claim already recorded by gate INSERT — also log to auto_fund_log for analytics
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await (supabase as any).from("auto_fund_log").insert({
         wallet: walletAddress,
@@ -199,6 +185,7 @@ export async function POST(req: NextRequest) {
       | undefined;
 
     if (!usdcMintAddr) {
+      if (gate.claimId) await releaseFaucetClaim(supabase, gate.claimId);
       return NextResponse.json(
         { error: "Test USDC mint not configured" },
         { status: 500 },
@@ -210,6 +197,7 @@ export async function POST(req: NextRequest) {
     // Load sealed mint authority signer (GH#1382: replaces raw Keypair.fromSecretKey)
     const mintSigner = getDevnetMintSigner();
     if (!mintSigner) {
+      if (gate.claimId) await releaseFaucetClaim(supabase, gate.claimId);
       return NextResponse.json(
         { error: "Server not configured for minting (DEVNET_MINT_AUTHORITY_KEYPAIR missing)" },
         { status: 500 },
@@ -225,6 +213,7 @@ export async function POST(req: NextRequest) {
     try {
       const mintInfo = await connection.getAccountInfo(usdcMint);
       if (!mintInfo) {
+        if (gate.claimId) await releaseFaucetClaim(supabase, gate.claimId);
         return NextResponse.json(
           { error: `Test USDC mint ${usdcMintAddr} does not exist on devnet` },
           { status: 500 },
@@ -236,6 +225,7 @@ export async function POST(req: NextRequest) {
         const hasAuthority =
           new DataView(mintData.buffer, mintData.byteOffset).getUint32(0, true) === 1;
         if (!hasAuthority) {
+          if (gate.claimId) await releaseFaucetClaim(supabase, gate.claimId);
           return NextResponse.json(
             { error: "Test USDC mint has no mint authority (fixed supply)" },
             { status: 500 },
@@ -249,6 +239,7 @@ export async function POST(req: NextRequest) {
             ),
             { tags: { endpoint: "/api/faucet", step: "authority_check" } },
           );
+          if (gate.claimId) await releaseFaucetClaim(supabase, gate.claimId);
           return NextResponse.json(
             {
               error:
@@ -269,6 +260,7 @@ export async function POST(req: NextRequest) {
         tags: { endpoint: "/api/faucet", step: "authority_check" },
         extra: { walletAddress },
       });
+      if (gate.claimId) await releaseFaucetClaim(supabase, gate.claimId);
       return NextResponse.json(
         { error: "Could not verify mint authority due to RPC error. Please retry.", retryable: true },
         { status: 503 },
@@ -344,7 +336,6 @@ export async function POST(req: NextRequest) {
     Sentry.captureException(error, {
       tags: { endpoint: "/api/faucet", method: "POST" },
     });
-    // GH#1474: ensure error is never empty string — fall back to toString() or generic message
     const errorMsg =
       error instanceof Error
         ? error.message || error.toString() || "Internal server error"

--- a/app/lib/faucet-rate-gate.ts
+++ b/app/lib/faucet-rate-gate.ts
@@ -1,0 +1,83 @@
+/**
+ * GH#1595: INSERT-as-gate rate limiter for faucet + auto-fund.
+ *
+ * Uses the `faucet_claims` table with UNIQUE(wallet, fund_type).
+ * Concurrent requests race on INSERT — exactly one wins, others get 23505.
+ * Eliminates the SELECT→INSERT TOCTOU window.
+ *
+ * Same pattern as tryAirdropClaimGate in /api/airdrop (PR #1587).
+ */
+
+const RATE_LIMIT_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+export interface GateResult {
+  allowed: boolean;
+  nextClaimAt: string | null;
+  claimId?: number;
+}
+
+/**
+ * Attempt to claim a faucet rate-limit slot.
+ *
+ * @param supabase  Service-role Supabase client
+ * @param wallet    Wallet address
+ * @param fundType  "sol" | "usdc" | "auto-fund"
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function tryFaucetGate(supabase: any, wallet: string, fundType: string): Promise<GateResult> {
+  const windowStart = new Date(Date.now() - RATE_LIMIT_MS).toISOString();
+
+  try {
+    // Step 1: Clear expired claim so unique slot is free for re-claim.
+    await supabase
+      .from("faucet_claims")
+      .delete()
+      .eq("wallet", wallet)
+      .eq("fund_type", fundType)
+      .lt("claimed_at", windowStart);
+
+    // Step 2: INSERT-as-gate — race winner records the claim; all others hit 23505.
+    const { data, error } = await supabase
+      .from("faucet_claims")
+      .insert({ wallet, fund_type: fundType, claimed_at: new Date().toISOString() })
+      .select("id, claimed_at")
+      .maybeSingle();
+
+    if (error) {
+      if (error.code === "23505") {
+        // Active claim within window — compute nextClaimAt from existing row.
+        const { data: existing } = await supabase
+          .from("faucet_claims")
+          .select("claimed_at")
+          .eq("wallet", wallet)
+          .eq("fund_type", fundType)
+          .maybeSingle();
+
+        const nextClaimAt = existing
+          ? new Date(new Date(existing.claimed_at as string).getTime() + RATE_LIMIT_MS).toISOString()
+          : null;
+        return { allowed: false, nextClaimAt };
+      }
+
+      // Unexpected DB error — fail open (devnet-only, don't block users)
+      console.warn(`[faucet-gate] INSERT error (code=${error.code}): ${error.message}`);
+      return { allowed: true, nextClaimAt: null };
+    }
+
+    return { allowed: true, nextClaimAt: null, claimId: (data as { id: number } | null)?.id };
+  } catch (err) {
+    console.warn("[faucet-gate] threw:", err instanceof Error ? err.message : String(err));
+    return { allowed: true, nextClaimAt: null };
+  }
+}
+
+/**
+ * Release a faucet claim slot (on mint failure so user isn't locked out).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function releaseFaucetClaim(supabase: any, claimId: number): Promise<void> {
+  const { error } = await supabase.from("faucet_claims").delete().eq("id", claimId);
+  if (error) {
+    console.warn(`[faucet-gate] release failed (id=${claimId}): ${error.message}`);
+  }
+}

--- a/supabase/migrations/20260323065800_faucet_claims_unique.sql
+++ b/supabase/migrations/20260323065800_faucet_claims_unique.sql
@@ -1,0 +1,26 @@
+-- GH#1595: TOCTOU fix for faucet/auto-fund rate limiting
+-- Creates a gate table with unique constraint on (wallet, fund_type)
+-- so concurrent requests race on INSERT (23505), not SELECT→INSERT.
+
+CREATE TABLE IF NOT EXISTS faucet_claims (
+  id BIGSERIAL PRIMARY KEY,
+  wallet TEXT NOT NULL,
+  fund_type TEXT NOT NULL,  -- 'sol', 'usdc', or 'auto-fund'
+  claimed_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- The gate: only one active claim per wallet+type at a time.
+-- DELETE expired rows before INSERT; race loser gets 23505.
+CREATE UNIQUE INDEX uq_faucet_claims_wallet_type
+  ON faucet_claims(wallet, fund_type);
+
+-- RLS: service role only
+ALTER TABLE faucet_claims ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "faucet_claims_service_all"
+  ON faucet_claims FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+COMMENT ON TABLE faucet_claims IS 'Rate-limit gate for devnet faucet + auto-fund. UNIQUE on (wallet, fund_type) prevents TOCTOU races.';


### PR DESCRIPTION
## Problem
/api/faucet and /api/auto-fund use SELECT→INSERT on auto_fund_log without unique constraint. Concurrent requests can bypass rate limiting (TOCTOU).

## Fix
Same pattern as PR #1587 (airdrop): INSERT-as-gate with UNIQUE constraint on faucet_claims(wallet, fund_type). Race loser gets Postgres 23505.

## Changes
- **Migration 20260323065800**: new faucet_claims table with UNIQUE(wallet, fund_type)
- **lib/faucet-rate-gate.ts**: shared tryFaucetGate + releaseFaucetClaim
- **/api/faucet**: uses gate for SOL and USDC paths; releases on failure
- **/api/auto-fund**: uses gate with 'auto-fund' type; releases when nothing funded

## DevOps
Apply migration 20260323065800 in Supabase after merge.

## Tests
424/424 pass

Closes #1595