### PR TITLE
fix(markets): sort=health ranks vault=0 markets as empty, not healthy (GH#1608)

### DIFF
--- a/app/__tests__/api/gh1608-health-sort-vault-zero.test.ts
+++ b/app/__tests__/api/gh1608-health-sort-vault-zero.test.ts
@@ -127,8 +127,7 @@ describe("GH#1608 — health sort: vault=0 markets must not rank as healthy", ()
       // vault=null → guard doesn't fire → computeMarketHealthFromStats called
       // result depends on stats, but we just verify no crash and a valid rank
       const rank = healthRank(noVault);
-      expect(rank).toBeGreaterThanOrEqual(0);
-      expect(rank).toBeLessThanOrEqual(5);
+      expect([0, 1, 2, 3]).toContain(rank);
     });
 
     it("vault=999999 (dust, < MIN_VAULT_FOR_OI) → rank 3 (empty)", () => {

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -467,10 +467,8 @@ export async function GET(request: NextRequest) {
       // This caused vault=0 markets (with legacy c_tot from FF7K keeper pattern) to rank
       // as best health (0) and appear first in sort=health results.
       // Fix: treat no-vault markets as rank 3 (empty) directly, before health computation.
-      const vaultNum = typeof m.vault_balance === "number"
-        ? m.vault_balance
-        : (m.vault_balance != null ? Number(m.vault_balance) : null);
-      if (vaultNum !== null && !Number.isNaN(vaultNum) && vaultNum < MIN_VAULT_FOR_OI) {
+      const vaultNum = numericOrNull(m.vault_balance);
+      if (vaultNum !== null && vaultNum < MIN_VAULT_FOR_OI) {
         return HEALTH_ORDER["empty"]; // 3 — no vault = no real LP market
       }
       const h = computeMarketHealthFromStats({


### PR DESCRIPTION
## Summary

Fixes GH#1608: `/api/markets?sort=health` was returning markets with `vault_balance=0` at the top of results instead of showing highest-health markets first.

## Root Cause

Markets with `vault_balance=0` but `c_tot > 0` and a live price pass the zombie filter (FF7K keeper pattern: `c_tot > 0 + hasActivity → not zombie`).

`computeMarketHealthFromStats` suppresses their OI to 0 via the phantom guard (`vault < MIN_VAULT_FOR_OI`), then sees:
- `oi = 0` (phantom-suppressed)
- `capital = c_tot = 1_000_000` (real legacy value)

→ `oi=0 + capital > 0` → returns **"healthy"** (rank 0)

These vault=0 markets appeared **first** in ascending health sort (rank 0 = best) despite having no LP vault backing.

## Fix

In `healthRank()` in `app/api/markets/route.ts`, add an explicit vault guard **before** calling `computeMarketHealthFromStats`:

```ts
const vaultNum = typeof m.vault_balance === 'number'
  ? m.vault_balance
  : (m.vault_balance != null ? Number(m.vault_balance) : null);
if (vaultNum !== null && !Number.isNaN(vaultNum) && vaultNum < MIN_VAULT_FOR_OI) {
  return HEALTH_ORDER['empty']; // 3 — no vault = no real LP market
}
```

Handles both numeric `0` and raw Supabase NUMERIC strings (`"0"`) since vault_balance is not overridden in the sanitized spread.

Also imports `MIN_VAULT_FOR_OI` from `lib/phantom-oi.ts` (single source of truth) instead of duplicating the constant.

## How to Test

```bash
curl 'https://percolatorlaunch.com/api/markets?sort=health&limit=20'
# Expect: WENDYS, RIGGED, SIEVE (vault=0) appear at the END, not positions 1/6/7
# Expect: Markets with high insurance/vault ratio (AdjMocJX etc.) appear near the top
```

## Tests

14 new tests in `gh1608-health-sort-vault-zero.test.ts`:
- vault=0 numeric → rank 3 (empty)
- vault='0' string (raw Supabase) → rank 3
- vault=null → guard skipped, computed normally
- vault=999999 (dust) → rank 3
- vault=MIN_VAULT_FOR_OI → NOT forced empty (strict < boundary)
- full ascending sort order: healthy → caution → warning → empty
- vault=0 markets appear last in asc, first in desc
- regression baseline: documents the bug and confirms the fix

All **1452 existing tests pass**.

Closes #1608

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Health-sort now treats markets with zero or below-minimum vault balance as "empty", ensuring they appear at the end of ascending sorts and correctly ordered in descending sorts.

* **Tests**
  * Added tests covering zero, string-zero, null, boundary vault balances and regression cases to validate health-sort behavior and ranking consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->