### PR TITLE
fix(devnet-mint): update hint text — all active market mints supported (GH#1707)

### DIFF
--- a/app/app/devnet-mint/devnet-mint-content.tsx
+++ b/app/app/devnet-mint/devnet-mint-content.tsx
@@ -552,7 +552,7 @@ const DevnetMintContent: FC = () => {
                 Paste a devnet mirror mint address to get $500 worth of test tokens airdropped to your wallet.
                 <br />
                 <span className="text-[var(--text-dim)] text-[10px]">
-                  Token must be a mirrored market mint (created by the launch wizard).
+                  Token must be an active market mint on Percolator devnet.
                 </span>
               </p>
             )}


### PR DESCRIPTION
## What
Updates the description hint on the /devnet-mint page.

**Before:** "Token must be a mirrored market mint (created by the launch wizard)."  
**After:** "Token must be an active market mint on Percolator devnet."

## Why
PR #1704 extended `/api/devnet-mint-token` to accept any active market mint, not just mirrored wizard-created ones. The UI description was never updated, leading to a confusing mismatch reported in GH#1707.

## How to test
Navigate to `/devnet-mint` — verify the hint text reads correctly.

Fixes #1707

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated instructional text for devnet mint address input to clarify requirements for active market mints on Percolator devnet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->