### PR TITLE
fix(devnet-mint): sync label to match hint text (CodeRabbit nitpick #1708)

### DIFF
--- a/app/app/devnet-mint/devnet-mint-content.tsx
+++ b/app/app/devnet-mint/devnet-mint-content.tsx
@@ -558,7 +558,7 @@ const DevnetMintContent: FC = () => {
             )}
             <div className="space-y-2">
               <div>
-                <label className="mb-1 block text-xs text-[var(--text-secondary)]">Devnet Mirror Mint Address</label>
+                <label className="mb-1 block text-xs text-[var(--text-secondary)]">Devnet Active Market Mint Address</label>
                 <input
                   type="text"
                   value={faucetMint}


### PR DESCRIPTION
## What
Update label text from 'Devnet Mirror Mint Address' → 'Devnet Active Market Mint Address' to match the updated hint text in the same form (PR #1708 fix).

## Why
CodeRabbit nitpick on PR #1708: label used stale 'mirror mint' terminology while hint text was updated to say 'active market mint'. One-character class fix for consistency.

## How to Test
1. Visit /devnet-mint
2. Confirm label reads 'Devnet Active Market Mint Address'
3. Confirm hint text below reads 'active market mint on Percolator devnet'
4. Both should be consistent now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Updated the label text for the devnet faucet mint input field to reflect current terminology and improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->