### PR TITLE
fix(markets): apply MIN_VAULT_FOR_OI vault guard to render-time isOracleDown

### DIFF
--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -770,6 +770,22 @@ function MarketsPageInner() {
                     return Number.isFinite(n) ? n : null;
                   };
                   const isOracleDown: boolean = (() => {
+                    // GH#1638 / CodeRabbit MAJOR: Apply the same MIN_VAULT_FOR_OI vault guard
+                    // as the sort comparator (computeIsOracleDown). Without this guard, markets
+                    // with vault_balance < MIN_VAULT_FOR_OI (phantom OI zeroed server-side)
+                    // could render an "oracle-down" badge while sorting as "empty", creating a
+                    // client/server sort mismatch at the threshold boundary.
+                    // Mirror computeIsOracleDown: prefer vault_balance, fall back to c_tot.
+                    const rawVaultR = m.supabase?.vault_balance;
+                    const rawCtotR  = m.supabase?.c_tot;
+                    const vaultBalR = numericOrNull(
+                      rawVaultR != null && Number(rawVaultR) > 0 ? rawVaultR : rawCtotR
+                    );
+                    if (vaultBalR !== null && vaultBalR < MIN_VAULT_FOR_OI) {
+                      // Sub-threshold vault: phantom OI suppressed server-side → render as empty, not oracle-down
+                      return false;
+                    }
+
                     // On-chain market: use resolveMarketPriceE6 as oracle-availability signal.
                     // If the resolved price is 0n the keeper has not cranked or oracle is unavailable.
                     if (m.onChain) {


### PR DESCRIPTION
## What
Adds the `MIN_VAULT_FOR_OI` vault guard to the render-time `isOracleDown` check inside the `/markets` page `.map()` loop.

## Why (CodeRabbit MAJOR — GH#1638)
The sort comparator (`computeIsOracleDown`) already guards sub-threshold markets (`vault_balance < MIN_VAULT_FOR_OI`) from being ranked as `oracle-down` — it returns `false` so they sort as `empty`.

The render-time `isOracleDown` was **missing the same guard**. Without it, a market at the threshold boundary could:
- sort as `empty` (correct, via `computeIsOracleDown`)
- render an `oracle-down` / `No Oracle` badge (wrong)

This creates a client/server sort disagreement and an incorrect badge for the user.

## Fix
Mirror the vault guard from `computeIsOracleDown`:
- Prefer `vault_balance`, fall back to `c_tot` (matches sort logic)
- If sub-threshold → short-circuit to `false` (render as empty, not oracle-down)

## How to Test
Markets with `vault_balance < 1_000_000` (phantom OI suppressed server-side) should show the **Empty** health state, not **No Oracle**, on /markets.

## References
- GH#1638 (CodeRabbit MAJOR flag)
- GH#1639 (MIN_VAULT_FOR_OI guard introduction)
- PERC-816

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined market status badge behavior to align more consistently with sorting rankings, particularly for markets with minimal vault balances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->