### PR TITLE
fix(GH#1654): MarketInfoBar — sticky full-width bar with logo, all breakpoints

### DIFF
--- a/app/__tests__/unit/gh1654-market-info-bar-visibility.test.ts
+++ b/app/__tests__/unit/gh1654-market-info-bar-visibility.test.ts
@@ -1,0 +1,53 @@
+/**
+ * GH#1654 — MarketInfoBar visibility regression
+ * Verifies:
+ * 1. data-testid="market-info-bar" attribute present
+ * 2. sticky positioning class
+ * 3. No `hidden` class on the wrapper (visible on all breakpoints)
+ * 4. MarketLogo is imported and rendered
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const barSource = readFileSync(
+  join(__dirname, "../../components/trade/MarketInfoBar.tsx"),
+  "utf-8"
+);
+
+const pageSource = readFileSync(
+  join(__dirname, "../../app/trade/[slab]/page.tsx"),
+  "utf-8"
+);
+
+describe("GH#1654 — MarketInfoBar visibility", () => {
+  test("has data-testid attribute", () => {
+    expect(barSource).toContain('data-testid="market-info-bar"');
+  });
+
+  test("is sticky positioned", () => {
+    expect(barSource).toContain("sticky");
+  });
+
+  test("imports MarketLogo", () => {
+    expect(barSource).toContain("MarketLogo");
+    expect(barSource).toContain("@/components/market/MarketLogo");
+  });
+
+  test("page renders MarketInfoBar without hidden wrapper", () => {
+    // Find the MarketInfoBar JSX usage line
+    const lines = pageSource.split("\n");
+    const barLine = lines.findIndex((l) => l.includes("<MarketInfoBar"));
+    expect(barLine).toBeGreaterThan(-1);
+
+    // The previous line should NOT contain "hidden" class
+    const prevLine = lines[barLine - 1] ?? "";
+    // Allow "hidden" only if it's part of lg:hidden (mobile header), not wrapping MarketInfoBar
+    const wrapperLine = lines.slice(Math.max(0, barLine - 3), barLine).join(" ");
+    expect(wrapperLine).not.toMatch(/className="[^"]*hidden[^"]*"/);
+  });
+
+  test("passes mintAddress prop", () => {
+    expect(pageSource).toMatch(/MarketInfoBar[^>]*mintAddress/);
+  });
+});

--- a/app/app/trade/[slab]/page.tsx
+++ b/app/app/trade/[slab]/page.tsx
@@ -306,9 +306,6 @@ function TradePageInner({ slab }: { slab: string }) {
             <UsdToggleButton />
             {health && <HealthBadge level={health.level} />}
             {oracleMode && <OracleBadge mode={oracleMode} status={oracleBadgeStatus} />}
-            {!slabLoading && (
-              <span className={`shrink-0 text-sm font-bold ${priceDisplay ? "text-[var(--text)]" : "text-[var(--text-dim)]"}`} style={{ fontFamily: "var(--font-mono)" }}>{priceDisplay ?? "\u2014"}</span>
-            )}
           </div>
         </div>
         <div className="mt-1 flex items-center gap-2 flex-wrap">
@@ -334,10 +331,8 @@ function TradePageInner({ slab }: { slab: string }) {
         </div>
       </div>
 
-      {/* ── DESKTOP: Market info bar ── */}
-      <div className="hidden lg:block">
-        <MarketInfoBar slabAddress={slab} symbol={symbol} logoUrl={logoUrl} />
-      </div>
+      {/* ── Market info bar (all breakpoints — horizontally scrollable on mobile) ── */}
+      <MarketInfoBar slabAddress={slab} symbol={symbol} logoUrl={logoUrl} mintAddress={mintAddress} />
 
 
       {/* ── Quick start guide — desktop only, hidden after first trade ── */}

--- a/app/components/trade/MarketInfoBar.tsx
+++ b/app/components/trade/MarketInfoBar.tsx
@@ -4,12 +4,13 @@ import { FC } from "react";
 import { useLivePrice } from "@/hooks/useLivePrice";
 import { useMarketInfo } from "@/hooks/useMarketInfo";
 import { useEngineState } from "@/hooks/useEngineState";
