### PR TITLE
fix(gh-1685): totalCommits stat mismatch + open issues shows — for 0

### DIFF
--- a/app/app/developers/page.tsx
+++ b/app/app/developers/page.tsx
@@ -5,6 +5,7 @@ import {
   getAllCommitActivity,
   getGoodFirstIssues,
   getAllCIStatuses,
+  type CommitActivityMap,
 } from "@/lib/github";
 import { DevelopersClient } from "./DevelopersClient";
 
@@ -36,15 +37,26 @@ export default async function DevelopersPage() {
     (r) => r.stargazers_count > 0 || r.forks_count > 0
   );
 
+  // Compute totalCommits from commitActivity so both stats are derived from
+  // the same API response — avoids the 202-cache-race that caused mismatch.
+  const commitActivityData: CommitActivityMap =
+    commitActivity.status === "fulfilled" ? commitActivity.value : {};
+  const totalCommitsFromActivity = Object.values(commitActivityData)
+    .flat()
+    .reduce((sum, w) => sum + (w.total || 0), 0);
+
+  const rawContributorStats =
+    contributorStats.status === "fulfilled" ? contributorStats.value : null;
+  const resolvedContributorStats =
+    rawContributorStats && totalCommitsFromActivity > 0
+      ? { ...rawContributorStats, totalCommits: totalCommitsFromActivity }
+      : rawContributorStats;
+
   return (
     <DevelopersClient
       repos={repoData}
       isLive={isLive}
-      contributorStats={
-        contributorStats.status === "fulfilled"
-          ? contributorStats.value
-          : null
-      }
+      contributorStats={resolvedContributorStats}
       commitActivity={
         commitActivity.status === "fulfilled" ? commitActivity.value : null
       }

--- a/app/components/ContributorStatsBar.tsx
+++ b/app/components/ContributorStatsBar.tsx
@@ -21,7 +21,7 @@ function AnimatedNumber({
 
   useEffect(() => {
     if (!visible || value === 0) {
-      setDisplay(0);
+      setDisplay(value);
       return;
     }
 
@@ -41,8 +41,6 @@ function AnimatedNumber({
 
     requestAnimationFrame(animate);
   }, [value, visible]);
-
-  if (value === 0 && !suffix) return <span>—</span>;
 
   const text = suffix
     ? `${display.toLocaleString()}${suffix}`
@@ -102,8 +100,8 @@ export const ContributorStatsBar: FC<Props> = ({ stats }) => {
             valueNode = cfg.static;
           } else if (cfg.key && stats) {
             const val = stats[cfg.key] as number;
-            // Show dash for falsy/NaN/undefined values instead of animating to 0
-            valueNode = val && Number.isFinite(val) && val > 0
+            // Show dash only for undefined/null/NaN — display 0 as a real value
+            valueNode = Number.isFinite(val)
               ? <AnimatedNumber value={val} visible={visible} />
               : <span>—</span>;
           } else {


### PR DESCRIPTION
## Problem

Two bugs on the `/developers` page (GH#1685):

### Bug 1: totalCommits shows 1,272 but RSC payload has 2,817

`getContributorStats()` and `getAllCommitActivity()` each make independent `/stats/commit_activity` requests to GitHub. GitHub's async 202 cache can return different data at different times, causing the stats bar number to diverge from what the heatmap actually computed.

### Bug 2: Open Issues shows "—" instead of "0"

Two cascading guards were both too aggressive:
- `AnimatedNumber` returned `<span>—</span>` when `value === 0`
- `ContributorStatsBar` checked `val && val > 0`, which is falsy for 0

## Fix

- **totalCommits**: In `page.tsx`, derive `totalCommits` from the already-fetched `commitActivity` data before passing to `DevelopersClient`. Guarantees both values are always derived from the same API response.
- **Open Issues / 0 display**: Allow 0 as a valid display value — only show "—" for `NaN`/`null`/`undefined`. Fixed both in `AnimatedNumber` and the stats bar render logic.

## How to Test

1. Visit `/developers` — Total Commits stat should match the heatmap week totals
2. If all repos have 0 open issues, the stat should show `0` not `—`
3. No visual regressions on other stats