### PR TITLE
fix(developers): treat cancelled CI runs as unknown, not failing (GH#1679)

### DIFF
--- a/app/lib/github.ts
+++ b/app/lib/github.ts
@@ -309,13 +309,30 @@ export async function getGoodFirstIssues(): Promise<GoodFirstIssue[]> {
   }
 }
 
-/** Fetch CI status for a repo */
+/** Fetch CI status for a repo.
+ *
+ * We fetch the last 10 completed runs and skip any that were cancelled —
+ * a cancelled run is not a signal of failure, just an interrupted run.
+ * We look for the first run with a meaningful conclusion (success/failure/
+ * timed_out/action_required/startup_failure) to determine CI health.
+ * If all recent runs are cancelled (or no runs exist), we return null
+ * ("unknown") rather than falsely reporting failure.
+ */
 export async function getRepoCIStatus(
   repo: string
 ): Promise<RepoCIStatus> {
+  /** Conclusions that actually represent a real CI result */
+  const MEANINGFUL_CONCLUSIONS = new Set([
+    "success",
+    "failure",
+    "timed_out",
+    "action_required",
+    "startup_failure",
+  ]);
+
   try {
     const res = await fetch(
-      `https://api.github.com/repos/dcccrypto/${repo}/actions/runs?per_page=1&status=completed`,
+      `https://api.github.com/repos/dcccrypto/${repo}/actions/runs?per_page=10&status=completed`,
       { headers: githubHeaders, next: { revalidate: 600 } }
     );
     if (!res.ok) return { passing: null };
@@ -323,9 +340,18 @@ export async function getRepoCIStatus(
     if (!data.workflow_runs || data.workflow_runs.length === 0) {
       return { passing: null };
     }
-    return {
-      passing: data.workflow_runs[0].conclusion === "success",
-    };
+
+    // Find the first run that has a meaningful conclusion (skip cancelled)
+    const meaningful = (
+      data.workflow_runs as Array<{ conclusion: string }>
+    ).find((run) => MEANINGFUL_CONCLUSIONS.has(run.conclusion));
+
+    if (!meaningful) {
+      // All recent runs were cancelled — treat as unknown, not failing
+      return { passing: null };
+    }
+
+    return { passing: meaningful.conclusion === "success" };
   } catch {
     return { passing: null };
   }


### PR DESCRIPTION
## Problem
The `/developers` page showed ✗ CI failing for `percolator-sdk` because the last 3 workflow runs all had `conclusion=cancelled`. The old code fetched 1 completed run and returned `passing = conclusion === 'success'`, so any cancelled run was treated as failure.

## Root Cause
`cancelled` is a valid GitHub Actions conclusion included in `status=completed` results. It happens when:
- A newer push supersedes the run
- A run is manually cancelled
- Workflow concurrency limits kill the old run

None of these indicate a broken CI pipeline.

## Fix
- Fetch 10 completed runs instead of 1
- Define a set of **meaningful conclusions**: `success`, `failure`, `timed_out`, `action_required`, `startup_failure`
- Skip `cancelled` (and `skipped`/`neutral`) conclusions
- Return `passing=null` (unknown/grey badge) if all recent runs are cancelled
- Return `passing=true/false` based on the first meaningful run found

## Result
- `percolator-sdk`: was ✗ Failing → now shows as unknown/grey (no meaningful run in last 10)
- All other repos: unaffected (they have successful runs)

## Testing
- TypeScript: `pnpm tsc --noEmit` ✅ clean
- Closes GH#1679

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI status accuracy by evaluating up to the last 10 completed runs instead of just the most recent one.
  * Cancelled workflow runs are now ignored when determining CI status, preventing false negatives.
  * Returns inconclusive status when no meaningful runs exist, rather than making incorrect determinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->