### PR TITLE
fix(oracle): GH#1807 stop /api/oracle/publishers 500 retry storm + GH#1808 portfolio skeleton

### DIFF
--- a/app/__tests__/api/oracle-publishers.test.ts
+++ b/app/__tests__/api/oracle-publishers.test.ts
@@ -162,4 +162,35 @@ describe("GET /api/oracle/publishers", () => {
     // Hyperp fallback returns null (not 0) so UI suppresses "0 publishers" text
     expect(body.publisherCount).toBeNull();
   });
+
+  // GH#1807: Pythnet RPC unreachable — must return 200 with null counts, not 500
+  it("GH#1807: returns 200 with null counts when Pythnet RPC times out", async () => {
+    mockFetch.mockRejectedValueOnce(Object.assign(new Error("The operation was aborted"), { name: "AbortError" }));
+
+    // Use a distinct feedId to avoid the route-level cache returning a prior successful result
+    const feedId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const resp = await GET(makeRequest({ mode: "pyth-pinned", feedId }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json();
+    expect(body.mode).toBe("pyth-pinned");
+    expect(body.publisherCount).toBeNull();
+    expect(body.publisherTotal).toBeNull();
+    expect(body.publishers).toHaveLength(0);
+  });
+
+  it("GH#1807: returns 200 with null counts when Pythnet RPC returns non-200", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 429 });
+
+    // Use a distinct feedId to avoid the route-level cache returning a prior successful result
+    const feedId = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const resp = await GET(makeRequest({ mode: "pyth-pinned", feedId }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json();
+    expect(body.mode).toBe("pyth-pinned");
+    expect(body.publisherCount).toBeNull();
+    expect(body.publisherTotal).toBeNull();
+    expect(body.publishers).toHaveLength(0);
+  });
 });

--- a/app/app/api/oracle/publishers/route.ts
+++ b/app/app/api/oracle/publishers/route.ts
@@ -143,20 +143,30 @@ async function fetchPythPublishers(feedIdHex: string): Promise<PublishersRespons
   const feedBytes = hexToBytes(feedIdHex);
   const accountAddress = bytesToBase58(feedBytes);
 
-  const resp = await fetch(PYTHNET_RPC, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: 1,
-      method: "getAccountInfo",
-      params: [accountAddress, { encoding: "base64", commitment: "confirmed" }],
-    }),
-    signal: AbortSignal.timeout(8000),
-  });
+  let resp: Response;
+  try {
+    resp = await fetch(PYTHNET_RPC, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "getAccountInfo",
+        params: [accountAddress, { encoding: "base64", commitment: "confirmed" }],
+      }),
+      signal: AbortSignal.timeout(8000),
+    });
+  } catch (err) {
+    // GH#1807: Pythnet RPC unreachable (timeout, DNS, network) — return empty rather
+    // than propagating a 500 that triggers a client-side retry storm.
+    console.warn("[oracle/publishers] Pythnet RPC unreachable:", (err as Error).message);
+    return { mode: "pyth-pinned", publisherCount: null, publisherTotal: null, publishers: [] };
+  }
 
   if (!resp.ok) {
-    throw new Error(`Pythnet RPC error: ${resp.status}`);
+    // Non-200 from Pythnet — treat as unavailable, not as a server error.
+    console.warn(`[oracle/publishers] Pythnet RPC returned ${resp.status}`);
+    return { mode: "pyth-pinned", publisherCount: null, publisherTotal: null, publishers: [] };
   }
 
   const json = await resp.json();

--- a/app/app/portfolio/page.tsx
+++ b/app/app/portfolio/page.tsx
@@ -76,7 +76,10 @@ export default function PortfolioPage() {
     (pos) => pos.account.positionSize !== 0n || pos.account.capital > 0n
   );
 
