### PR TITLE
fix(developers): update repo list, add H+A/K formulas section

### DIFF
--- a/app/app/developers/DevelopersClient.tsx
+++ b/app/app/developers/DevelopersClient.tsx
@@ -95,6 +95,54 @@ export const DevelopersClient: FC<Props> = ({
         {/* Repo Grid (with CI statuses for health badges) */}
         <RepoGrid repos={repos} isLive={isLive} ciStatuses={ciStatuses} />
 
+        {/* ★ H + A/K Risk Engine Formulas */}
+        <section className="mt-16 mb-12">
+          <h2
+            className="mb-2 text-2xl font-bold tracking-tight text-[var(--text)] sm:text-3xl"
+            style={{ fontFamily: "var(--font-display)" }}
+          >
+            Risk Engine — H&nbsp;+&nbsp;A/K
+          </h2>
+          <p className="mb-6 max-w-2xl text-sm leading-relaxed text-[var(--text-secondary)]">
+            516 formally verified proofs across the codebase (Kani). H gates
+            profit extraction when the vault is stressed. A/K socialises
+            liquidation deficits pro-rata with O(1) settlement. Together: no
+            user can withdraw more than exists, no user is singled out for
+            forced closure, markets always recover.
+          </p>
+
+          <div className="grid gap-6 sm:grid-cols-2">
+            {/* H — Haircut Ratio */}
+            <div className="rounded-xl border border-white/[0.08] bg-white/[0.02] p-6">
+              <h3 className="mb-1 font-mono text-xs font-semibold uppercase tracking-widest text-violet-400">
+                H — Fair Exits (Haircut Ratio)
+              </h3>
+              <pre className="mt-3 overflow-x-auto rounded-lg bg-black/40 p-4 font-mono text-[13px] leading-relaxed text-[var(--text-secondary)]">
+{`Residual = max(0, V − C_tot − I)
+
+h = min(Residual, PNL_matured_pos_tot)
+    / PNL_matured_pos_tot
+
+effective_pnl_i = ⌊max(PNL_i, 0) × h⌋`}
+              </pre>
+            </div>
+
+            {/* A/K — Lazy Side Indices */}
+            <div className="rounded-xl border border-white/[0.08] bg-white/[0.02] p-6">
+              <h3 className="mb-1 font-mono text-xs font-semibold uppercase tracking-widest text-violet-400">
+                A/K — Fair Overhang Clearing
+              </h3>
+              <pre className="mt-3 overflow-x-auto rounded-lg bg-black/40 p-4 font-mono text-[13px] leading-relaxed text-[var(--text-secondary)]">
+{`effective_pos(i) = ⌊basis_i × A / a_basis_i⌋
+
+pnl_delta(i) = ⌊|basis_i|
+  × (K − k_snap_i)
+  / (a_basis_i × POS_SCALE)⌋`}
+              </pre>
+            </div>
+          </div>
+        </section>
+
         {/* ★ Commit Activity Heatmap */}
         {commitActivity && Object.keys(commitActivity).length > 0 && (
           <CommitHeatmap commitActivity={commitActivity} />

--- a/app/lib/github.ts
+++ b/app/lib/github.ts
@@ -55,12 +55,11 @@ export interface RepoCIStatus {
 /** Hardcoded repo list — order determines fallback display order */
 export const REPOS = [
   "percolator-launch",
-  "percolator",
   "percolator-prog",
-  "percolator-matcher",
-  "percolator-stake",
+  "percolator",
   "percolator-sdk",
-  "percolator-ops",
+  "percolator-stake",
+  "percolator-nft",
   "percolator-mobile",
 ] as const;
 
@@ -68,15 +67,15 @@ export const REPOS = [
 export const REPO_DESCRIPTIONS: Record<string, string> = {
   "percolator-launch":
     "Permissionless perpetual futures launcher — deploy a perp market for any Solana token",
-  percolator: "Core on-chain program",
+  percolator:
+    "No-std Rust risk engine — H + A/K mechanics, formally verified with Kani",
   "percolator-prog": "Percolator programs",
-  "percolator-matcher":
-    "Prediction market matcher program (Solana on-chain)",
   "percolator-stake":
     "Insurance LP staking — PDA admin architecture, Kani formal verification",
   "percolator-sdk":
     "TypeScript SDK for interacting with Percolator on-chain programs",
-  "percolator-ops": "AI-powered ops dashboard",
+  "percolator-nft":
+    "Token2022 Position NFTs — transfer your perpetual futures positions via Transfer Hooks",
   "percolator-mobile": "Solana Seeker mobile app",
 };
 
@@ -85,10 +84,9 @@ export const REPO_LANGUAGES: Record<string, string> = {
   "percolator-launch": "TypeScript",
   percolator: "Rust",
   "percolator-prog": "Rust",
-  "percolator-matcher": "Rust",
   "percolator-stake": "Rust",
   "percolator-sdk": "TypeScript",
-  "percolator-ops": "TypeScript",
+  "percolator-nft": "Rust",
   "percolator-mobile": "TypeScript",
 };
 


### PR DESCRIPTION
Closes #1672

## Changes
- **Removed** percolator-ops (internal) and percolator-matcher (archived/replaced by percolator-match)
- **Added** percolator-nft: Token2022 Position NFTs via Transfer Hooks
- **Added** percolator (core): No-std Rust risk engine with H+A/K mechanics
- **Correct repo list**: percolator-launch, percolator-prog, percolator, percolator-sdk, percolator-stake, percolator-nft, percolator-mobile
- **New section**: H + A/K risk engine formulas with styled code blocks
- **Kani proof count**: 516 formally verified proofs

## How to test
1. Visit /developers on preview deploy
2. Verify 7 repos shown (no ops, no matcher; nft and core present)
3. Verify H + A/K formulas section between repo grid and heatmap
4. Check formulas render correctly in code blocks