### PR TITLE
fix(GH#1600,GH#1601): TOCTOU races in devnet-mint-token and devnet-pre-fund

### DIFF
--- a/app/__tests__/api/gh1600-devnet-mint-token-toctou.test.ts
+++ b/app/__tests__/api/gh1600-devnet-mint-token-toctou.test.ts
@@ -1,0 +1,110 @@
+/**
+ * GH#1600: TOCTOU race in /api/devnet-mint-token
+ *
+ * Tests that the INSERT-as-gate pattern handles the race condition
+ * where concurrent requests for the same mainnetCA both pass the SELECT check.
+ *
+ * We test the DB-insert logic in isolation since the full route involves
+ * Solana on-chain operations that require a live connection.
+ */
+
+import { describe, it, expect } from "vitest";
+
+// Simulates the INSERT-as-gate behavior from devnet-mint-token/route.ts
+async function simulateInsert(
+  supabase: {
+    insert: (row: Record<string, unknown>) => Promise<{ error: { code: string; message: string } | null }>;
+    selectWinner: (mainnetCA: string) => Promise<string | null>;
+  },
+  mainnetCA: string,
+  devnetMint: string,
+  symbol: string,
+) {
+  const { error: insertErr } = await supabase.insert({ mainnet_ca: mainnetCA, devnet_mint: devnetMint, symbol });
+
+  if (insertErr?.code === "23505") {
+    const winner = await supabase.selectWinner(mainnetCA);
+    return {
+      status: "already_exists" as const,
+      devnetMint: winner ?? devnetMint,
+      symbol,
+    };
+  }
+  if (insertErr) {
+    throw new Error(`DB insert failed: ${insertErr.message}`);
+  }
+  return { status: "created" as const, devnetMint, symbol };
+}
+
+describe("GH#1600: devnet-mint-token INSERT-as-gate TOCTOU logic", () => {
+  it("returns created when INSERT succeeds (race winner)", async () => {
+    const supabase = {
+      insert: async () => ({ error: null }),
+      selectWinner: async () => null,
+    };
+    const result = await simulateInsert(supabase, "MAINNET_CA_1", "DEVNET_MINT_A", "SOL");
+    expect(result.status).toBe("created");
+    expect(result.devnetMint).toBe("DEVNET_MINT_A");
+  });
+
+  it("returns already_exists with winner mint on 23505 (race loser)", async () => {
+    const supabase = {
+      insert: async () => ({ error: { code: "23505", message: "duplicate key" } }),
+      selectWinner: async (_ca: string) => "DEVNET_MINT_WINNER",
+    };
+    const result = await simulateInsert(supabase, "MAINNET_CA_1", "DEVNET_MINT_LOSER", "SOL");
+    expect(result.status).toBe("already_exists");
+    expect(result.devnetMint).toBe("DEVNET_MINT_WINNER");
+  });
+
+  it("falls back to own mint when winner lookup returns null", async () => {
+    const supabase = {
+      insert: async () => ({ error: { code: "23505", message: "duplicate key" } }),
+      selectWinner: async (_ca: string) => null,
+    };
+    const result = await simulateInsert(supabase, "MAINNET_CA_1", "DEVNET_MINT_FALLBACK", "SOL");
+    expect(result.status).toBe("already_exists");
+    expect(result.devnetMint).toBe("DEVNET_MINT_FALLBACK");
+  });
+
+  it("throws on unexpected DB error (not 23505)", async () => {
+    const supabase = {
+      insert: async () => ({ error: { code: "42501", message: "permission denied" } }),
+      selectWinner: async (_ca: string) => null,
+    };
+    await expect(simulateInsert(supabase, "MAINNET_CA_1", "DEVNET_MINT_X", "SOL")).rejects.toThrow(
+      "DB insert failed: permission denied",
+    );
+  });
+
+  it("simulates true concurrent race: second INSERT gets 23505 and returns winner", async () => {
+    const db = new Map<string, string>(); // mainnet_ca → devnet_mint
+    let callCount = 0;
+
+    const makeSupabase = (ownMint: string) => ({
+      insert: async (row: Record<string, unknown>) => {
+        callCount++;
+        const ca = row["mainnet_ca"] as string;
+        if (db.has(ca)) {
+          return { error: { code: "23505", message: "duplicate key" } };
+        }
+        db.set(ca, row["devnet_mint"] as string);
+        return { error: null };
+      },
+      selectWinner: async (ca: string) => db.get(ca) ?? null,
+    });
+
+    const [r1, r2] = await Promise.all([
+      simulateInsert(makeSupabase("MINT_A"), "SAME_CA", "MINT_A", "TKN"),
+      simulateInsert(makeSupabase("MINT_B"), "SAME_CA", "MINT_B", "TKN"),
+    ]);
+
+    // Exactly one winner, one loser
+    const statuses = [r1.status, r2.status].sort();
+    expect(statuses).toEqual(["already_exists", "created"]);
+
+    // Both end up pointing to the same (winner's) devnet mint
+    expect(r1.devnetMint).toBe(r2.devnetMint);
+    expect(callCount).toBe(2);
+  });
+});

--- a/app/__tests__/api/gh1601-devnet-pre-fund-rate-limit.test.ts
+++ b/app/__tests__/api/gh1601-devnet-pre-fund-rate-limit.test.ts
@@ -1,0 +1,152 @@
+/**
+ * GH#1601: Per-wallet rate limit for /api/devnet-pre-fund
+ *
+ * Tests that the tryFaucetGate call prevents concurrent same-wallet+mint
+ * requests from all passing through to the on-chain mintTo instruction.
+ *
+ * We test the gate integration in isolation (no live Solana RPC needed).
+ */
+
+import { describe, it, expect } from "vitest";
+
+interface GateResult {
+  allowed: boolean;
+  nextClaimAt: string | null;
+  claimId?: number;
+}
+
+// Simulates the per-wallet gate flow from devnet-pre-fund/route.ts
+async function simulatePreFund(
+  wallet: string,
+  mintAddress: string,
+  tryFaucetGate: (wallet: string, fundType: string) => Promise<GateResult>,
+  doMint: () => Promise<{ sig: string }>,
+  releaseClaim: (id: number) => Promise<void>,
+): Promise<
+  | { status: "funded"; sig: string }
+  | { status: "sufficient" }
+  | { status: "rate_limited"; nextClaimAt: string | null }
+  | { status: "error"; message: string }
+> {
+  const fundType = `devnet-pre-fund:${mintAddress}`;
+  const gate = await tryFaucetGate(wallet, fundType);
+  if (!gate.allowed) {
+    return { status: "rate_limited", nextClaimAt: gate.nextClaimAt };
+  }
+
+  try {
+    const { sig } = await doMint();
+    return { status: "funded", sig };
+  } catch (err) {
+    if (gate.claimId != null) await releaseClaim(gate.claimId);
+    return { status: "error", message: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+describe("GH#1601: devnet-pre-fund per-wallet rate limit", () => {
+  it("allows first request through", async () => {
+    const tryFaucetGate = async () => ({ allowed: true, nextClaimAt: null, claimId: 1 });
+    const doMint = async () => ({ sig: "SIG_1" });
+    const releaseClaim = async () => {};
+
+    const result = await simulatePreFund("WALLET_A", "MINT_X", tryFaucetGate, doMint, releaseClaim);
+    expect(result.status).toBe("funded");
+    if (result.status === "funded") expect(result.sig).toBe("SIG_1");
+  });
+
+  it("blocks second request within rate window (23505 from gate)", async () => {
+    const nextClaimAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    const tryFaucetGate = async () => ({ allowed: false, nextClaimAt, claimId: undefined });
+    const doMint = async () => ({ sig: "SHOULD_NOT_REACH" });
+    const releaseClaim = async () => {};
+
+    const result = await simulatePreFund("WALLET_A", "MINT_X", tryFaucetGate, doMint, releaseClaim);
+    expect(result.status).toBe("rate_limited");
+    if (result.status === "rate_limited") expect(result.nextClaimAt).toBe(nextClaimAt);
+  });
+
+  it("releases gate on mint failure so user can retry", async () => {
+    let released = false;
+    const tryFaucetGate = async () => ({ allowed: true, nextClaimAt: null, claimId: 42 });
+    const doMint = async () => { throw new Error("tx timeout"); };
+    const releaseClaim = async (id: number) => {
+      expect(id).toBe(42);
+      released = true;
+    };
+
+    const result = await simulatePreFund("WALLET_A", "MINT_X", tryFaucetGate, doMint, releaseClaim);
+    expect(result.status).toBe("error");
+    expect(released).toBe(true);
+  });
+
+  it("gate is per-wallet (different wallets allowed concurrently)", async () => {
+    const claims = new Map<string, number>();
+    let claimIdSeq = 0;
+    const tryFaucetGate = async (wallet: string, fundType: string) => {
+      const key = `${wallet}:${fundType}`;
+      if (claims.has(key)) {
+        return { allowed: false, nextClaimAt: new Date().toISOString() };
+      }
+      claims.set(key, ++claimIdSeq);
+      return { allowed: true, nextClaimAt: null, claimId: claimIdSeq };
+    };
+    const doMint = async () => ({ sig: "SIG_OK" });
+    const releaseClaim = async () => {};
+
+    const [r1, r2] = await Promise.all([
+      simulatePreFund("WALLET_A", "MINT_X", tryFaucetGate, doMint, releaseClaim),
+      simulatePreFund("WALLET_B", "MINT_X", tryFaucetGate, doMint, releaseClaim),
+    ]);
+    // Both wallets funded independently
+    expect(r1.status).toBe("funded");
+    expect(r2.status).toBe("funded");
+  });
+
+  it("gate is per-mint (same wallet, different mints allowed concurrently)", async () => {
+    const claims = new Map<string, number>();
+    let claimIdSeq = 0;
+    const tryFaucetGate = async (wallet: string, fundType: string) => {
+      const key = `${wallet}:${fundType}`;
+      if (claims.has(key)) {
+        return { allowed: false, nextClaimAt: new Date().toISOString() };
+      }
+      claims.set(key, ++claimIdSeq);
+      return { allowed: true, nextClaimAt: null, claimId: claimIdSeq };
+    };
+    const doMint = async () => ({ sig: "SIG_OK" });
+    const releaseClaim = async () => {};
+
+    const [r1, r2] = await Promise.all([
+      simulatePreFund("WALLET_A", "MINT_X", tryFaucetGate, doMint, releaseClaim),
+      simulatePreFund("WALLET_A", "MINT_Y", tryFaucetGate, doMint, releaseClaim),
+    ]);
+    // Same wallet, different mints — both allowed
+    expect(r1.status).toBe("funded");
+    expect(r2.status).toBe("funded");
+  });
+
+  it("same wallet + same mint: concurrent requests — exactly one funded, one rate-limited", async () => {
+    const claims = new Map<string, number>();
+    let claimIdSeq = 0;
+    const tryFaucetGate = async (wallet: string, fundType: string) => {
+      const key = `${wallet}:${fundType}`;
+      if (claims.has(key)) {
+        return { allowed: false, nextClaimAt: new Date().toISOString() };
+      }
+      claims.set(key, ++claimIdSeq);
+      return { allowed: true, nextClaimAt: null, claimId: claimIdSeq };
+    };
+    const doMint = async () => ({ sig: "SIG_OK" });
+    const releaseClaim = async () => {};
+
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () =>
+        simulatePreFund("WALLET_A", "MINT_X", tryFaucetGate, doMint, releaseClaim),
+      ),
+    );
+    const funded = results.filter((r) => r.status === "funded");
+    const limited = results.filter((r) => r.status === "rate_limited");
+    expect(funded).toHaveLength(1);
+    expect(limited).toHaveLength(4);
+  });
+});

--- a/app/app/api/devnet-mint-token/route.ts
+++ b/app/app/api/devnet-mint-token/route.ts
@@ -322,9 +322,10 @@ export async function POST(req: NextRequest) {
 
     const devnetMint = mintKeypair.publicKey.toBase58();
 
-    // Store in DB
+    // Store in DB — INSERT-as-gate: devnet_mints has UNIQUE(mainnet_ca).
+    // Under concurrent requests, the race loser gets Postgres 23505.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await (supabase as any).from("devnet_mints").insert({
+    const { error: insertErr } = await (supabase as any).from("devnet_mints").insert({
       mainnet_ca: mainnetCA,
       devnet_mint: devnetMint,
       market_address: marketAddress ?? null,
@@ -334,6 +335,37 @@ export async function POST(req: NextRequest) {
       logo_url: tokenInfo.logoUrl ?? null,
       creator_wallet: creatorWallet,
     });
+
+    if (insertErr?.code === "23505") {
+      // Race lost — a concurrent request already created and inserted this CA's mint.
+      // The on-chain mint we just created is orphaned (devnet-only, ~0.002 SOL wasted).
+      // Return the winner's mint address so the caller still gets a valid devnetMint.
+      console.warn(
+        `devnet-mint-token: TOCTOU race for ${mainnetCA} — orphaned mint ${devnetMint}, fetching winner`,
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data: winner } = await (supabase as any)
+        .from("devnet_mints")
+        .select("devnet_mint")
+        .eq("mainnet_ca", mainnetCA)
+        .maybeSingle();
+      return NextResponse.json({
+        status: "already_exists",
+        devnetMint: winner?.devnet_mint ?? devnetMint,
+        symbol: tokenInfo.symbol,
+        name: tokenInfo.name,
+        decimals,
+        priceUsd: tokenInfo.priceUsd,
+      });
+    }
+
+    if (insertErr) {
+      // Unexpected DB error — log and surface (mint exists on-chain but not in DB)
+      console.error("devnet-mint-token: DB insert failed:", insertErr.message);
+      Sentry.captureException(insertErr, {
+        tags: { endpoint: "/api/devnet-mint-token", phase: "db-insert" },
+      });
+    }
 
     // FIX: Also upsert markets table so /api/airdrop can find the mint.
     // The airdrop route looks up mint_address in the markets table, not devnet_mints.

--- a/app/app/api/devnet-pre-fund/route.ts
+++ b/app/app/api/devnet-pre-fund/route.ts
@@ -32,6 +32,7 @@ import {
 } from "@solana/spl-token";
 import { getConfig } from "@/lib/config";
 import { getServiceClient } from "@/lib/supabase";
+import { tryFaucetGate, releaseFaucetClaim } from "@/lib/faucet-rate-gate";
 import * as Sentry from "@sentry/nextjs";
 
 export const dynamic = "force-dynamic";
@@ -176,6 +177,22 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Invalid walletAddress" }, { status: 400 });
     }
 
+    // GH#1601: per-wallet rate limit using INSERT-as-gate on faucet_claims.
+    // fund_type = `devnet-pre-fund:<mintAddress>` so each mint is gated independently.
+    // Concurrent requests for the same wallet+mint race on INSERT — loser gets 23505.
+    const supabaseForGate = getServiceClient();
+    const fundType = `devnet-pre-fund:${mintAddress}`;
+    const gate = await tryFaucetGate(supabaseForGate, walletAddress, fundType);
+    if (!gate.allowed) {
+      return NextResponse.json(
+        {
+          error: "Already pre-funded recently",
+          nextClaimAt: gate.nextClaimAt,
+        },
+        { status: 429 },
+      );
+    }
+
     // Load mint authority
     const mintAuthKeyJson = process.env.DEVNET_MINT_AUTHORITY_KEYPAIR;
     if (!mintAuthKeyJson) {
@@ -268,6 +285,8 @@ export async function POST(req: NextRequest) {
     }
 
     if (currentBalance >= FULL_MARKET_TOKEN_REQUIREMENT) {
+      // Release gate so concurrent requests (and future calls) aren't locked out
+      if (gate.claimId != null) await releaseFaucetClaim(supabaseForGate, gate.claimId);
       return NextResponse.json({
         status: "sufficient",
         balance: currentBalance.toString(),
@@ -302,10 +321,17 @@ export async function POST(req: NextRequest) {
       ),
     );
 
-    const sig = await withTimeout(
-      sendAndConfirmTransaction(connection, tx, [mintAuthority], { commitment: "confirmed" }),
-      30_000, // 30s — devnet RPC should confirm well within this
-    );
+    let sig: string;
+    try {
+      sig = await withTimeout(
+        sendAndConfirmTransaction(connection, tx, [mintAuthority], { commitment: "confirmed" }),
+        30_000, // 30s — devnet RPC should confirm well within this
+      );
+    } catch (txErr) {
+      // TX failed — release gate so user can retry
+      if (gate.claimId != null) await releaseFaucetClaim(supabaseForGate, gate.claimId);
+      throw txErr; // re-throw to outer catch for Sentry + 500 response
+    }
 
     return NextResponse.json({
       status: "funded",


### PR DESCRIPTION
## Problems

### GH#1600 — /api/devnet-mint-token: Duplicate SPL mints on TOCTOU race
Two concurrent requests with same `mainnetCA` both pass the `SELECT devnet_mints WHERE mainnet_ca = ?` check (finding no existing row), then both create separate SPL mints on-chain and race to INSERT. One INSERT wins; the other creates an orphaned devnet SPL mint.

### GH#1601 — /api/devnet-pre-fund: No per-wallet rate limit
Only global IP rate limiting (120 req/min). A wallet can send concurrent requests, all passing the `getAccount` balance check before any `mintTo` confirms, receiving N× the intended token amount.

## Fixes

### GH#1600 — INSERT-as-gate in devnet-mint-token
`devnet_mints` already has `UNIQUE(mainnet_ca)` (migration 032). Replace the SELECT→INSERT two-step with INSERT-as-gate:
- Race loser gets Postgres `23505` → look up winner's mint and return it
- No new migration needed (constraint already exists)

### GH#1601 — Per-wallet gate in devnet-pre-fund
Reuse existing `faucet_claims` table + `tryFaucetGate` from `lib/faucet-rate-gate.ts` (merged PR #1597).
- `fund_type = 'devnet-pre-fund:<mintAddress>'` so each wallet+mint combination is gated independently
- Gate released on: already-sufficient balance, TX failure/timeout (so user can retry)
- Returns 429 with `nextClaimAt` when blocked

## No new migration needed
Both fixes reuse existing DB infrastructure:
- GH#1600: `devnet_mints_mainnet_ca_idx` unique index (migration 032)
- GH#1601: `faucet_claims` table (migration 20260323065800, merged in PR #1597)

## Tests
- 5 new tests for GH#1600 (INSERT race simulation, fallback cases)
- 6 new tests for GH#1601 (gate allow/block/release, per-wallet/per-mint isolation, concurrent 5-way race)
- **1427/1427 tests pass**

Closes #1600
Closes #1601