### PR TITLE
fix(devnet-pre-fund): replace .maybeSingle() with .order().limit(1) — GH#1799

### DIFF
--- a/app/app/api/devnet-pre-fund/route.ts
+++ b/app/app/api/devnet-pre-fund/route.ts
@@ -172,11 +172,18 @@ export async function POST(req: NextRequest) {
         // Not in static list — check dynamic mirror-mint table as fallback
         try {
           const supabase = getServiceClient();
-          const { data: mirrorRow } = await (supabase as any)
+          const { data: mirrorRows, error: mirrorErr } = await (supabase as any)
             .from("devnet_mints")
             .select("devnet_mint")
             .eq("devnet_mint", mintAddress)
-            .maybeSingle();
+            .order("created_at", { ascending: false })
+            .limit(1);
+          if (mirrorErr) {
+            Sentry.captureException(mirrorErr, {
+              tags: { endpoint: "/api/devnet-pre-fund", phase: "dynamic-mint-check" },
+            });
+          }
+          const mirrorRow = mirrorRows?.[0];
           finallyPermitted = !!mirrorRow?.devnet_mint;
         } catch (e) {
           Sentry.captureException(e, {
@@ -190,11 +197,18 @@ export async function POST(req: NextRequest) {
       // #873: No static allowlist — ALWAYS query DB (never default to permitted=true)
       try {
         const supabase = getServiceClient();
-        const { data: mirrorRow } = await (supabase as any)
+        const { data: mirrorRows, error: mirrorErr } = await (supabase as any)
           .from("devnet_mints")
           .select("devnet_mint")
           .eq("devnet_mint", mintAddress)
-          .maybeSingle();
+          .order("created_at", { ascending: false })
+          .limit(1);
+        if (mirrorErr) {
+          Sentry.captureException(mirrorErr, {
+            tags: { endpoint: "/api/devnet-pre-fund", phase: "dynamic-mint-check" },
+          });
+        }
+        const mirrorRow = mirrorRows?.[0];
         finallyPermitted = !!mirrorRow?.devnet_mint;
       } catch (e) {
         Sentry.captureException(e, {


### PR DESCRIPTION
## Problem
`devnet-pre-fund` rejects BONK (CCPHprPU6RsT4KbwVRC5Gk21L3B7VFsPUZFxEjZS4SeC) with 400 not-permitted.

## Root Cause
Same as GH#1771 (fixed in PR#1773): `.maybeSingle()` returns `{data: null, error: PGRST116}` without throwing when multiple `devnet_mints` rows exist for the same mint. Code checked `mirrorRow?.devnet_mint` without inspecting the error field → treated valid mints as not-permitted.

## Fix
Replace both `.maybeSingle()` calls (lines ~179 and ~197) with `.order('created_at', { ascending: false }).limit(1)` and explicitly check the error field, logging to Sentry if the query fails.

## Testing
- BONK mint with 2 market rows should now resolve correctly
- Single-row mints unaffected (same behavior)
- DB errors are captured to Sentry instead of silently returning null

Closes #1799

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error tracking and monitoring for devnet pre-funding operations with improved diagnostic logging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->