### PR TITLE
fix(GH#1658): health sort vault guard — fallback to c_tot when vault_balance=0/null

### DIFF
--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -388,7 +388,14 @@ function MarketsPageInner() {
           // Guard: return false (not oracle-down) for sub-threshold markets so they sort as "empty".
           const computeIsOracleDown = (m: MergedMarket): boolean => {
             // Vault guard — mirrors route.ts MIN_VAULT_FOR_OI check (PERC-816 / GH#1639)
-            const vaultBal = numericOrNullForSort(m.supabase?.vault_balance);
+            // GH#1658: vault_balance may be 0/null when indexer hasn't populated it yet.
+            //   Fallback to c_tot (total vault capacity) so oracle-down markets with a real
+            //   c_tot don't get incorrectly excluded by the guard.
+            const rawVault = m.supabase?.vault_balance;
+            const rawCtot  = m.supabase?.c_tot;
+            const vaultBal = numericOrNullForSort(
+              rawVault != null && Number(rawVault) > 0 ? rawVault : rawCtot
+            );
             if (vaultBal !== null && vaultBal < MIN_VAULT_FOR_OI) {
               // Sub-threshold vault: phantom OI suppressed server-side → treat as empty, not oracle-down
               return false;


### PR DESCRIPTION
## Summary

Fixes the health sort contradiction where 3 SOL oracle-down markets (EkQty1Ls/DD9Ym1xS/8Wxmx93j) appeared at positions 1-3 in `/markets?sort=health` while displaying the **No Oracle** badge.

## Root Cause

`computeIsOracleDown()` had a MIN_VAULT_FOR_OI guard:
```ts
const vaultBal = numericOrNullForSort(m.supabase?.vault_balance);
if (vaultBal !== null && vaultBal < MIN_VAULT_FOR_OI) return false;
```
These 3 markets have `vault_balance=0` in Supabase (indexer hasn't populated it), so `numericOrNullForSort(0)` returns `0` (finite number), `0 < MIN_VAULT_FOR_OI` fires, and the function returns `false` (not oracle-down) → sort rank = healthy. But badge logic checks `onChainPriceE6 === 0n` directly → No Oracle badge. Rank ≠ badge.

## Fix

Fall back to `c_tot` when `vault_balance` is null or zero:
```ts
const rawVault = m.supabase?.vault_balance;
const rawCtot  = m.supabase?.c_tot;
const vaultBal = numericOrNullForSort(
  rawVault != null && Number(rawVault) > 0 ? rawVault : rawCtot
);
```
The 3 affected markets have `c_tot` = 500M / 1B / 2.5B atoms — all well above `MIN_VAULT_FOR_OI` — so the guard passes, the secondary oracle-down checks run, `onChainPriceE6 === 0n` returns true, and they sort below healthy markets as expected.

## Testing

- Verify on `/markets?sort=health`: EkQty1Ls, DD9Ym1xS, 8Wxmx93j should appear BELOW healthy markets
- Badge and sort rank should match (both show oracle-down)

Closes #1658

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved oracle status classification to correctly handle incomplete or zero vault balance data, ensuring accurate market status display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->