### PR TITLE
fix(GH#1654): MarketInfoBar sticky positioning + data-testid

### DIFF
--- a/app/__tests__/unit/gh1654-market-info-bar-sticky.test.ts
+++ b/app/__tests__/unit/gh1654-market-info-bar-sticky.test.ts
@@ -1,0 +1,46 @@
+/**
+ * GH#1654: MarketInfoBar — sticky positioning + data-testid
+ *
+ * Verifies that:
+ * 1. MarketInfoBar component has data-testid="market-info-bar" in its root element
+ * 2. Desktop wrapper in trade page uses sticky top-0 z-30 for correct scroll behavior
+ * 3. MarketInfoBar is only visible on lg+ (hidden on mobile — mobile uses its own sticky header)
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const MARKET_INFO_BAR = join(__dirname, "../../components/trade/MarketInfoBar.tsx");
+const TRADE_PAGE = join(__dirname, "../../app/trade/[slab]/page.tsx");
+
+describe("GH#1654 — MarketInfoBar sticky + data-testid", () => {
+  let barSource: string;
+  let pageSource: string;
+
+  beforeAll(() => {
+    barSource = readFileSync(MARKET_INFO_BAR, "utf-8");
+    pageSource = readFileSync(TRADE_PAGE, "utf-8");
+  });
+
+  it('MarketInfoBar root element has data-testid="market-info-bar"', () => {
+    expect(barSource).toContain('data-testid="market-info-bar"');
+  });
+
+  it("Desktop wrapper has sticky top-0 z-30 classes", () => {
+    // The wrapper div around MarketInfoBar on desktop must be sticky
+    expect(pageSource).toMatch(/sticky\s+top-0\s+z-30[^>]*hidden\s+lg:block|hidden\s+lg:block[^>]*sticky\s+top-0\s+z-30/);
+  });
+
+  it("MarketInfoBar is hidden on mobile (hidden lg:block wrapper)", () => {
+    expect(pageSource).toMatch(/hidden\s+lg:block/);
+    // Confirm MarketInfoBar is inside the hidden lg:block section
+    const wrapperIdx = pageSource.indexOf("sticky top-0 z-30 hidden lg:block");
+    const barIdx = pageSource.indexOf("<MarketInfoBar", wrapperIdx);
+    expect(barIdx).toBeGreaterThan(wrapperIdx);
+    expect(barIdx - wrapperIdx).toBeLessThan(200); // MarketInfoBar is immediately inside the wrapper
+  });
+
+  it("MarketInfoBar has backdrop-blur-sm for glass effect", () => {
+    expect(barSource).toContain("backdrop-blur-sm");
+  });
+});

--- a/app/app/trade/[slab]/page.tsx
+++ b/app/app/trade/[slab]/page.tsx
@@ -334,8 +334,8 @@ function TradePageInner({ slab }: { slab: string }) {
         </div>
       </div>
 
-      {/* ── DESKTOP: Market info bar ── */}
-      <div className="hidden lg:block">
+      {/* ── DESKTOP: Market info bar — sticky so it stays visible while scrolling ── */}
+      <div className="sticky top-0 z-30 hidden lg:block">
         <MarketInfoBar slabAddress={slab} symbol={symbol} logoUrl={logoUrl} />
       </div>
 

--- a/app/components/trade/MarketInfoBar.tsx
+++ b/app/components/trade/MarketInfoBar.tsx
@@ -59,7 +59,10 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol }) =
   })();
 
   return (
-    <div className="bg-[var(--bg)]/95 border-b border-[var(--border)]/50 px-4 py-2 flex items-center gap-4 overflow-x-auto whitespace-nowrap">
+    <div
+      data-testid="market-info-bar"
+      className="bg-[var(--bg)]/95 border-b border-[var(--border)]/50 px-4 py-2 flex items-center gap-4 overflow-x-auto whitespace-nowrap backdrop-blur-sm"
+    >
       {/* Symbol */}
       <span className="text-sm font-bold text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>
         {symbol}/USD


### PR DESCRIPTION
## Problem
GH#1654: MarketInfoBar was rendering as a non-sticky bar — scrolled out of view immediately. Also missing `data-testid` attribute which blocked test selectors.

## Root Cause
Desktop wrapper div was `hidden lg:block` only — no sticky positioning. The bar disappeared on scroll.

## Fix
- `page.tsx`: Desktop wrapper → `sticky top-0 z-30 hidden lg:block` (matches mobile sticky header z-index)
- `MarketInfoBar.tsx`: Add `data-testid="market-info-bar"` to root element
- Add `backdrop-blur-sm` for glass effect consistent with mobile header

## Testing
- All 133 test files pass (1597 tests)
- New unit test: `gh1654-market-info-bar-sticky.test.ts` — verifies sticky class, testid, mobile/desktop split

## Closes
Fixes GH#1654

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Market info bar now remains sticky at the top of the page when scrolling on desktop, improving accessibility during trading.
  * Enhanced market info bar with a glass-blur visual effect for improved aesthetics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->