### PR TITLE
fix(designer-audit): homepage NO ORACLE filter, contrast fixes, Earn CTA style

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -239,10 +239,14 @@ export default function Home() {
           // with zeroed OI and null price are excluded from Active Markets display.
           // Without this, DfLoAzny (vault=1M=MIN_VAULT, OI zeroed by phantom guard,
           // price=null after sanitization) still appeared in the sorted featured list.
+          // Designer audit 2026-03-24: filter markets with no oracle price from homepage
+          // display — showing "NO ORACLE" in red on the homepage is bad UX. Markets
+          // without a live price should not appear in the top-5 featured list.
           const converted = phantomAwareData
             .filter((m) => m.slab_address != null)
             .filter((m) => !isBlockedSlab(m.slab_address!))
             .filter(isActiveMarket)
+            .filter((m) => m.last_price != null && m.last_price > 0 && m.last_price <= MAX_SANE_PRICE_USD)
             .map((m) => ({
             slab_address: m.slab_address!,
             symbol: m.symbol,
@@ -471,7 +475,7 @@ export default function Home() {
               </div>
 
               <div className="overflow-x-auto border border-[var(--border)] bg-[var(--panel-bg)]">
-                <div className="grid min-w-[480px] grid-cols-5 gap-2 sm:gap-4 border-b border-[var(--border)] bg-[var(--bg-surface)] px-3 sm:px-5 py-3 text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-dim)]">
+                <div className="grid min-w-[480px] grid-cols-5 gap-2 sm:gap-4 border-b border-[var(--border)] bg-[var(--bg-surface)] px-3 sm:px-5 py-3 text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-muted)]">
                   <div>Token</div>
                   <div className="text-right">Price</div>
                   <div className="text-right">Volume</div>

--- a/app/components/layout/Footer.tsx
+++ b/app/components/layout/Footer.tsx
@@ -26,12 +26,12 @@ export const Footer: FC = () => {
               alt="Percolator"
               className="h-4 w-auto"
             />
-            <span className="text-[var(--text-dim)]">/</span>
-            <span className="text-[11px] text-[var(--text-muted)]">perpetual futures engine</span>
+            <span className="text-[var(--text-muted)]">/</span>
+            <span className="text-[11px] text-[var(--text-secondary)]">perpetual futures engine</span>
           </div>
 
           {/* Center - links */}
-          <div className="flex flex-wrap items-center justify-center gap-3 sm:gap-5 text-[11px] text-[var(--text-muted)]">
+          <div className="flex flex-wrap items-center justify-center gap-3 sm:gap-5 text-[11px] text-[var(--text-secondary)]">
             <button
               onClick={copyCA}
               className="group flex items-center gap-1.5 transition-colors hover:text-[var(--text-secondary)]"
@@ -99,9 +99,9 @@ export const Footer: FC = () => {
           </div>
 
           {/* Right - powered by */}
-          <div className="flex items-center gap-2 text-[11px] text-[var(--text-dim)]">
+          <div className="flex items-center gap-2 text-[11px] text-[var(--text-muted)]">
             <span>powered by</span>
-            <span className="font-semibold text-[var(--text-muted)]">solana</span>
+            <span className="font-semibold text-[var(--text-secondary)]">solana</span>
           </div>
         </div>
       </div>

--- a/app/components/marketing/HeroCtaGroup.tsx
+++ b/app/components/marketing/HeroCtaGroup.tsx
@@ -62,10 +62,23 @@ export function HeroCtaGroup() {
       </Link>
 
       <Link
-        href="#how-it-works"
-        className={`hero-cta inline-flex items-center gap-1 text-[14px] font-medium text-[var(--cyan)] border-b border-[var(--cyan)]/40 pb-px transition-colors hover:text-[var(--cyan)] hover:border-[var(--cyan)]/70 ${prefersReduced ? '' : 'gsap-fade'}`}
+        href="/earn"
+        className={`hero-cta group inline-flex items-center gap-2 bg-violet-700 hover:bg-violet-600 text-white rounded-md px-5 py-2.5 text-sm font-semibold transition-all duration-150 min-h-[44px] ${prefersReduced ? '' : 'gsap-fade'}`}
       >
-        Earn as Creator <span aria-hidden="true">→</span>
+        Earn as Creator
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="transition-transform group-hover:translate-x-0.5"
+        >
+          <path d="M5 12h14M12 5l7 7-7 7" />
+        </svg>
       </Link>
     </div>
   );


### PR DESCRIPTION
## Summary

Visual audit fixes from designer (2026-03-24).

## Changes

### Priority: NO ORACLE filter on homepage
- **page.tsx**: Filters markets with `null` or invalid `last_price` from the homepage featured list before sorting. Markets without a live oracle price no longer appear in the Active Markets table — removes the red `NO ORACLE` badges from the landing page entirely.

### Contrast fixes
- **page.tsx**: Active Markets table column headers changed from `text-[var(--text-dim)]` (`#2A2E3D`) to `text-[var(--text-muted)]` (`#454B5F`) — the dim value was near-invisible on the panel background.
- **Footer.tsx**: All footer text nodes changed from `text-[var(--text-dim)]` / `text-[var(--text-muted)]` to `text-[var(--text-secondary)]` / `text-[var(--text-muted)]` respectively — was unreadable at `#2A2E3D` on a dark background.

### Earn as Creator CTA
- **HeroCtaGroup.tsx**: Changed from unstyled text link (`border-b` cyan style) to a filled violet button matching `Launch a Market` and `Trade Now` siblings. Route updated from `#how-it-works` anchor to `/earn`.

## Not in this PR (follow-up)
- Raw address hashes as market names in Active Markets table — needs investigation into when `symbol` is null vs when metadata fetch fails
- Sparkline chart inconsistency on `/markets` — sparklines are not on the markets page; may be in a sub-component I haven't found yet
- Pagination/virtual scrolling on markets page — separate concern

## Tests
```
134 passed | 2 skipped (136 files)
1605 passed | 34 skipped (1639 tests)
```

## How to Test
1. Visit `/` — Active Markets table should show only markets with live prices (no red NO ORACLE rows)
2. Check table column headers are readable (Token / Price / Volume / OI / Status)
3. Footer text should be legible on all screen sizes
4. Hero CTA group: all 3 buttons should be visually consistent filled violet buttons