### PR TITLE
fix(PERC-8202): pass token decimals to formatTokenAmount/formatPnl across all components

### DIFF
--- a/app/components/dashboard/PositionSummary.tsx
+++ b/app/components/dashboard/PositionSummary.tsx
@@ -20,7 +20,7 @@ function formatPnlPct(pct: number): string {
   return `${sign}${pct.toFixed(2)}%`;
 }
 
-function PositionCard({ pos, symbol }: { pos: PortfolioPosition; symbol: string }) {
+function PositionCard({ pos, symbol, decimals = 6 }: { pos: PortfolioPosition; symbol: string; decimals?: number }) {
   const posSize = pos.account?.positionSize ?? 0n;
   const side = posSize > 0n ? "Long" : posSize < 0n ? "Short" : "Flat";
   const sizeAbs = posSize < 0n ? -posSize : posSize;
@@ -84,7 +84,7 @@ function PositionCard({ pos, symbol }: { pos: PortfolioPosition; symbol: string 
                   className={`text-[11px] font-bold ${pos.unrealizedPnl >= 0n ? "text-[var(--long)]" : "text-[var(--short)]"}`}
                   style={{ fontFamily: "var(--font-jetbrains-mono)" }}
                 >
-                  {formatPnl(pos.unrealizedPnl)}
+                  {formatPnl(pos.unrealizedPnl, decimals)}
                 </span>
                 <span
                   className={`ml-1 text-[9px] ${pos.pnlPercent >= 0 ? "text-[var(--long)]/70" : "text-[var(--short)]/70"}`}
@@ -105,7 +105,7 @@ function PositionCard({ pos, symbol }: { pos: PortfolioPosition; symbol: string 
           <div>
             <span className="text-[var(--text-dim)]">Size: </span>
             <span className="text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
-              {formatTokenAmount(sizeAbs)}
+              {formatTokenAmount(sizeAbs, decimals)}
             </span>
           </div>
           <div>
@@ -226,6 +226,7 @@ export function PositionSummary() {
                     ? `${tokenMetaMap.get(pos.market.config.collateralMint.toBase58())!.symbol}/USD`
                     : `${pos.slabAddress.slice(0, 6)}…/USD`
                 }
+                decimals={tokenMetaMap.get(pos.market.config.collateralMint.toBase58())?.decimals ?? 6}
               />
             ))}
           </div>

--- a/app/components/trade/AccountsCard.tsx
+++ b/app/components/trade/AccountsCard.tsx
@@ -32,6 +32,7 @@ export const AccountsCard: FC = () => {
   const { params } = useEngineState();
   const { priceE6: livePriceE6 } = useLivePrice();
   const tokenMeta = useTokenMeta(mktConfig?.collateralMint ?? null);
+  const decimals = tokenMeta?.decimals ?? 6;
   const [tab, setTab] = useState<Tab>("open");
   const [sortKey, setSortKey] = useState<SortKey>("position");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
@@ -171,7 +172,7 @@ export const AccountsCard: FC = () => {
                     )}
                     {isOpenLike && (
                       <td className={`whitespace-nowrap px-2 py-1.5 text-right ${row.positionSize > 0n ? "text-[var(--long)]" : row.positionSize < 0n ? "text-[var(--short)]" : "text-[var(--text-dim)]"}`} style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
-                        {row.positionSize !== 0n ? formatTokenAmount(absPos) : "-"}
+                        {row.positionSize !== 0n ? formatTokenAmount(absPos, decimals) : "-"}
                       </td>
                     )}
                     {isOpenLike && <td className="whitespace-nowrap px-2 py-1.5 text-right text-[var(--text)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>{row.entryPrice > 0n ? formatUsd(row.entryPrice) : "-"}</td>}
@@ -188,9 +189,9 @@ export const AccountsCard: FC = () => {
                       </td>
                     )}
                     <td className={`whitespace-nowrap px-2 py-1.5 text-right ${row.pnl > 0n ? "text-[var(--long)]" : row.pnl < 0n ? "text-[var(--short)]" : "text-[var(--text-dim)]"}`} style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
-                      {formatPnl(row.pnl)}
+                      {formatPnl(row.pnl, decimals)}
                     </td>
-                    <td className="whitespace-nowrap px-2 py-1.5 text-right text-[var(--text)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>{formatTokenAmount(row.capital)}</td>
+                    <td className="whitespace-nowrap px-2 py-1.5 text-right text-[var(--text)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>{formatTokenAmount(row.capital, decimals)}</td>
                     {isOpenLike && (
                       <td className={`whitespace-nowrap px-2 py-1.5 text-right ${row.marginPct > 50 ? "text-[var(--long)]" : row.marginPct > 20 ? "text-[var(--warning)]" : "text-[var(--short)]"}`} style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
                         {row.positionSize !== 0n ? `${row.marginPct.toFixed(1)}%` : "-"}

--- a/app/components/trade/DepositTrigger.tsx
+++ b/app/components/trade/DepositTrigger.tsx
@@ -24,6 +24,7 @@ export const DepositTrigger: FC<{ slabAddress: string }> = ({ slabAddress }) => 
   const { config } = useSlabState();
   const tokenMeta = useTokenMeta(config?.collateralMint ?? null);
   const symbol = tokenMeta?.symbol ?? "Token";
+  const decimals = tokenMeta?.decimals ?? 6;
 
   const [expanded, setExpanded] = useState(false);
   const [hasDeposited, setHasDeposited] = useState(true); // default true to avoid flash
@@ -99,7 +100,7 @@ export const DepositTrigger: FC<{ slabAddress: string }> = ({ slabAddress }) => 
         <div className="flex items-center gap-2">
           <span className="text-[9px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Account</span>
           <span className="text-[11px] font-medium text-[var(--text)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
-            {formatTokenAmount(capital)} {symbol}
+            {formatTokenAmount(capital, decimals)} {symbol}
           </span>
         </div>
         <div className="flex items-center gap-1.5">

--- a/app/components/trade/MarketBookCard.tsx
+++ b/app/components/trade/MarketBookCard.tsx
@@ -19,6 +19,7 @@ export const MarketBookCard: FC = () => {
   const { priceE6: livePriceE6 } = useLivePrice();
   const tokenMeta = useTokenMeta(mktConfig?.collateralMint ?? null);
   const symbol = tokenMeta?.symbol ?? "Token";
+  const decimals = tokenMeta?.decimals ?? 6;
 
   const lps = useMemo(
     () => accounts.filter(({ account }) => account.kind === AccountKind.LP),
@@ -112,7 +113,7 @@ export const MarketBookCard: FC = () => {
             className="text-[11px] font-semibold text-[var(--long)]"
             style={{ fontFamily: "var(--font-mono)" }}
           >
-            {formatTokenAmount(lpTotalCapital)}
+            {formatTokenAmount(lpTotalCapital, decimals)}
           </p>
           {/* 3px utilisation fill bar */}
           <div className="mt-1.5 h-[3px] w-full bg-[var(--border)]/20 overflow-hidden">
@@ -128,7 +129,7 @@ export const MarketBookCard: FC = () => {
             className="text-[11px] font-semibold text-[var(--short)]"
             style={{ fontFamily: "var(--font-mono)" }}
           >
-            {formatTokenAmount(askDepth)}
+            {formatTokenAmount(askDepth, decimals)}
           </p>
           {/* 3px utilisation fill bar */}
           <div className="mt-1.5 h-[3px] w-full bg-[var(--border)]/20 overflow-hidden">
@@ -171,9 +172,9 @@ export const MarketBookCard: FC = () => {
                 <div key={idx} className="flex items-center gap-1 py-1 text-[10px]">
                   <span className="w-5 text-[var(--text-dim)]" style={{ fontFamily: "var(--font-mono)" }}>{i + 1}</span>
                   <span className="flex-1 text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-mono)" }}>{shortenAddress(account.owner.toBase58())}</span>
-                  <span className="w-20 text-right text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>{formatTokenAmount(account.capital)}</span>
+                  <span className="w-20 text-right text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>{formatTokenAmount(account.capital, decimals)}</span>
                   <span className={`w-20 text-right ${account.positionSize >= 0n ? "text-[var(--long)]" : "text-[var(--short)]"}`} style={{ fontFamily: "var(--font-mono)" }}>
-                    {formatTokenAmount(account.positionSize < 0n ? -account.positionSize : account.positionSize)}
+                    {formatTokenAmount(account.positionSize < 0n ? -account.positionSize : account.positionSize, decimals)}
                   </span>
                   <span className={`w-16 text-right font-medium ${utilColor}`} style={{ fontFamily: "var(--font-mono)" }}>
                     {utilPct.toFixed(1)}%

--- a/app/components/trade/PositionPanel.tsx
+++ b/app/components/trade/PositionPanel.tsx
@@ -282,6 +282,7 @@ export const PositionPanel: FC<{ slabAddress: string }> = ({ slabAddress }) => {
               pnlBarWidth={pnlBarWidth}
               hasValidMark={hasValidMark}
               symbol={symbol}
+              decimals={decimals}
             />
 
             {/* 3.5: Liq warning when <15% away */}
@@ -301,7 +302,7 @@ export const PositionPanel: FC<{ slabAddress: string }> = ({ slabAddress }) => {
               <div className="flex items-center justify-between py-1.5">
                 <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Size</span>
                 <span className="text-[11px] text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>
-                  {formatTokenAmount(absPosition)} {symbol}
+                  {formatTokenAmount(absPosition, decimals)} {symbol}
                 </span>
               </div>
               <div className="flex items-center justify-between py-1.5">
@@ -420,6 +421,7 @@ interface PnlSectionProps {
   pnlBarWidth: number;
   hasValidMark: boolean;
   symbol: string;
+  decimals: number;
 }
 
 function abs_n(n: bigint): bigint {
@@ -434,6 +436,7 @@ const PnlSection: FC<PnlSectionProps> = ({
   pnlBarWidth,
   hasValidMark,
   symbol,
+  decimals,
 }) => {
   // 3.2: Flash on PnL sign change
   const [flashClass, setFlashClass] = useState("");
@@ -471,7 +474,7 @@ const PnlSection: FC<PnlSectionProps> = ({
                 style={{ fontFamily: "var(--font-mono)" }}
               >
                 {pnlTokens > 0n ? "+" : pnlTokens < 0n ? "-" : ""}
-                {formatTokenAmount(abs_n(pnlTokens))} {symbol}
+                {formatTokenAmount(abs_n(pnlTokens), decimals)} {symbol}
               </span>
               {pnlUsd !== null && (
                 <span


### PR DESCRIPTION
## Summary

Fixes GH#1830: Multiple components called `formatTokenAmount()` and `formatPnl()` without the `decimals` parameter. Both functions default to 6 decimals, so any market using a non-6-decimal collateral (SOL=9, WBTC=8, devnet PERC token=9) shows values off by 10x–1000x.

## Components Fixed

| Component | Callsites Fixed | Impact |
|-----------|----------------|--------|
| `AccountsCard.tsx` | position size, PnL, capital (3 calls) | Accounts table values 1000x wrong for 9-dec tokens |
| `DepositTrigger.tsx` | account balance (1 call) | Balance bar 1000x wrong |
| `MarketBookCard.tsx` | bid depth, ask depth, LP capital, LP position size (4 calls) | Book depths 1000x wrong |
| `PositionPanel.tsx` | position size, PnlSection amount (2 calls + prop addition) | PnL panel 1000x wrong |
| `PositionSummary.tsx` | PnL, position size in PositionCard (2 calls + decimals prop) | Dashboard portfolio 1000x wrong |

## Testing
- 141/141 tests passing
- `tsc --noEmit` clean

## How to test
1. Open a market with SOL (9 decimals) or WBTC (8 decimals) as collateral
2. Check Accounts Card — position size, PnL, capital columns should show correct values
3. Check Market Book Card — bid/ask depth should match reality
4. Check Deposit Trigger — balance bar should show correct balance
5. Compare with Portfolio/Dashboard — values should be consistent