### PR TITLE
fix(markets): sort=health tiebreak vault>0 before vault=0 (GH#1612)

### DIFF
--- a/app/__tests__/unit/gh1612-health-sort-tiebreak.test.ts
+++ b/app/__tests__/unit/gh1612-health-sort-tiebreak.test.ts
@@ -1,0 +1,91 @@
+/**
+ * GH#1612: sort=health must not interleave vault=0 and vault>0 markets
+ * within the same health rank. vault>0 markets should always appear
+ * before vault=0 markets when both have rank "empty" (3).
+ */
+import { describe, it, expect } from "vitest";
+
+// Inline the same logic used in route.ts for unit testing
+const HEALTH_ORDER: Record<string, number> = { healthy: 0, caution: 1, warning: 2, empty: 3 };
+const MIN_VAULT_FOR_OI = 1_000_000;
+
+function numericOrNull(v: unknown): number | null {
+  if (v == null) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function healthRank(m: Record<string, unknown>): number {
+  const vaultNum = numericOrNull(m.vault_balance);
+  if (vaultNum !== null && vaultNum < MIN_VAULT_FOR_OI) {
+    return HEALTH_ORDER["empty"];
+  }
+  // Simplified: if c_tot=0, insurance=0, oi=0 → empty
+  const capital = numericOrNull(m.c_tot) ?? 0;
+  const oi = numericOrNull(m.total_open_interest) ?? 0;
+  const insurance = numericOrNull(m.insurance_balance) ?? 0;
+  if (capital === 0 && insurance === 0 && oi === 0) return HEALTH_ORDER["empty"];
+  if (oi === 0) return HEALTH_ORDER["healthy"];
+  return HEALTH_ORDER["healthy"];
+}
+
+function sortByHealth(markets: Record<string, unknown>[]): Record<string, unknown>[] {
+  return [...markets].sort((a, b) => {
+    const ra = healthRank(a);
+    const rb = healthRank(b);
+    if (ra !== rb) return ra - rb;
+    // GH#1612 tiebreaker
+    const va = numericOrNull(a.vault_balance) ?? 0;
+    const vb = numericOrNull(b.vault_balance) ?? 0;
+    if (va > 0 && vb === 0) return -1;
+    if (va === 0 && vb > 0) return 1;
+    return 0;
+  });
+}
+
+describe("GH#1612: sort=health tiebreak vault>0 before vault=0", () => {
+  it("vault>0 empty markets sort before vault=0 empty markets", () => {
+    const markets = [
+      { symbol: "A", vault_balance: 0, c_tot: 0, total_open_interest: 0, insurance_balance: 0 },
+      { symbol: "B", vault_balance: 1000000, c_tot: 0, total_open_interest: 0, insurance_balance: 0 },
+      { symbol: "C", vault_balance: 0, c_tot: 0, total_open_interest: 0, insurance_balance: 0 },
+      { symbol: "D", vault_balance: 1000000, c_tot: 0, total_open_interest: 0, insurance_balance: 0 },
+    ];
+    const sorted = sortByHealth(markets);
+    // Both B and D (vault=1M) should come before A and C (vault=0)
+    const symbols = sorted.map((m) => m.symbol);
+    expect(symbols).toEqual(["B", "D", "A", "C"]);
+  });
+
+  it("no vault>0 market appears after any vault=0 market within same rank", () => {
+    const markets: Record<string, unknown>[] = [];
+    // Mix of vault=0 and vault=1000000, all empty rank
+    for (let i = 0; i < 50; i++) {
+      markets.push({
+        symbol: `V0_${i}`,
+        vault_balance: 0,
+        c_tot: 0,
+        total_open_interest: 0,
+        insurance_balance: 0,
+      });
+    }
+    for (let i = 0; i < 25; i++) {
+      markets.push({
+        symbol: `V1M_${i}`,
+        vault_balance: 1000000,
+        c_tot: 0,
+        total_open_interest: 0,
+        insurance_balance: 0,
+      });
+    }
+    const sorted = sortByHealth(markets);
+    let seenVault0 = false;
+    for (const m of sorted) {
+      const v = numericOrNull(m.vault_balance) ?? 0;
+      if (v === 0) seenVault0 = true;
+      if (seenVault0 && v > 0) {
+        throw new Error(`vault>0 market ${m.symbol} appeared after vault=0`);
+      }
+    }
+  });
+});

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -489,7 +489,16 @@ export async function GET(request: NextRequest) {
         ? [...oracleModeFiltered].sort((a, b) => {
             const ra = healthRank(a as Record<string, unknown>);
             const rb = healthRank(b as Record<string, unknown>);
-            return sortDir * (ra - rb);
+            if (ra !== rb) return sortDir * (ra - rb);
+            // GH#1612: Tiebreaker within same health rank — vault>0 before vault=0.
+            // Markets with vault_balance=1000000 but c_tot=0 both score rank 3 (empty)
+            // alongside vault=0 markets, causing interleaving. Break ties by vault presence.
+            const va = numericOrNull((a as Record<string, unknown>).vault_balance) ?? 0;
+            const vb = numericOrNull((b as Record<string, unknown>).vault_balance) ?? 0;
+            // vault>0 sorts first (ascending): compare so that higher vault comes first
+            if (va > 0 && vb === 0) return -1;
+            if (va === 0 && vb > 0) return 1;
+            return 0;
           })
         : effectiveSortParam && SORTABLE_FIELDS.has(effectiveSortParam)
           ? [...oracleModeFiltered].sort((a, b) => {


### PR DESCRIPTION
## Problem
`sort=health` interleaves vault=0 and vault>0 markets when both have the same health rank (empty/3). Markets with `vault_balance=1000000` but `c_tot=0` score rank 3 (empty) — same as vault=0 markets — so JS sort doesn't guarantee grouping.

## Root Cause
PR #1609 correctly forced vault<MIN_VAULT_FOR_OI to rank 3, but didn't handle the case where vault≥MIN_VAULT_FOR_OI markets ALSO score rank 3 via `computeMarketHealthFromStats` (when c_tot=0, insurance=0, oi=0 → empty).

## Fix
Add a tiebreaker in the health sort comparator: within the same rank, vault>0 sorts before vault=0. This ensures all vault=0 markets cluster at the end.

## Test
- New unit test: `gh1612-health-sort-tiebreak.test.ts` — verifies no vault>0 market appears after any vault=0 market within same rank.
- Manual: `curl .../api/markets?sort=health&limit=200` — all vault=0 at the end.

Closes #1612

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deterministic ordering when sorting markets by health; markets with identical health rankings are now consistently sorted by vault balance, ensuring markets with positive vault balance appear before those with zero vault balance.

* **Tests**
  * Added comprehensive unit tests validating health-based market sorting behavior and tiebreaker logic across various market states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->