### PR TITLE
fix: No Oracle health badge wraps to two lines on mobile

### DIFF
--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -728,7 +728,7 @@ function MarketsPageInner() {
             <>
               <div className="relative rounded-sm border border-[var(--border)] hud-corners overflow-x-auto">
                 {/* Header row: xs=4 cols (name|price|lev|health), sm+=7 cols */}
-                <div className="grid w-full sm:min-w-[700px] grid-cols-[minmax(120px,2.5fr)_minmax(80px,1.2fr)_minmax(55px,0.7fr)_minmax(55px,0.7fr)] sm:grid-cols-[minmax(160px,3fr)_minmax(90px,1.2fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(65px,0.8fr)_minmax(80px,0.9fr)] gap-2 sm:gap-4 border-b border-[var(--border)] bg-[var(--bg-surface)] px-3 sm:px-5 py-2.5 text-[9px] sm:text-[10px] font-semibold uppercase tracking-[0.15em] text-[var(--text-dim)]">
+                <div className="grid w-full sm:min-w-[700px] grid-cols-[minmax(120px,2.5fr)_minmax(80px,1.2fr)_minmax(50px,0.6fr)_minmax(75px,0.8fr)] sm:grid-cols-[minmax(160px,3fr)_minmax(90px,1.2fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(65px,0.8fr)_minmax(80px,0.9fr)] gap-2 sm:gap-4 border-b border-[var(--border)] bg-[var(--bg-surface)] px-3 sm:px-5 py-2.5 text-[9px] sm:text-[10px] font-semibold uppercase tracking-[0.15em] text-[var(--text-dim)]">
                   <div>token</div>
                   <div className="text-right">price</div>
                   <div className="hidden sm:block text-right">OI</div>
@@ -860,7 +860,7 @@ function MarketsPageInner() {
                       key={m.slabAddress}
                       href={`/trade/${m.slabAddress}`}
                       className={[
-                        "grid w-full sm:min-w-[700px] grid-cols-[minmax(120px,2.5fr)_minmax(80px,1.2fr)_minmax(55px,0.7fr)_minmax(55px,0.7fr)] sm:grid-cols-[minmax(160px,3fr)_minmax(90px,1.2fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(65px,0.8fr)_minmax(80px,0.9fr)] gap-2 sm:gap-4 items-center px-3 sm:px-5 py-3 transition-all duration-200 hover:bg-[var(--accent)]/[0.06] border-l-2 border-l-transparent hover:border-l-[var(--accent)]/40",
+                        "grid w-full sm:min-w-[700px] grid-cols-[minmax(120px,2.5fr)_minmax(80px,1.2fr)_minmax(50px,0.6fr)_minmax(75px,0.8fr)] sm:grid-cols-[minmax(160px,3fr)_minmax(90px,1.2fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(65px,0.8fr)_minmax(80px,0.9fr)] gap-2 sm:gap-4 items-center px-3 sm:px-5 py-3 transition-all duration-200 hover:bg-[var(--accent)]/[0.06] border-l-2 border-l-transparent hover:border-l-[var(--accent)]/40",
                         i > 0 ? "border-t border-[var(--border)]" : "",
                         i % 2 === 1 ? "bg-white/[0.05]" : "",
                       ].join(" ")}

--- a/app/components/market/HealthBadge.tsx
+++ b/app/components/market/HealthBadge.tsx
@@ -30,7 +30,7 @@ const TOOLTIPS: Record<HealthLevel, string> = {
 
 export const HealthBadge: FC<{ level: HealthLevel }> = ({ level }) => (
   <Tooltip text={TOOLTIPS[level]}>
-    <span className={`inline-block rounded-full px-1.5 py-0.5 text-[10px] font-bold ${STYLES[level]}${level === "warning" || level === "caution" || level === "oracle-down" ? " animate-pulse" : ""}`}>
+    <span className={`inline-block whitespace-nowrap rounded-full px-1.5 py-0.5 text-[10px] font-bold ${STYLES[level]}${level === "warning" || level === "caution" || level === "oracle-down" ? " animate-pulse" : ""}`}>
       {LABELS[level]}
     </span>
   </Tooltip>


### PR DESCRIPTION
## Summary
- "No Oracle" health badge in the markets table wraps to two lines ("No\nOracle") on mobile viewports
- TOKEN column names clipped on left edge due to tight column allocation

## Root Cause
`HealthBadge` span had no `whitespace-nowrap`, and the mobile HEALTH column was `minmax(55px, 0.7fr)` — too narrow for the 9-character "No Oracle" label at `text-[10px]` with `px-1.5` padding.

## Fix
- Add `whitespace-nowrap` to the `HealthBadge` `<span>` — prevents wrap regardless of container width
- Widen mobile HEALTH column: `minmax(55px, 0.7fr)` → `minmax(75px, 0.8fr)`
- Narrow mobile LEV column: `minmax(55px, 0.7fr)` → `minmax(50px, 0.6fr)` to compensate (LEV only shows short values like "20x")

## Files Changed
- `app/components/market/HealthBadge.tsx` — add `whitespace-nowrap`
- `app/app/markets/page.tsx` — rebalance mobile grid column widths (2 occurrences: header + row)

## Testing
1. Open `/markets` on mobile viewport (320-375px)
2. Find a market with "No Oracle" health status
3. Verify badge displays on single line
4. Verify TOKEN names aren't clipped on left edge
5. Verify LEV column still readable ("20x" etc.)
6. Desktop layout unchanged (these are mobile-only grid columns)

## Checklist
- [x] CSS-only fix, no logic changes
- [x] `whitespace-nowrap` is a universal safety net for all badge labels
- [x] Column rebalance stays within same total fractional space
- [x] 2 files, 3 lines changed

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined markets table column sizing on mobile devices to improve layout alignment and visual presentation.
  * Updated health badge styling to prevent label text wrapping, ensuring content displays on a single line for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->