### PR TITLE
fix(ui): P3 followup — leverage border, slider track + GH#1711 funding overflow

### DIFF
--- a/app/components/trade/FundingRateCard.tsx
+++ b/app/components/trade/FundingRateCard.tsx
@@ -14,10 +14,13 @@ import { useTokenMeta } from "@/hooks/useTokenMeta";
 /** P3-4: Mini bar chart showing last N 8h funding rate periods */
 function FundingMiniChart({ rates }: { rates: number[] }) {
   if (!rates.length) return null;
-  const max = Math.max(...rates.map(Math.abs), 0.0001);
+  // Guard against Infinity/NaN from overflow data slipping through
+  const safeRates = rates.filter(r => Number.isFinite(r));
+  if (!safeRates.length) return null;
+  const max = Math.max(...safeRates.map(Math.abs), 0.0001);
   return (
     <div className="flex items-end gap-1 h-8">
-      {rates.map((r, i) => {
+      {safeRates.map((r, i) => {
         const heightPct = Math.max(10, (Math.abs(r) / max) * 100);
         const isPos = r >= 0;
         return (
@@ -106,7 +109,16 @@ export const FundingRateCard: FC<{ slabAddress: string }> = ({ slabAddress }) =>
           if (histRes.ok) {
             const histData = await histRes.json();
             const pts: { rateBpsPerSlot?: number }[] = histData.history ?? [];
-            const rates = pts.map(p => ((p.rateBpsPerSlot ?? 0) / 10000) * 9000 * 8);
+            // Clamp outlier values before display — legacy on-chain data can have overflowed
+            // rateBpsPerSlot (e.g. from unchecked i64 arithmetic). Guard: ±10_000 bps max.
+            const RATE_BPS_MAX = 10_000;
+            const rates = pts
+              .map(p => {
+                const raw = p.rateBpsPerSlot ?? 0;
+                if (!Number.isFinite(raw) || Math.abs(raw) > RATE_BPS_MAX) return null;
+                return (raw / 10000) * 9000 * 8;
+              })
+              .filter((r): r is number => r !== null);
             setMiniChartRates(rates);
           }
         } catch { /* silently skip — mini chart is optional */ }

--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -632,7 +632,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
           style={{
             background: `linear-gradient(to right, var(--accent) 0%, var(--accent) ${maxLeverage > 1 ? ((leverage - 1) / (maxLeverage - 1)) * 100 : 100}%, rgba(255,255,255,0.12) ${maxLeverage > 1 ? ((leverage - 1) / (maxLeverage - 1)) * 100 : 100}%, rgba(255,255,255,0.12) 100%)`,
           }}
-          className="mb-3 h-1.5 w-full cursor-pointer appearance-none touch-none accent-[var(--accent)] [&::-webkit-slider-thumb]:h-5 [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-[var(--accent)] [&::-webkit-slider-thumb]:shadow-[0_0_6px_rgba(153,69,255,0.4)] [&::-moz-range-thumb]:h-5 [&::-moz-range-thumb]:w-5 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-[var(--accent)]"
+          className="mb-3 h-1.5 w-full cursor-pointer appearance-none touch-none accent-[var(--accent)] [&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-white/[0.12] [&::-webkit-slider-thumb]:h-5 [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-[var(--accent)] [&::-webkit-slider-thumb]:shadow-[0_0_6px_rgba(153,69,255,0.4)] [&::-moz-range-thumb]:h-5 [&::-moz-range-thumb]:w-5 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-[var(--accent)] [&::-moz-range-track]:rounded-full [&::-moz-range-track]:bg-white/[0.12]"
         />
         <div className="flex flex-wrap gap-1">
           {availableLeverage.map((l) => (
@@ -642,7 +642,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
               className={`flex-1 basis-0 min-w-[32px] rounded-none py-1.5 min-h-[36px] text-[9px] font-medium transition-all duration-150 focus-visible:ring-1 focus-visible:ring-[var(--accent)]/30 touch-manipulation ${
                 leverage === l
                   ? "bg-[var(--accent)] text-white border border-[var(--accent)]"
-                  : "border border-[var(--border)] text-[var(--text)] hover:border-[var(--accent)]/60 hover:text-[var(--text)] bg-[var(--bg-elevated)]/40"
+                  : "border border-white/20 text-[var(--text)] hover:border-[var(--accent)]/60 hover:text-[var(--text)] bg-[var(--bg-elevated)]/40"
               }`}
             >
               {l}x


### PR DESCRIPTION
## Changes

### P3-1 Leverage snap buttons (designer follow-up)
- Changed inactive button border from `border-[var(--border)]` (resolves to rgb(28,31,46), invisible) to `border-white/20` — clearly visible as interactive controls

### P3-2 Slider track (designer follow-up)
- Added `[&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-white/[0.12]` class to leverage range input
- Also added `[&::-moz-range-track]` for Firefox parity
- Chrome doesn't apply `background` inline style to the track pseudo-element when `appearance-none` is set — Tailwind arbitrary class is required

### GH#1711 FundingRateCard overflow (QA report)
- History endpoint rateBpsPerSlot values for legacy slab Bc7A4y... contain overflow values from unchecked i64 arithmetic
- Added guard in history fetch: filter any rateBpsPerSlot outside ±10_000 bps (matching on-chain guard constant)
- Added Infinity/NaN filter in FundingMiniChart itself as second layer of defence
- Corrupt bars (e.g. +127678966738138336.0000%) will now be excluded from the chart rather than displayed

## Testing
- TypeScript: `tsc --noEmit` clean
- Leverage snap buttons now have visible border in dark theme
- Slider track visible between thumb and unfilled region
- FundingMiniChart on Bc7A4y... slab will show only valid period bars (may show fewer than 4)

## Reviewers
- **Designer**: verify P3-1 and P3-2 visually
- **QA**: verify GH#1711 funding chart no longer shows corrupt values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of invalid funding rate values in the rate chart to prevent rendering errors

* **Style**
  * Improved leverage slider track styling and adjusted preset button appearance for better visual consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->