### PR TITLE
feat: Trading UI quick wins — mark price, Long/Short toggle, candle colors, entry line

### DIFF
--- a/app/components/trade/MarketInfoBar.tsx
+++ b/app/components/trade/MarketInfoBar.tsx
@@ -74,7 +74,7 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol, log
 
       {/* Mark Price — large, colored by direction */}
       <span
-        className={`text-lg font-bold tabular-nums shrink-0 ${isUp ? "text-green-400" : "text-red-400"}`}
+        className={`text-2xl font-bold tabular-nums shrink-0 ${isUp ? "text-green-400" : "text-red-400"}`}
         style={{ fontFamily: "var(--font-mono)" }}
       >
         {priceDisplay}

--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -378,10 +378,10 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
         <button
           ref={longBtnRef}
           onClick={() => setDirection("long")}
-          className={`flex-1 rounded-none py-2 text-[11px] font-medium uppercase tracking-[0.1em] transition-all duration-150 ${
+          className={`flex-1 rounded-none py-2.5 text-[11px] font-bold uppercase tracking-[0.1em] transition-all duration-150 ${
             direction === "long"
-              ? "bg-green-500/20 border border-green-500/50 text-green-400"
-              : "border border-[var(--border)] text-[var(--text-dim)]"
+              ? "bg-green-500 border border-green-500 text-black"
+              : "border border-[var(--border)] bg-gray-800 text-[var(--text-dim)]"
           }`}
         >
           Long
@@ -389,10 +389,10 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
         <button
           ref={shortBtnRef}
           onClick={() => setDirection("short")}
-          className={`flex-1 rounded-none py-2 text-[11px] font-medium uppercase tracking-[0.1em] transition-all duration-150 ${
+          className={`flex-1 rounded-none py-2.5 text-[11px] font-bold uppercase tracking-[0.1em] transition-all duration-150 ${
             direction === "short"
-              ? "bg-red-500/20 border border-red-500/50 text-red-400"
-              : "border border-[var(--border)] text-[var(--text-dim)]"
+              ? "bg-red-500 border border-red-500 text-white"
+              : "border border-[var(--border)] bg-gray-800 text-[var(--text-dim)]"
           }`}
         >
           Short

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -105,6 +105,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
   const volumeSeriesRef = useRef<ISeriesApi<"Histogram"> | null>(null);
   const priceLineRef = useRef<ReturnType<ISeriesApi<"Candlestick">["createPriceLine"]> | null>(null);
   const liqLineRef = useRef<ReturnType<ISeriesApi<"Candlestick">["createPriceLine"]> | null>(null);
+  const entryLineRef = useRef<ReturnType<ISeriesApi<"Candlestick">["createPriceLine"]> | null>(null);
 
   const {
     candles: externalCandles,
@@ -193,8 +194,18 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
       volumeSeriesRef.current = null;
       priceLineRef.current = null;
       liqLineRef.current = null;
+      entryLineRef.current = null;
     };
   }, []);
