### PR TITLE
fix(PERC-8201): apply config.invert flag to price display in resolveMarketPriceE6

### DIFF
--- a/app/lib/oraclePrice.ts
+++ b/app/lib/oraclePrice.ts
@@ -50,10 +50,27 @@ export function detectOracleMode(cfg: {
 }
 
 /**
+ * Apply the market's `invert` flag to a price in E6 format.
+ *
+ * When `invert === 1`, the price represents an inverted pair (e.g., USD/SOL instead of SOL/USD).
+ * We invert by computing: 1e12 / priceE6, which keeps the result in E6 format.
+ * (1e6 USD * 1e6 precision / priceE6 = inverted priceE6)
+ *
+ * Returns 0n if priceE6 is 0 (division by zero guard).
+ */
+export function applyInvert(priceE6: bigint, invert: number | undefined): bigint {
+  if (!invert || priceE6 === 0n) return priceE6;
+  // 1e12 / priceE6 to keep E6 format: (1_000_000 USD * 1_000_000 precision) / priceE6
+  return 1_000_000_000_000n / priceE6;
+}
+
+/**
  * Resolve the correct USD price (in E6 format) for a market based on its oracle mode.
  *
  * For display purposes (markets page, trade page), this returns the best available
  * price from on-chain data. The caller should divide by 1_000_000 to get USD.
+ *
+ * Applies `invert` flag when set to 1: price = 1e12 / raw_price (inverted pair support).
  *
  * @returns priceE6 (bigint) or 0n if no valid price available
  */
@@ -63,6 +80,7 @@ export function resolveMarketPriceE6(cfg: {
   lastEffectivePriceE6: bigint;
   authorityPriceE6: bigint;
   authorityTimestamp?: bigint;
+  invert?: number;
 }): bigint {
   const mode = detectOracleMode(cfg);
 
@@ -91,8 +109,11 @@ export function resolveMarketPriceE6(cfg: {
       return 0n;
   }
 
+  // Apply invert flag: if config.invert === 1, the pair is displayed as the reciprocal
+  const inverted = applyInvert(raw, cfg.invert);
+
   // Sanitize: reject corrupt/uninitialized values that exceed Rust MAX_ORACLE_PRICE
-  return sanitizePriceE6(raw);
+  return sanitizePriceE6(inverted);
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes GH#1831: `MarketConfig.invert` was parsed from on-chain data but never applied during price resolution.

## Root Cause

`resolveMarketPriceE6()` in `lib/oraclePrice.ts` didn't accept or check `invert`. Inverted markets (those using pair direction like USD/SOL) displayed the raw oracle price instead of its reciprocal.

## Fix

1. Added `applyInvert(priceE6: bigint, invert?: number): bigint`:
   - If `invert === 1`: returns `1_000_000_000_000n / priceE6` (= 1e12/price → keeps E6 format)
   - Otherwise: returns price unchanged

2. Added `invert?: number` to `resolveMarketPriceE6` config parameter (optional for backward compat)

3. `resolveMarketPriceE6` applies inversion before sanitization

## How it works

All call sites already pass `mktConfig` from the SDK which includes `invert: number`. TypeScript will pass it through since `invert` is part of `MarketConfig` but was just previously unused.

## Testing
- 141/141 tests passing  
- `tsc --noEmit` clean

## How to test
1. Create a market with `invert: 1` on devnet
2. Push an oracle price (e.g., 150_000_000 = $150 in E6)
3. Navigate to the market — price should display as ~$0.0067 (1/150), not $150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional price inversion capability to market price resolution, enabling alternate price representations.

* **Bug Fixes**
  * Improved price calculation robustness with enhanced edge case handling and division-by-zero protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->