### PR TITLE
fix(trade): oracleDown impossible logic + FundingRateCard rateBpsPerSlot mapping

### DIFF
--- a/app/components/trade/FundingRateCard.tsx
+++ b/app/components/trade/FundingRateCard.tsx
@@ -99,12 +99,15 @@ export const FundingRateCard: FC<{ slabAddress: string }> = ({ slabAddress }) =>
           netLpPosition: BigInt(data.netLpPosition ?? 0),
         });
         // P3-4: fetch last 4 funding history points for mini bar chart
+        // /history returns { rateBpsPerSlot } — convert to 8h rate%:
+        // hourly% = (rateBpsPerSlot / 10000) * 9000  →  8h% = hourly * 8
         try {
           const histRes = await fetch(`/api/funding/${slabAddress}/history?limit=4`);
           if (histRes.ok) {
             const histData = await histRes.json();
-            const pts: { hourlyRatePercent?: number }[] = histData.history ?? [];
-            setMiniChartRates(pts.map(p => (p.hourlyRatePercent ?? 0) * 8));
+            const pts: { rateBpsPerSlot?: number }[] = histData.history ?? [];
+            const rates = pts.map(p => ((p.rateBpsPerSlot ?? 0) / 10000) * 9000 * 8);
+            setMiniChartRates(rates);
           }
         } catch { /* silently skip — mini chart is optional */ }
         setError(null);

--- a/app/components/trade/MarketInfoBar.tsx
+++ b/app/components/trade/MarketInfoBar.tsx
@@ -64,7 +64,7 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol, log
   const { priceUsd, change24h } = useLivePrice();
   const { market } = useMarketInfo(slabAddress);
   const { fundingRate, engine } = useEngineState();
-  const { level: oracleLevel, ready: oracleReady } = useOracleFreshness();
+  const { level: oracleLevel } = useOracleFreshness();
 
   const priceDisplay = priceUsd != null
     ? `$${priceUsd < 0.01 ? priceUsd.toFixed(6) : priceUsd < 1 ? priceUsd.toFixed(4) : priceUsd.toFixed(2)}`
@@ -77,8 +77,9 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol, log
   const fundingColor = funding8h != null ? (funding8h < 0 ? "text-orange-400" : "text-green-400") : "text-[var(--text)]";
 
   // P3-3: oracle + vault status for health badge
-  // oracleDown = never cranked (unavailable) or stale beyond fresh threshold
-  const oracleDown = oracleReady && oracleLevel === "unavailable";
+  // oracleDown = unavailable (never cranked) or stale — oracleReady && unavailable is
+  // always false (they're mutually exclusive), so check level directly.
+  const oracleDown = oracleLevel === "unavailable" || oracleLevel === "stale";
   // vaultEmpty = engine loaded but vault is 0
   const vaultEmpty = engine !== null && (engine.vault ?? 0n) === 0n;
 


### PR DESCRIPTION
## Summary

Two bugs flagged by CodeRabbit on PR #1702 (merged) — fixing now.

### Bug 1 — MarketInfoBar: `oracleDown` always false

`oracleReady && oracleLevel === "unavailable"` is an impossible condition: `useOracleFreshness` only sets `ready = true` when `lastUpdateMs !== null`, but level is `"unavailable"` only when `lastUpdateMs === null`. They are mutually exclusive.

**Result before fix:** `MarketHealthBadge` never shows `NO_ORACLE` or `INACTIVE` states.

**Fix:** Drop `oracleReady &&`, check level directly. Also added `|| oracleLevel === "stale"` as the comment intended.

```diff
- const oracleDown = oracleReady && oracleLevel === "unavailable";
+ const oracleDown = oracleLevel === "unavailable" || oracleLevel === "stale";
```

### Bug 2 — FundingRateCard: mini chart shows all zeros

`/api/funding/:slab/history` returns `{ rateBpsPerSlot }` per backend schema, but the frontend was reading `p.hourlyRatePercent` (always `undefined`), resulting in `(undefined ?? 0) * 8 = 0` for every bar.

**Fix:** Convert using the documented formula: `(rateBpsPerSlot / 10000) * 9000 * 8` for 8h rate %.

```diff
- const pts: { hourlyRatePercent?: number }[] = histData.history ?? [];
- setMiniChartRates(pts.map(p => (p.hourlyRatePercent ?? 0) * 8));
+ const pts: { rateBpsPerSlot?: number }[] = histData.history ?? [];
+ const rates = pts.map(p => ((p.rateBpsPerSlot ?? 0) / 10000) * 9000 * 8);
+ setMiniChartRates(rates);
```

## Testing
- [ ] Oracle badge transitions (LIVE → NO ORACLE → STALE → INACTIVE) on a cranked devnet market
- [ ] Mini chart renders real bars on a market with funding history