### PR TITLE
fix(db): set mainnet_ca + symbol for SEEKER/USD market (GH#1726)

### DIFF
--- a/supabase/migrations/20260326083400_seeker_market_mainnet_ca.sql
+++ b/supabase/migrations/20260326083400_seeker_market_mainnet_ca.sql
@@ -1,0 +1,17 @@
+-- GH#1726: Add mainnet_ca for SEEKER/USD market so oracle-keeper discovers and prices it.
+--
+-- Root cause: SEEKER/USD slab (FPFcixRnhYDVY7wLVRTATVV1banRFefQAfX9Gn2LyoRY) was created
+-- with a devnet collateral mint (7KyVYJNha6bKNMmMHzsirKc4QGjFCqsSEzDJNtdGoZn7) that has
+-- no DexScreener/Jupiter listing. The oracle-keeper's discoverNewMarkets() skips markets
+-- where mainnet_ca is null. Setting mainnet_ca to the SKR mainnet address allows the
+-- oracle-keeper to fetch a live price via Jupiter/DexScreener and push it on-chain.
+--
+-- SKR (Seeker/Solana Mobile) mainnet mint: SKRbvo6Gf7GondiT3BbTfuRDPqLWei4j2Qy2NPGZhW3
+-- Oracle authority: FF7KFfU5Bb3Mze2AasDHCCZuyhdaSLjUZy2K3JvjdB7x (matches keeper admin key)
+
+UPDATE markets
+SET
+  mainnet_ca  = 'SKRbvo6Gf7GondiT3BbTfuRDPqLWei4j2Qy2NPGZhW3',
+  symbol      = 'SKR',
+  name        = 'Seeker'
+WHERE slab_address = 'FPFcixRnhYDVY7wLVRTATVV1banRFefQAfX9Gn2LyoRY';


### PR DESCRIPTION
## Problem

GH#1726 — SEEKER/USD market shows NO ORACLE badge indefinitely.

The oracle-keeper's discoverNewMarkets() queries Supabase WHERE mainnet_ca IS NOT NULL. The SEEKER/USD market row had mainnet_ca = NULL so it was never discovered — oracle-keeper never pushes a price for this market.

## Fix

Migration 20260326083400 updates the SEEKER market row to set mainnet_ca='SKRbvo6Gf7GondiT3BbTfuRDPqLWei4j2Qy2NPGZhW3', symbol='SKR', name='Seeker' for slab FPFcixRnhYDVY7wLVRTATVV1banRFefQAfX9Gn2LyoRY.

SKR mainnet mint confirmed via DexScreener (~$0.019 live). Oracle authority on slab FF7KFfU5... matches keeper admin key.

## Companion

percolator-oracle-keeper PR #1 adds SKR/SEEKER to JUPITER_MINTS (belt-and-suspenders alongside CA path).

## Deploy
1. Merge this PR (migration sets mainnet_ca)
2. Merge oracle-keeper PR #1 + Railway redeploy
3. Within 30s oracle-keeper discovers + pushes price, NO ORACLE badge clears