### PR TITLE
fix(GH#1599): phantom OI guard suppressing total_open_interest_usd=0 for vault=0 markets

### DIFF
--- a/app/__tests__/api/gh1564-volume-oi-usd-null.test.ts
+++ b/app/__tests__/api/gh1564-volume-oi-usd-null.test.ts
@@ -132,18 +132,40 @@ describe("GH#1564: volume_24h_usd and total_open_interest_usd when Supabase retu
     expect(market.total_open_interest_usd).toBeNull();
   });
 
-  it("returns null total_open_interest_usd for phantom OI market (total_accounts=0, vault<1M)", async () => {
+  it("returns null total_open_interest_usd for phantom OI market (total_accounts=0, vault<1M, non-zero OI)", async () => {
     mockRows = [makeMarket({
       total_accounts: "0",
       vault_balance: "0",
       c_tot: "0",
+      // total_open_interest retains default non-zero value (1500000000)
     })];
     const res = await GET(makeRequest({ include_zombie: "true" }));
     const body = await res.json();
     const market = body.markets[0];
 
-    // Phantom OI guard: total_accounts=0 → displayOiUsd = null
+    // Phantom OI guard fires when OI is non-zero but vault/accounts indicate no real positions.
     expect(market.total_open_interest_usd).toBeNull();
+  });
+
+  it("GH#1599: returns total_open_interest_usd=0 (not null) for vault=0 market with zero OI and valid price", async () => {
+    // Pattern: vault_balance=0 + total_open_interest=0 + last_price set.
+    // Before fix: isPhantomOI fired unconditionally → displayOiUsd=null even though OI is genuinely 0.
+    // After fix: phantom guard only suppresses non-zero OI. Zero OI → total_open_interest_usd=0.
+    mockRows = [makeMarket({
+      total_accounts: "0",
+      vault_balance: "0",
+      total_open_interest: "0",
+      open_interest_long: "0",
+      open_interest_short: "0",
+      c_tot: "0",
+      last_price: "1.50", // valid price — ensures the null wasn't from missing price
+    })];
+    const res = await GET(makeRequest({ include_zombie: "true" }));
+    const body = await res.json();
+    const market = body.markets[0];
+
+    expect(market.total_open_interest_usd).toBe(0);
+    expect(market.total_open_interest).toBe(0);
   });
 
   it("correctly computes USD fields for multiple markets with string NUMERIC fields", async () => {

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -255,7 +255,12 @@ export async function GET(request: NextRequest) {
       const accountsCount = n_total_accounts ?? 0;
       const vaultBal = n_vault_balance ?? 0;
       const isPhantomOI = isPhantomOpenInterest(accountsCount, vaultBal);
-      const displayOiUsd = isPhantomOI ? null : total_open_interest_usd;
+      // GH#1599: Phantom OI guard only suppresses non-zero OI (positions without real backing).
+      // When total_open_interest_usd === 0, the market genuinely has zero OI — returning 0 is
+      // correct regardless of vault_balance. Vault=0 markets with OI=0 were returning null due
+      // to the phantom guard, bypassing the combined===0 fix from GH#1594. Fix: only apply
+      // isPhantomOI suppression when there is actually non-zero OI to suppress.
+      const displayOiUsd = (isPhantomOI && total_open_interest_usd !== 0) ? null : total_open_interest_usd;
 
       // GH#1270: Pre-compute volume_24h in USD so consumers (e.g. Watchlist) don't need
       // to divide by 10^decimals manually. Mirrors the total_open_interest_usd pattern.


### PR DESCRIPTION
## Summary

Fixes GH#1599 — follow-up to PR #1596.

**Root cause:** `isPhantomOI` guard was unconditionally nulling `total_open_interest_usd` for vault=0 markets, overriding the GH#1594 combined===0 fix. The phantom guard is designed to suppress non-zero phantom OI, but was incorrectly firing on zero-OI markets too.

**Fix:** phantom guard only applies when `total_open_interest_usd !== 0`. vault=0 + OI=0 + valid price now correctly returns `total_open_interest_usd=0`.

## Testing
- 426 API tests pass including new regression test
- Regression test covers: vault=0 + OI=0 + valid price → expect USD=0

## Evidence of Bug (production, 08:18 UTC 2026-03-23)
- 14/20 sampled markets returning `total_open_interest_usd: null` despite having valid price and zero OI
- Affects markets with vault_balance=0: WENDYS, B43WXDGU, BnPwCr57, SIEVE, DARK etc.

Closes #1599

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed incorrect null values displayed for open interest USD in markets with zero open interest. Markets now correctly show 0 instead of null when there is genuine zero open interest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->