### PR TITLE
fix(PERC-8196,PERC-8204): responsive chart width + mobile table overflow

### DIFF
--- a/app/components/dashboard/TradeHistory.tsx
+++ b/app/components/dashboard/TradeHistory.tsx
@@ -180,7 +180,7 @@ export function TradeHistory() {
             )}
           </div>
         ) : (
-          <table className="w-full min-w-[600px]">
+          <table className="w-full">
             <thead>
               <tr className="border-b border-[var(--border)] text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">
                 <th className="px-4 py-3 text-left">Time</th>

--- a/app/components/trade/FundingRateChart.tsx
+++ b/app/components/trade/FundingRateChart.tsx
@@ -264,7 +264,7 @@ export const FundingRateChart: FC<{ slabAddress: string }> = ({ slabAddress }) =
         </div>
       </div>
 
-      <svg width={W} height={H} className="w-full" style={{ maxWidth: "100%" }} onMouseMove={handleMouseMove} onMouseLeave={handleMouseLeave}>
+      <svg viewBox={`0 0 ${W} ${H}`} className="w-full" style={{ display: "block" }} onMouseMove={handleMouseMove} onMouseLeave={handleMouseLeave}>
         {/* Grid lines */}
         {yLabels.map((label, i) => (
           <line


### PR DESCRIPTION
## Summary

Two quick P2 layout fixes.

### PERC-8196 (P2): FundingRateChart 800px hardcoded width (GH#1840)
SVG had `width={800}` which caused horizontal overflow in any container narrower than 800px.

**Fix:** Replaced `width={W} height={H}` with `viewBox=`0 0 ${W} ${H}`` and `className="w-full"`. The SVG now scales proportionally within its container.

### PERC-8204 (P2): Dashboard TradeHistory table mobile overflow (GH#1841)
Table had `min-w-[600px]` which forced it wider than mobile viewports (~375px).

**Fix:** Removed `min-w-[600px]` — table is now `w-full` and respects its container. The parent `overflow-x-auto` wrapper already handles scrolling if content is wider.

## Testing
- 141/141 tests passing
- `tsc --noEmit` clean