### PR TITLE
fix(GH#1662): move MusicPlayer to bottom-left on /trade at lg+ to clear STATS panel

### DIFF
--- a/app/__tests__/unit/gh1662-music-player-trade-overlap.test.ts
+++ b/app/__tests__/unit/gh1662-music-player-trade-overlap.test.ts
@@ -1,0 +1,55 @@
+/**
+ * GH#1662 — MusicPlayer overlap in STATS panel at 1440px desktop
+ *
+ * Root cause: MusicPlayer is `fixed bottom-5 right-5` and at 1440px overlaps
+ * the 340px right STATS column (◀ ▶ ✕ volume controls visible over stat cells).
+ *
+ * Fix: On /trade routes at lg+ breakpoints, the player moves to bottom-LEFT
+ * (lg:left-5 lg:right-auto) so it sits below the chart, away from right panel.
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const playerSrc = readFileSync(
+  join(__dirname, "../../components/ui/MusicPlayer.tsx"),
+  "utf8"
+);
+
+describe("GH#1662 – MusicPlayer does not overlap STATS panel at 1440px", () => {
+  it("defines MOVE_TO_BOTTOM_LEFT_ROUTES_LG constant containing /trade", () => {
+    expect(playerSrc).toContain("MOVE_TO_BOTTOM_LEFT_ROUTES_LG");
+    // Must include /trade
+    const match = playerSrc.match(/MOVE_TO_BOTTOM_LEFT_ROUTES_LG\s*=\s*\[([^\]]*)\]/);
+    expect(match).not.toBeNull();
+    expect(match![1]).toContain('"/trade"');
+  });
+
+  it("applies lg:left-5 and lg:right-auto classes on /trade routes", () => {
+    expect(playerSrc).toContain("lg:left-5");
+    expect(playerSrc).toContain("lg:right-auto");
+  });
+
+  it("uses moveToBottomLeftLg flag derived from MOVE_TO_BOTTOM_LEFT_ROUTES_LG", () => {
+    expect(playerSrc).toContain("moveToBottomLeftLg");
+    expect(playerSrc).toContain(
+      "MOVE_TO_BOTTOM_LEFT_ROUTES_LG.some((r) => pathname?.startsWith(r))"
+    );
+  });
+
+  it("places lg position classes inside the conditional className (not unconditionally)", () => {
+    // The lg:left-5 must appear only inside the moveToBottomLeftLg ternary branch,
+    // not in the fallback or the moveToTop branch.
+    const lines = playerSrc.split("\n");
+    const lgLeftIdx = lines.findIndex((l) => l.includes("lg:left-5"));
+    expect(lgLeftIdx).toBeGreaterThan(-1);
+    // The line or its predecessor must reference moveToBottomLeftLg
+    const context = lines.slice(lgLeftIdx - 2, lgLeftIdx + 1).join("\n");
+    expect(context).toMatch(/moveToBottomLeftLg/);
+  });
+
+  it("does not change behaviour for non-trade routes (fallback branch unchanged)", () => {
+    // The original bottom-right fallback classes still appear
+    expect(playerSrc).toContain("bottom-3 right-3 sm:bottom-5 sm:right-5");
+  });
+});

--- a/app/components/ui/MusicPlayer.tsx
+++ b/app/components/ui/MusicPlayer.tsx
@@ -45,6 +45,16 @@ const HIDE_ON_MOBILE_ROUTES = ["/trade", "/stake"];
  */
 const MOVE_TO_TOP_ROUTES = ["/stake"];
 
+/**
+ * Routes where the player must move to the bottom-LEFT at lg+ breakpoints
+ * to avoid overlapping a right-side panel.
+ * /trade: 3-column layout has a fixed 340px right STATS column — player at
+ * bottom-right bleeds over Oracle/Stats cells and is mis-read as lw-charts
+ * toolbar (GH#1662). Shift to bottom-left at ≥1024px so it sits below the
+ * chart, clear of the right panel entirely.
+ */
+const MOVE_TO_BOTTOM_LEFT_ROUTES_LG = ["/trade"];
+
 export function MusicPlayer() {
   const [playing, setPlaying] = useState(false);
   const [volume, setVolume] = useState(0.5);
@@ -94,6 +104,9 @@ export function MusicPlayer() {
 
   /* Determine if the player should move to top-right to avoid content overlap */
   const moveToTop = MOVE_TO_TOP_ROUTES.some((r) => pathname?.startsWith(r));
+
+  /* Determine if the player should move to bottom-left at lg+ to avoid right panel overlap */
+  const moveToBottomLeftLg = MOVE_TO_BOTTOM_LEFT_ROUTES_LG.some((r) => pathname?.startsWith(r));
 
   useEffect(() => {
     if (audioRef.current) audioRef.current.volume = volume;
@@ -158,6 +171,8 @@ export function MusicPlayer() {
       className={`fixed z-[90] gsap-fade${hideOnMobile ? " hidden sm:block" : ""}${
         moveToTop
           ? " top-[80px] right-3 sm:top-[72px] sm:right-5"
+          : moveToBottomLeftLg
+          ? " bottom-3 right-3 sm:bottom-5 sm:right-5 lg:bottom-5 lg:right-auto lg:left-5"
           : " bottom-3 right-3 sm:bottom-5 sm:right-5"
       }`}
       style={{ opacity: 0 }}


### PR DESCRIPTION
## Problem

**GH#1662** — after PR #1661 (contain:paint fix), the `◀ 30 ▶ ✕` controls were still appearing in the STATS panel near the Oracle row at 1440px desktop.

**Root cause:** These are **not** lw-charts toolbar buttons. They are the **MusicPlayer** component (`fixed z-[90] bottom-5 right-5`). At 1440px the 340px right STATS column occupies the full right edge of the viewport — the bottom-right player renders directly over Oracle/Accounts stat cells.

The contain:paint fix was correct for lw-charts but the floating MusicPlayer (Play, progressbar, VolDown, volume level, VolUp, Minimize) was the actual overlapper.

## Fix

Added `MOVE_TO_BOTTOM_LEFT_ROUTES_LG = ["/trade"]`. On `/trade` routes at `lg+` (≥1024px) breakpoints, the player shifts to **bottom-left** (`lg:bottom-5 lg:right-auto lg:left-5`) — sitting below the chart column, away from the 340px right STATS panel entirely.

- sm/md behaviour (bottom-right) unchanged
- All other routes (/, /stake, etc.) unchanged
- `/stake` already uses `top-right` override — also unchanged

## How to test

1. Go to any trade page at 1440px width
2. MusicPlayer should appear **bottom-left**, not bottom-right
3. STATS panel (Mark, Index, Spread, OI, Vault, Funding, Oracle row) should be completely clear of player controls

## Tests

New: `gh1662-music-player-trade-overlap.test.ts` — 5 assertions
All 134 test files pass (1603 assertions)

Closes #1662

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated music player positioning on the trade page at larger screen sizes; player now appears at the bottom-left instead of bottom-right positioning.

* **Tests**
  * Added comprehensive unit test to verify music player positioning behavior on the trade page and confirm existing positioning remains unchanged on other routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->