### PR TITLE
fix(PERC-8203): abort in-flight fetches on market switch — FundingRateCard + InsuranceDashboard

### DIFF
--- a/app/components/market/InsuranceDashboard.tsx
+++ b/app/components/market/InsuranceDashboard.tsx
@@ -65,16 +65,23 @@ export const InsuranceDashboard: FC<{ slabAddress: string }> = ({
   const [showExplainer, setShowExplainer] = useState(false);
   const [showTopUp, setShowTopUp] = useState(false);
 
-  // Fetch insurance data from API
+  // Fetch insurance data from API.
+  // GH#1832: AbortController prevents stale responses from a previous market
+  // overwriting the current market's data on fast market switches.
   useEffect(() => {
     if (mockMode) return;
+
+    let cancelled = false;
+    const controller = new AbortController();
+    const { signal } = controller;
 
     const fetchInsurance = async () => {
       try {
         setLoading(true);
-        const res = await fetch(`/api/insurance/${slabAddress}`);
+        const res = await fetch(`/api/insurance/${slabAddress}`, { signal });
         if (!res.ok) throw new Error("Failed to fetch insurance data");
         const data = await res.json();
+        if (cancelled) return;
         // Map API response shape to InsuranceData interface
         const balance = data.balance ?? data.currentBalance ?? "0";
         const feeRevenue = data.feeRevenue ?? "0";
@@ -86,40 +93,50 @@ export const InsuranceDashboard: FC<{ slabAddress: string }> = ({
           timestamp: typeof h.timestamp === "string" ? new Date(h.timestamp).getTime() : h.timestamp,
           balance: typeof h.balance === "string" ? Number(BigInt(h.balance)) / (10 ** decimals) : h.balance,
         }));
-        setInsuranceData({
-          balance,
-          feeRevenue,
-          totalRisk,
-          coverageRatio,
-          dailyAccumulationRate: data.dailyAccumulationRate ?? 0,
-          historicalBalance,
-        });
-        setError(null);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Unknown error");
-        // Fallback to on-chain data when API unavailable
-        if (engine) {
-          const balance = engine.insuranceFund?.balance ?? 0n;
-          const feeRev = engine.insuranceFund?.feeRevenue ?? 0n;
-          const totalOi = engine.totalOpenInterest ?? 0n;
-          const ratio = totalOi > 0n ? Number(balance * 10000n / totalOi) / 10000 : 0;
+        if (!cancelled) {
           setInsuranceData({
-            balance: balance.toString(),
-            feeRevenue: feeRev.toString(),
-            totalRisk: totalOi.toString(),
-            coverageRatio: ratio,
-            dailyAccumulationRate: 0,
-            historicalBalance: [],
+            balance,
+            feeRevenue,
+            totalRisk,
+            coverageRatio,
+            dailyAccumulationRate: data.dailyAccumulationRate ?? 0,
+            historicalBalance,
           });
+          setError(null);
+        }
+      } catch (err) {
+        // Ignore AbortError — this is expected when switching markets
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Unknown error");
+          // Fallback to on-chain data when API unavailable
+          if (engine) {
+            const balance = engine.insuranceFund?.balance ?? 0n;
+            const feeRev = engine.insuranceFund?.feeRevenue ?? 0n;
+            const totalOi = engine.totalOpenInterest ?? 0n;
+            const ratio = totalOi > 0n ? Number(balance * 10000n / totalOi) / 10000 : 0;
+            setInsuranceData({
+              balance: balance.toString(),
+              feeRevenue: feeRev.toString(),
+              totalRisk: totalOi.toString(),
+              coverageRatio: ratio,
+              dailyAccumulationRate: 0,
+              historicalBalance: [],
+            });
+          }
         }
       } finally {
-        setLoading(false);
+        if (!cancelled) setLoading(false);
       }
     };
 
     fetchInsurance();
     const interval = setInterval(fetchInsurance, 30000); // Refresh every 30s
-    return () => clearInterval(interval);
+    return () => {
+      cancelled = true;
+      controller.abort();
+      clearInterval(interval);
+    };
   }, [slabAddress, mockMode, engine]);
 
   // Calculate health status

--- a/app/components/trade/FundingRateCard.tsx
+++ b/app/components/trade/FundingRateCard.tsx
@@ -87,16 +87,23 @@ export const FundingRateCard: FC<{ slabAddress: string }> = ({ slabAddress }) =>
   // P3-4: last 4 funding rate periods for mini bar chart (8h rates in %)
   const [miniChartRates, setMiniChartRates] = useState<number[]>([]);
 
-  // Fetch funding data from API, fall back to on-chain data
+  // Fetch funding data from API, fall back to on-chain data.
+  // GH#1832: AbortController prevents stale responses from a previous market
+  // overwriting the current market's data on fast market switches.
   useEffect(() => {
     if (mockMode) return;
+
+    let cancelled = false;
+    const controller = new AbortController();
+    const { signal } = controller;
     
     const fetchFunding = async () => {
       try {
         setLoading(true);
-        const res = await fetch(`/api/funding/${slabAddress}`);
+        const res = await fetch(`/api/funding/${slabAddress}`, { signal });
         if (!res.ok) throw new Error("API unavailable");
         const data = await res.json();
+        if (cancelled) return;
         setFundingData({
           ...data,
           netLpPosition: BigInt(data.netLpPosition ?? 0),
@@ -105,8 +112,8 @@ export const FundingRateCard: FC<{ slabAddress: string }> = ({ slabAddress }) =>
         // /history returns { rateBpsPerSlot } — convert to 8h rate%:
         // hourly% = (rateBpsPerSlot / 10000) * 9000  →  8h% = hourly * 8
         try {
-          const histRes = await fetch(`/api/funding/${slabAddress}/history?limit=4`);
-          if (histRes.ok) {
+          const histRes = await fetch(`/api/funding/${slabAddress}/history?limit=4`, { signal });
+          if (histRes.ok && !cancelled) {
             const histData = await histRes.json();
             const pts: { rateBpsPerSlot?: number }[] = histData.history ?? [];
             // Clamp outlier values before display — legacy on-chain data can have overflowed
@@ -119,13 +126,15 @@ export const FundingRateCard: FC<{ slabAddress: string }> = ({ slabAddress }) =>
                 return (raw / 10000) * 9000 * 8;
               })
               .filter((r): r is number => r !== null);
-            setMiniChartRates(rates);
+            if (!cancelled) setMiniChartRates(rates);
           }
         } catch { /* silently skip — mini chart is optional */ }
-        setError(null);
-      } catch {
+        if (!cancelled) setError(null);
+      } catch (err) {
+        // Ignore AbortError — this is expected when switching markets
+        if (err instanceof DOMException && err.name === "AbortError") return;
         // Silently fall back to on-chain data — no error shown to user
-        if (engine && sanitizeFundingRateBps(fundingRate) !== null) {
+        if (!cancelled && engine && sanitizeFundingRateBps(fundingRate) !== null) {
           const rate = Number(sanitizeFundingRateBps(fundingRate)!);
           const hourly = (rate * 9000) / 10000;
           const apr = hourly * 24 * 365;
@@ -144,13 +153,17 @@ export const FundingRateCard: FC<{ slabAddress: string }> = ({ slabAddress }) =>
           setMiniChartRates([hourly * 8, hourly * 8, hourly * 8, hourly * 8]);
         }
       } finally {
-        setLoading(false);
+        if (!cancelled) setLoading(false);
       }
     };
 
     fetchFunding();
     const interval = setInterval(fetchFunding, 30000);
-    return () => clearInterval(interval);
+    return () => {
+      cancelled = true;
+      controller.abort();
+      clearInterval(interval);
+    };
   }, [slabAddress, mockMode, engine, fundingRate]);
 
   // Update countdown every second


### PR DESCRIPTION
## Summary

Fixes GH#1832: Race condition where stale API responses from a previous market could overwrite current market data after switching.

## Root Cause

Both components polled their APIs with `setInterval`. The cleanup only cleared the interval — in-flight requests were not aborted. On a slow connection or under API load, a response from market A could arrive after the user switched to market B, overwriting the correct data.

## Fix

Added `AbortController` pattern to both components:
1. Create `AbortController` + `cancelled` flag on each effect mount
2. Pass `{ signal }` to all `fetch()` calls
3. Check `!cancelled` before all `setState` calls
4. Catch `AbortError` and return early (not an error condition)
5. Cleanup: `controller.abort()` + `clearInterval()`

This matches the pattern already used by `useOraclePublishers`, `useLivePrice`, `useDexPoolSearch`, and `usePriceRouter`.

## Testing
- 141/141 tests passing
- `tsc --noEmit` clean

## How to test
1. Open market A — wait for funding rate + insurance data to load
2. Immediately switch to market B (before A's slow requests complete)
3. Only market B's data should appear — no flicker back to market A values