### PR TITLE
fix: 24h% badge always visible + Funding/8h label consistency

### DIFF
--- a/app/components/trade/MarketInfoBar.tsx
+++ b/app/components/trade/MarketInfoBar.tsx
@@ -37,8 +37,10 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol }) =
     ? `$${priceUsd < 0.01 ? priceUsd.toFixed(6) : priceUsd < 1 ? priceUsd.toFixed(4) : priceUsd.toFixed(2)}`
     : "—";
 
-  const has24hChange = change24h != null;
-  const isUp = (change24h ?? 0) >= 0;
+  // Always show badge — display "0.00%" when no change data is available (devnet null/0)
+  const has24hChange = true;
+  const change24hDisplay = change24h ?? 0;
+  const isUp = change24hDisplay >= 0;
 
   // Phase 2: use 8h rate to match UI label (was hourly, label said /8h — now consistent)
   const funding8h = fundingRate != null ? fundingRateBpsTo8h(fundingRate) : null;
@@ -74,12 +76,10 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol }) =
         {priceDisplay}
       </span>
 
-      {/* Phase 2: 24h change badge — always visible next to price (was already here, kept prominent) */}
-      {has24hChange && (
-        <span className={`shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded-sm ${isUp ? "bg-green-500/20 text-green-400" : "bg-red-500/20 text-red-400"}`}>
-          {isUp ? "+" : ""}{change24h!.toFixed(2)}%
-        </span>
-      )}
+      {/* 24h change badge — always visible; shows "0.00%" when devnet price data returns null */}
+      <span className={`shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded-sm ${change24h == null ? "bg-[var(--border)]/30 text-[var(--text-dim)]" : isUp ? "bg-green-500/20 text-green-400" : "bg-red-500/20 text-red-400"}`}>
+        {change24h == null ? "0.00%" : `${isUp ? "+" : ""}${change24hDisplay.toFixed(2)}%`}
+      </span>
 
       <span className="h-3.5 w-px bg-[var(--border)]/40 shrink-0" />
 

--- a/app/components/trade/MarketStatsCard.tsx
+++ b/app/components/trade/MarketStatsCard.tsx
@@ -37,12 +37,13 @@ function formatPriceE6(priceE6: bigint): string {
 }
 
 /**
- * Convert fundingRateBpsPerSlotLast (i64) to hourly percentage.
- * Solana slots ≈ 400ms → 9000 slots/hr
- * hourlyRate% = (rateBpsPerSlot * 9000) / 10000
+ * Convert fundingRateBpsPerSlotLast (i64) to 8-hour percentage.
+ * Solana slots ≈ 400ms → 9000 slots/hr → 72000 slots/8h
+ * 8h rate% = (rateBpsPerSlot * 9000 * 8) / 10000 / 100
+ * Consistent with MarketInfoBar label "/ 8h".
  */
-function fundingRateBpsToHourly(rateBps: bigint): number {
-  return (Number(rateBps) * 9000) / 10000;
+function fundingRateBpsTo8h(rateBps: bigint): number {
+  return ((Number(rateBps) * 9000 * 8) / 10000) / 100;
 }
 
 export const MarketStatsCard: FC = () => {
@@ -101,7 +102,7 @@ export const MarketStatsCard: FC = () => {
   // offset reads on old devnet slabs) that would render as e.g. "+1.6e15%/hr".
   // Valid range matches the on-chain guard: abs(rate) <= 10_000 bps/slot.
   const fundingHourlyPct = sanitizeFundingRateBps(fundingRate) !== null
-    ? fundingRateBpsToHourly(sanitizeFundingRateBps(fundingRate)!)
+    ? fundingRateBpsTo8h(sanitizeFundingRateBps(fundingRate)!)
     : null;
 
   if (loading || !engine || !config || !params) {
@@ -155,9 +156,9 @@ export const MarketStatsCard: FC = () => {
     return "text-[var(--text-dim)]";
   })();
 
-  // Funding rate display: "+0.0081%/hr"
+  // Funding rate display: "+0.0081%/8h" — consistent with MarketInfoBar label
   const fundingDisplay = fundingHourlyPct !== null
-    ? `${fundingHourlyPct >= 0 ? "+" : ""}${fundingHourlyPct.toFixed(4)}%/hr`
+    ? `${fundingHourlyPct >= 0 ? "+" : ""}${fundingHourlyPct.toFixed(4)}%/8h`
     : "—";
   const fundingColor = fundingHourlyPct === null
     ? "text-[var(--text-dim)]"
@@ -197,9 +198,9 @@ export const MarketStatsCard: FC = () => {
     { label: "Open Interest", value: oiDisplay, tooltip: oiFullDisplay },
     { label: "Vault", value: vaultDisplay, tooltip: vaultFullDisplay },
     {
-      label: "Funding/hr",
+      label: "Funding/8h",
       value: fundingDisplay,
-      tooltip: "Hourly funding rate. Positive: longs pay shorts.",
+      tooltip: "8-hour funding rate. Positive: longs pay shorts.",
       valueClass: fundingColor,
     },
     // Row 3 — Market parameters


### PR DESCRIPTION
## Summary

Fixes two UI inconsistencies flagged in designer Phase 2 review.

## Changes

### 1. 24h% change badge — always visible (MarketInfoBar)
- **Before:** Badge only rendered when `change24h != null`. On devnet, oracle price data returns null/0 for 24h change → badge was absent in prod DOM snapshot.
- **After:** Badge always rendered. Shows `0.00%` in muted/dimmed style when data is null; shows colored +/- when data present.
- Conditional rendering logic simplified (no more `has24hChange` guard).

### 2. Funding label — Funding/hr → Funding/8h (MarketStatsCard)
- **Before:** Stats tile showed `Funding/hr` with hourly rate (e.g. `+0.0000%/hr`).
- **After:** Stats tile shows `Funding/8h` with 8h rate, matching MarketInfoBar `/ 8h` label.
- Calculation updated: `bpsPerSlot × 9000slots/hr × 8h / 10000 / 100` — same formula already used in MarketInfoBar.
- Tooltip updated: "8-hour funding rate. Positive: longs pay shorts."

## Testing
- All 1,816 tests passing (app: 1495, api: 149, keeper: 98, indexer: 74)
- No new tests required — pure display/label changes

## Designer review items addressed
- ⚠️ → ✅ 24h% badge conditional rendering fixed
- ⚠️ → ✅ Funding/hr vs Funding/8h inconsistency resolved