### PR TITLE
fix(PERC-8062): widen /markets page container to fix compressed layout

### DIFF
--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -523,7 +523,7 @@ function MarketsPageInner() {
       {/* Grid background — subtle decorative element */}
       <div className="absolute inset-x-0 top-0 h-16 bg-grid pointer-events-none opacity-50" />
 
-      <div className="relative mx-auto max-w-4xl px-4 pt-4 pb-10">
+      <div className="relative mx-auto max-w-[1100px] px-4 sm:px-6 pt-4 pb-10">
         {/* Header */}
         <ScrollReveal>
           <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
@@ -970,7 +970,7 @@ export default function MarketsPage() {
     <Suspense fallback={
       <div className="min-h-[calc(100dvh-48px)] relative">
         <div className="absolute inset-x-0 top-0 h-32 bg-grid pointer-events-none" />
-        <div className="relative mx-auto max-w-4xl px-4 pt-4 pb-10">
+        <div className="relative mx-auto max-w-[1100px] px-4 sm:px-6 pt-4 pb-10">
           <div className="mb-8">
             <ShimmerSkeleton className="h-3 w-20 mb-2" />
             <ShimmerSkeleton className="h-8 w-48 mb-2" />


### PR DESCRIPTION
## What
Widens the /markets page container from `max-w-4xl` (896px) to `max-w-[1100px]` to match the homepage layout width.

## Why
Designer visual review (message #16266) flagged the /markets page as rendering "very narrow/compressed" — the 7-column table (token, price, OI, vol, insurance, leverage, health) was cramped at 896px.

## Changes
- `max-w-4xl` → `max-w-[1100px]` on both the main component and Suspense fallback wrappers
- Added responsive horizontal padding `sm:px-6` (was `px-4` only)

## How to test
1. Visit /markets on desktop (>1100px viewport)
2. Confirm table columns have adequate spacing and aren't cramped
3. Verify mobile layout is unchanged (columns still stack/hide correctly)

Fixes PERC-8062

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated markets page container width for improved content display and visual layout.
  * Enhanced responsive spacing with adaptive horizontal padding that adjusts across mobile, tablet, and desktop devices for better visual balance and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->