### PR TITLE
fix(markets): admin-oracle OI USD returns 0 not null when price unavailable (GH#1610)

### DIFF
--- a/app/__tests__/api/gh1564-volume-oi-usd-null.test.ts
+++ b/app/__tests__/api/gh1564-volume-oi-usd-null.test.ts
@@ -122,14 +122,18 @@ describe("GH#1564: volume_24h_usd and total_open_interest_usd when Supabase retu
     expect(market.total_open_interest_usd).toBeCloseTo(630, 0);
   });
 
-  it("returns null USD fields when last_price is null (no price = no USD)", async () => {
+  it("returns null volume_24h_usd and 0 total_open_interest_usd when last_price is null", async () => {
+    // volume_24h_usd: no price → null (can't value volume without a price)
+    // total_open_interest_usd: GH#1610 — atoms=1.5B > 0, price=null → 0 not null.
+    // Admin-oracle markets where the keeper never posted a price still have real OI;
+    // returning 0 (not null) lets sort=oi rank them above zero-OI markets correctly.
     mockRows = [makeMarket({ last_price: null, mark_price: null, index_price: null })];
     const res = await GET(makeRequest());
     const body = await res.json();
     const market = body.markets[0];
 
     expect(market.volume_24h_usd).toBeNull();
-    expect(market.total_open_interest_usd).toBeNull();
+    expect(market.total_open_interest_usd).toBe(0); // GH#1610: atoms > 0, no price → 0
   });
 
   it("returns 0 total_open_interest_usd for phantom OI market (GH#1606: atoms zeroed → USD=0)", async () => {

--- a/app/__tests__/api/gh1610-admin-oracle-null-oi-usd.test.ts
+++ b/app/__tests__/api/gh1610-admin-oracle-null-oi-usd.test.ts
@@ -1,0 +1,78 @@
+/**
+ * GH#1610: 29 admin-oracle markets with real vault + OI atoms > 0 but oracle
+ * price = null (keeper never cranked) returned total_open_interest_usd: null.
+ *
+ * Root cause: rawToUsd returns null when price is null. computeDisplayOiUsd
+ * propagated that null directly. The fix: when atoms > 0 but USD is null,
+ * return 0 rather than null so sort=oi ranks these consistently.
+ *
+ * These markets are NOT phantom (vault=1M, real accounts) — the OI atoms are
+ * genuine but simply cannot be priced yet.
+ */
+import { describe, it, expect } from "vitest";
+import { computeDisplayOiUsd } from "@/lib/oi-display";
+
+describe("GH#1610 — admin-oracle OI USD null→0 when atoms > 0, price unavailable", () => {
+  // ── Core fix ──────────────────────────────────────────────────────────────
+
+  it("returns 0 when atoms > 0 and USD is null (oracle price unavailable)", () => {
+    // vault=1M, oracle_mode=admin, total_open_interest=2_000_000_000_000 atoms
+    // last_price=null (keeper never cranked) → rawToUsd returns null
+    expect(computeDisplayOiUsd(null, false, 2_000_000_000_000)).toBe(0);
+  });
+
+  it("returns 0 for small atom amounts with no price", () => {
+    // e.g. total_open_interest=9_000_000 atoms, last_price=null
+    expect(computeDisplayOiUsd(null, false, 9_000_000)).toBe(0);
+  });
+
+  it("returns 0 for single atom with no price", () => {
+    expect(computeDisplayOiUsd(null, false, 1)).toBe(0);
+  });
+
+  // ── Null propagation preserved when atoms are 0 or absent ─────────────────
+
+  it("returns null when atoms=0 and USD is null (no OI at all, no price)", () => {
+    // True zero OI with no price → there are no positions, null is acceptable
+    // BUT wait: rawToUsd short-circuits 0 → returns 0 before price check.
+    // This case (atoms=0, usd=null) should not occur in practice, but guard it.
+    expect(computeDisplayOiUsd(null, false, 0)).toBe(null);
+  });
+
+  it("returns null when no atoms provided and USD is null (pre-GH1610 compat)", () => {
+    // Callers without rawOiAtoms behave identically to before: null propagates.
+    expect(computeDisplayOiUsd(null, false)).toBe(null);
+    expect(computeDisplayOiUsd(null, false, undefined)).toBe(null);
+  });
+
+  it("returns null when atoms is null and USD is null", () => {
+    expect(computeDisplayOiUsd(null, false, null)).toBe(null);
+  });
+
+  // ── Existing GH#1606 phantom behaviour preserved ──────────────────────────
+
+  it("returns 0 for phantom markets regardless of atoms or USD (GH#1606)", () => {
+    expect(computeDisplayOiUsd(null, true, 2_000_000_000_000)).toBe(0);
+    expect(computeDisplayOiUsd(null, true, 0)).toBe(0);
+    expect(computeDisplayOiUsd(42000.5, true, 100)).toBe(0);
+  });
+
+  // ── Existing zero-USD behaviour preserved (GH#1599) ───────────────────────
+
+  it("returns 0 when USD is exactly 0 regardless of atoms (GH#1599)", () => {
+    expect(computeDisplayOiUsd(0, false, 0)).toBe(0);
+    expect(computeDisplayOiUsd(0, false, 1000)).toBe(0);
+    expect(computeDisplayOiUsd(0, false, undefined)).toBe(0);
+  });
+
+  // ── Normal priced path preserved ─────────────────────────────────────────
+
+  it("returns USD value when price is available and atoms > 0", () => {
+    // oracle_mode=admin, keeper posted price → rawToUsd returns positive USD
+    expect(computeDisplayOiUsd(1234.56, false, 2_000_000_000_000)).toBe(1234.56);
+  });
+
+  it("returns USD value when price is available and no atoms provided", () => {
+    expect(computeDisplayOiUsd(5000, false)).toBe(5000);
+  });
+});

--- a/app/__tests__/api/markets-price-sanitize.test.ts
+++ b/app/__tests__/api/markets-price-sanitize.test.ts
@@ -218,7 +218,7 @@ describe("GET /api/markets — price sanitization (#856)", () => {
 
     expect(norm?.total_open_interest_usd).toBeCloseTo(0.001, 6);   // 1000 / 1e6 * 1.0
     expect(sentinel?.total_open_interest_usd).toBe(0);              // GH#1594: sentinel primary rejected, but long=0+short=0 → valid zero OI
-    expect(noprice?.total_open_interest_usd).toBeNull();            // no price
+    expect(noprice?.total_open_interest_usd).toBe(0);               // GH#1610: atoms=1000 > 0, price=null → 0 not null (admin-oracle, unpriced)
     expect(fallback?.total_open_interest_usd).toBeCloseTo(0.001, 6); // (600+400) / 1e6 * 1.0
   });
 
@@ -328,7 +328,9 @@ describe("GET /api/markets — price sanitization (#856)", () => {
       // market still appears in the response and its raw total_open_interest is non-zero.
       const pureOi1M = body.markets.find((m) => m.symbol === "PURE_OI_1M");
       expect(pureOi1M).toBeDefined(); // market is included (vault=1M is not phantom)
-      expect(pureOi1M?.total_open_interest_usd).toBeNull(); // no price → USD is null, not phantom-suppressed
+      // GH#1610: atoms=5B > 0, price=null → USD=0 (not null). Unpriced OI displays as 0
+      // so sort=oi ranks these markets above zero-OI markets, not below them.
+      expect(pureOi1M?.total_open_interest_usd).toBe(0);
       expect((pureOi1M as Record<string, unknown>)?.total_open_interest).toBe(5_000_000_000); // raw OI passes through
     });
 

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -259,7 +259,9 @@ export async function GET(request: NextRequest) {
       // GH#1599: When OI is genuinely 0, display 0 regardless of phantom status.
       // The phantom guard only suppresses *positive* OI values that are stale/orphaned
       // (no vault backing). Zero OI is always valid — it means "no positions".
-      const displayOiUsd = computeDisplayOiUsd(total_open_interest_usd, isPhantomOI);
+      // GH#1610: pass rawOiAtoms so the helper can return 0 (not null) when atoms > 0
+      // but oracle price is unavailable (admin-oracle markets where keeper never cranked).
+      const displayOiUsd = computeDisplayOiUsd(total_open_interest_usd, isPhantomOI, rawOi);
 
       // GH#1270: Pre-compute volume_24h in USD so consumers (e.g. Watchlist) don't need
       // to divide by 10^decimals manually. Mirrors the total_open_interest_usd pattern.

--- a/app/lib/oi-display.ts
+++ b/app/lib/oi-display.ts
@@ -3,6 +3,9 @@
  *
  * GH#1599: Zero OI is always valid (means "no open positions") — the phantom
  * guard should only suppress *positive* OI on un-backed markets, not zeros.
+ * GH#1610: admin-oracle markets with real vault + OI atoms but no oracle price
+ * (keeper never cranked) return null from rawToUsd. Display as 0 not null so
+ * sort=oi ranks these consistently instead of placing them after zero-OI markets.
  */
 
 /**
@@ -10,14 +13,19 @@
  *
  * @param totalOpenInterestUsd - Computed OI in USD (may be 0 or null)
  * @param isPhantom             - Whether isPhantomOpenInterest() returned true
+ * @param rawOiAtoms            - Raw OI atom value before USD conversion (optional).
+ *                                GH#1610: used to distinguish "atoms > 0 but no price"
+ *                                (→ 0) from "genuinely no OI data" (→ null).
  * @returns 0 when phantom (atoms are zeroed, USD must match),
  *          0 when OI is zero (valid regardless of phantom status),
- *          null when no price available,
+ *          0 when atoms > 0 but price unavailable (GH#1610: admin-oracle, unpriced),
+ *          null when no OI atoms and no USD value,
  *          otherwise the raw OI USD value.
  */
 export function computeDisplayOiUsd(
   totalOpenInterestUsd: number | null,
   isPhantom: boolean,
+  rawOiAtoms?: number | null,
 ): number | null {
   // GH#1606: phantom markets have all OI atom fields zeroed in the response
   // (total_open_interest, open_interest_long, open_interest_short → 0).
@@ -27,7 +35,13 @@ export function computeDisplayOiUsd(
   if (isPhantom) return 0;
   // GH#1599: zero OI is always valid regardless of vault/phantom status
   if (totalOpenInterestUsd === 0) return 0;
-  // No price available → no USD value computable
-  if (totalOpenInterestUsd === null) return null;
+  if (totalOpenInterestUsd === null) {
+    // GH#1610: atoms > 0 but oracle price unavailable (admin-oracle, keeper never cranked).
+    // rawToUsd returns null when price is null/zero. Rather than propagating null (which
+    // breaks sort=oi — null ranks after zero-OI markets), return 0 to signal "OI exists
+    // but cannot be priced". Atoms field is still correctly populated in the response.
+    if (rawOiAtoms != null && rawOiAtoms > 0) return 0;
+    return null;
+  }
   return totalOpenInterestUsd;
 }


### PR DESCRIPTION
## Problem

29 non-zombie markets with `oracle_mode=admin`, `vault=1M`, and `total_open_interest` atoms > 0 returned `total_open_interest_usd=null`. Root cause: the oracle authority never posted a price to the keeper (`last_price=null`), so `rawToUsd` returns `null`, and `computeDisplayOiUsd` propagated that `null` directly.

## Impact of Bug

- `sort=oi` ranks these 29 markets *after* zero-OI markets (NULLS LAST), so they appear below truly empty markets
- UI displays `null` for OI USD instead of a sensible fallback

## Fix

Add optional `rawOiAtoms` param to `computeDisplayOiUsd`. When `totalOpenInterestUsd` is `null` but `rawOiAtoms > 0`, return `0` instead of `null`. This signals "OI exists but cannot be priced" without breaking sort logic.

**Decision** (same as QA posed): return **0** with atoms populated. This is semantically honest — we don't know the USD value, but we know positions exist. `null` breaks sorting; `0` sorts these with zero-OI markets (acceptable) and the raw atoms field shows the real data.

## Behaviour Changes

| Field | Before | After |
|-------|--------|-------|
| `total_open_interest` (atoms) | Correct (e.g. 2T) | Unchanged |
| `total_open_interest_usd` | `null` | `0` |
| `volume_24h_usd` | `null` (no price) | `null` (unchanged) |

## Not Changed

- Phantom markets (GH#1606): still return 0 via existing `isPhantom` path
- Zero-OI markets (GH#1599): unchanged
- Priced markets: unchanged

## Tests

- **New:** `gh1610-admin-oracle-null-oi-usd.test.ts` — 9 cases covering core fix + edge cases + backward compat
- **Updated:** `markets-price-sanitize.test.ts` — NOPRICE + PURE_OI_1M assertions updated to 0
- **Updated:** `gh1564-volume-oi-usd-null.test.ts` — null-price case updated + comment clarified
- **All 1462 tests pass**

Closes #1610

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed open interest USD display for unpriced markets with existing open interest. Markets without price data now correctly show `0` USD open interest instead of `null`, improving accuracy in market ranking and sorting.

* **Tests**
  * Added comprehensive test coverage for open interest USD calculations across various market scenarios, including unpriced and admin-oracle markets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->