### PR TITLE
fix(ui): P3 designer visual feedback — leverage, SHORT button, oracle warnings, LIVE badge

### DIFF
--- a/app/components/oracle/OracleFreshnessIndicator.tsx
+++ b/app/components/oracle/OracleFreshnessIndicator.tsx
@@ -41,14 +41,15 @@ export const OracleFreshnessIndicator: FC = () => {
   if (!mode) return null;
 
   // GH#1341: Oracle mode detected but price never cranked — show unavailable banner
+  // P3-5: Use amber/orange (not red) to match order panel oracle warning design language.
   if (!ready) {
     return (
       <>
         <div
           className="flex items-center gap-1.5 px-2 py-1 text-[10px]"
           style={{
-            backgroundColor: "rgba(239,68,68,0.10)",
-            color: "#ef4444",
+            backgroundColor: "rgba(245,158,11,0.07)",
+            color: "#f59e0b",
             fontFamily: "var(--font-mono)",
           }}
         >
@@ -139,12 +140,13 @@ export const OracleFreshnessIndicator: FC = () => {
       </button>
 
       {/* Stale / unavailable warning banner (GH#1338) */}
+      {/* P3-5: Consistent amber/orange for both stale and unavailable — matches order panel warning */}
       {(level === "stale" || level === "unavailable") && (
         <div
           className="flex items-center gap-1.5 px-2 py-1 text-[10px]"
           style={{
-            backgroundColor: level === "unavailable" ? "rgba(239,68,68,0.10)" : "rgba(234,179,8,0.10)",
-            color: level === "unavailable" ? "#ef4444" : "#eab308",
+            backgroundColor: "rgba(245,158,11,0.07)",
+            color: "#f59e0b",
             fontFamily: "var(--font-mono)",
           }}
         >

--- a/app/components/trade/MarketInfoBar.tsx
+++ b/app/components/trade/MarketInfoBar.tsx
@@ -134,10 +134,10 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol, log
 
       <span className="h-4 w-px bg-[var(--border)]/40 shrink-0" />
 
-      {/* Stats group */}
-      <div className="flex items-center gap-4 shrink-0">
+      {/* Stats group — flex-1 fills remaining space so ml-auto on badge works correctly */}
+      <div className="flex flex-1 items-center gap-4 min-w-0">
         {/* Volume 24h */}
-        <div className="flex flex-col">
+        <div className="flex flex-col shrink-0">
           <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">Vol 24h</span>
           <span className="text-xs font-medium text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>
             {formatCompact(volume as number)}
@@ -145,27 +145,27 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol, log
         </div>
 
         {/* OI */}
-        <div className="flex flex-col">
+        <div className="flex flex-col shrink-0">
           <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">Open Interest</span>
           <span className="text-xs font-medium text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>
             {formatCompact(oi as number)}
           </span>
         </div>
 
-        {/* Funding Rate */}
+        {/* Funding Rate — P3-6: pr-2 padding prevents right-edge clipping */}
         {funding8h != null && (
-          <div className="flex flex-col">
+          <div className="flex flex-col shrink-0 pr-2">
             <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">Funding / 8h</span>
             <span className={`text-xs font-semibold ${fundingColor}`} style={{ fontFamily: "var(--font-mono)" }}>
               {funding8h >= 0 ? "+" : ""}{funding8h.toFixed(4)}%
             </span>
           </div>
         )}
-      </div>
 
-      {/* P3-3: Market health badge — far right, always visible */}
-      <span className="ml-auto h-4 w-px bg-[var(--border)]/40 shrink-0" />
-      <MarketHealthBadge oracleDown={oracleDown} vaultEmpty={vaultEmpty} />
+        {/* P3-3: Market health badge — ml-auto pushes to far right within flex-1 group */}
+        <span className="ml-auto h-4 w-px bg-[var(--border)]/40 shrink-0" />
+        <MarketHealthBadge oracleDown={oracleDown} vaultEmpty={vaultEmpty} />
+      </div>
     </div>
   );
 };

--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -507,11 +507,12 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
 
       {/* GH#1330/1338: Oracle warning — stale or unavailable oracle blocks trading.
           "unavailable" = oracle never cranked (no price on-chain, e.g. test tokens without a feed).
-          "stale" = price exists but hasn't updated recently. Both prevent "Oracle is invalid" tx failure. */}
+          "stale" = price exists but hasn't updated recently. Both prevent "Oracle is invalid" tx failure.
+          P3-5: Use consistent amber/orange design language matching OracleFreshnessIndicator warning strip. */}
       {oracleStale && !mockMode && (
-        <div className="mb-3 rounded-none border border-[var(--short)]/30 bg-[var(--short)]/5 p-2.5">
-          <p className="text-[9px] font-bold uppercase tracking-[0.15em] text-[var(--short)]">
-            {oracleUnavailable ? "⚠️ Oracle Unavailable" : "Oracle Stale"}
+        <div className="mb-3 rounded-none border border-amber-500/30 bg-amber-500/[0.07] p-2.5">
+          <p className="text-[9px] font-bold uppercase tracking-[0.15em] text-amber-400">
+            {oracleUnavailable ? "⚠ Oracle Unavailable" : "⚠ Oracle Stale"}
           </p>
           <p className="mt-1 text-[9px] text-[var(--text-secondary)] leading-relaxed">
             {oracleUnavailable
@@ -540,7 +541,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
           className={`flex-1 rounded-none py-2.5 text-[11px] font-bold uppercase tracking-[0.1em] transition-all duration-150 ${
             direction === "short"
               ? "bg-red-500 border border-red-500 text-white"
-              : "border border-red-500/40 bg-red-500/10 text-red-400/70 hover:bg-red-500/20 hover:text-red-400"
+              : "border border-red-400/60 bg-red-500/[0.08] text-red-400 hover:bg-red-500/20 hover:border-red-400/80"
           }`}
         >
           Short
@@ -629,7 +630,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
           value={leverage}
           onChange={(e) => setLeverage(Number(e.target.value))}
           style={{
-            background: `linear-gradient(to right, var(--accent) 0%, var(--accent) ${maxLeverage > 1 ? ((leverage - 1) / (maxLeverage - 1)) * 100 : 100}%, rgba(255,255,255,0.03) ${maxLeverage > 1 ? ((leverage - 1) / (maxLeverage - 1)) * 100 : 100}%, rgba(255,255,255,0.03) 100%)`,
+            background: `linear-gradient(to right, var(--accent) 0%, var(--accent) ${maxLeverage > 1 ? ((leverage - 1) / (maxLeverage - 1)) * 100 : 100}%, rgba(255,255,255,0.12) ${maxLeverage > 1 ? ((leverage - 1) / (maxLeverage - 1)) * 100 : 100}%, rgba(255,255,255,0.12) 100%)`,
           }}
           className="mb-3 h-1.5 w-full cursor-pointer appearance-none touch-none accent-[var(--accent)] [&::-webkit-slider-thumb]:h-5 [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-[var(--accent)] [&::-webkit-slider-thumb]:shadow-[0_0_6px_rgba(153,69,255,0.4)] [&::-moz-range-thumb]:h-5 [&::-moz-range-thumb]:w-5 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-[var(--accent)]"
         />
@@ -640,8 +641,8 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
               onClick={() => setLeverage(l)}
               className={`flex-1 basis-0 min-w-[32px] rounded-none py-1.5 min-h-[36px] text-[9px] font-medium transition-all duration-150 focus-visible:ring-1 focus-visible:ring-[var(--accent)]/30 touch-manipulation ${
                 leverage === l
-                  ? "bg-[var(--accent)] text-white"
-                  : "border border-[var(--border)]/50 text-[var(--text-secondary)] hover:border-[var(--accent)]/40 hover:text-[var(--text)]"
+                  ? "bg-[var(--accent)] text-white border border-[var(--accent)]"
+                  : "border border-[var(--border)] text-[var(--text)] hover:border-[var(--accent)]/60 hover:text-[var(--text)] bg-[var(--bg-elevated)]/40"
               }`}
             >
               {l}x


### PR DESCRIPTION
## Summary
Addresses all 6 P3 items from designer review of PRs #1706 + #1708.

## Changes

### P3-1 [HIGH] Leverage snap buttons — low contrast unselected state
- Before: `border-[var(--border)]/50 text-[var(--text-secondary)]` — nearly invisible
- After: full `border-[var(--border)]` + `text-[var(--text)]` + subtle bg-elevated tint — clearly readable

### P3-2 [MED] Leverage slider track nearly invisible
- Before: unfilled track at `rgba(255,255,255,0.03)` — essentially invisible
- After: `rgba(255,255,255,0.12)` — 4× more visible, track clearly shows range

### P3-3 [MED] LIVE badge not flush-right
- Before: stats group was `shrink-0` — badge sat at content end, not viewport right
- After: stats group is `flex-1` so `ml-auto` on separator correctly pins badge to far right

### P3-4 [MED] SHORT button washed-out/pastel red
- Before: `border-red-500/40 text-red-400/70` — muted, doesn't balance LONG green
- After: `border-red-400/60 text-red-400` — saturated, full-weight red matches LONG visual weight

### P3-5 [MED] Oracle warnings inconsistent styling
- Before: TradeForm used `var(--short)` (red), OracleFreshnessIndicator used `#ef4444` (red) — different shades
- After: both use amber-500 (`#f59e0b`) — consistent with existing amber oracle badge in MarketHealthBadge

### P3-6 [LOW] FUNDING/8H value clipped at panel right edge
- Added `pr-2` to funding rate column to prevent edge clipping

## Files Changed
- `app/components/trade/TradeForm.tsx` — leverage snap buttons, slider track, SHORT button, oracle warning
- `app/components/trade/MarketInfoBar.tsx` — LIVE badge flush-right, FUNDING/8H padding
- `app/components/oracle/OracleFreshnessIndicator.tsx` — amber oracle warning strip

## How to Test
1. Open trade page on devnet
2. Check leverage buttons (2x, 5x, 10x etc.) — unselected text should be clearly readable
3. Drag leverage slider — unfilled track should be visible
4. Click SHORT — should be clearly red, not washed out
5. LIVE/NO ORACLE badge should be right-aligned in the ticker bar
6. Oracle warnings in order panel + stats panel should both be amber

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated oracle freshness indicator styling to use consistent coloring across warning states
  * Improved market info bar layout for better badge positioning and element alignment
  * Refined trade form styling including warning banners, button appearance, leverage controls, and slider opacity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->