### PR TITLE
fix(developers): correct contributor/commit counts & clip empty weeks (GH#1681)

### DIFF
--- a/app/components/CommitHeatmap.tsx
+++ b/app/components/CommitHeatmap.tsx
@@ -109,9 +109,13 @@ export const CommitHeatmap: FC<Props> = ({ commitActivity }) => {
     return commitActivity[selectedRepo] || [];
   }, [commitActivity, selectedRepo]);
 
-  /** Determine how many weeks to show (responsive to viewport) */
+  /** Clip leading zero-commit weeks, then apply responsive limit */
   const visibleCount = useResponsiveWeeks();
-  const weeks = weekData.slice(-visibleCount);
+  const trimmedData = useMemo(() => {
+    const firstActiveIdx = weekData.findIndex((w) => w.total > 0);
+    return firstActiveIdx > 0 ? weekData.slice(firstActiveIdx) : weekData;
+  }, [weekData]);
+  const weeks = trimmedData.slice(-visibleCount);
 
   /** Month labels aligned to weeks */
   const monthLabels = useMemo(() => {

--- a/app/lib/github.ts
+++ b/app/lib/github.ts
@@ -169,6 +169,18 @@ const githubHeaders: HeadersInit = {
     : {}),
 };
 
+/** Fetch a GitHub stats endpoint with 202 retry (exponential backoff, up to 3 attempts) */
+async function fetchGitHubStats(url: string): Promise<Response> {
+  let res = await fetch(url, { headers: githubHeaders, next: { revalidate: 600 } });
+
+  for (let attempt = 0; attempt < 3 && res.status === 202; attempt++) {
+    await new Promise((r) => setTimeout(r, 1000 * Math.pow(2, attempt + 1))); // 2s, 4s, 8s
+    res = await fetch(url, { headers: githubHeaders, next: { revalidate: 600 } });
+  }
+
+  return res;
+}
+
 /** Fetch contributor stats aggregated across all repos */
 export async function getContributorStats(): Promise<ContributorStats> {
   const allLogins = new Set<string>();
@@ -178,23 +190,9 @@ export async function getContributorStats(): Promise<ContributorStats> {
 
   const results = await Promise.allSettled(
     REPOS.map(async (repo) => {
-      // Fetch contributor stats (which includes commit counts)
-      const res = await fetch(
-        `https://api.github.com/repos/dcccrypto/${repo}/stats/contributors`,
-        { headers: githubHeaders, next: { revalidate: 600 } }
+      const res = await fetchGitHubStats(
+        `https://api.github.com/repos/dcccrypto/${repo}/stats/contributors`
       );
-
-      // GitHub returns 202 on first request — retry once after 2s
-      if (res.status === 202) {
-        await new Promise((r) => setTimeout(r, 2000));
-        const retry = await fetch(
-          `https://api.github.com/repos/dcccrypto/${repo}/stats/contributors`,
-          { headers: githubHeaders, next: { revalidate: 600 } }
-        );
-        if (!retry.ok) return [];
-        return retry.json();
-      }
-
       if (!res.ok) return [];
       return res.json();
     })
@@ -246,23 +244,9 @@ export async function getAllCommitActivity(): Promise<CommitActivityMap> {
 
   const results = await Promise.allSettled(
     REPOS.map(async (repo) => {
-      const res = await fetch(
-        `https://api.github.com/repos/dcccrypto/${repo}/stats/commit_activity`,
-        { headers: githubHeaders, next: { revalidate: 600 } }
+      const res = await fetchGitHubStats(
+        `https://api.github.com/repos/dcccrypto/${repo}/stats/commit_activity`
       );
-
-      // GitHub returns 202 on first request — retry once after 2s
-      if (res.status === 202) {
-        await new Promise((r) => setTimeout(r, 2000));
-        const retry = await fetch(
-          `https://api.github.com/repos/dcccrypto/${repo}/stats/commit_activity`,
-          { headers: githubHeaders, next: { revalidate: 600 } }
-        );
-        if (!retry.ok) return { repo, data: [] };
-        const data = await retry.json();
-        return { repo, data: Array.isArray(data) ? data : [] };
-      }
-
       if (!res.ok) return { repo, data: [] };
       const data = await res.json();
       return { repo, data: Array.isArray(data) ? data : [] };


### PR DESCRIPTION
## Fixes
Closes #1681

### What changed
1. **Contributor count (3→7)** & **Total commits (2128→3416)**: GitHub's stats API returns 202 "computing" on cold cache. Old code retried once after 2s — not enough for larger repos. New `fetchGitHubStats` helper retries up to 3 times with exponential backoff (2s/4s/8s), ensuring all 7 repos return real data.

2. **Activity chart clipped**: Leading zero-commit weeks are now trimmed so the chart starts at the first week with actual commits instead of showing 28 empty weeks from Jul 2025.

### How to test
- Visit `/developers` — contributors should show 7, total commits ~3416
- Activity chart should start around Feb 2026, no leading empty weeks
- Filter by individual repo pills to verify per-repo data loads