### PR TITLE
fix(developers): don't override totalCommits from partial commitActivity (GH#1685)

### DIFF
--- a/app/app/developers/page.tsx
+++ b/app/app/developers/page.tsx
@@ -5,6 +5,7 @@ import {
   getAllCommitActivity,
   getGoodFirstIssues,
   getAllCIStatuses,
+  REPOS,
   type CommitActivityMap,
 } from "@/lib/github";
 import { DevelopersClient } from "./DevelopersClient";
@@ -37,18 +38,28 @@ export default async function DevelopersPage() {
     (r) => r.stargazers_count > 0 || r.forks_count > 0
   );
 
-  // Compute totalCommits from commitActivity so both stats are derived from
-  // the same API response — avoids the 202-cache-race that caused mismatch.
+  // Compute totalCommits from commitActivity, but ONLY if all repos returned
+  // data. GitHub's stats endpoint responds with 202 (cache being built) for
+  // repos whose stats are cold — a partial response covers only the repos that
+  // were already cached and produces an artificially low number (e.g. 1,272
+  // instead of 2,817).  When the coverage check fails, fall back to the value
+  // computed by getContributorStats(), which retries 202s and is more reliable.
   const commitActivityData: CommitActivityMap =
     commitActivity.status === "fulfilled" ? commitActivity.value : {};
-  const totalCommitsFromActivity = Object.values(commitActivityData)
-    .flat()
-    .reduce((sum, w) => sum + (w.total || 0), 0);
+  const reposCovered = Object.keys(commitActivityData).length;
+  const allReposCovered = reposCovered >= REPOS.length;
+  const totalCommitsFromActivity = allReposCovered
+    ? Object.values(commitActivityData)
+        .flat()
+        .reduce((sum, w) => sum + (w.total || 0), 0)
+    : 0;
 
   const rawContributorStats =
     contributorStats.status === "fulfilled" ? contributorStats.value : null;
+  // Override totalCommits only when commitActivity covered every repo;
+  // otherwise trust getContributorStats() to avoid showing a partial count.
   const resolvedContributorStats =
-    rawContributorStats && totalCommitsFromActivity > 0
+    rawContributorStats && allReposCovered && totalCommitsFromActivity > 0
       ? { ...rawContributorStats, totalCommits: totalCommitsFromActivity }
       : rawContributorStats;
 


### PR DESCRIPTION
## Problem

Closes GH#1685

The `/developers` page showed **1,272 Total Commits** instead of the correct **2,817**.

### Root Cause

`getAllCommitActivity()` fetches GitHub's `/stats/commit_activity` endpoint per repo. GitHub responds with **202** (cache being built) for cold repos — only returning data for repos already cached. With 6 of 7 repos cold, only `percolator-launch` (1,272 commits) returned data.

The prior guard was `totalCommitsFromActivity > 0` — satisfied by the single warm repo — so it overrode the correct cross-repo total from `getContributorStats()` with a partial sum.

### Fix

Only override `totalCommits` when `commitActivityData` covers **all repos** (`reposCovered >= REPOS.length`). When coverage is partial, fall through to the `getContributorStats()` value, which has its own 202-retry logic and returns the correct aggregate.

## Changes

- `app/app/developers/page.tsx`: Add `allReposCovered` guard before overriding `totalCommits`; import `REPOS` constant for coverage check.

## Testing

1. Visit `/developers` on a cold cache — Total Commits should show the `getContributorStats()` value (2,817)
2. After GitHub warms all 7 repo caches, both paths should converge to the same number