### PR TITLE
fix(markets): prevent No Oracle badge text wrapping on mobile (GH#1785)

### DIFF
--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -732,7 +732,7 @@ function MarketsPageInner() {
                 {/* GH#1775: sticky inside overflow-x-auto is broken by CSS spec (overflow clips stacking context).
                     Removed sticky top-0 z-10 — header scrolls with content on mobile.
                     Desktop (sm+) is unaffected since the table fits in viewport width. */}
-                <div className="grid w-full min-w-[500px] sm:min-w-[700px] grid-cols-[minmax(120px,2.5fr)_minmax(80px,1.2fr)_minmax(55px,0.7fr)_minmax(55px,0.7fr)] sm:grid-cols-[minmax(160px,3fr)_minmax(90px,1.2fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(65px,0.8fr)_minmax(80px,0.9fr)] gap-2 sm:gap-4 border-b border-[var(--border)] bg-[var(--bg-surface)] px-3 sm:px-5 py-2.5 text-[9px] sm:text-[10px] font-semibold uppercase tracking-[0.15em] text-[var(--text-dim)]">
+                <div className="grid w-full min-w-[500px] sm:min-w-[700px] grid-cols-[minmax(120px,2.5fr)_minmax(80px,1.2fr)_minmax(50px,0.6fr)_minmax(75px,0.8fr)] sm:grid-cols-[minmax(160px,3fr)_minmax(90px,1.2fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(65px,0.8fr)_minmax(80px,0.9fr)] gap-2 sm:gap-4 border-b border-[var(--border)] bg-[var(--bg-surface)] px-3 sm:px-5 py-2.5 text-[9px] sm:text-[10px] font-semibold uppercase tracking-[0.15em] text-[var(--text-dim)]">
                   <div>token</div>
                   <div className="text-right">price</div>
                   <div className="hidden sm:block text-right">OI</div>
@@ -864,7 +864,7 @@ function MarketsPageInner() {
                       key={m.slabAddress}
                       href={`/trade/${m.slabAddress}`}
                       className={[
-                        "grid w-full min-w-[500px] sm:min-w-[700px] grid-cols-[minmax(120px,2.5fr)_minmax(80px,1.2fr)_minmax(55px,0.7fr)_minmax(55px,0.7fr)] sm:grid-cols-[minmax(160px,3fr)_minmax(90px,1.2fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(65px,0.8fr)_minmax(80px,0.9fr)] gap-2 sm:gap-4 items-center px-3 sm:px-5 py-3 transition-all duration-200 hover:bg-[var(--accent)]/[0.06] border-l-2 border-l-transparent hover:border-l-[var(--accent)]/40",
+                        "grid w-full min-w-[500px] sm:min-w-[700px] grid-cols-[minmax(120px,2.5fr)_minmax(80px,1.2fr)_minmax(50px,0.6fr)_minmax(75px,0.8fr)] sm:grid-cols-[minmax(160px,3fr)_minmax(90px,1.2fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(65px,0.8fr)_minmax(80px,0.9fr)] gap-2 sm:gap-4 items-center px-3 sm:px-5 py-3 transition-all duration-200 hover:bg-[var(--accent)]/[0.06] border-l-2 border-l-transparent hover:border-l-[var(--accent)]/40",
                         i > 0 ? "border-t border-[var(--border)]" : "",
                         i % 2 === 1 ? "bg-white/[0.05]" : "",
                       ].join(" ")}

--- a/app/components/market/HealthBadge.tsx
+++ b/app/components/market/HealthBadge.tsx
@@ -30,7 +30,7 @@ const TOOLTIPS: Record<HealthLevel, string> = {
 
 export const HealthBadge: FC<{ level: HealthLevel }> = ({ level }) => (
   <Tooltip text={TOOLTIPS[level]}>
-    <span className={`inline-block rounded-full px-1.5 py-0.5 text-[10px] font-bold ${STYLES[level]}${level === "warning" || level === "caution" || level === "oracle-down" ? " animate-pulse" : ""}`}>
+    <span className={`inline-block whitespace-nowrap rounded-full px-1.5 py-0.5 text-[10px] font-bold ${STYLES[level]}${level === "warning" || level === "caution" || level === "oracle-down" ? " animate-pulse" : ""}`}>
       {LABELS[level]}
     </span>
   </Tooltip>


### PR DESCRIPTION
## Summary
Fixes GH#1785 — "No Oracle" health badge wraps to two lines on mobile (34px height).

**Replaces conflicting PR #1787** (rebased on current main post-#1789 merge).

## Changes
- **HealthBadge.tsx**: Add `whitespace-nowrap` to prevent text wrapping
- **markets/page.tsx**: Rebalance mobile grid columns — shrink leverage col (50px/0.6fr), widen health col (75px/0.8fr) to fit badge

## Testing
- Check markets page on mobile viewport (~375px) — "No Oracle" badge should be single-line
- Desktop layout unchanged (sm+ breakpoint uses same columns as before)

cc @qa @security