### PR TITLE
fix(GH#1622): show 'No Oracle' badge for markets with null mark/index price

### DIFF
--- a/app/__tests__/unit/gh1622-oracle-down-badge.test.ts
+++ b/app/__tests__/unit/gh1622-oracle-down-badge.test.ts
@@ -1,0 +1,115 @@
+/**
+ * GH#1622: Oracle Down badge — markets with null mark_price + null index_price
+ * should show "No Oracle" health level (oracle-down) instead of liquidity-based
+ * health, regardless of oracle mode (admin, hyperp, pyth).
+ *
+ * This test verifies:
+ * 1. HealthLevel type accepts "oracle-down"
+ * 2. Markets with null prices are flagged as oracle-down (not "Healthy")
+ * 3. Zombie markets are NOT flagged oracle-down (they show "Empty")
+ * 4. Markets with valid prices retain their liquidity-based health
+ * 5. LIVE vs NO ORACLE label logic on homepage
+ */
+
+import type { HealthLevel } from "@/lib/health";
+
+// ── Helper: mirrors the oracle-down detection logic in app/app/markets/page.tsx ──
+interface FakeSupabaseMarket {
+  mark_price: number | null;
+  index_price: number | null;
+  is_zombie?: boolean;
+  vault_balance?: number | null;
+  total_accounts?: number | null;
+}
+
+function isOracleDown(supabase: FakeSupabaseMarket | null): boolean {
+  if (supabase == null) return false;
+  if (supabase.is_zombie) return false;
+  const markOk = supabase.mark_price != null && supabase.mark_price > 0;
+  const indexOk = supabase.index_price != null && supabase.index_price > 0;
+  return !markOk && !indexOk;
+}
+
+// ── Helper: mirrors homepage LIVE/NO ORACLE label logic ──
+function homepageLabel(lastPrice: number | null): string {
+  return lastPrice != null ? "LIVE" : "NO ORACLE";
+}
+
+describe("GH#1622 – oracle-down health badge", () => {
+  // ── HealthLevel type accepts "oracle-down" ──
+  it("HealthLevel type includes oracle-down", () => {
+    const level: HealthLevel = "oracle-down";
+    expect(level).toBe("oracle-down");
+  });
+
+  // ── Oracle-down detection ──
+  it("detects oracle-down when both mark_price and index_price are null", () => {
+    expect(isOracleDown({ mark_price: null, index_price: null })).toBe(true);
+  });
+
+  it("detects oracle-down when mark_price is 0 and index_price is null", () => {
+    expect(isOracleDown({ mark_price: 0, index_price: null })).toBe(true);
+  });
+
+  it("detects oracle-down when mark_price is null and index_price is 0", () => {
+    expect(isOracleDown({ mark_price: null, index_price: 0 })).toBe(true);
+  });
+
+  it("does NOT flag oracle-down when mark_price is valid (> 0)", () => {
+    expect(isOracleDown({ mark_price: 1.5, index_price: null })).toBe(false);
+  });
+
+  it("does NOT flag oracle-down when index_price is valid (> 0)", () => {
+    expect(isOracleDown({ mark_price: null, index_price: 130.0 })).toBe(false);
+  });
+
+  it("does NOT flag oracle-down when both prices are valid", () => {
+    expect(isOracleDown({ mark_price: 130.0, index_price: 129.8 })).toBe(false);
+  });
+
+  it("does NOT flag oracle-down when supabase is null (on-chain only market)", () => {
+    expect(isOracleDown(null)).toBe(false);
+  });
+
+  // ── Zombie markets exempt ──
+  it("does NOT flag oracle-down for zombie markets (they show Empty)", () => {
+    expect(isOracleDown({ mark_price: null, index_price: null, is_zombie: true })).toBe(false);
+  });
+
+  it("zombie with prices still not flagged oracle-down", () => {
+    expect(isOracleDown({ mark_price: 1.0, index_price: 1.0, is_zombie: true })).toBe(false);
+  });
+
+  // ── Homepage LIVE/NO ORACLE logic ──
+  it("shows LIVE when last_price is set", () => {
+    expect(homepageLabel(0.00063)).toBe("LIVE");
+    expect(homepageLabel(130.0)).toBe("LIVE");
+    expect(homepageLabel(0.01)).toBe("LIVE");
+  });
+
+  it("shows NO ORACLE when last_price is null", () => {
+    expect(homepageLabel(null)).toBe("NO ORACLE");
+  });
+
+  // ── Real-world: 82/168 devnet markets have null prices ──
+  it("correctly categorises a batch of markets like the 82/168 scenario", () => {
+    const markets: FakeSupabaseMarket[] = [
+      // 3 healthy markets with prices
+      { mark_price: 130.5, index_price: 130.2 },
+      { mark_price: 0.000630, index_price: 0.000628 },
+      { mark_price: 2.5, index_price: 2.48 },
+      // 3 oracle-down markets (keeper not cranked)
+      { mark_price: null, index_price: null },
+      { mark_price: 0, index_price: null },
+      { mark_price: null, index_price: 0 },
+      // 1 zombie (exempt)
+      { mark_price: null, index_price: null, is_zombie: true },
+    ];
+
+    const oracleDown = markets.filter(isOracleDown);
+    const notOracleDown = markets.filter(m => !isOracleDown(m));
+
+    expect(oracleDown).toHaveLength(3);
+    expect(notOracleDown).toHaveLength(4); // 3 priced + 1 zombie
+  });
+});

--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -359,8 +359,25 @@ function MarketsPageInner() {
           const hb = b.onChain
             ? computeMarketHealth(b.onChain.engine)
             : (b.supabase ? computeMarketHealthFromStats(b.supabase) : { level: "empty" as const });
-          const order: Record<string, number> = { healthy: 0, caution: 1, warning: 2, empty: 3 };
-          return (order[ha.level] ?? 5) - (order[hb.level] ?? 5);
+          // GH#1622: oracle-down markets sort to the bottom (after empty=3), before total unknowns.
+          const order: Record<string, number> = { healthy: 0, caution: 1, warning: 2, empty: 3, "oracle-down": 4 };
+          // Apply oracle-down override for sort (mirrors effectiveHealth logic in render)
+          const numericOrNullSort = (v: unknown): number | null => {
+            if (v == null) return null;
+            const n = Number(v);
+            return Number.isFinite(n) ? n : null;
+          };
+          const isOracleDownA = a.supabase != null
+            && !(a.supabase as Record<string, unknown>).is_zombie
+            && (a.supabase.mark_price == null || numericOrNullSort(a.supabase.mark_price) === null || numericOrNullSort(a.supabase.mark_price)! <= 0)
+            && (a.supabase.index_price == null || numericOrNullSort(a.supabase.index_price) === null || numericOrNullSort(a.supabase.index_price)! <= 0);
+          const isOracleDownB = b.supabase != null
+            && !(b.supabase as Record<string, unknown>).is_zombie
+            && (b.supabase.mark_price == null || numericOrNullSort(b.supabase.mark_price) === null || numericOrNullSort(b.supabase.mark_price)! <= 0)
+            && (b.supabase.index_price == null || numericOrNullSort(b.supabase.index_price) === null || numericOrNullSort(b.supabase.index_price)! <= 0);
+          const levelA = isOracleDownA ? "oracle-down" : ha.level;
+          const levelB = isOracleDownB ? "oracle-down" : hb.level;
+          return (order[levelA] ?? 5) - (order[levelB] ?? 5);
         }
         case "recent": {
           // Sort by created_at descending; fall back to slab address if missing
@@ -680,6 +697,22 @@ function MarketsPageInner() {
                   const onChainPriceE6 = m.onChain ? resolveMarketPriceE6(m.onChain.config) : 0n;
                   const rawPrice = m.supabase?.last_price ?? priceE6ToUsd(onChainPriceE6);
                   const lastPrice = rawPrice != null && rawPrice > MAX_SANE_PRICE_USD ? null : rawPrice;
+                  
+                  // GH#1622: Override health to "oracle-down" when both mark_price and
+                  // index_price are null from the API — keeper has not cranked this market
+                  // regardless of oracle mode (admin, hyperp, or pyth). Without this guard,
+                  // markets with null oracle data still display their liquidity-based health
+                  // level (e.g. "Healthy") giving a false impression of a live, tradeable market.
+                  // Only override to oracle-down when Supabase data is present but prices are
+                  // missing — if supabase is null we have no data at all (show computed health).
+                  // Do NOT override for zombie markets (is_zombie=true) — they show "Empty".
+                  const isOracleDown = m.supabase != null
+                    && !(m.supabase as Record<string, unknown>).is_zombie
+                    && (m.supabase.mark_price == null || (m.supabase.mark_price as number) <= 0)
+                    && (m.supabase.index_price == null || (m.supabase.index_price as number) <= 0);
+                  const effectiveHealth = isOracleDown
+                    ? { level: "oracle-down" as const, label: "No Oracle", insuranceRatio: 0, capitalRatio: 0 }
+                    : health;
                   const rawDecimals = tokenMetaMap.get(m.mintAddress)?.decimals ?? (m.supabase?.decimals ?? 6);
                   const mintDecimals = Math.min(Math.max(rawDecimals, 0), 18); // clamp to sane range
                   const tokenDivisor = 10 ** mintDecimals;
@@ -816,7 +849,7 @@ function MarketsPageInner() {
                       </div>
                       <div className="hidden sm:block text-right text-sm text-[var(--text)] truncate tabular-nums" style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>{insuranceDisplay}</div>
                       <div className="text-right text-sm text-[var(--text-secondary)] tabular-nums" style={{ fontVariantNumeric: "tabular-nums" }}>{m.maxLeverage}x</div>
-                      <div className="text-right"><HealthBadge level={health.level} /></div>
+                      <div className="text-right"><HealthBadge level={effectiveHealth.level} /></div>
                     </Link>
                   );
                 })}

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -500,7 +500,10 @@ export default function Home() {
                     <div className="text-right text-[12px] text-[var(--text-secondary)]">
                       {m.total_open_interest > 0 ? formatCompact(m.total_open_interest) : "—"}
                     </div>
-                    <div className="text-right text-[11px] text-[var(--long)]">LIVE</div>
+                    {/* GH#1622: show oracle status — "LIVE" only when price is available */}
+                    <div className={`text-right text-[11px] ${m.last_price != null ? "text-[var(--long)]" : "text-[var(--warning)]"}`}>
+                      {m.last_price != null ? "LIVE" : "NO ORACLE"}
+                    </div>
                   </Link>
                 ))}
               </div>

