### PR TITLE
fix(GH#1753): soft-default limit=NaN/abc to MAX_LIMIT instead of 400

### DIFF
--- a/app/__tests__/api/markets-gh1744-limit-clamp.test.ts
+++ b/app/__tests__/api/markets-gh1744-limit-clamp.test.ts
@@ -1,8 +1,9 @@
 /**
  * GH#1744: /api/markets returns null total/activeTotal when limit=0 or limit=NaN.
+ * GH#1753: Non-numeric limit (limit=abc, limit=NaN) now soft-defaults to MAX_LIMIT (500)
+ *          instead of returning 400. This matches the fix for limit=0 (clamped to MIN_LIMIT).
  *
- * Fix: clamp limit to [1, 500] instead of rejecting limit=0 with 400.
- * Non-numeric strings (limit=abc) still return 400.
+ * Fix: clamp limit to [1, 500] instead of rejecting limit=0/NaN/string with 400.
  * Ensures total and activeTotal are always numbers in 200 responses.
  */
 
@@ -92,16 +93,26 @@ describe("GH#1744 — limit=0 and limit=NaN should never return null total/activ
     expect(body.markets.length).toBeLessThanOrEqual(1);
   });
 
-  it("limit=NaN returns 400 (non-numeric)", async () => {
+  it("limit=NaN returns 200 with total as number, defaults to MAX_LIMIT (GH#1753)", async () => {
     const { GET } = await import("@/app/api/markets/route");
     const res = await GET(makeRequest({ limit: "NaN" }));
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(typeof body.total).toBe("number");
+    expect(typeof body.activeTotal).toBe("number");
+    // All 3 markets returned (default MAX_LIMIT=500 applies)
+    expect(body.markets.length).toBe(3);
   });
 
-  it("limit=abc returns 400 (non-numeric)", async () => {
+  it("limit=abc returns 200 with total as number, defaults to MAX_LIMIT (GH#1753)", async () => {
     const { GET } = await import("@/app/api/markets/route");
     const res = await GET(makeRequest({ limit: "abc" }));
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(typeof body.total).toBe("number");
+    expect(typeof body.activeTotal).toBe("number");
+    // All 3 markets returned (default MAX_LIMIT=500 applies)
+    expect(body.markets.length).toBe(3);
   });
 
   it("limit=1 returns 200 with total as number and 1 market", async () => {

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -538,21 +538,24 @@ export async function GET(request: NextRequest) {
     // Follow-up: use validated .value directly (not re-parsed) to reject "1.5"/"20abc".
     // GH#1737: Clamp limit to MAX_LIMIT instead of rejecting — limit=510 was returning
     // a 400 error which the frontend silently swallowed, showing 0 markets. Any value
-    // > MAX_LIMIT is treated as MAX_LIMIT (500). Non-numeric values still return 400.
+    // > MAX_LIMIT is treated as MAX_LIMIT (500).
+    // GH#1753: Soft-default non-numeric/NaN strings to MAX_LIMIT instead of returning 400.
+    // parseInt("abc") and parseInt("NaN") both return NaN — previously this caused the
+    // validator to return 400, which some callers (mobile, SDK clients) swallowed silently,
+    // receiving null total/activeTotal. Now: ?limit=abc and ?limit=NaN default to MAX_LIMIT.
     const MAX_LIMIT = 500;
     const MIN_LIMIT = 1;
+    const DEFAULT_LIMIT = MAX_LIMIT; // returned when limit is absent or non-numeric
     const limitParam = request?.nextUrl?.searchParams?.get("limit") ?? null;
     let limitNum = 0;
     if (limitParam !== null) {
-      // Validate numeric format first (rejects floats, garbage strings, negatives).
-      // GH#1744: Use min:0 here (not min:1) so limit=0 doesn't return 400 — we clamp
-      // below. Non-numeric strings (limit=abc, limit=NaN) still reject with 400.
-      const limitValidation = validateNumericParam(limitParam, { min: 0 });
-      if (!limitValidation.valid) return limitValidation.response;
-      // GH#1744: Clamp to [MIN_LIMIT, MAX_LIMIT] — limit=0 becomes 1 (returns
-      // at least one market), limit>500 falls back to 500. Never returns 400 for
-      // numeric inputs, so total/activeTotal are always present in 200 responses.
-      limitNum = Math.min(Math.max(limitValidation.value, MIN_LIMIT), MAX_LIMIT);
+      // GH#1753: Use parseInt with NaN fallback to DEFAULT_LIMIT.
+      // parseInt handles: "abc" → NaN, "NaN" → NaN, "0" → 0, "510" → 510.
+      // Then clamp to [MIN_LIMIT, MAX_LIMIT] — limit=0 → 1, limit>500 → 500.
+      const parsed = parseInt(limitParam, 10);
+      limitNum = Number.isNaN(parsed)
+        ? DEFAULT_LIMIT
+        : Math.min(Math.max(parsed, MIN_LIMIT), MAX_LIMIT);
     }
 
     const offsetParam = request?.nextUrl?.searchParams?.get("offset") ?? null;


### PR DESCRIPTION
## Problem
`GET /api/markets?limit=abc` and `?limit=NaN` were returning 400 (from `validateNumericParam`) with no markets. Some callers silently swallowed the 400, getting `null total/activeTotal` and 0 markets — production regression reported by QA.

`limit=0` was fixed in GH#1744 (PR #1745) but NaN/string coercion was missed.

## Fix
Replace `validateNumericParam` for the `limit` path with a direct `parseInt` + NaN-fallback to `DEFAULT_LIMIT (500)`. Mirrors the existing clamp pattern:
- `limit=abc` → parseInt returns NaN → defaults to 500 (returns all markets)
- `limit=NaN` → parseInt returns NaN → defaults to 500 (returns all markets)
- `limit=0` → clamped to MIN_LIMIT=1 (existing GH#1744 behaviour, unchanged)
- `limit=510` → clamped to MAX_LIMIT=500 (existing GH#1737 behaviour, unchanged)

`validateNumericParam` is still used for `offset` (strict validation correct there).

## Tests
Updated `markets-gh1744-limit-clamp.test.ts`:
- `limit=NaN` → 200, all markets, numeric total ✅
- `limit=abc` → 200, all markets, numeric total ✅
- All 6 tests pass ✅

## How to Test
```bash
curl 'https://percolatorlaunch.com/api/markets?limit=abc'   # should return markets + numeric total
curl 'https://percolatorlaunch.com/api/markets?limit=NaN'   # same
curl 'https://percolatorlaunch.com/api/markets?limit=0'     # still clamped to 1 (unchanged)
```

Fixes GH#1753. Follow-up to PR #1745 (GH#1744).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced limit parameter validation: Non-numeric values now gracefully default to the maximum available limit instead of returning errors. Numeric inputs continue to be properly clamped within the acceptable range, improving API robustness and consistency across different request scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->