-  const tokenMetasLoading = collateralMints.length > 0 && tokenMetaMap.size === 0;
+  // GH#1808: Only block on tokenMetas if positions are still loading too. If positions have
+  // loaded (loading=false) but tokenMetas haven't resolved, the fetch likely failed silently —
+  // unblock the UI instead of leaving it stuck in infinite skeleton state.
+  const tokenMetasLoading = collateralMints.length > 0 && tokenMetaMap.size === 0 && loading;
 
   const computeUsdTotals = () => {
     let depositedUsd = 0;

--- a/app/hooks/useMultiTokenMeta.ts
+++ b/app/hooks/useMultiTokenMeta.ts
@@ -30,7 +30,11 @@ export function useMultiTokenMeta(mints: PublicKey[]): Map<string, TokenMeta> {
         if (!cancelled) setMetaMap(map);
       })
       .catch(() => {
-        // Keep existing map on error
+        // GH#1808: On fetch failure, set an empty map explicitly so callers can detect
+        // completion vs. never-resolved. Keeps existing data if we had partial results.
+        if (!cancelled && metaMap.size === 0) {
+          setMetaMap(new Map());
+        }
       });
 
     return () => { cancelled = true; };

--- a/app/hooks/useOraclePublishers.ts
+++ b/app/hooks/useOraclePublishers.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useMemo, useState, useRef } from "react";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { detectOracleMode } from "@/lib/oraclePrice";
 
@@ -23,8 +23,10 @@ export interface OraclePublishersState {
   error: string | null;
 }
 
-/** Refresh interval for publisher data (60s — changes rarely) */
+/** Normal refresh interval for publisher data (60s — changes rarely) */
 const POLL_INTERVAL_MS = 60_000;
