### PR TITLE
fix: show N/A for liq price on 1x coin-margined positions (#1805)

### DIFF
--- a/app/__tests__/lib/format-extended.test.ts
+++ b/app/__tests__/lib/format-extended.test.ts
@@ -48,9 +48,9 @@ describe("formatUsd (extended)", () => {
 });
 
 describe("formatLiqPrice", () => {
-  it("returns '-' for null", () => expect(formatLiqPrice(null)).toBe("-"));
-  it("returns '-' for undefined", () => expect(formatLiqPrice(undefined)).toBe("-"));
-  it("returns '-' for zero", () => expect(formatLiqPrice(0n)).toBe("-"));
+  it("returns 'N/A' for null", () => expect(formatLiqPrice(null)).toBe("N/A"));
+  it("returns 'N/A' for undefined", () => expect(formatLiqPrice(undefined)).toBe("N/A"));
+  it("returns 'N/A' for zero", () => expect(formatLiqPrice(0n)).toBe("N/A"));
   it("returns '∞' for unliquidatable sentinel", () => {
     expect(formatLiqPrice(LIQ_PRICE_UNLIQUIDATABLE)).toBe("∞");
   });

--- a/app/__tests__/lib/format.test.ts
+++ b/app/__tests__/lib/format.test.ts
@@ -149,12 +149,12 @@ describe("formatUsd", () => {
 });
 
 describe("formatLiqPrice", () => {
-  it("returns '-' for null", () => {
-    expect(formatLiqPrice(null)).toBe("-");
+  it("returns 'N/A' for null", () => {
+    expect(formatLiqPrice(null)).toBe("N/A");
   });
 
-  it("returns '-' for zero", () => {
-    expect(formatLiqPrice(0n)).toBe("-");
+  it("returns 'N/A' for zero", () => {
+    expect(formatLiqPrice(0n)).toBe("N/A");
   });
 
   it("returns '∞' for unliquidatable sentinel", () => {

--- a/app/components/trade/PositionsTable.tsx
+++ b/app/components/trade/PositionsTable.tsx
@@ -116,7 +116,8 @@ export const PositionsTable: FC<{ slabAddress: string }> = ({ slabAddress }) => 
 
   // Liq price danger color: amber when mark is within 10% of liq, red within 5%
   const liqPriceColor = (() => {
-    if (liqPriceE6 <= 0n || !hasValidMark || currentPriceE6 <= 0n) return "text-[var(--warning)]";
+    if (liqPriceE6 <= 0n) return "text-[var(--text-muted)]";
+    if (!hasValidMark || currentPriceE6 <= 0n) return "text-[var(--warning)]";
     const markNum = Number(currentPriceE6);
     const liqNum = Number(liqPriceE6);
     const distPct = Math.abs(markNum - liqNum) / markNum;

--- a/app/components/trade/TradeConfirmationModal.tsx
+++ b/app/components/trade/TradeConfirmationModal.tsx
@@ -145,7 +145,7 @@ export const TradeConfirmationModal: FC<TradeConfirmationModalProps> = ({
           <div className="flex justify-between border-t border-[var(--border)]/30 pt-2">
             <span className="text-[var(--text-dim)]">Est. Liquidation Price:</span>
             <span className="font-mono font-medium text-[var(--short)]">
-              ${formatPerc(estimatedLiqPrice, 6)}
+              {estimatedLiqPrice <= 0n ? "N/A" : `$${formatPerc(estimatedLiqPrice, 6)}`}
             </span>
           </div>
         </div>

--- a/app/lib/format.ts
+++ b/app/lib/format.ts
@@ -107,7 +107,7 @@ export function formatUsd(priceE6: bigint | null | undefined): string {
  * "-" when zero/null, otherwise delegates to formatUsd.
  */
 export function formatLiqPrice(liqPriceE6: bigint | null | undefined): string {
-  if (liqPriceE6 == null || liqPriceE6 === 0n) return "-";
+  if (liqPriceE6 == null || liqPriceE6 <= 0n) return "N/A";
   if (liqPriceE6 >= LIQ_PRICE_UNLIQUIDATABLE) return "∞";
   return formatUsd(liqPriceE6);
 }


### PR DESCRIPTION
## Summary
Fixes #1805 — liquidation price inconsistency between confirm dialog and positions table.

## Problem
- Confirm dialog showed **$0** for 1x coin-margined positions (mathematically correct but misleading)
- Positions table showed **-** for the same positions (inconsistent)

## Changes
- **TradeConfirmationModal**: render `N/A` instead of `$0` when `estimatedLiqPrice <= 0n`
- **formatLiqPrice** (lib/format.ts): return `N/A` (previously `-`) for null/zero/negative — unifies all views that use this helper
- **PositionsTable**: apply muted text color (not warning amber) for N/A liq price, since these positions are not at liquidation risk
- Update format tests to assert `N/A`

## Testing
- 154 format tests passing
- Visual: confirm dialog and positions table now both show `N/A` for 1x longs/shorts

## Risk
Low — display-only change, no trading logic affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Liquidation price now displays "N/A" when the value is non-positive, replacing the previous dash indicator for improved clarity in trade confirmations and positions overview.

* **Style**
  * Updated styling for unavailable liquidation prices from warning color to muted coloring to better distinguish between unavailable prices and actual liquidation risk states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->