+import { MarketLogo } from "@/components/market/MarketLogo";
 
 interface MarketInfoBarProps {
   slabAddress: string;
   symbol: string;
-  // logoUrl accepted but not rendered in bar (used by parent for MarketLogo)
   logoUrl?: string | null;
+  mintAddress?: string | null;
 }
 
 function formatCompact(n: number | null | undefined): string {
@@ -28,7 +29,7 @@ function fundingRateBpsTo8h(rateBps: bigint): number {
   return ((Number(rateBps) * 9000 * 8) / 10000) / 100;
 }
 
-export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol }) => {
+export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol, logoUrl, mintAddress }) => {
   const { priceUsd, change24h } = useLivePrice();
   const { market } = useMarketInfo(slabAddress);
   const { fundingRate } = useEngineState();
@@ -37,12 +38,9 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol }) =
     ? `$${priceUsd < 0.01 ? priceUsd.toFixed(6) : priceUsd < 1 ? priceUsd.toFixed(4) : priceUsd.toFixed(2)}`
     : "—";
 
-  // Always show badge — display "0.00%" when no change data is available (devnet null/0)
-  const has24hChange = true;
   const change24hDisplay = change24h ?? 0;
   const isUp = change24hDisplay >= 0;
 
-  // Phase 2: use 8h rate to match UI label (was hourly, label said /8h — now consistent)
   const funding8h = fundingRate != null ? fundingRateBpsTo8h(fundingRate) : null;
   const fundingColor = funding8h != null ? (funding8h < 0 ? "text-orange-400" : "text-green-400") : "text-[var(--text)]";
 
