### PR TITLE
fix: GH#1737 clamp /api/markets limit≥510 to 500 + P3 slider/snap contrast (designer)

### DIFF
--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -536,13 +536,18 @@ export async function GET(request: NextRequest) {
     // validateNumericParam() from route-validators.ts. Previously limit=-1/0/999999
     // all returned the full dataset and non-numeric offset was silently ignored.
     // Follow-up: use validated .value directly (not re-parsed) to reject "1.5"/"20abc".
+    // GH#1737: Clamp limit to MAX_LIMIT instead of rejecting — limit=510 was returning
+    // a 400 error which the frontend silently swallowed, showing 0 markets. Any value
+    // > MAX_LIMIT is treated as MAX_LIMIT (500). Non-numeric values still return 400.
     const MAX_LIMIT = 500;
     const limitParam = request?.nextUrl?.searchParams?.get("limit") ?? null;
     let limitNum = 0;
     if (limitParam !== null) {
-      const limitValidation = validateNumericParam(limitParam, { min: 1, max: MAX_LIMIT });
+      // Validate numeric format first (rejects floats, garbage strings, negatives)
+      const limitValidation = validateNumericParam(limitParam, { min: 1 });
       if (!limitValidation.valid) return limitValidation.response;
-      limitNum = limitValidation.value;
+      // Clamp to MAX_LIMIT — values above 500 silently fall back to 500
+      limitNum = Math.min(limitValidation.value, MAX_LIMIT);
     }
 
     const offsetParam = request?.nextUrl?.searchParams?.get("offset") ?? null;

--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -630,9 +630,9 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
           value={leverage}
           onChange={(e) => setLeverage(Number(e.target.value))}
           style={{
-            background: `linear-gradient(to right, var(--accent) 0%, var(--accent) ${maxLeverage > 1 ? ((leverage - 1) / (maxLeverage - 1)) * 100 : 100}%, rgba(255,255,255,0.22) ${maxLeverage > 1 ? ((leverage - 1) / (maxLeverage - 1)) * 100 : 100}%, rgba(255,255,255,0.22) 100%)`,
+            background: `linear-gradient(to right, var(--accent) 0%, var(--accent) ${maxLeverage > 1 ? ((leverage - 1) / (maxLeverage - 1)) * 100 : 100}%, rgba(255,255,255,0.38) ${maxLeverage > 1 ? ((leverage - 1) / (maxLeverage - 1)) * 100 : 100}%, rgba(255,255,255,0.38) 100%)`,
           }}
-          className="mb-3 h-1.5 w-full cursor-pointer appearance-none touch-none accent-[var(--accent)] [&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-white/[0.22] [&::-webkit-slider-thumb]:h-5 [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-[var(--accent)] [&::-webkit-slider-thumb]:shadow-[0_0_6px_rgba(153,69,255,0.4)] [&::-moz-range-thumb]:h-5 [&::-moz-range-thumb]:w-5 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-[var(--accent)] [&::-moz-range-track]:rounded-full [&::-moz-range-track]:bg-white/[0.22]"
+          className="mb-3 h-1.5 w-full cursor-pointer appearance-none touch-none accent-[var(--accent)] [&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-white/[0.38] [&::-webkit-slider-thumb]:h-5 [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-[var(--accent)] [&::-webkit-slider-thumb]:shadow-[0_0_6px_rgba(153,69,255,0.4)] [&::-moz-range-thumb]:h-5 [&::-moz-range-thumb]:w-5 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-[var(--accent)] [&::-moz-range-track]:rounded-full [&::-moz-range-track]:bg-white/[0.38]"
         />
         <div className="flex flex-wrap gap-1">
           {availableLeverage.map((l) => (
@@ -642,7 +642,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
               className={`flex-1 basis-0 min-w-[32px] rounded-none py-1.5 min-h-[36px] text-[9px] font-medium transition-all duration-150 focus-visible:ring-1 focus-visible:ring-[var(--accent)]/30 touch-manipulation ${
                 leverage === l
                   ? "bg-[var(--accent)] text-white"
-                  : "border border-white/30 text-[var(--text-muted)] hover:border-[var(--accent)]/50 hover:text-[var(--text-secondary)]"
+                  : "border border-white/45 text-[var(--text-muted)] hover:border-[var(--accent)]/50 hover:text-[var(--text-secondary)]"
               }`}
             >
               {l}x


### PR DESCRIPTION
## Changes

### GH#1737 — /api/markets silent 0 results at limit >= 510
**Root cause:** `validateNumericParam(max=500)` returns a 400 error when `limit=510`. The frontend swallowed the error response silently → 0 markets shown.

**Fix:** Remove `max` constraint from `validateNumericParam`. Clamp parsed value to `MAX_LIMIT=500` after validation — any limit > 500 silently floors to 500. Non-numeric strings still return 400. The 500-row Supabase default cap is unaffected (our query has no `.limit()` call; this only clips the in-memory JS `.slice()`).

**Boundary:** limit=500 → 168 markets ✅, limit=510 → now also 168 markets ✅ (was 0 silently).

### P3 — Slider track opacity + snap button border contrast (designer feedback on PR #1734)
Track still barely visible at 22% on dark panel. Two cosmetic changes per designer spec:
- **Slider track:** `rgba(255,255,255,0.22)` → `rgba(255,255,255,0.38)` (midpoint of recommended 35-40%)
- **Inactive snap buttons:** `border-white/30` → `border-white/45` for legibility

No logic changes. Active snap button (green fill) unchanged.

## Tests
161/161 markets tests pass.

Closes GH#1737.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Market API limit parameter now clamps excessive values to maximum instead of returning an error.

* **Style**
  * Increased opacity of leverage slider track and preset button borders for enhanced visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->