### PR TITLE
fix(create): pass walletAddress to devnet-mirror-mint API (GH#1614)

### DIFF
--- a/app/__tests__/components/StepTokenSelect.test.tsx
+++ b/app/__tests__/components/StepTokenSelect.test.tsx
@@ -18,6 +18,11 @@ import { StepTokenSelect } from "@/components/create/StepTokenSelect";
 const DEVNET_MINT = "4RkzTf5WWPVJHuFr8TW7et4SsQwKK1veJqEKdxMNmKyX";
 const MAINNET_MINT = "So11111111111111111111111111111111111111112";
 
+const mockPublicKey = {
+  toBase58: () => "G7NGnUffoo2bKBY7nGjJmSZq7rSvG4bsJpK931rGQshD",
+  equals: () => false,
+};
+
 vi.mock("@/hooks/useWalletCompat", () => ({
   useWalletCompat: () => ({ publicKey: null }),
   useConnectionCompat: () => ({
@@ -157,5 +162,44 @@ describe("StepTokenSelect — GH#1263 debounce race condition", () => {
 
     const input = screen.getByPlaceholderText(/paste mint address/i) as HTMLInputElement;
     expect(input.value).toBe(DEVNET_MINT);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// GH#1614 — mirror-mint walletAddress regression (unit)
+// ─────────────────────────────────────────────────────────────
+describe("StepTokenSelect — GH#1614 mirror-mint walletAddress", () => {
+  // Verify the fix in source: the mirror-mint fetch body includes walletAddress.
+  // We test this by inspecting the component source text directly — a lightweight
+  // guard that catches regressions without requiring a full JSDOM render of the
+  // wallet-connected flow (which needs a more complex test harness).
+  it("source includes walletAddress in the devnet-mirror-mint POST body", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const src = fs.readFileSync(
+      path.resolve(
+        __dirname,
+        "../../components/create/StepTokenSelect.tsx"
+      ),
+      "utf-8"
+    );
+    // The fix should include walletAddress in the JSON body sent to devnet-mirror-mint
+    expect(src).toContain("walletAddress: mirrorWallet");
+    // And it should derive mirrorWallet from publicKey
+    expect(src).toContain("publicKey?.toBase58()");
+  });
+
+  it("effect dep array includes publicKey so it re-runs on wallet connect", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const src = fs.readFileSync(
+      path.resolve(
+        __dirname,
+        "../../components/create/StepTokenSelect.tsx"
+      ),
+      "utf-8"
+    );
+    // Confirm publicKey is in the effect dependency array alongside mintPk/connection/isDevnet
+    expect(src).toContain("}, [mintPk, connection, isDevnet, publicKey]);");
   });
 });

--- a/app/components/create/StepTokenSelect.tsx
+++ b/app/components/create/StepTokenSelect.tsx
@@ -209,10 +209,13 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
           // Step 2: Mint not found on devnet after retries — try mirror from mainnet
           if (cancelled) return;
           setMintNetworkStatus("mirroring");
+          // GH#1614: include walletAddress so /api/devnet-mirror-mint can associate
+          // the mirror with the connected wallet (required field — API returns 400 without it).
+          const mirrorWallet = publicKey?.toBase58() ?? null;
           const resp = await fetch("/api/devnet-mirror-mint", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ mainnetCA: mintAddr }),
+            body: JSON.stringify({ mainnetCA: mintAddr, walletAddress: mirrorWallet }),
           });
           if (cancelled) return;
           const data = await resp.json();
@@ -279,9 +282,10 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
     })();
     return () => { cancelled = true; };
     // GH#1258: intentionally exclude callback props — accessed via stable refs above.
-    // Only restart on genuine mint/network changes.
+    // GH#1614: publicKey added so effect re-runs when wallet connects after mint is entered,
+    // enabling mirror-mint to include walletAddress on the retry attempt.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mintPk, connection, isDevnet]);
+  }, [mintPk, connection, isDevnet, publicKey]);
 
   // Propagate token meta changes.
   // PERC-1093: Don't override an already-resolved devnet/mirror meta with null mainnet metadata.


### PR DESCRIPTION
## Summary
Fixes GH#1614 — `/create` wizard shows "Missing walletAddress" when pasting a mainnet CA, even though wallet is connected. Blocks ALL mainnet-CA market creation.

## Root Cause
`StepTokenSelect` was calling `/api/devnet-mirror-mint` with only `{ mainnetCA }`. The API requires `walletAddress` and returns HTTP 400 without it. The component had `publicKey` from `useWalletCompat()` but never included it in the fetch body.

## Fix
- Capture `publicKey?.toBase58()` as `mirrorWallet` at effect run time
- Include `walletAddress: mirrorWallet` in the POST body to `/api/devnet-mirror-mint`
- Add `publicKey` to the effect dependency array so the effect re-runs when the wallet connects after the mint is pasted

## Verification
```bash
# Before fix — returns 400:
curl -X POST /api/devnet-mirror-mint -d '{"mainnetCA":"DezXAZ8z7..."}' 
# → {"error":"Missing walletAddress"}

# After fix — walletAddress included from Privy context
# → {"status":"existing","devnetMint":"CCPHpr..."}
```

## Tests
- 2 new regression tests in `StepTokenSelect.test.tsx`
- All 1466 tests pass

## How to Test
1. Go to `/create` with a connected wallet
2. Paste BONK CA: `DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263`
3. Should show 🪞 "Creating devnet mirror..." then resolve token card
4. CONTINUE button should become enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved devnet token mirroring by including wallet address information in requests
  * Enhanced token validation to properly re-trigger when a wallet is connected after entering a token address

<!-- end of auto-generated comment: release notes by coderabbit.ai -->