### PR TITLE
fix(GH#1639): apply MIN_VAULT_FOR_OI vault guard in health sort comparator (page.tsx)

### DIFF
--- a/app/__tests__/unit/gh1639-min-vault-for-oi-sort-comparator.test.ts
+++ b/app/__tests__/unit/gh1639-min-vault-for-oi-sort-comparator.test.ts
@@ -1,0 +1,164 @@
+/**
+ * GH#1639 — Client-side health sort comparator must apply MIN_VAULT_FOR_OI vault guard
+ *
+ * Problem: page.tsx's `computeIsOracleDown` did not apply the same vault threshold
+ * guard that route.ts applies (MIN_VAULT_FOR_OI = 1_000_000). Markets with
+ * vault_balance < 1_000_000 have their phantom OI zeroed server-side, but if the
+ * client sorts them as "oracle-down" instead of "empty", the sort rank disagrees with
+ * the API response at the threshold boundary.
+ *
+ * Fix: Before the oracle-down check, return false for sub-threshold-vault markets so
+ * they retain an "empty" sort rank (consistent with server-side treatment).
+ *
+ * These tests validate the pure logic extracted from page.tsx's `computeIsOracleDown`
+ * and the resulting sort behaviour near the threshold boundary.
+ */
+
+import { MIN_VAULT_FOR_OI } from "@/lib/phantom-oi";
+
+// ── Mirrored logic from page.tsx ─────────────────────────────────────────────
+
+const numericOrNullForSort = (v: unknown): number | null => {
+  if (v == null) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+};
+
+/**
+ * Simplified version of page.tsx's computeIsOracleDown, reflecting the GH#1639 fix.
+ * Real page.tsx reads on-chain config; here we accept explicit flags for unit testing.
+ */
+function computeIsOracleDown({
+  vaultBalance,
+  onChainPriceZero,   // true if resolveMarketPriceE6 returns 0n
+  markPrice,
+  indexPrice,
+  hasOnChain,
+}: {
+  vaultBalance: number | null;
+  onChainPriceZero?: boolean;
+  markPrice?: number | null;
+  indexPrice?: number | null;
+  hasOnChain?: boolean;
+}): boolean {
+  // GH#1639: Vault guard — mirrors route.ts MIN_VAULT_FOR_OI (PERC-816)
+  const vaultBal = numericOrNullForSort(vaultBalance);
+  if (vaultBal !== null && vaultBal < MIN_VAULT_FOR_OI) {
+    return false; // sub-threshold → empty, not oracle-down
+  }
+
+  if (hasOnChain) {
+    return onChainPriceZero === true;
+  }
+
+  const mp = numericOrNullForSort(markPrice ?? null);
+  const ip = numericOrNullForSort(indexPrice ?? null);
+  return (mp == null || mp <= 0) && (ip == null || ip <= 0);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("GH#1639 — MIN_VAULT_FOR_OI vault guard in health sort comparator", () => {
+  describe("MIN_VAULT_FOR_OI constant", () => {
+    it("is 1_000_000", () => {
+      expect(MIN_VAULT_FOR_OI).toBe(1_000_000);
+    });
+  });
+
+  describe("vault guard: sub-threshold markets are NOT oracle-down", () => {
+    it("returns false for vault_balance = 0 even if on-chain price is zero", () => {
+      expect(
+        computeIsOracleDown({ vaultBalance: 0, hasOnChain: true, onChainPriceZero: true })
+      ).toBe(false);
+    });
+
+    it("returns false for vault_balance = 999_999 (one below threshold)", () => {
+      expect(
+        computeIsOracleDown({ vaultBalance: 999_999, hasOnChain: true, onChainPriceZero: true })
+      ).toBe(false);
+    });
+
+    it("returns false for vault_balance = 1 with both prices null", () => {
+      expect(
+        computeIsOracleDown({ vaultBalance: 1, markPrice: null, indexPrice: null })
+      ).toBe(false);
+    });
+
+    it("returns false for vault_balance = 500_000 with both prices zero", () => {
+      expect(
+        computeIsOracleDown({ vaultBalance: 500_000, markPrice: 0, indexPrice: 0 })
+      ).toBe(false);
+    });
+  });
+
+  describe("vault guard: at/above threshold markets use normal oracle-down logic", () => {
+    it("returns true for vault_balance = 1_000_000 (exact threshold) with on-chain price zero", () => {
+      expect(
+        computeIsOracleDown({ vaultBalance: 1_000_000, hasOnChain: true, onChainPriceZero: true })
+      ).toBe(true);
+    });
+
+    it("returns false for vault_balance = 1_000_000 with on-chain price non-zero", () => {
+      expect(
+        computeIsOracleDown({ vaultBalance: 1_000_000, hasOnChain: true, onChainPriceZero: false })
+      ).toBe(false);
+    });
+
+    it("returns true for vault_balance = 5_000_000 with both prices null (Supabase-only market)", () => {
+      expect(
+        computeIsOracleDown({ vaultBalance: 5_000_000, markPrice: null, indexPrice: null })
+      ).toBe(true);
+    });
+
+    it("returns false for vault_balance = 5_000_000 with valid mark_price", () => {
+      expect(
+        computeIsOracleDown({ vaultBalance: 5_000_000, markPrice: 1234, indexPrice: null })
+      ).toBe(false);
+    });
+
+    it("returns false for vault_balance = 5_000_000 with valid index_price only", () => {
+      expect(
+        computeIsOracleDown({ vaultBalance: 5_000_000, markPrice: null, indexPrice: 5678 })
+      ).toBe(false);
+    });
+  });
+
+  describe("vault = null: no vault data — falls through to price check", () => {
+    it("returns true when vault is null and both prices are null (Supabase-only)", () => {
+      expect(
+        computeIsOracleDown({ vaultBalance: null, markPrice: null, indexPrice: null })
+      ).toBe(true);
+    });
+
+    it("returns false when vault is null and mark_price is valid", () => {
+      expect(
+        computeIsOracleDown({ vaultBalance: null, markPrice: 42, indexPrice: null })
+      ).toBe(false);
+    });
+  });
+
+  describe("sort rank consistency: sub-threshold markets rank as 'empty', not 'oracle-down'", () => {
+    const order: Record<string, number> = {
+      healthy: 0, caution: 1, warning: 2, "oracle-down": 3, empty: 4,
+    };
+
+    function getLevel(params: Parameters<typeof computeIsOracleDown>[0], baseLevel: string) {
+      return computeIsOracleDown(params) ? "oracle-down" : baseLevel;
+    }
+
+    it("sub-threshold market with 'empty' base level stays at rank 4 (empty)", () => {
+      const level = getLevel({ vaultBalance: 999_999, markPrice: null, indexPrice: null }, "empty");
+      expect(order[level]).toBe(4);
+    });
+
+    it("above-threshold oracle-down market ranks at 3 (oracle-down)", () => {
+      const level = getLevel({ vaultBalance: 2_000_000, markPrice: null, indexPrice: null }, "empty");
+      expect(order[level]).toBe(3);
+    });
+
+    it("healthy above-threshold market ranks at 0 (healthy)", () => {
+      const level = getLevel({ vaultBalance: 2_000_000, markPrice: 100, indexPrice: 100, hasOnChain: true, onChainPriceZero: false }, "healthy");
+      expect(order[level]).toBe(0);
+    });
+  });
+});

--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -25,6 +25,7 @@ import { MarketLogo } from "@/components/market/MarketLogo";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
 import { detectOracleMode, resolveMarketPriceE6, priceE6ToUsd } from "@/lib/oraclePrice";
 import { formatStatValue } from "@/lib/format";
+import { MIN_VAULT_FOR_OI } from "@/lib/phantom-oi";
 
 /** Max sane price (USD) for both active-market filtering and display capping.
  *  Mirrors /api/stats sanitizePrice() cap. Corrupt oracle prices (e.g. $7.9T)
@@ -371,7 +372,18 @@ function MarketsPageInner() {
           };
           // For on-chain markets: isOracleDown when resolveMarketPriceE6 returns 0
           // For Supabase-only markets: isOracleDown when both mark_price and index_price are null/zero
+          // GH#1639: Apply the same MIN_VAULT_FOR_OI guard as route.ts.
+          // Markets with vault_balance < MIN_VAULT_FOR_OI have phantom OI zeroed out
+          // server-side; calling isOracleDown on them may produce "oracle-down" sort rank
+          // instead of "empty", causing client/server sort disagreement at the threshold boundary.
+          // Guard: return false (not oracle-down) for sub-threshold markets so they sort as "empty".
           const computeIsOracleDown = (m: MergedMarket): boolean => {
+            // Vault guard — mirrors route.ts MIN_VAULT_FOR_OI check (PERC-816 / GH#1639)
+            const vaultBal = numericOrNullForSort(m.supabase?.vault_balance);
+            if (vaultBal !== null && vaultBal < MIN_VAULT_FOR_OI) {
+              // Sub-threshold vault: phantom OI suppressed server-side → treat as empty, not oracle-down
+              return false;
+            }
             if (m.onChain) {
               const priceE6 = resolveMarketPriceE6(m.onChain.config);
               return priceE6 === 0n;


### PR DESCRIPTION
## Problem

CodeRabbit flagged a **MAJOR** issue on PR #1638.

`page.tsx`'s `computeIsOracleDown` did not apply the same `MIN_VAULT_FOR_OI = 1_000_000` vault threshold guard that `route.ts` uses when computing health for server-side sorting. Markets with `vault_balance < 1_000_000` have their phantom OI zeroed server-side (PERC-816), but the client-side health sort comparator could classify them as `oracle-down` (rank 3) instead of `empty` (rank 4), causing client/server sort disagreement at the boundary.

## Fix

- Import `MIN_VAULT_FOR_OI` from `@/lib/phantom-oi`
- Add vault guard at the top of `computeIsOracleDown`: return `false` (not oracle-down) for any market where `vault_balance < MIN_VAULT_FOR_OI`, mirroring `route.ts` logic (PERC-816 / migration 051)

## Tests

15 new unit tests in `__tests__/unit/gh1639-min-vault-for-oi-sort-comparator.test.ts` covering:
- Sub-threshold markets are never classified as oracle-down
- At-threshold and above-threshold markets use normal oracle-down logic
- Sort rank consistency: sub-threshold markets always rank as 'empty' (4), not 'oracle-down' (3)
- Null vault falls through to price check (unchanged behaviour)

**1569/1603 tests passing (1569 pass, 34 skipped)**

## References
- Closes #1639
- CodeRabbit MAJOR comment on PR #1638
- `route.ts` `MIN_VAULT_FOR_OI` guard (migration 051 / PERC-816)