### PR TITLE
fix(designer-bugs): P1/P2 visual fixes from production review

### DIFF
--- a/app/components/trade/ChartEmptyState.tsx
+++ b/app/components/trade/ChartEmptyState.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { FC } from "react";
-import Image from "next/image";
 
 interface ChartEmptyStateProps {
   /** Optional current price to display alongside the empty state */
@@ -22,17 +21,16 @@ export const ChartEmptyState: FC<ChartEmptyStateProps> = ({
     <div
       className={`relative flex ${heightClass} flex-col items-center justify-center rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 overflow-hidden`}
     >
-      {/* Background SVG illustration */}
-      <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-        <Image
-          src="/chart-empty-state.svg"
-          alt=""
-          width={600}
-          height={320}
-          className="w-full h-full object-contain opacity-80"
-          priority={false}
-          aria-hidden="true"
-        />
+      {/* Subtle grid lines background — no phantom candles */}
+      <div className="absolute inset-0 pointer-events-none overflow-hidden opacity-10" aria-hidden="true">
+        <svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse">
+              <path d="M 48 0 L 0 0 0 48" fill="none" stroke="currentColor" strokeWidth="0.5"/>
+            </pattern>
+          </defs>
+          <rect width="100%" height="100%" fill="url(#grid)" className="text-[var(--border)]" />
+        </svg>
       </div>
 
       {/* Overlay content — sits above the SVG */}

--- a/app/components/trade/MarketBookCard.tsx
+++ b/app/components/trade/MarketBookCard.tsx
@@ -35,12 +35,14 @@ export const MarketBookCard: FC = () => {
 
   const oraclePrice = livePriceE6 ?? (mktConfig ? resolveMarketPriceE6(mktConfig) : 0n);
   const feeBps = Number(params.tradingFeeBps ?? 0n);
-  const bestBid = oraclePrice > 0n ? Number(oraclePrice) * (1 - feeBps / 10000) : 0;
-  const bestAsk = oraclePrice > 0n ? Number(oraclePrice) * (1 + feeBps / 10000) : 0;
+  const bestBidE6 = oraclePrice > 0n ? BigInt(Math.round(Number(oraclePrice) * (1 - feeBps / 10000))) : 0n;
+  const bestAskE6 = oraclePrice > 0n ? BigInt(Math.round(Number(oraclePrice) * (1 + feeBps / 10000))) : 0n;
 
-  // 2.2: Spread
-  const spread = bestAsk - bestBid;
-  const spreadPct = bestAsk > 0 ? (spread / bestAsk) * 100 : 0;
+  // 2.2: Spread (BigInt)
+  const spreadE6 = bestAskE6 - bestBidE6;
+  const spreadUsd = Number(spreadE6) / 1_000_000;
+  const oraclePriceUsd = Number(oraclePrice) / 1_000_000;
+  const spreadPct = oraclePriceUsd > 0 ? (spreadUsd / oraclePriceUsd) * 100 : 0;
 
   const lpTotalCapital = lps.reduce((sum, { account }) => sum + account.capital, 0n);
 
@@ -72,12 +74,7 @@ export const MarketBookCard: FC = () => {
         {/* Bid */}
         <div className="bg-[var(--bg)] p-2 text-center">
           <p className="text-[8px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Bid</p>
-          <p
-            className="text-[13px] font-medium text-[var(--long)]"
-            style={{ fontFamily: "var(--font-mono)" }}
-          >
-            {bestBid > 0 ? `$${(bestBid / 1_000_000).toFixed(bestBid / 1_000_000 < 1 ? 6 : 2)}` : "—"}
-          </p>
+          <p className="text-[11px] font-medium text-[var(--long)]" style={{ fontFamily: "var(--font-mono)" }}>{formatUsd(bestBidE6)}</p>
         </div>
         {/* Oracle — subtle accent border + bg */}
         <div className="p-2 text-center border-x border-[var(--accent)]/20 bg-[var(--accent)]/[0.03]">
@@ -92,12 +89,7 @@ export const MarketBookCard: FC = () => {
         {/* Ask */}
         <div className="bg-[var(--bg)] p-2 text-center">
           <p className="text-[8px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Ask</p>
-          <p
-            className="text-[13px] font-medium text-[var(--short)]"
-            style={{ fontFamily: "var(--font-mono)" }}
-          >
-            {bestAsk > 0 ? `$${(bestAsk / 1_000_000).toFixed(bestAsk / 1_000_000 < 1 ? 6 : 2)}` : "—"}
-          </p>
+          <p className="text-[11px] font-medium text-[var(--short)]" style={{ fontFamily: "var(--font-mono)" }}>{formatUsd(bestAskE6)}</p>
         </div>
       </div>
 
@@ -106,7 +98,7 @@ export const MarketBookCard: FC = () => {
         <div className="mb-3 flex items-center justify-between px-0.5">
           <span className="text-[9px] uppercase tracking-[0.12em] text-[var(--text-dim)] font-mono">Spread</span>
           <span className="text-[9px] text-[var(--text-dim)] font-mono">
-            ${(spread / 1_000_000).toFixed(spread / 1_000_000 < 0.001 ? 6 : 4)}{" "}
+            ${spreadUsd.toFixed(spreadUsd < 0.001 ? 6 : 4)}{" "}
             <span className="text-[var(--text-dim)]/60">({spreadPct.toFixed(3)}%)</span>
           </span>
         </div>
@@ -151,13 +143,10 @@ export const MarketBookCard: FC = () => {
       {/* 2.4: LP table — with UTILISATION column, capped at 5 */}
       {lps.length > 0 && (
         <div>
-          <p className="mb-1 text-[8px] uppercase tracking-[0.15em] text-[var(--text-dim)]">
-            Liquidity Providers
-          </p>
           {/* Header */}
-          <div className="mb-1 flex text-[8px] uppercase tracking-[0.15em] text-[var(--text-dim)]">
+          <div className="mb-1 flex gap-1 text-[8px] uppercase tracking-[0.1em] text-[var(--text-muted)] font-medium">
             <span className="w-5">#</span>
-            <span className="flex-1">LP</span>
+            <span className="flex-1">L.P.</span>
             <span className="w-20 text-right">Capital</span>
             <span className="w-20 text-right">Net Pos</span>
             <span className="w-16 text-right">Util</span>
@@ -179,20 +168,11 @@ export const MarketBookCard: FC = () => {
                   : "text-[var(--text-dim)]";
 
               return (
-                <div key={idx} className="flex items-center py-1 text-[10px]">
-                  <span className="w-5 text-[var(--text-dim)]" style={{ fontFamily: "var(--font-mono)" }}>
-                    {i + 1}
-                  </span>
-                  <span className="flex-1 text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-mono)" }}>
-                    {shortenAddress(account.owner.toBase58())}
-                  </span>
-                  <span className="w-20 text-right text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>
-                    {formatTokenAmount(account.capital)}
-                  </span>
-                  <span
-                    className={`w-20 text-right ${account.positionSize >= 0n ? "text-[var(--long)]" : "text-[var(--short)]"}`}
-                    style={{ fontFamily: "var(--font-mono)" }}
-                  >
+                <div key={idx} className="flex items-center gap-1 py-1 text-[10px]">
+                  <span className="w-5 text-[var(--text-dim)]" style={{ fontFamily: "var(--font-mono)" }}>{i + 1}</span>
+                  <span className="flex-1 text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-mono)" }}>{shortenAddress(account.owner.toBase58())}</span>
+                  <span className="w-20 text-right text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>{formatTokenAmount(account.capital)}</span>
+                  <span className={`w-20 text-right ${account.positionSize >= 0n ? "text-[var(--long)]" : "text-[var(--short)]"}`} style={{ fontFamily: "var(--font-mono)" }}>
                     {formatTokenAmount(account.positionSize < 0n ? -account.positionSize : account.positionSize)}
                   </span>
                   <span className={`w-16 text-right font-medium ${utilColor}`} style={{ fontFamily: "var(--font-mono)" }}>

--- a/app/components/trade/MarketStatsCard.tsx
+++ b/app/components/trade/MarketStatsCard.tsx
@@ -245,9 +245,9 @@ export const MarketStatsCard: FC = () => {
               /* min-w-0 prevents the grid cell from overflowing its track (#864) */
               className="min-w-0 px-1.5 py-1 overflow-hidden border-b border-r border-[var(--border)]/20 [&:nth-child(3n)]:border-r-0 [&:nth-last-child(-n+3)]:border-b-0"
             >
-              <p className="text-[8px] uppercase tracking-[0.05em] text-[var(--text-muted)] truncate" title={s.label}>{s.label}</p>
+              <p className="text-[7px] uppercase tracking-[0.02em] text-[var(--text-muted)] leading-tight" style={{ wordBreak: "break-word", overflowWrap: "anywhere" }} title={s.label}>{s.label}</p>
               <p
-                className={`text-[11px] font-medium truncate ${s.valueClass ?? "text-[var(--text)]"}`}
+                className={`text-[10px] font-medium truncate ${s.valueClass ?? "text-[var(--text)]"}`}
                 title={s.tooltip ?? s.value}
                 style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}
               >

--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -403,7 +403,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
       <div className="mb-2">
         <div className="mb-1 flex items-center justify-between">
           <label className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Margin ({symbol})<InfoIcon tooltip="The amount of collateral you're putting up for this trade. If your position loses more than your margin, you get liquidated." /></label>
-          <span className="text-[10px] text-[var(--text-dim)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
+          <span className="text-[10px] text-[var(--text-dim)] whitespace-nowrap min-w-0 shrink-0" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
             {/* GH#1133: When no trading account exists yet, show wallet ATA balance (not 0) */}
             Bal: {userAccount ? formatPerc(capital, decimals) : (walletAtaBalance !== null ? formatPerc(walletAtaBalance, decimals) : "—")}
           </span>
@@ -574,10 +574,10 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
 
       {/* Coin-margined info */}
       <div className="mt-3 rounded-none border border-[var(--border)]/20 bg-[var(--bg)]/50 p-2.5">
-        <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-muted)]">
+        <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-secondary)]">
           Coin-Margined Market
         </p>
-        <p className="mt-1 text-[9px] leading-relaxed text-[var(--text-muted)]">
+        <p className="mt-1 text-[10px] leading-relaxed text-[var(--text-secondary)]">
           Margined in <strong className="text-[var(--text-secondary)]">{symbol}</strong>, not USD. Position value and liquidation risk are affected by the collateral token&apos;s price movements.
           Effective USD leverage: <span className="font-mono text-[var(--text-secondary)]">{leverage > 0 ? `~${leverage * 2}x` : "—"}</span> (nominal {leverage}x × 2 for coin exposure).
         </p>


### PR DESCRIPTION
## Changes

### P1 Fixes
- **MarketBookCard BID/ASK formatting**: Was using raw `toFixed(6)` with no comma. Now uses `formatUsd(priceE6)` matching Oracle column formatting.
- **Stats grid overflow**: Reduced label font to 7px + word-break CSS. Value cells to 10px. Prevents ACCOUNTS/FUNDING label truncation.
- **Empty chart phantom candles**: Removed ghost SVG illustration from ChartEmptyState. Replaced with subtle CSS grid lines. Zero phantom shapes.

### P2 Polish
- **LP table headers**: Increased contrast + gap-1 for better column spacing
- **Coin-margined description**: Font 9px → 10px, text-muted → text-secondary
- **MARGIN (TOKEN) Bal**: Added whitespace-nowrap + shrink-0 to prevent truncation

### Not Reproduced
- Pagination controls (◀ 4 50 ▶ ✕) — need designer screenshot to identify component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed balance display overflow in the trade form.
  * Improved text rendering and layout in market stats and LP table components.

* **Style**
  * Updated chart empty state with scalable grid background visualization.
  * Adjusted bid/ask value formatting in market book display.
  * Enhanced text wrapping and sizing consistency across trading interface components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->