@@ -59,50 +57,72 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol }) =
   })();
 
   return (
-    <div className="bg-[var(--bg)]/95 border-b border-[var(--border)]/50 px-4 py-2 flex items-center gap-4 overflow-x-auto whitespace-nowrap">
-      {/* Symbol */}
-      <span className="text-sm font-bold text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>
-        {symbol}/USD
-        <span className="ml-1.5 text-[9px] font-normal uppercase tracking-[0.12em] text-[var(--text-dim)]">PERP</span>
-      </span>
+    <div
+      data-testid="market-info-bar"
+      className="sticky top-0 z-30 w-full border-b border-[var(--border)]/50 bg-[var(--bg)]/95 backdrop-blur-sm px-4 py-2.5 flex items-center gap-5 overflow-x-auto whitespace-nowrap scrollbar-none"
+    >
+      {/* Symbol + Logo */}
+      <div className="flex items-center gap-2 shrink-0">
+        <MarketLogo logoUrl={logoUrl} mintAddress={mintAddress} symbol={symbol} size="sm" />
+        <span className="text-sm font-bold text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>
+          {symbol}/USD
+          <span className="ml-1.5 text-[9px] font-normal uppercase tracking-[0.12em] text-[var(--text-dim)]">PERP</span>
+        </span>
+      </div>
 
-      <span className="h-3.5 w-px bg-[var(--border)]/40 shrink-0" />
+      <span className="h-4 w-px bg-[var(--border)]/40 shrink-0" />
 
-      {/* Mark Price — color based on 24h direction for immediate at-a-glance read */}
+      {/* Mark Price — large, colored by direction */}
       <span
-        className={`text-lg font-bold tabular-nums ${has24hChange ? (isUp ? "text-green-400" : "text-red-400") : "text-[var(--text)]"}`}
+        className={`text-lg font-bold tabular-nums shrink-0 ${isUp ? "text-green-400" : "text-red-400"}`}
         style={{ fontFamily: "var(--font-mono)" }}
       >
         {priceDisplay}
       </span>
 
-      {/* 24h change badge — always visible; shows "0.00%" when devnet price data returns null */}
-      <span className={`shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded-sm ${change24h == null ? "bg-[var(--border)]/30 text-[var(--text-dim)]" : isUp ? "bg-green-500/20 text-green-400" : "bg-red-500/20 text-red-400"}`}>
+      {/* 24h change badge */}
+      <span
+        className={`shrink-0 text-[11px] font-semibold px-2 py-0.5 rounded ${
+          change24h == null
+            ? "bg-[var(--border)]/30 text-[var(--text-dim)]"
+            : isUp
+              ? "bg-green-500/15 text-green-400 border border-green-500/20"
+              : "bg-red-500/15 text-red-400 border border-red-500/20"
+        }`}
+      >
         {change24h == null ? "0.00%" : `${isUp ? "+" : ""}${change24hDisplay.toFixed(2)}%`}
       </span>
 
-      <span className="h-3.5 w-px bg-[var(--border)]/40 shrink-0" />
+      <span className="h-4 w-px bg-[var(--border)]/40 shrink-0" />
 
-      {/* Volume 24h */}
-      <span className="text-[10px] text-[var(--text-muted)]">
-        Vol 24h: <span className="text-[var(--text)] font-medium">{formatCompact(volume as number)}</span>
-      </span>
-
-      {/* OI */}
-      <span className="text-[10px] text-[var(--text-muted)]">
-        OI: <span className="text-[var(--text)] font-medium">{formatCompact(oi as number)}</span>
-      </span>
-
-      {/* Phase 2: Funding rate — 8h rate in sub-header (designer note: surface it here like Hyperliquid) */}
-      {funding8h != null && (
-        <span className="text-[10px] text-[var(--text-muted)] shrink-0">
-          Funding:{" "}
-          <span className={`font-semibold ${fundingColor}`}>
-            {funding8h >= 0 ? "+" : ""}{funding8h.toFixed(4)}%
+      {/* Stats group */}
+      <div className="flex items-center gap-4 shrink-0">
+        {/* Volume 24h */}
+        <div className="flex flex-col">
+          <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">Vol 24h</span>
+          <span className="text-xs font-medium text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>
+            {formatCompact(volume as number)}
           </span>
-          <span className="text-[var(--text-dim)]"> / 8h</span>
-        </span>
-      )}
+        </div>
+
+        {/* OI */}
+        <div className="flex flex-col">
+          <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">Open Interest</span>
+          <span className="text-xs font-medium text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>
+            {formatCompact(oi as number)}
+          </span>
+        </div>
+
+        {/* Funding Rate */}
+        {funding8h != null && (
+          <div className="flex flex-col">
+            <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">Funding / 8h</span>
+            <span className={`text-xs font-semibold ${fundingColor}`} style={{ fontFamily: "var(--font-mono)" }}>
+              {funding8h >= 0 ? "+" : ""}{funding8h.toFixed(4)}%
+            </span>
+          </div>
+        )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
Fixes #1654 — MarketInfoBar was rendering as the old compact inline header and was desktop-only.

## Changes
- **MarketInfoBar.tsx**: Redesigned as a proper sticky full-width bar
  - Added `data-testid="market-info-bar"` for test discoverability
  - Imported and rendered `MarketLogo` with CDN fallback via `mintAddress`
  - Sticky positioning (`sticky top-0 z-30`) with backdrop blur
  - Vol/OI/Funding displayed as stacked label+value pairs (not inline text)
  - 24h change as a bordered badge with green/red color coding
  - Scrollable on mobile via `overflow-x-auto scrollbar-none`
- **page.tsx**: Removed `hidden lg:block` wrapper — bar visible on all breakpoints
  - Removed duplicate price from mobile sticky header (MarketInfoBar covers it)
  - Passes `mintAddress` prop for logo CDN fallback
- **Unit tests**: 5 tests verifying testid, sticky, logo import, no hidden wrapper, mintAddress prop

## Testing
- `pnpm vitest run __tests__/unit/gh1654-market-info-bar-visibility.test.ts` — 5/5 pass
- Visual: bar renders as full-width sticky bar on desktop and mobile