### PR TITLE
fix(GH#1590): devnet_mints lookups use non-existent market_address column

### DIFF
--- a/app/app/api/airdrop/route.ts
+++ b/app/app/api/airdrop/route.ts
@@ -166,10 +166,11 @@ async function resolveServerOwnedMint(
   }
 
   // 2. Server does NOT own storedMint. Look for a server-owned mirror in devnet_mints.
+  // GH#1590: devnet_mints has no market_address column — use mainnet_ca with synthetic key
   const { data: mirror } = await supabase
     .from("devnet_mints")
     .select("devnet_mint")
-    .eq("market_address", marketAddress)
+    .eq("mainnet_ca", `__market_mirror__${marketAddress}`)
     .eq("creator_wallet", mintAuthPubkey)
     .order("created_at", { ascending: false })
     .limit(1)
@@ -231,7 +232,6 @@ async function resolveServerOwnedMint(
     {
       mainnet_ca: `__market_mirror__${marketAddress}`, // synthetic key for market-owned mirrors
       devnet_mint: newMint,
-      market_address: marketAddress,
       symbol: "TOKEN", // will be overwritten by real symbol on next market info fetch
       name: `Mirror ${marketAddress.slice(0, 6)}`,
       decimals,
@@ -301,10 +301,11 @@ export async function POST(req: NextRequest) {
     // Fallback to devnet_mints table if markets table doesn't have the mint
     if (!mintAddress) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // GH#1590: devnet_mints has no market_address column — use mainnet_ca synthetic key
       const { data: devnetMintData, error: fallbackErr } = await (supabase as any)
         .from("devnet_mints")
         .select("devnet_mint, symbol")
-        .eq("market_address", marketAddress)
+        .eq("mainnet_ca", `__market_mirror__${marketAddress}`)
         .order("created_at", { ascending: false })
         .limit(1)
         .maybeSingle();


### PR DESCRIPTION
## Problem
resolveServerOwnedMint() and the fallback mint lookup in /api/airdrop query devnet_mints using `.eq('market_address', ...)` — but devnet_mints has no market_address column. This silently fails, causing every legacy market airdrop to create a new orphaned mirror mint.

## Fix
Changed all devnet_mints lookups to use `mainnet_ca = '__market_mirror__${marketAddress}'` which matches the synthetic key already used by the upsert path. Removed market_address from the upsert object.

## Tests
16 airdrop tests pass.

Closes #1590