+
+  // Derive entry price from user account
+  const entryPriceNum = (() => {
+    const ua = realUserAccount;
+    if (!ua) return null;
+    const ep = ua.account.entryPrice;
+    if (ep == null || ep === 0n) return null;
+    return Number(ep) / 1e6;
+  })();
 
   // Update series when data or chartType changes
   useEffect(() => {
@@ -212,15 +223,16 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
     }
     priceLineRef.current = null;
     liqLineRef.current = null;
+    entryLineRef.current = null;
 
     if (chartType === "candle" && candleData.length > 0) {
       const series = chart.addCandlestickSeries({
-        upColor: "#22d3ee",
+        upColor: "#22c55e",
         downColor: "#ef4444",
         borderDownColor: "#ef4444",
-        borderUpColor: "#22d3ee",
+        borderUpColor: "#22c55e",
         wickDownColor: "#ef4444",
-        wickUpColor: "#22d3ee",
+        wickUpColor: "#22c55e",
       });
 
       const formatted = candleData.map((c) => ({
@@ -249,7 +261,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
         time: (Math.floor(c.timestamp / 1000)) as import("lightweight-charts").UTCTimestamp,
         // Phase 2: use a tiny sentinel value so lwc renders the pane even when vol=0
         value: (c.volume ?? 0) > 0 ? c.volume : 0.001,
-        color: c.close >= c.open ? "rgba(34,211,238,0.6)" : "rgba(239,68,68,0.6)",
+        color: c.close >= c.open ? "rgba(34,197,94,0.6)" : "rgba(239,68,68,0.6)",
       }));
       volumeSeries.setData(volumeData);
       volumeSeriesRef.current = volumeSeries;
@@ -258,7 +270,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
       if (priceUsd != null) {
         priceLineRef.current = series.createPriceLine({
           price: priceUsd,
-          color: "#9945FF",
+          color: "rgba(255,255,255,0.6)",
           lineWidth: 1,
           lineStyle: LineStyle.Dashed,
           axisLabelVisible: true,
@@ -266,21 +278,33 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
         });
       }
 
-      // Phase 2: Liq price overlay — show orange dashed line when user has position
+      // Phase 2: Liq price overlay
       const liqPriceNum = liqPriceE6 != null && liqPriceE6 > 0n ? Number(liqPriceE6) / 1e6 : null;
       if (liqPriceNum != null && liqPriceNum > 0) {
         liqLineRef.current = series.createPriceLine({
           price: liqPriceNum,
-          color: "#f97316",
-          lineWidth: 1,
-          lineStyle: LineStyle.Dashed,
+          color: "#ef4444",
+          lineWidth: 2,
+          lineStyle: LineStyle.Solid,
           axisLabelVisible: true,
           title: "Liq",
         });
       }
+
+      // Entry price overlay — cyan dashed when position is open
+      if (entryPriceNum != null && entryPriceNum > 0) {
+        entryLineRef.current = series.createPriceLine({
+          price: entryPriceNum,
+          color: "#22d3ee",
+          lineWidth: 1,
+          lineStyle: LineStyle.Dashed,
+          axisLabelVisible: true,
+          title: "Entry",
+        });
+      }
     } else if (chartType === "line" && lineData.length > 0) {
       const series = chart.addLineSeries({
-        color: "#22d3ee",
+        color: "#22c55e",
         lineWidth: 2,
       });
       const formatted = lineData.map((p) => ({
@@ -294,7 +318,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
       if (priceUsd != null) {
         priceLineRef.current = series.createPriceLine({
           price: priceUsd,
-          color: "#9945FF",
+          color: "rgba(255,255,255,0.6)",
           lineWidth: 1,
           lineStyle: LineStyle.Dashed,
           axisLabelVisible: true,
@@ -302,22 +326,34 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
         });
       }
 
-      // Phase 2: Liq price on line chart too
+      // Liq price on line chart
       const liqPriceNum = liqPriceE6 != null && liqPriceE6 > 0n ? Number(liqPriceE6) / 1e6 : null;
       if (liqPriceNum != null && liqPriceNum > 0) {
         liqLineRef.current = series.createPriceLine({
           price: liqPriceNum,
-          color: "#f97316",
+          color: "#ef4444",
+          lineWidth: 2,
+          lineStyle: LineStyle.Solid,
+          axisLabelVisible: true,
+          title: "Liq",
+        });
+      }
+
+      // Entry price on line chart
+      if (entryPriceNum != null && entryPriceNum > 0) {
+        entryLineRef.current = series.createPriceLine({
+          price: entryPriceNum,
+          color: "#22d3ee",
           lineWidth: 1,
           lineStyle: LineStyle.Dashed,
           axisLabelVisible: true,
-          title: "Liq",
+          title: "Entry",
         });
       }
     }
 
     chart.timeScale().fitContent();
-  }, [chartType, candleData, lineData, priceUsd, liqPriceE6]);
+  }, [chartType, candleData, lineData, priceUsd, liqPriceE6, entryPriceNum]);
 
   // Update mark price line when live price changes
   useEffect(() => {


### PR DESCRIPTION
## Summary
Implements designer spec items 1-5 from the Trading UI Redesign Spec (2026-03-25).

### Changes
- **Ticker bar**: Mark price bumped from `text-lg` to `text-2xl` — dominant, hard to miss
- **Long/Short toggle**: Full color fill — green bg + black text (Long), red bg + white text (Short). No more subtle tinted borders.
- **Candle colors**: Cyan → green for up candles (`#22c55e`) matching industry standard (Hyperliquid, dYdX, Drift)
- **Volume bars**: Updated to green/red matching candle scheme
- **Mark price line**: Purple → white (`rgba(255,255,255,0.6)`) per spec
- **Liq price line**: Changed to solid red, lineWidth 2 — more visible
- **Entry price line**: New cyan dashed overlay (`#22d3ee`) shown when user has open position
- **Line chart**: Color updated from cyan to green for consistency

### How to Test
1. Navigate to any trade page (`/trade/[slab]`)
2. Verify mark price is large and prominent in ticker bar
3. Toggle Long/Short — should show full green/red fill
4. Check candles are green (up) / red (down)
5. Open a position — entry (cyan dashed) and liq (red solid) lines appear on chart

### Spec Reference
`~/.openclaw/percolator/handoff/2026-03-25-trading-ui-redesign-spec.md` — Items 1-5