### PR TITLE
fix(oracle): GH#1813 graceful return on non-Pyth magic bytes

### DIFF
--- a/app/app/api/oracle/publishers/route.ts
+++ b/app/app/api/oracle/publishers/route.ts
@@ -185,7 +185,10 @@ async function fetchPythPublishers(feedIdHex: string): Promise<PublishersRespons
 
   const magic = data.readUInt32LE(0);
   if (magic !== PYTH_MAGIC) {
-    throw new Error(`Invalid Pyth magic: 0x${magic.toString(16)}`);
+    // GH#1813: Account exists but is not a Pyth price account (wrong magic bytes).
+    // Return empty rather than throwing — same graceful pattern as network error path.
+    console.warn(`[oracle/publishers] Non-Pyth account magic: 0x${magic.toString(16)}`);
+    return { mode: "pyth-pinned", publisherCount: null, publisherTotal: null, publishers: [] };
   }
 
   const numComponents = data.readUInt32LE(24);


### PR DESCRIPTION
## Problem
`GET /api/oracle/publishers?mode=pyth-pinned` returned 500 when the resolved Pythnet account had non-Pyth magic bytes. The `throw` inside `fetchPythPublishers()` was caught by the outer `try/catch` in the route handler and surfaced as a 500 response.

## Fix
Replace `throw new Error(...)` with a graceful `return { publisherCount: null, ... }` — identical pattern to the network-error path added in GH#1807.

## Testing
- Non-Pyth account → 200 with empty publishers array, console.warn logged
- Valid Pyth account → unchanged behaviour
- Network failure → unchanged behaviour (existing GH#1807 path)

Fixes: #1813

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced oracle publisher data retrieval reliability with improved error handling. The system now gracefully manages validation issues by returning appropriate responses instead of failing, ensuring consistent behavior across different error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->