### PR TITLE
fix(p3): bump leverage snap ghost button contrast

### DIFF
--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -641,7 +641,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
               className={`flex-1 basis-0 min-w-[32px] rounded-none py-1.5 min-h-[36px] text-[9px] font-medium transition-all duration-150 focus-visible:ring-1 focus-visible:ring-[var(--accent)]/30 touch-manipulation ${
                 leverage === l
                   ? "bg-[var(--accent)] text-white"
-                  : "border border-[var(--border)]/30 text-[var(--text-muted)] hover:border-[var(--accent)]/30 hover:text-[var(--text-secondary)]"
+                  : "border border-[var(--border)]/50 text-[var(--text-secondary)] hover:border-[var(--accent)]/40 hover:text-[var(--text)]"
               }`}
             >
               {l}x


### PR DESCRIPTION
## Summary

Inactive leverage snap buttons (2x, 5x, etc.) were low contrast against the dark background — flagged by designer after PERC-8090 visual review.

## Changes

- Text: `text-[var(--text-muted)]` (#454B5F) → `text-[var(--text-secondary)]` (#7A7F96) — raises contrast while keeping them visually subordinate to the active state
- Border: `border-[var(--border)]/30` → `border-[var(--border)]/50` — slightly more visible pill outline
- Hover: `hover:text-[var(--text-secondary)]` → `hover:text-[var(--text)]` — cleaner hover affordance

## Testing
- [ ] Devnet: confirm inactive buttons are readable against dark bg
- [ ] Active state unchanged (full `bg-[var(--accent)]\ + white text`)
- [ ] No overflow or layout change

Closes PERC-8090 P3 follow-up.