### PR TITLE
fix(GH#1662-followup): exact-or-child route matching via matchesRoute() helper

### DIFF
--- a/app/__tests__/unit/gh1662-music-player-trade-overlap.test.ts
+++ b/app/__tests__/unit/gh1662-music-player-trade-overlap.test.ts
@@ -6,6 +6,9 @@
  *
  * Fix: On /trade routes at lg+ breakpoints, the player moves to bottom-LEFT
  * (lg:left-5 lg:right-auto) so it sits below the chart, away from right panel.
+ *
+ * CodeRabbit follow-up: route matching now uses exact-or-child semantics via
+ * matchesRoute() to prevent "/trade" from matching "/trader" etc.
  */
 
 import { readFileSync } from "fs";
@@ -30,11 +33,34 @@ describe("GH#1662 – MusicPlayer does not overlap STATS panel at 1440px", () =>
     expect(playerSrc).toContain("lg:right-auto");
   });
 
-  it("uses moveToBottomLeftLg flag derived from MOVE_TO_BOTTOM_LEFT_ROUTES_LG", () => {
+  it("uses moveToBottomLeftLg flag derived from MOVE_TO_BOTTOM_LEFT_ROUTES_LG via matchesRoute", () => {
     expect(playerSrc).toContain("moveToBottomLeftLg");
+    // Must use matchesRoute helper (not raw startsWith) to avoid false positives like /trader
     expect(playerSrc).toContain(
-      "MOVE_TO_BOTTOM_LEFT_ROUTES_LG.some((r) => pathname?.startsWith(r))"
+      "MOVE_TO_BOTTOM_LEFT_ROUTES_LG.some((r) => matchesRoute(pathname, r))"
     );
+  });
+
+  it("defines matchesRoute helper with exact-or-child semantics", () => {
+    expect(playerSrc).toContain("function matchesRoute");
+    // Helper must check exact match OR pathname starts with route + "/"
+    expect(playerSrc).toContain('pathname === route');
+    expect(playerSrc).toContain('pathname.startsWith(route + "/")');
+  });
+
+  it("matchesRoute prevents /trader from matching /trade prefix", () => {
+    // Inline test of the logic described in the source
+    function matchesRoute(pathname: string | null | undefined, route: string): boolean {
+      if (!pathname) return false;
+      return pathname === route || pathname.startsWith(route + "/");
+    }
+    expect(matchesRoute("/trade", "/trade")).toBe(true);
+    expect(matchesRoute("/trade/BTC-PERP", "/trade")).toBe(true);
+    expect(matchesRoute("/trader", "/trade")).toBe(false);
+    expect(matchesRoute("/tradex", "/trade")).toBe(false);
+    expect(matchesRoute(null, "/trade")).toBe(false);
+    expect(matchesRoute(undefined, "/trade")).toBe(false);
+    expect(matchesRoute("/markets", "/trade")).toBe(false);
   });
 
   it("places lg position classes inside the conditional className (not unconditionally)", () => {

--- a/app/components/ui/MusicPlayer.tsx
+++ b/app/components/ui/MusicPlayer.tsx
@@ -55,6 +55,17 @@ const MOVE_TO_TOP_ROUTES = ["/stake"];
  */
 const MOVE_TO_BOTTOM_LEFT_ROUTES_LG = ["/trade"];
 
+/**
+ * Match a pathname against a route prefix using exact-or-child semantics:
+ * - exact: pathname === route  (e.g. "/trade" matches "/trade")
+ * - child: pathname.startsWith(route + "/")  (e.g. "/trade/BTC-PERP" matches "/trade")
+ * This prevents false positives like "/trader" matching the prefix "/trade".
+ */
+function matchesRoute(pathname: string | null | undefined, route: string): boolean {
+  if (!pathname) return false;
+  return pathname === route || pathname.startsWith(route + "/");
+}
+
 export function MusicPlayer() {
   const [playing, setPlaying] = useState(false);
   const [volume, setVolume] = useState(0.5);
@@ -100,13 +111,13 @@ export function MusicPlayer() {
   }, []);
 
   /* Determine if the player should be hidden on mobile for this route */
-  const hideOnMobile = HIDE_ON_MOBILE_ROUTES.some((r) => pathname?.startsWith(r));
+  const hideOnMobile = HIDE_ON_MOBILE_ROUTES.some((r) => matchesRoute(pathname, r));
 
   /* Determine if the player should move to top-right to avoid content overlap */
-  const moveToTop = MOVE_TO_TOP_ROUTES.some((r) => pathname?.startsWith(r));
+  const moveToTop = MOVE_TO_TOP_ROUTES.some((r) => matchesRoute(pathname, r));
 
   /* Determine if the player should move to bottom-left at lg+ to avoid right panel overlap */
-  const moveToBottomLeftLg = MOVE_TO_BOTTOM_LEFT_ROUTES_LG.some((r) => pathname?.startsWith(r));
+  const moveToBottomLeftLg = MOVE_TO_BOTTOM_LEFT_ROUTES_LG.some((r) => matchesRoute(pathname, r));
 
   useEffect(() => {
     if (audioRef.current) audioRef.current.volume = volume;


### PR DESCRIPTION
## Summary
CodeRabbit review on PR #1663 flagged that `pathname?.startsWith(r)` causes false positives — e.g. `/trade` matching `/trader`.

## Root Cause
All three route flag computations in `MusicPlayer.tsx` used raw `startsWith`, meaning a future route like `/trader` or `/tradex` would incorrectly trigger the same class overrides as `/trade`.

## Fix
Introduce `matchesRoute(pathname, route)` helper:
```ts
pathname === route || pathname.startsWith(route + "/")
```
Applied to:
- `hideOnMobile` (HIDE\_ON\_MOBILE\_ROUTES)
- `moveToTop` (MOVE\_TO\_TOP\_ROUTES)  
- `moveToBottomLeftLg` (MOVE\_TO\_BOTTOM\_LEFT\_ROUTES\_LG)

## Tests
- Added exact-or-child unit cases: `/trader` does NOT match `/trade`, `/trade/BTC-PERP` does, null/undefined return false
- 134/134 tests pass

## How to Test
Navigate to `/trade` → MusicPlayer should be bottom-left at lg+.
Navigate to any hypothetical `/trader` route → MusicPlayer should remain bottom-right.