+/** Back-off interval after a failed fetch (5 minutes — avoid retry storm on 500s) */
+const ERROR_BACKOFF_MS = 5 * 60_000;
 
 /**
  * Fetch live oracle publisher data for the current market.
@@ -33,7 +35,11 @@ const POLL_INTERVAL_MS = 60_000;
  * - hyperp: Queries oracle bridge for DEX price sources
  * - admin: Returns the single oracle authority
  *
- * Replaces the former hardcoded publisher counts (7/9, 5/7) in useOracleFreshness.
+ * GH#1807: The effect was previously keyed on `config` (the full slab object), which
+ * changes every 3s from SlabProvider. This triggered a new fetch on every poll cycle,
+ * creating a continuous 500-storm when the Pythnet RPC was unreachable. Fixed by:
+ *   1. Deriving a stable `fetchKey` (mode + feedId/authority) and keying the effect on that.
+ *   2. Using ERROR_BACKOFF_MS (5 min) after a failed fetch instead of retrying immediately.
  */
 export function useOraclePublishers(): OraclePublishersState {
   const { config } = useSlabState();
@@ -47,11 +53,33 @@ export function useOraclePublishers(): OraclePublishersState {
   const abortRef = useRef<AbortController | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval>>(undefined);
 
+  // Derive a stable fetch key from the parts that actually matter for the API call.
+  // This prevents re-mounting the effect every 3s when SlabProvider polls the slab.
+  const fetchKey = useMemo(() => {
+    if (!config) return null;
+    const mode = detectOracleMode(config);
+    if (!mode) return null;
+
+    if (mode === "pyth-pinned" && config.indexFeedId) {
+      const feedIdBytes = config.indexFeedId.toBytes();
+      const feedIdHex = Array.from(feedIdBytes)
+        .map((b: number) => b.toString(16).padStart(2, "0"))
+        .join("");
+      return `pyth-pinned:${feedIdHex}`;
+    }
+    if (mode === "admin" && config.oracleAuthority) {
+      return `admin:${config.oracleAuthority.toBase58()}`;
+    }
+    return mode; // "hyperp" — no extra params needed
+  }, [config]);
+
   useEffect(() => {
-    if (!config) return;
+    if (!fetchKey || !config) return;
 
     const mode = detectOracleMode(config);
     if (!mode) return;
+
+    let nextIntervalMs = POLL_INTERVAL_MS;
 
     const fetchPublishers = async () => {
       abortRef.current?.abort();
@@ -63,7 +91,7 @@ export function useOraclePublishers(): OraclePublishersState {
       try {
         const params = new URLSearchParams({ mode });
 
-        if (mode === "pyth-pinned") {
+        if (mode === "pyth-pinned" && config.indexFeedId) {
           const feedIdBytes = config.indexFeedId.toBytes();
           const feedIdHex = Array.from(feedIdBytes)
             .map((b: number) => b.toString(16).padStart(2, "0"))
@@ -92,24 +120,31 @@ export function useOraclePublishers(): OraclePublishersState {
           loading: false,
           error: null,
         });
+        nextIntervalMs = POLL_INTERVAL_MS;
       } catch (err) {
         if ((err as Error).name === "AbortError") return;
+        // GH#1807: Back off on failure — don't hammer a broken endpoint every 60s.
+        nextIntervalMs = ERROR_BACKOFF_MS;
         setState((prev) => ({
           ...prev,
           loading: false,
           error: err instanceof Error ? err.message : String(err),
         }));
+      } finally {
+        // Reschedule with the appropriate interval (normal or back-off)
+        clearInterval(intervalRef.current);
+        intervalRef.current = setInterval(fetchPublishers, nextIntervalMs);
       }
     };
 
     fetchPublishers();
-    intervalRef.current = setInterval(fetchPublishers, POLL_INTERVAL_MS);
 
     return () => {
       abortRef.current?.abort();
       clearInterval(intervalRef.current);
     };
-  }, [config]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchKey]);
 
   return state;
 }


### PR DESCRIPTION
## Summary
Fixes two bugs from 3AM prod testing reported by QA.

## GH#1807 — /api/oracle/publishers continuous 500 on BONK trade page (Medium)

**Root cause:** `useOraclePublishers` effect was keyed on the full `config` object from SlabProvider. SlabProvider polls the slab every 3s, updating `config` on every tick. This caused the effect to re-mount every 3s, issuing a new fetch each time. When Pythnet RPC was unreachable (timeout/429), the route returned 500, and the hook re-tried again 3s later → continuous storm.

**Fixes:**
1. **Hook (fetchKey):** Memoize a stable `fetchKey` (mode + feedId/authority string) so the effect only re-mounts when oracle params actually change, not on every 3s slab poll.
2. **Hook (backoff):** After a failed fetch, reschedule at `ERROR_BACKOFF_MS` (5 min) instead of re-using `POLL_INTERVAL_MS` (60s). Stops hammering a broken endpoint.
3. **Route (graceful fallback):** Pythnet RPC network errors (timeout, 429, DNS failure) now return `200 { publisherCount: null, publishers: [] }` instead of propagating a 500. UI already handles null counts gracefully.

## GH#1808 — Portfolio stats bar stuck in loading state (Low)

**Root cause:** `tokenMetasLoading` was computed as `collateralMints.length > 0 && tokenMetaMap.size === 0`. If `fetchTokenMetaBatch` fails silently (network error, the catch block swallows it), `tokenMetaMap` stays empty indefinitely → all 5 summary stats cells show `…` forever.

**Fix:** Gate `tokenMetasLoading` on `loading` from `usePortfolio`. Once positions have finished loading (`loading=false`), if tokenMetas still haven't resolved it means the fetch failed — unblock the UI. Values will fall back to default 6 decimals, which is acceptable for display.

## Tests
- Added 2 new GH#1807 test cases: RPC timeout and RPC non-200 both return 200 with null counts.
- Full suite: 1683 passed, 0 failed.

## How to test
1. Navigate to a BONK market trade page → open console → confirm no 500 errors on `/api/oracle/publishers`
2. Navigate to /portfolio with wallet connected → confirm stats load (or show `—`) after positions resolve, not infinite `…`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Oracle publishers API now gracefully handles network timeouts and server errors, returning safe defaults instead of failing.
  * Portfolio page loading state now correctly reflects both token data and position loading status.
  * Token metadata fetch failures now properly complete with empty results instead of hanging.
  * Oracle data polling now uses adaptive retry timing with longer waits after errors.

* **Tests**
  * Added integration tests for oracle publishers error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->