### PR TITLE
fix(GH#1660): contain:paint on chart wrapper to clip lw-charts nav buttons

### DIFF
--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -421,8 +421,11 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
       {/* Phase 2: mobile uses 40svh, desktop keeps 500px */}
       {/* overflow-hidden clips lightweight-charts toolbar/navigation buttons so they
           cannot escape the chart boundary and bleed into adjacent stat grid cells
-          (GH#1647: ◀ 32 ▶ ✕ appearing in ACCOUNTS cell of STATS tab) */}
-      <div className="relative overflow-hidden">
+          (GH#1647: ◀ 32 ▶ ✕ appearing in ACCOUNTS cell of STATS tab)
+          GH#1660: `contain: paint` creates a new paint containment boundary so lw-charts
+          absolutely-positioned nav buttons are painted within this element only,
+          preventing them from bleeding into sibling DOM at 1440px desktop. */}
+      <div className="relative overflow-hidden [contain:paint]">
         {/* GH#1652: always mount the container so lightweight-charts canvas initialises.
             The chart ref is always created in useEffect; empty-state is overlaid on top
             when candles=[] so the canvas element exists in the DOM on first render. */}


### PR DESCRIPTION
## Summary

Fixes lw-charts pagination/navigation controls (◀ 4 50 ▶ ✕) still bleeding into the ACCOUNTS stat cell on the STATS tab at 1440px desktop, as caught by designer visual review of PR #1655.

## Why overflow-hidden wasn't enough

PR #1648 added `overflow: hidden` to the chart wrapper. `overflow: hidden` clips children that overflow the element's *layout* box, but only when they are positioned within the element's stacking context. If lw-charts renders its toolbar buttons in a way that escapes our stacking context, overflow-hidden cannot clip them.

## Fix

Added `contain: paint` (via Tailwind `[contain:paint]`) to the chart wrapper div:
```html
<div className="relative overflow-hidden [contain:paint]">
```

**CSS Paint Containment** (CSS Containment Level 1) creates an explicit paint boundary. Any content descendant of the element — including absolutely-positioned children — is painted *within* the element's box. This is a harder guarantee than `overflow: hidden`.

`overflow-hidden` is kept for belt-and-suspenders coverage.

## Testing

- Verify STATS tab ACCOUNTS cell shows only the account count (e.g. "4/50") — no ◀ ▶ ✕ controls
- Test at 1440px desktop width

Closes #1660