### PR TITLE
fix(trade): oracle badge flush-right — ml-auto on separator

### DIFF
--- a/app/components/trade/MarketInfoBar.tsx
+++ b/app/components/trade/MarketInfoBar.tsx
@@ -164,7 +164,7 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol, log
       </div>
 
       {/* P3-3: Market health badge — far right, always visible */}
-      <span className="h-4 w-px bg-[var(--border)]/40 shrink-0" />
+      <span className="ml-auto h-4 w-px bg-[var(--border)]/40 shrink-0" />
       <MarketHealthBadge oracleDown={oracleDown} vaultEmpty={vaultEmpty} />
     </div>
   );


### PR DESCRIPTION
## What
Adds `ml-auto` to the separator span immediately before `MarketHealthBadge` in `MarketInfoBar.tsx`.

## Why
Designer sign-off (msg #16792): badge was rendering mid-bar after stats items rather than flush-right. Single-line fix per spec.

## Change
```tsx
// Before
<span className="h-4 w-px bg-[var(--border)]/40 shrink-0" />
// After
<span className="ml-auto h-4 w-px bg-[var(--border)]/40 shrink-0" />
```

## Tests
137 test files pass (1632 tests). No logic changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Repositioned the market health badge to align at the far right of the market information display for improved visual layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->