### PR TITLE
fix: GH#1719 wizard stale state on fresh navigation + GH#1720 devnet-mint friendly error

### DIFF
--- a/app/app/api/devnet-airdrop/route.ts
+++ b/app/app/api/devnet-airdrop/route.ts
@@ -268,7 +268,7 @@ export async function POST(req: NextRequest) {
 
       if (marketErr || !marketRow) {
         return NextResponse.json(
-          { error: "mintAddress is not a known devnet mirror mint" },
+          { error: "This address is not a Percolator devnet market mint. Paste the mint address of an active market from /markets." },
           { status: 400 },
         );
       }

--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -80,8 +80,23 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
   // This fixes the "Continue button does nothing" bug — without persisted state,
   // allValid is false after refresh because all fields are empty.
   const WIZARD_STORAGE_KEY = "percolator-wizard-state";
+  // GH#1719: Use sessionStorage to track whether this is a fresh navigation to /create
+  // vs. a same-session page refresh. On fresh navigation (new browser tab, link click from
+  // another page), always start at step 1 to avoid showing stale Token step as "Complete"
+  // with a mint that may no longer exist on devnet.
+  // sessionStorage is cleared when the tab is closed; localStorage persists across sessions.
+  const SESSION_VISITED_KEY = "percolator-wizard-visited";
+  const isPageRefresh = typeof window !== "undefined" && sessionStorage.getItem(SESSION_VISITED_KEY) === "1";
 
   const [wizard, setWizard] = useState<WizardState>(() => {
+    // GH#1719: Only restore persisted state on same-session page refresh.
+    // On fresh navigation (new tab, external link), always start at Step 1 — Token.
+    if (!isPageRefresh) {
+      // Mark this tab as visited so a subsequent F5 refresh can restore.
+      try { sessionStorage.setItem(SESSION_VISITED_KEY, "1"); } catch {}
+      // Still pre-fill mintAddress from URL param when provided.
+      return { ...DEFAULT_STATE, mintAddress: initialMint ?? "" };
+    }
     try {
       const persisted = typeof window !== "undefined" ? localStorage.getItem(WIZARD_STORAGE_KEY) : null;
       if (persisted) {
@@ -124,7 +139,9 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
   // the user to click back to previous steps during resume.
   // GH#1298: Use safeStep (same clamping as wizard state above) so completedSteps
   // doesn't mark step 3 as complete when we've rewound to step 2/3.
+  // GH#1719: Same fresh-navigation guard — don't restore completedSteps on new tabs.
   const [completedSteps, setCompletedSteps] = useState<Set<number>>(() => {
+    if (!isPageRefresh) return new Set<number>();
     try {
       const persisted = typeof window !== "undefined" ? localStorage.getItem(WIZARD_STORAGE_KEY) : null;
       if (persisted) {


### PR DESCRIPTION
## Summary

Fixes two live regression bugs reported by QA.

---

### GH#1719 (Medium) — /create wizard stale state on fresh navigation

**Root cause:** Wizard persists state to `localStorage` (PERC-516 fix). On fresh navigation (new tab, external link), the state was restored and Token step showed as `✓ Complete` with the old mint pre-filled. If that mint no longer exists on devnet, the Review step showed `Mint Not Found` with the deploy button disabled. No way out except manually editing the URL.

**Fix:** Use `sessionStorage` to distinguish fresh navigation from same-session page refresh:
- **Fresh navigation** (`sessionStorage` key absent): reset to `DEFAULT_STATE` / Step 1. Mark key so a subsequent F5 within the same tab restores as expected.
- **Same-session F5 refresh** (`sessionStorage` key present): restore from `localStorage` as before — work-in-progress survives reload.

This also fixes the `completedSteps` false-positive (Token showing ✓ on a new session) and the downstream BACK button confusion.

**Files changed:** `app/components/create/CreateMarketWizard.tsx`

---

### GH#1720 (Low) — /devnet-mint raw API param name in error

**Root cause:** `/api/devnet-airdrop` returned `"mintAddress is not a known devnet mirror mint"` — exposes the internal param name.

**Fix:** Replace with user-facing copy: _"This address is not a Percolator devnet market mint. Paste the mint address of an active market from /markets."_

**Files changed:** `app/app/api/devnet-airdrop/route.ts`

---

## How to Test

### GH#1719
1. Complete Step 1 (Token) on `/create`, advance to Step 2
2. Open a **new browser tab** and navigate to `/create`
3. ✅ Wizard opens at Step 1 — Token input is empty, no ✓ on Token step
4. In the **same tab**, navigate to `/create` (or press F5)
5. ✅ State is restored (existing behaviour preserved)

### GH#1720
1. Navigate to `/devnet-mint`
2. Paste any valid Solana address that is NOT an active market mint
3. Click "Get Test Tokens"
4. ✅ Error reads: "This address is not a Percolator devnet market mint. Paste the mint address of an active market from /markets."

## Risk
Low. `sessionStorage` is widely supported and cleared on tab close. Only the state restoration path is changed; all other wizard behaviour (PERC-516 refresh persistence, GH#1298 review-step guard, GH#1280 completedSteps restore) is preserved for same-session refreshes.