### PR TITLE
fix(PERC-8200): TradeHistory + TradeHistoryTable use correct token decimals

### DIFF
--- a/app/components/trade/TradeHistory.tsx
+++ b/app/components/trade/TradeHistory.tsx
@@ -5,6 +5,8 @@ import { formatTokenAmount, formatPriceE6 } from "@/lib/format";
 import { explorerTxUrl } from "@/lib/config";
 import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab, getMockTrades } from "@/lib/mock-trade-data";
+import { useSlabState } from "@/components/providers/SlabProvider";
+import { useTokenMeta } from "@/hooks/useTokenMeta";
 
 interface Trade {
   id: string;
@@ -25,6 +27,11 @@ function toBigInt(val: number | string | bigint): bigint {
 }
 
 export const TradeHistory: FC<{ slabAddress: string }> = ({ slabAddress }) => {
+  const { config: mktConfig } = useSlabState();
+  const tokenMeta = useTokenMeta(mktConfig?.collateralMint ?? null);
+  // Use on-chain decimals — size from API is in raw token units (i128 on-chain)
+  const decimals = tokenMeta?.decimals ?? 6;
+
   const [trades, setTrades] = useState<Trade[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -118,7 +125,7 @@ export const TradeHistory: FC<{ slabAddress: string }> = ({ slabAddress }) => {
                   </span>
                 </div>
                 <div className="text-right text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>
-                  {trade.size != null ? formatTokenAmount(toBigInt(Math.abs(typeof trade.size === "number" ? trade.size : parseFloat(trade.size)))) : "—"}
+                  {trade.size != null ? formatTokenAmount(toBigInt(Math.abs(typeof trade.size === "number" ? trade.size : parseFloat(trade.size))), decimals) : "—"}
                 </div>
                 <div className="text-right text-[var(--text-muted)]" style={{ fontFamily: "var(--font-mono)" }}>
                   {trade.price != null ? formatPriceE6(BigInt(Math.round(Number(trade.price) * 1e6))) : "—"}

--- a/app/components/trade/TradeHistoryTable.tsx
+++ b/app/components/trade/TradeHistoryTable.tsx
@@ -3,6 +3,7 @@
 import { useTradeHistory } from "@/hooks/useTradeHistory";
 import { formatTokenAmount } from "@/lib/format";
 import { useMultiTokenMeta } from "@/hooks/useMultiTokenMeta";
+import { useEffect, useState } from "react";
 import { ShimmerSkeleton } from "@/components/ui/ShimmerSkeleton";
 
 interface TradeHistoryTableProps {
@@ -19,24 +20,24 @@ function formatPrice(priceNum: number): string {
   return `$${priceNum.toPrecision(4)}`;
 }
 
-function formatFee(feeNum: number): string {
+function formatFee(feeNum: number, decimals = 6): string {
   if (!feeNum) return "—";
-  // fee is stored in token base units (e6 scale) — formatTokenAmount expects bigint
+  // fee is stored in token base units — formatTokenAmount expects bigint
   try {
-    return formatTokenAmount(BigInt(Math.round(feeNum)), 6);
+    return formatTokenAmount(BigInt(Math.round(feeNum)), decimals);
   } catch {
-    return (feeNum / 1_000_000).toFixed(6);
+    return (feeNum / Math.pow(10, decimals)).toFixed(decimals > 4 ? 6 : 4);
   }
 }
 
-function formatSize(sizeStr: string): string {
+function formatSize(sizeStr: string, decimals = 6): string {
   try {
     const raw = BigInt(sizeStr.split(".")[0]);
     const abs = raw < 0n ? -raw : raw;
-    return formatTokenAmount(abs, 6);
+    return formatTokenAmount(abs, decimals);
   } catch {
     const n = Math.abs(parseFloat(sizeStr) || 0);
-    return formatTokenAmount(BigInt(Math.round(n)), 6);
+    return formatTokenAmount(BigInt(Math.round(n)), decimals);
   }
 }
 
@@ -52,6 +53,38 @@ function shortAddress(addr: string): string {
   return addr.length > 12 ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : addr;
 }
 
+/** Fetch slab → collateral decimals from /api/markets once, cache in module scope. */
+const slabDecimalsCache: Record<string, number> = {};
+let marketsFetchAttempted = false;
+
+async function loadMarketDecimals(): Promise<void> {
+  if (marketsFetchAttempted) return;
+  marketsFetchAttempted = true;
+  try {
+    const res = await fetch("/api/markets?limit=200");
+    if (!res.ok) return;
+    const data = await res.json();
+    for (const m of (data.markets ?? [])) {
+      if (m.slab_address && typeof m.decimals === "number") {
+        slabDecimalsCache[m.slab_address] = m.decimals;
+      }
+    }
+  } catch {
+    // best-effort — fall back to 6
+  }
+}
+
+/** Hook to lazily fetch and return slab → decimals map. */
+function useSlabDecimals(): Record<string, number> {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (!marketsFetchAttempted) {
+      loadMarketDecimals().then(() => setTick((t) => t + 1));
+    }
+  }, []);
+  return slabDecimalsCache;
+}
+
 export function TradeHistoryTable({
   wallet,
   slabFilter,
@@ -63,6 +96,9 @@ export function TradeHistoryTable({
     slabFilter,
   });
 
+  // Slab → collateral decimals map (fetched from /api/markets)
+  const slabDecimals = useSlabDecimals();
+
   // Collect unique slab addresses to resolve market symbols
   const slabAddresses = [...new Set(trades.map((t) => t.slab_address))];
   const tokenMetaMap = useMultiTokenMeta(
@@ -72,6 +108,7 @@ export function TradeHistoryTable({
     [],
   );
   void tokenMetaMap; // not used yet — we show slab short address as market id
+  void slabAddresses;
 
   if (!wallet) return null;
 
@@ -140,6 +177,8 @@ export function TradeHistoryTable({
           const txLink = trade.tx_signature
             ? `https://solscan.io/tx/${trade.tx_signature}?cluster=devnet`
             : null;
+          // Use per-slab decimals if available; default 6 (USDC) as safe fallback
+          const tradeDecimals = slabDecimals[trade.slab_address] ?? 6;
 
           return (
             <div
@@ -176,7 +215,7 @@ export function TradeHistoryTable({
                   className="text-[11px] text-white"
                   style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}
                 >
-                  {formatSize(trade.size)}
+                  {formatSize(trade.size, tradeDecimals)}
                 </p>
               </div>
 
@@ -196,7 +235,7 @@ export function TradeHistoryTable({
                   className="text-[11px] text-[var(--text-secondary)]"
                   style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}
                 >
-                  {formatFee(trade.fee)}
+                  {formatFee(trade.fee, tradeDecimals)}
                 </p>
               </div>
 


### PR DESCRIPTION
## Summary

Fixes GH#1834: Trade history components displayed sizes without applying token decimals.

### TradeHistory.tsx (trade page sidebar)
- Added `useSlabState` + `useTokenMeta` to get collateral mint decimals
- Pass `decimals` to `formatTokenAmount` for trade size column

### TradeHistoryTable.tsx (portfolio page)
- `formatSize` + `formatFee` accept optional `decimals` parameter (default 6)
- Added `useSlabDecimals` hook: fetches `/api/markets?limit=200` once on mount, builds module-level `slab → decimals` cache
- Each trade row uses `slabDecimals[trade.slab_address] ?? 6` to look up its market's decimals

## Testing
- 141/141 tests passing
- `tsc --noEmit` clean

## How to test
1. Open trade page on a SOL (9 dec) or WBTC (8 dec) market
2. Trade history sizes should now be correctly scaled (not 1000x/100x too large)
3. Portfolio page trade history should also show correct sizes for all markets