### PR TITLE
fix: music player overlaps mobile bottom nav, blocking Earn tab

### DIFF
--- a/app/__tests__/unit/gh1662-music-player-trade-overlap.test.ts
+++ b/app/__tests__/unit/gh1662-music-player-trade-overlap.test.ts
@@ -75,7 +75,7 @@ describe("GH#1662 – MusicPlayer does not overlap STATS panel at 1440px", () =>
   });
 
   it("does not change behaviour for non-trade routes (fallback branch unchanged)", () => {
-    // The original bottom-right fallback classes still appear
-    expect(playerSrc).toContain("bottom-3 right-3 sm:bottom-5 sm:right-5");
+    // The original bottom-right fallback classes still appear (mobile bottom clears nav bar)
+    expect(playerSrc).toContain("bottom-[72px] right-3 md:bottom-3 sm:right-5");
   });
 });

--- a/app/components/ui/MusicPlayer.tsx
+++ b/app/components/ui/MusicPlayer.tsx
@@ -184,7 +184,7 @@ export function MusicPlayer() {
           ? " top-[80px] right-3 sm:top-[72px] sm:right-5"
           : moveToBottomLeftLg
           ? " bottom-3 right-3 sm:bottom-5 sm:right-5 lg:bottom-5 lg:right-auto lg:left-5"
-          : " bottom-3 right-3 sm:bottom-5 sm:right-5"
+          : " bottom-[72px] right-3 md:bottom-3 sm:right-5"
       }`}
       style={{ opacity: 0 }}
     >


### PR DESCRIPTION
The floating MusicPlayer was positioned at bottom-3 (12px) on mobile, sitting inside the 56px MobileBottomNav zone at z-90 > z-50, blocking the rightmost "Earn" tab.

- Change mobile default from bottom-3 to bottom-[72px] (clears 56px nav + 16px gap)
- Add md:bottom-3 to restore original position when bottom nav hides (≥768px)
- Update existing GH#1662 test assertion to match new fallback classes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted Music Player positioning on mobile and medium-sized screens for improved layout spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->