### PR TITLE
fix(PERC-8198,PERC-8197): use LP mint decimals not collateral decimals

### DIFF
--- a/app/components/trade/InsuranceLPPanel.tsx
+++ b/app/components/trade/InsuranceLPPanel.tsx
@@ -28,6 +28,9 @@ export function InsuranceLPPanel() {
   const tokenSymbol = tokenMeta?.symbol ?? 'Token';
   const tokenDecimals = tokenMeta?.decimals ?? 6;
   const { state, loading, error, createMint, deposit, withdraw } = useInsuranceLP();
+  // LP tokens have their own decimals — separate from collateral token decimals.
+  // Using collateral decimals for LP amounts causes off-by-1000x errors (PERC-8198).
+  const lpDecimals = state.lpDecimals;
   const [mode, setMode] = useState<'deposit' | 'withdraw'>('deposit');
   const [amount, setAmount] = useState('');
   const [txStatus, setTxStatus] = useState<string | null>(null);
@@ -54,7 +57,8 @@ export function InsuranceLPPanel() {
     if (!amount) return;
     setTxStatus('Withdrawing...');
     try {
-      const lpTokens = parseHumanAmount(amount, tokenDecimals);
+      // Withdraw input is LP token amount — use lpDecimals, NOT collateral decimals
+      const lpTokens = parseHumanAmount(amount, lpDecimals);
       await withdraw(lpTokens);
       setTxStatus('Withdrawal successful!');
       setAmount('');
@@ -78,6 +82,8 @@ export function InsuranceLPPanel() {
   };
 
   // Preview calculation — use parseHumanAmount for precision
+  // Deposit: user enters collateral amount → preview shows LP tokens received
+  // Withdraw: user enters LP token amount → preview shows collateral received
   const previewTokens = (() => {
     if (!amount || mode !== 'deposit') return null;
     try {
@@ -92,7 +98,8 @@ export function InsuranceLPPanel() {
   const previewCollateral = (() => {
     if (!amount || mode !== 'withdraw') return null;
     try {
-      const lpTokens = parseHumanAmount(amount, tokenDecimals);
+      // Withdraw input is LP token amount — use lpDecimals, NOT collateral decimals
+      const lpTokens = parseHumanAmount(amount, lpDecimals);
       if (lpTokens <= 0n) return null;
       if (state.lpSupply === 0n) return null;
       return (lpTokens * state.insuranceBalance) / state.lpSupply;
@@ -118,7 +125,7 @@ export function InsuranceLPPanel() {
         </div>
         <div>
           <p className="text-[10px] text-[var(--text-muted)] uppercase tracking-wider">LP Supply</p>
-          <p className="text-sm font-mono text-[var(--text)]">{formatCollateral(state.lpSupply, tokenDecimals)}</p>
+          <p className="text-sm font-mono text-[var(--text)]">{formatCollateral(state.lpSupply, lpDecimals)}</p>
         </div>
         <div>
           <p className="text-[10px] text-[var(--text-muted)] uppercase tracking-wider">Rate</p>
@@ -138,7 +145,7 @@ export function InsuranceLPPanel() {
           <div className="flex justify-between items-center">
             <div>
               <p className="text-[10px] text-[var(--text-muted)] uppercase">Your LP Tokens</p>
-              <p className="text-sm font-mono text-[var(--text)]">{formatCollateral(state.userLpBalance, tokenDecimals)}</p>
+              <p className="text-sm font-mono text-[var(--text)]">{formatCollateral(state.userLpBalance, lpDecimals)}</p>
             </div>
             <div className="text-right">
               <p className="text-[10px] text-[var(--text-muted)] uppercase">Redeemable</p>
@@ -206,7 +213,7 @@ export function InsuranceLPPanel() {
             />
             {mode === 'withdraw' && state.userLpBalance > 0n && (
               <button
-                onClick={() => setAmount(formatTokenAmount(state.userLpBalance, tokenDecimals))}
+                onClick={() => setAmount(formatTokenAmount(state.userLpBalance, lpDecimals))}
                 className="absolute right-2 top-1/2 -translate-y-1/2 text-[10px] text-[var(--long)] hover:text-[var(--long)]/80"
               >
                 MAX
@@ -217,7 +224,7 @@ export function InsuranceLPPanel() {
           {/* Preview */}
           {previewTokens !== null && mode === 'deposit' && (
             <p className="text-xs text-[var(--text-muted)] mb-3">
-              You receive: <span className="text-[var(--text-secondary)] font-mono">~{formatCollateral(previewTokens, tokenDecimals)}</span> LP tokens
+              You receive: <span className="text-[var(--text-secondary)] font-mono">~{formatCollateral(previewTokens, lpDecimals)}</span> LP tokens
             </p>
           )}
           {previewCollateral !== null && mode === 'withdraw' && (

--- a/app/hooks/useInsuranceLP.ts
+++ b/app/hooks/useInsuranceLP.ts
@@ -48,6 +48,8 @@ export interface InsuranceLPState {
   mintExists: boolean;
   /** The insurance LP mint address */
   lpMintAddress: PublicKey | null;
+  /** Decimals of the LP token mint (NOT collateral decimals) */
+  lpDecimals: number;
 }
 
 export function useInsuranceLP() {
@@ -67,6 +69,7 @@ export function useInsuranceLP() {
     userRedeemableValue: 0n,
     mintExists: false,
     lpMintAddress: null,
+    lpDecimals: 6,
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -105,12 +108,15 @@ export function useInsuranceLP() {
         mintExists && rawBalance <= U64_MAX / 2n ? rawBalance : 0n;
 
       let lpSupply = 0n;
+      let lpDecimals = 6;
       let userLpBalance = 0n;
 
       if (mintExists) {
-        // Read supply from mint (using static import — dynamic import breaks vi.mock in tests)
+        // Read supply and decimals from LP mint
+        // IMPORTANT: LP tokens have their own decimals — do NOT use collateral decimals here.
         const mint = unpackMint(lpMintInfo.mintPda, mintInfo);
         lpSupply = mint.supply;
+        lpDecimals = mint.decimals;
 
         // Get user's LP token balance — use stabilized string to avoid re-render loops
         if (walletPubkeyStr) {
@@ -153,6 +159,7 @@ export function useInsuranceLP() {
         userRedeemableValue,
         mintExists,
         lpMintAddress: mintExists ? lpMintInfo.mintPda : null,
+        lpDecimals,
       });
     } catch (err) {
       console.error('Failed to refresh insurance LP state:', err);

--- a/app/hooks/useLpPositions.ts
+++ b/app/hooks/useLpPositions.ts
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { PublicKey } from '@solana/web3.js';
 import { useWalletCompat, useConnectionCompat } from '@/hooks/useWalletCompat';
-import { getAssociatedTokenAddressSync, unpackAccount } from '@solana/spl-token';
+import { getAssociatedTokenAddressSync, unpackAccount, unpackMint } from '@solana/spl-token';
 import { getStakeProgramId, deriveDepositPda } from '@percolator/sdk';
 
 
@@ -133,7 +133,26 @@ export function useLpPositions(): LpPositionsState & { refresh: () => void } {
       // Resolve stake program ID for current network
       const stakeProgramPk = getStakeProgramId();
 
-      // 2. For each pool, fetch user's LP token ATA and deposit PDA in parallel
+      // 2a. Batch-fetch LP mint accounts to read per-mint decimals (PERC-8197).
+      // LP tokens are NOT guaranteed to have 6 decimals — hardcoding causes wrong display values.
+      const lpMintKeys = pools.map((p) => new PublicKey(p.lpMint));
+      const lpMintInfos = await connection.getMultipleAccountsInfo(lpMintKeys);
+      const lpDecimalsByMint: Record<string, number> = {};
+      for (let i = 0; i < pools.length; i++) {
+        const mintInfo = lpMintInfos[i];
+        if (mintInfo && mintInfo.data.length >= 82) {
+          try {
+            const mint = unpackMint(lpMintKeys[i], mintInfo);
+            lpDecimalsByMint[pools[i].lpMint] = mint.decimals;
+          } catch {
+            lpDecimalsByMint[pools[i].lpMint] = 6; // safe fallback
+          }
+        } else {
+          lpDecimalsByMint[pools[i].lpMint] = 6; // safe fallback
+        }
+      }
+
+      // 2b. For each pool, fetch user's LP token ATA and deposit PDA in parallel
       const slotNow = await connection.getSlot();
 
       const positionResults = await Promise.allSettled(
@@ -164,15 +183,17 @@ export function useLpPositions(): LpPositionsState & { refresh: () => void } {
           if (lpBalanceRaw === 0n) return null;
 
           // 3. Compute redeemable value: (lpBalance / totalLpSupply) * tvl
-          const DECIMALS = 6; // USDC 6 decimals
-          const lpBalance = Number(lpBalanceRaw) / Math.pow(10, DECIMALS);
+          // Use per-mint decimals — do NOT hardcode 6 (PERC-8197).
+          const lpMintDecimals = lpDecimalsByMint[pool.lpMint] ?? 6;
+          const lpBalance = Number(lpBalanceRaw) / Math.pow(10, lpMintDecimals);
           const totalLpSupply = pool.totalLpSupply;
           const tvlRaw = BigInt(pool.tvlRaw);
 
           const redeemableRaw: bigint = totalLpSupply > 0
             ? (lpBalanceRaw * tvlRaw) / BigInt(Math.round(totalLpSupply))
             : 0n;
-          const redeemable = Number(redeemableRaw) / Math.pow(10, DECIMALS);
+          // Redeemable value is in collateral token (e.g. USDC 6 dec) — use collateral decimals (6)
+          const redeemable = Number(redeemableRaw) / Math.pow(10, 6);
           const userSharePct = totalLpSupply > 0
             ? (Number(lpBalanceRaw) / totalLpSupply) * 100
             : 0;


### PR DESCRIPTION
## Summary

Fixes two decimal bugs in the insurance LP flow.

### PERC-8198 (P0 — off by 1000x)

**Root cause:** `InsuranceLPPanel` used `tokenDecimals` (collateral token decimals, e.g. USDC=6) for all LP token amounts. LP tokens are a separate SPL mint with their own decimal precision. If LP decimals ≠ collateral decimals, every displayed balance, deposit preview, and withdrawal parse is off by a power of 10.

**Fix:**
- Added `lpDecimals: number` field to `InsuranceLPState`, populated from `mint.decimals` via `unpackMint` in `useInsuranceLP`
- `InsuranceLPPanel` now uses `lpDecimals` for LP token amounts: LP supply display, user LP balance display, MAX button, withdraw parse, deposit preview (LP tokens received)
- Collateral amounts (Pool Size, Redeemable, deposit input) continue using `tokenDecimals`

### PERC-8197 (P1 — hardcoded 6 decimals)

**Root cause:** `useLpPositions` hardcoded `DECIMALS = 6` for LP balance conversion.

**Fix:** Batch-fetch all LP mint accounts via `getMultipleAccountsInfo`, unpack with `unpackMint`, use `mint.decimals` per pool. Redeemable value (in collateral/USDC) stays at 6.

## Testing
- 141/141 tests pass
- `tsc --noEmit` clean

## How to test
1. Open Insurance Pool panel on a devnet market
2. Check Pool Size (collateral) vs LP Supply (LP tokens) — both should show reasonable values
3. Deposit → confirm preview LP tokens received uses correct decimals
4. Withdraw → confirm MAX sets correct LP amount, withdrawal executes correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected LP token decimal precision handling across the insurance LP interface, ensuring proper display and calculations for LP balances, supply amounts, and received tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->