### PR TITLE
fix: block 2XQC-PUMP-PERP from oracle-keeper + set indexer_excluded=true

### DIFF
--- a/bots/oracle-keeper/index.ts
+++ b/bots/oracle-keeper/index.ts
@@ -74,6 +74,7 @@ const HARDCODED_BLOCKED_MARKETS = new Set<string>([
   "HjBePQZnoZVftg9B52gyeuHGjBvt2f8FNCVP4FeoP3YT", // PERCOLATOR-PERP-1 (Small)
   "484DG6KQi5eVXuaXzWxaWMWeXDp9LFXyshNi33UnWfxV", // PERCOLATOR-PERP-2 (Small)
   "GDyHCzpiuEsWDkLuji3NEFYJfqbDTzMCKn9ugUzTZqAW", // PERCOLATOR-PERP-3 (Large)
+  "6F86pCA6DcJxx3eY8ZaUteLL6bTw1uAyVGQ71ahGqjtC", // 2xQc...pump (2XQC-PUMP-PERP) — dead token, no open positions, indexer_excluded=true (2026-03-26)
 ]);
 
 /**


### PR DESCRIPTION
## Summary
Dead token cleanup for 2XQC-PUMP-PERP (slab: `6F86pCA6DcJxx3eY8ZaUteLL6bTw1uAyVGQ71ahGqjtC`).

## Changes
- **oracle-keeper**: Added slab to `HARDCODED_BLOCKED_MARKETS` — prevents keeper from attempting crank txns on a market with no active oracle/pool
- **Supabase**: Set `indexer_excluded=true` on market `bfe1704b` via REST API — excludes dead market from indexer stats queries

## Why
- Token mainnet CA: `2xQcYitABjwjVEc5Z5zZ97N33BhGD27zNWUhv2Q7pump` — confirmed dead
- No open positions on this market (confirmed PM 2026-03-26)
- Oracle keeper was wasting txn fees attempting to crank a market with no liquidity/activity
- Indexer was polluting stats with stale/zero data from this market

## How to test
- Confirm oracle-keeper logs no longer show crank attempts for `6F86pCA6DcJxx3eY8ZaUteLL6bTw1uAyVGQ71ahGqjtC`
- Confirm indexer stats queries exclude this market
- No user-facing regression (market was already dead)