### PR TITLE
fix(PERC-8075): markets table — zebra tint 4%→5%, column headers font-semibold

### DIFF
--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -728,7 +728,7 @@ function MarketsPageInner() {
             <>
               <div className="relative rounded-sm border border-[var(--border)] hud-corners overflow-x-auto">
                 {/* Header row: xs=4 cols (name|price|lev|health), sm+=7 cols */}
-                <div className="grid w-full sm:min-w-[700px] grid-cols-[minmax(120px,2.5fr)_minmax(80px,1.2fr)_minmax(55px,0.7fr)_minmax(55px,0.7fr)] sm:grid-cols-[minmax(160px,3fr)_minmax(90px,1.2fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(65px,0.8fr)_minmax(80px,0.9fr)] gap-2 sm:gap-4 border-b border-[var(--border)] bg-[var(--bg-surface)] px-3 sm:px-5 py-2.5 text-[9px] sm:text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">
+                <div className="grid w-full sm:min-w-[700px] grid-cols-[minmax(120px,2.5fr)_minmax(80px,1.2fr)_minmax(55px,0.7fr)_minmax(55px,0.7fr)] sm:grid-cols-[minmax(160px,3fr)_minmax(90px,1.2fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(65px,0.8fr)_minmax(80px,0.9fr)] gap-2 sm:gap-4 border-b border-[var(--border)] bg-[var(--bg-surface)] px-3 sm:px-5 py-2.5 text-[9px] sm:text-[10px] font-semibold uppercase tracking-[0.15em] text-[var(--text-dim)]">
                   <div>token</div>
                   <div className="text-right">price</div>
                   <div className="hidden sm:block text-right">OI</div>
@@ -862,7 +862,7 @@ function MarketsPageInner() {
                       className={[
                         "grid w-full sm:min-w-[700px] grid-cols-[minmax(120px,2.5fr)_minmax(80px,1.2fr)_minmax(55px,0.7fr)_minmax(55px,0.7fr)] sm:grid-cols-[minmax(160px,3fr)_minmax(90px,1.2fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(65px,0.8fr)_minmax(80px,0.9fr)] gap-2 sm:gap-4 items-center px-3 sm:px-5 py-3 transition-all duration-200 hover:bg-[var(--accent)]/[0.06] border-l-2 border-l-transparent hover:border-l-[var(--accent)]/40",
                         i > 0 ? "border-t border-[var(--border)]" : "",
-                        i % 2 === 1 ? "bg-white/[0.04]" : "",
+                        i % 2 === 1 ? "bg-white/[0.05]" : "",
                       ].join(" ")}
                     >
                       <div>


### PR DESCRIPTION
## Summary

Follow-up to PR #1675. Designer visual review flagged that `bg-white/[0.04]` (4%) is still barely perceptible at typical screen brightness.

## Changes

- **Zebra stripe tint**: `bg-white/[0.04]` → `bg-white/[0.05]` (5%) on odd rows — stronger horizontal scanning aid without being garish
- **Column headers**: `font-medium` → `font-semibold` for clearer visual hierarchy between header labels and data rows

## Files Changed

- `app/app/markets/page.tsx`

## How to Test

1. Visit `/markets` with 10+ markets visible
2. Confirm odd rows have a clearly perceptible tint at normal screen brightness
3. Confirm column headers (token / price / OI / vol / insurance / max lev / health) render noticeably bolder than row data

Closes PERC-8075

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the markets table header font weight to enhance visual hierarchy and improve readability of column headers.
  * Adjusted the alternating row background opacity to provide better visual contrast and clearer distinction between rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->