### PR TITLE
fix(trade): snap buttons text-white/60 (designer P3)

### DIFF
--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -609,7 +609,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
           <button
             key={pct}
             onClick={() => setMarginPercent(pct)}
-            className="flex-1 rounded-none border border-[var(--border)]/30 py-1 text-[10px] font-medium text-[var(--text-muted)] transition-colors hover:border-[var(--accent)]/30 hover:text-[var(--text-secondary)] focus-visible:ring-1 focus-visible:ring-[var(--accent)]/30"
+            className="flex-1 rounded-none border border-[var(--border)]/30 py-1 text-[10px] font-medium text-white/60 transition-colors hover:border-[var(--accent)]/30 hover:text-[var(--text-secondary)] focus-visible:ring-1 focus-visible:ring-[var(--accent)]/30"
           >
             {pct === 100 ? "MAX" : `${pct}%`}
           </button>


### PR DESCRIPTION
## Change
Inactive snap buttons on /trade (25%, 50%, 75%, MAX) used `text-[var(--text-muted)]` (#454b5f) — near-invisible on the dark panel.

Changed to `text-white/60` per designer review of PR #1738.

## What's unchanged
- Active button (bg-accent) — untouched
- Hover state (`hover:text-[var(--text-secondary)]`) — untouched
- Border and layout — untouched