### PR TITLE
fix(markets): zero-OI markets with vault=0 return 0 not null (GH#1599)

### DIFF
--- a/app/__tests__/api/gh1599-zero-oi-zero-vault.test.ts
+++ b/app/__tests__/api/gh1599-zero-oi-zero-vault.test.ts
@@ -4,17 +4,12 @@
  *
  * The phantom OI guard (isPhantomOpenInterest) suppresses *positive* OI when
  * vault < MIN_VAULT_FOR_OI, but zero OI is always valid — it means "no positions".
+ *
+ * This test exercises the shared computeDisplayOiUsd helper used by the markets
+ * route so that route regressions are caught via a single source of truth.
  */
 import { describe, it, expect } from "vitest";
-
-// Inline the logic from route.ts to unit-test the displayOiUsd derivation
-function computeDisplayOiUsd(
-  totalOpenInterestUsd: number | null,
-  isPhantom: boolean,
-): number | null {
-  // GH#1599 fix: zero OI is always valid regardless of phantom status
-  return totalOpenInterestUsd === 0 ? 0 : (isPhantom ? null : totalOpenInterestUsd);
-}
+import { computeDisplayOiUsd } from "@/lib/oi-display";
 
 describe("GH#1599 — zero OI with zero vault", () => {
   it("returns 0 for zero-OI market with vault=0 (previously null)", () => {

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -8,6 +8,7 @@ import { getConfig } from "@/lib/config";
 import * as Sentry from "@sentry/nextjs";
 import { isSaneMarketValue, isActiveMarket, isZombieMarket } from "@/lib/activeMarketFilter";
 import { isPhantomOpenInterest } from "@/lib/phantom-oi";
+import { computeDisplayOiUsd } from "@/lib/oi-display";
 import { computeMarketHealthFromStats } from "@/lib/health";
 import { BLOCKED_SLAB_ADDRESSES } from "@/lib/blocklist";
 import { SLUG_ALIASES } from "@/lib/symbol-utils";
@@ -258,7 +259,7 @@ export async function GET(request: NextRequest) {
       // GH#1599: When OI is genuinely 0, display 0 regardless of phantom status.
       // The phantom guard only suppresses *positive* OI values that are stale/orphaned
       // (no vault backing). Zero OI is always valid — it means "no positions".
-      const displayOiUsd = total_open_interest_usd === 0 ? 0 : (isPhantomOI ? null : total_open_interest_usd);
+      const displayOiUsd = computeDisplayOiUsd(total_open_interest_usd, isPhantomOI);
 
       // GH#1270: Pre-compute volume_24h in USD so consumers (e.g. Watchlist) don't need
       // to divide by 10^decimals manually. Mirrors the total_open_interest_usd pattern.

--- a/app/lib/oi-display.ts
+++ b/app/lib/oi-display.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared helper for deriving the displayable OI USD value from a market row.
+ *
+ * GH#1599: Zero OI is always valid (means "no open positions") — the phantom
+ * guard should only suppress *positive* OI on un-backed markets, not zeros.
+ */
+
+/**
+ * Returns the total_open_interest_usd value to expose in API responses.
+ *
+ * @param totalOpenInterestUsd - Computed OI in USD (may be 0 or null)
+ * @param isPhantom             - Whether isPhantomOpenInterest() returned true
+ * @returns 0 when OI is zero (valid regardless of phantom status),
+ *          null when OI is positive but market is phantom (suppress stale OI),
+ *          otherwise the raw OI USD value.
+ */
+export function computeDisplayOiUsd(
+  totalOpenInterestUsd: number | null,
+  isPhantom: boolean,
+): number | null {
+  // GH#1599: zero OI is always valid regardless of vault/phantom status
+  return totalOpenInterestUsd === 0 ? 0 : isPhantom ? null : totalOpenInterestUsd;
+}


### PR DESCRIPTION
## Problem

46 markets with `vault_balance = 0` and zero OI showed `total_open_interest_usd: null` instead of `0`. This broke `sort=oi` on /markets — nulls sort inconsistently vs explicit 0 values.

## Root Cause

The phantom OI guard (`isPhantomOpenInterest`) suppresses OI when `vault_balance < MIN_VAULT_FOR_OI`. It correctly hides stale *positive* OI on un-backed markets, but also hid genuinely zero OI.

## Fix

One-line change: when `total_open_interest_usd === 0`, return `0` directly — bypass the phantom guard. Zero OI means 'no positions' and is valid regardless of vault backing. Positive phantom OI is still suppressed (null).

## Tests

- New test: `gh1599-zero-oi-zero-vault.test.ts` (5 cases)
- All 425 existing API tests pass
- No changes to `isPhantomOpenInterest` or `phantom-oi.ts` (shared helper untouched)

Closes #1599

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Market open interest now displays 0 when open interest is exactly zero, instead of hiding the value for certain market types.

* **Tests**
  * Added test coverage validating open interest display behavior across zero, positive, and null open interest scenarios for both suppressed and normal markets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->