--- a/app/components/market/HealthBadge.tsx
+++ b/app/components/market/HealthBadge.tsx
@@ -7,6 +7,9 @@ const STYLES: Record<HealthLevel, string> = {
   caution: "bg-[var(--warning)]/10 text-[var(--warning)] ring-1 ring-[var(--warning)]/20",
   warning: "bg-[var(--short)]/10 text-[var(--short)] ring-1 ring-[var(--short)]/20",
   empty: "bg-[var(--bg-surface)] text-[var(--text-secondary)]",
+  // GH#1622: oracle-down — keeper has not cranked this market, no price available.
+  // Shown when both mark_price and index_price are null from the API.
+  "oracle-down": "bg-[var(--warning)]/10 text-[var(--warning)] ring-1 ring-[var(--warning)]/30",
 };
 
 const LABELS: Record<HealthLevel, string> = {
@@ -14,6 +17,7 @@ const LABELS: Record<HealthLevel, string> = {
   caution: "Caution",
   warning: "Low Liq",
   empty: "Empty",
+  "oracle-down": "No Oracle",
 };
 
 const TOOLTIPS: Record<HealthLevel, string> = {
@@ -21,11 +25,14 @@ const TOOLTIPS: Record<HealthLevel, string> = {
   caution: "Insurance fund is getting low relative to open positions. Market still works but may struggle with large liquidations.",
   warning: "Very low liquidity. Large trades may fail or cause high slippage. Trade with caution.",
   empty: "No active positions or liquidity in this market.",
+  // GH#1622: oracle keeper has not cranked this market — no mark/index price available.
+  // New positions are blocked until the keeper pushes a valid price on-chain.
+  "oracle-down": "Oracle unavailable — keeper has not cranked this market. New position opens are blocked.",
 };
 
 export const HealthBadge: FC<{ level: HealthLevel }> = ({ level }) => (
   <Tooltip text={TOOLTIPS[level]}>
-    <span className={`inline-block rounded-full px-1.5 py-0.5 text-[10px] font-bold ${STYLES[level]}${level === "warning" || level === "caution" ? " animate-pulse" : ""}`}>
+    <span className={`inline-block rounded-full px-1.5 py-0.5 text-[10px] font-bold ${STYLES[level]}${level === "warning" || level === "caution" || level === "oracle-down" ? " animate-pulse" : ""}`}>
       {LABELS[level]}
     </span>
   </Tooltip>

--- a/app/lib/health.ts
+++ b/app/lib/health.ts
@@ -1,6 +1,6 @@
 import type { EngineState } from "@percolator/sdk";
 
-export type HealthLevel = "healthy" | "caution" | "warning" | "empty";
+export type HealthLevel = "healthy" | "caution" | "warning" | "empty" | "oracle-down";
 
 export interface MarketHealth {
   level: HealthLevel;


### PR DESCRIPTION
## Summary

Fixes GH#1622 — 82/168 devnet markets have `null` mark_price + index_price (keeper never cranked / authority mismatch). They previously displayed their liquidity-based health badge (e.g. `Healthy`) and the homepage showed a green `LIVE` chip — misleading traders when new position opens are actually blocked on-chain.

## Root Cause (for context)
Oracle keeper skips markets where it's not the oracle authority. 82/168 slabs were created with a different admin keypair or the keeper wallet ran dry. This is a devops infra issue. **This PR is the display-layer fix** — users are correctly informed while infra is fixed.

## Changes

| File | Change |
|------|--------|
| `lib/health.ts` | Added `"oracle-down"` to `HealthLevel` union type |
| `HealthBadge.tsx` | Added amber pulsing `"No Oracle"` badge with tooltip explaining keeper not cranked |
| `app/markets/page.tsx` | Override `effectiveHealth` to `oracle-down` when both `mark_price ≤ 0` AND `index_price ≤ 0` (skips zombies); oracle-down sorts to rank 4 (below `empty=3`) in `sort=health` |
| `app/page.tsx` | Replace hardcoded `LIVE` with conditional `LIVE` (green) / `NO ORACLE` (amber) on homepage featured markets row |
| `gh1622-oracle-down-badge.test.ts` | 13 new unit tests covering detection logic, zombie exemption, batch scenario, homepage label |

## Before / After

**Markets page health badge:**
- Before: `Healthy` (misleading) for 82 markets with no oracle price
- After: `No Oracle` (amber, pulsing) — tooltip: "Oracle unavailable — keeper has not cranked this market. New position opens are blocked."

**Homepage featured market:**
- Before: `LIVE` (green) for all markets
- After: `LIVE` (green) when price available, `NO ORACLE` (amber) when `last_price == null`

**Sort by health:**
- Before: oracle-down markets interleaved with healthy markets
- After: oracle-down sinks to bottom (rank 4, after empty=3)

## Tests
- 1508/1508 passing (13 new)
- TypeScript: clean (`pnpm tsc --noEmit` passes)

## Follow-up
- DevOps to investigate why 82 markets have keeper authority mismatch or wallet drain
- Admin UI `OracleFreshnessSection` already lists these markets with a `NO PRICE` badge — no change needed there
