### PR TITLE
fix(faucet): require type param — return 400 when missing (GH#1815)

### DIFF
--- a/app/__tests__/api/faucet-route.test.ts
+++ b/app/__tests__/api/faucet-route.test.ts
@@ -111,20 +111,22 @@ describe("/api/faucet route", () => {
     expect(SOL_AIRDROP_AMOUNT).toBe(2_000_000_000);
   });
 
-  it("type field defaults to 'usdc' when omitted", () => {
-    // GH#1399: type validation — only "sol" and "usdc" are accepted.
-    // Unknown/other values must be rejected (return 400), not silently coerced to usdc.
+  it("GH#1815: missing type returns 400 (type is required)", () => {
+    // GH#1815: type is now required — omitting it must return 400, not default to usdc.
+    // GH#1399: unknown types must also be rejected.
     const parseType = (t: unknown): "sol" | "usdc" | "invalid" => {
-      if (t !== undefined && t !== "sol" && t !== "usdc") return "invalid";
-      return t === "sol" ? "sol" : "usdc";
+      const normalized = typeof t === "string" ? t.trim().toLowerCase() : undefined;
+      if (!normalized || (normalized !== "sol" && normalized !== "usdc")) return "invalid";
+      return normalized as "sol" | "usdc";
     };
-    expect(parseType(undefined)).toBe("usdc");
+    expect(parseType(undefined)).toBe("invalid"); // GH#1815: missing → 400
     expect(parseType("sol")).toBe("sol");
     expect(parseType("usdc")).toBe("usdc");
-    // GH#1399: unknown types must be rejected, NOT coerced to "usdc"
     expect(parseType("token")).toBe("invalid");
     expect(parseType("mirror")).toBe("invalid");
     expect(parseType("other")).toBe("invalid");
+    expect(parseType("")).toBe("invalid"); // empty string → 400
+    expect(parseType("  ")).toBe("invalid"); // whitespace-only → 400
   });
 
   it("GH#1399: unknown type returns 400 with descriptive error (not authority_mismatch)", () => {

--- a/app/app/api/faucet/route.ts
+++ b/app/app/api/faucet/route.ts
@@ -1,12 +1,14 @@
 /**
  * PERC-376: Devnet faucet endpoint
  *
- * POST /api/faucet { wallet: string, type?: "sol" | "usdc" }
+ * POST /api/faucet { wallet: string, type: "sol" | "usdc" }
  *
  * GH#1399: Unknown type values now return 400 instead of silently routing to USDC.
+ * GH#1815: type is now REQUIRED — missing type returns 400 (was defaulting to USDC
+ *          which caused TokenOwnerOffCurveError for certain wallets).
  *
  * type="sol"  → airdrops 2 SOL via requestAirdrop on devnet public RPC
- * type="usdc" → mints 10,000 test USDC (default when type omitted)
+ * type="usdc" → mints 10,000 test USDC
  *
  * Rate-limited: 1 claim per wallet per type per 24h (tracked in Supabase auto_fund_log).
  *
@@ -69,24 +71,19 @@ export async function POST(req: NextRequest) {
     const body = await req.json();
     const walletAddress = body?.wallet;
 
-    // GH#1399: Validate type before coercing — unknown types must return 400,
-    // not silently fall through to the USDC mint path.
+    // GH#1815: type is required — reject early before any RPC/token operations.
+    // GH#1399: Unknown type values return 400 instead of silently routing to USDC.
     // Normalize type parameter: trim whitespace and lowercase before validation
     const rawType = body?.type;
     const normalizedType =
       typeof rawType === "string" ? rawType.trim().toLowerCase() : undefined;
-    if (
-      normalizedType !== undefined &&
-      normalizedType !== "sol" &&
-      normalizedType !== "usdc"
-    ) {
+    if (!normalizedType || (normalizedType !== "sol" && normalizedType !== "usdc")) {
       return NextResponse.json(
-        { error: "Invalid type. Use 'sol' or 'usdc'" },
+        { error: "Missing or invalid type. Must be 'sol' or 'usdc'" },
         { status: 400 },
       );
     }
-    const type: "sol" | "usdc" =
-      normalizedType === "sol" ? "sol" : "usdc";
+    const type: "sol" | "usdc" = normalizedType;
 
     if (!walletAddress || typeof walletAddress !== "string") {
       return NextResponse.json(


### PR DESCRIPTION
## Problem
POST /api/faucet returns 500 (TokenOwnerOffCurveError) when `type` param is missing, instead of 400.

## Root Cause
Missing `type` defaulted to `"usdc"` and proceeded to token operations, which threw `TokenOwnerOffCurveError` for certain wallets (e.g. off-curve addresses).

## Fix
Make `type` required. Missing or invalid type now returns 400 with a clear error message before any RPC/token operations.

## Tests
Updated existing test to validate new required-type behavior. All 48 faucet tests pass.

Closes #1815