### PR TITLE
fix(oracle): disable BTC/SOL HYPERP pool, map devnet BTC → mainnet wBTC CA (GH#1730)

### DIFF
--- a/supabase/migrations/20260326100000_fix_btc_oracle_decimal_gh1730.sql
+++ b/supabase/migrations/20260326100000_fix_btc_oracle_decimal_gh1730.sql
@@ -1,0 +1,73 @@
+-- Migration: Fix BTC/USD oracle decimal mismatch — GH#1730
+--
+-- Problem: Market GGU89iQLmceyXRDK8vgAxVvdi9RJb9JsPhXZ2NoFSENV (BTC/USD)
+-- was registered in oracle_markets with oracle_type='hyperp' pointing at a
+-- BTC/SOL PumpSwap pool. The on-chain UpdateHyperpMark computes:
+--
+--   price_e6 = quote_vault_lamports * 1_000_000 / base_vault_atoms
+--
+-- For a BTC/SOL pool this yields SOL-per-BTC (≈150 at current rates), NOT
+-- USD-per-BTC (≈$68,000). There is no SOL→USD conversion in this path.
+-- Result: 193 accounts see a mark price of ~$148 instead of ~$68,000 — a
+-- 466× error that would cause immediate cascading liquidations if trading
+-- were enabled.
+--
+-- Root cause: HYPERP oracle requires a USD-denominated quote token in the pool
+-- (e.g., USDC, USDT). A SOL-quoted pool is not valid for HYPERP oracle mode.
+--
+-- Fix:
+--   1. Disable the faulty oracle_markets HYPERP entry for this slab.
+--      The keeper will fall back to admin-oracle mode (PushOraclePrice) with
+--      DexScreener/Jupiter for the real USD price.
+--   2. Upsert a devnet_mints row mapping the devnet BTC mint to the mainnet
+--      wBTC CA. The oracle-keeper uses this as the price lookup key so
+--      DexScreener returns the real ~$68,000 price.
+--   3. Backfill markets.mainnet_ca for this slab so the keeper's per-market
+--      mainnetCA field is populated on next discovery.
+--
+-- References: GH#1730, 2026-03-26
+
+-- ── Step 1: Disable the faulty HYPERP oracle entry ──────────────────────────
+UPDATE oracle_markets
+SET
+  enabled    = false,
+  notes      = COALESCE(notes, '') || ' | DISABLED 2026-03-26 GH#1730: BTC/SOL pool gives SOL-denominated price, not USD. Use admin-oracle + DexScreener/Jupiter instead.',
+  updated_at = NOW()
+WHERE slab_address = 'GGU89iQLmceyXRDK8vgAxVvdi9RJb9JsPhXZ2NoFSENV'
+  AND enabled = true;
+
+-- ── Step 2: Map devnet BTC mint → mainnet wBTC CA ───────────────────────────
+-- Devnet token: CJUyV594JzJpK2BUakNpm6NbmCkhQoPJWkKjfKTvxJ3C (user-created BTC)
+-- Mainnet wBTC: 9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E (Wrapped Bitcoin)
+-- DexScreener for 9n4nbM75f... returns ~$68,000, correcting the price display.
+INSERT INTO devnet_mints (devnet_mint, mainnet_ca, symbol, name)
+VALUES (
+  'CJUyV594JzJpK2BUakNpm6NbmCkhQoPJWkKjfKTvxJ3C',
+  '9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E',
+  'BTC',
+  'Bitcoin'
+)
+ON CONFLICT (devnet_mint) DO UPDATE
+  SET mainnet_ca = EXCLUDED.mainnet_ca,
+      symbol     = EXCLUDED.symbol,
+      name       = EXCLUDED.name,
+      updated_at = NOW();
+
+-- ── Step 3: Backfill markets.mainnet_ca for BTC slabs with this devnet mint ─
+-- Covers GGU89iQLmceyXRDK8vgAxVvdi9RJb9JsPhXZ2NoFSENV and AB3ZN1vxbBEh...
+-- (both use CJUyV594 as collateral mint per migration 042).
+UPDATE markets
+SET
+  mainnet_ca = '9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E',
+  updated_at = NOW()
+WHERE mint_address = 'CJUyV594JzJpK2BUakNpm6NbmCkhQoPJWkKjfKTvxJ3C'
+  AND (mainnet_ca IS NULL OR mainnet_ca != '9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E');
+
+-- Verify (informational):
+-- SELECT slab_address, oracle_type, enabled FROM oracle_markets
+-- WHERE slab_address = 'GGU89iQLmceyXRDK8vgAxVvdi9RJb9JsPhXZ2NoFSENV';
+-- → should return enabled=false
+--
+-- SELECT devnet_mint, mainnet_ca, symbol FROM devnet_mints
+-- WHERE devnet_mint = 'CJUyV594JzJpK2BUakNpm6NbmCkhQoPJWkKjfKTvxJ3C';
+-- → should return mainnet_ca=9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E


### PR DESCRIPTION
## Problem

BTC/USD market (`GGU89iQLmceyXRDK8vgAxVvdi9RJb9JsPhXZ2NoFSENV`) was displaying **$148.38** instead of **~$68,000**. 193 accounts affected.

## Root Cause

The market had an `oracle_markets` entry with `oracle_type='hyperp'` pointing at a **BTC/SOL** PumpSwap pool.

The on-chain `UpdateHyperpMark` computes:
```
price_e6 = quote_vault_lamports * 1_000_000 / base_vault_atoms
```

For a BTC/SOL pool this gives **SOL-per-BTC** (≈150 at current SOL price), NOT **USD-per-BTC** (≈$68,000). There is no SOL→USD conversion in the HYPERP path. HYPERP oracle requires a USD-denominated quote token (USDC/USDT).

## Fix (migration `20260326100000`)

1. **Disable** the faulty HYPERP oracle entry for the GGU89iQL slab
2. **Add devnet_mints row**: `CJUyV594` (devnet BTC token) → `9n4nbM75` (mainnet wrapped BTC CA)
3. **Backfill** `markets.mainnet_ca` for the devnet BTC collateral mint

After migration + keeper restart: oracle-keeper uses admin-oracle mode, looks up price via DexScreener/Jupiter with mainnet wBTC CA → returns ~$68,000.

## How to Test

1. Apply migration: `supabase db push`
2. Restart oracle-keeper on Railway
3. Navigate to `/trade/GGU89iQLmceyXRDK8vgAxVvdi9RJb9JsPhXZ2NoFSENV` — mark price should show ~$68,000

## References
- Closes #1730
- Migration 042: established CJUyV594 as user-created BTC devnet token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved BTC/USD oracle decimal precision mismatch to ensure accurate pricing data and eliminate pricing inconsistencies across the platform.
  * Corrected market data mappings to maintain accurate cross-chain token references and improve overall data integrity.
  * Updated oracle market configuration to properly reflect correct quote currencies for all supported trading pairs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->