### PR TITLE
fix(markets): bump alternating row tint to bg-white/[0.04] for readability

### DIFF
--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -846,7 +846,7 @@ function MarketsPageInner() {
                       className={[
                         "grid w-full sm:min-w-[700px] grid-cols-[minmax(120px,2.5fr)_minmax(80px,1.2fr)_minmax(55px,0.7fr)_minmax(55px,0.7fr)] sm:grid-cols-[minmax(160px,3fr)_minmax(90px,1.2fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(65px,0.8fr)_minmax(80px,0.9fr)] gap-2 sm:gap-4 items-center px-3 sm:px-5 py-3 transition-all duration-200 hover:bg-[var(--accent)]/[0.06] border-l-2 border-l-transparent hover:border-l-[var(--accent)]/40",
                         i > 0 ? "border-t border-[var(--border)]" : "",
-                        i % 2 === 1 ? "bg-white/[0.012]" : "",
+                        i % 2 === 1 ? "bg-white/[0.04]" : "",
                       ].join(" ")}
                     >
                       <div>


### PR DESCRIPTION
## What
Bumps alternating row tint on the markets table from `bg-white/[0.012]` (1.2% opacity) to `bg-white/[0.04]` (4% opacity).

## Why
Designer review of PR #1674 flagged that the 1.2% tint is imperceptible at typical brightness settings and doesn't achieve its goal of aiding horizontal scanning. Minimum threshold identified as 3–4%.

## How to Test
Open /markets — odd rows should now have a visible (but subtle) white tint compared to even rows.

## Follow-up to
PR #1674