### PR TITLE
fix(PERC-8210): light mode — hero headings/stats/section labels invisible (white on white)

### DIFF
--- a/app/components/layout/Footer.tsx
+++ b/app/components/layout/Footer.tsx
@@ -48,7 +48,7 @@ export const Footer: FC = () => {
               href="https://github.com/dcccrypto/percolator-launch"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex h-7 w-7 items-center justify-center rounded-sm border border-[var(--border)] text-[var(--text-muted)] transition-all hover:border-[var(--border-hover)] hover:text-white hover:bg-white/[0.04]"
+              className="flex h-7 w-7 items-center justify-center rounded-sm border border-[var(--border)] text-[var(--text-muted)] transition-all hover:border-[var(--border-hover)] hover:text-[var(--text)] hover:bg-[var(--bg-elevated)]"
               title="GitHub"
             >
               <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
@@ -59,7 +59,7 @@ export const Footer: FC = () => {
               href="https://x.com/Percolator_ct"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex h-7 w-7 items-center justify-center rounded-sm border border-[var(--border)] text-[var(--text-muted)] transition-all hover:border-[var(--border-hover)] hover:text-white hover:bg-white/[0.04]"
+              className="flex h-7 w-7 items-center justify-center rounded-sm border border-[var(--border)] text-[var(--text-muted)] transition-all hover:border-[var(--border-hover)] hover:text-[var(--text)] hover:bg-[var(--bg-elevated)]"
               title="X / Twitter"
             >
               <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor">

--- a/app/components/layout/Header.tsx
+++ b/app/components/layout/Header.tsx
@@ -238,7 +238,7 @@ export const Header: FC = () => {
                         "px-3 py-2 text-[13px] font-medium rounded-sm transition-all",
                         pathname === item.href
                           ? "text-[#22d3ee] bg-[rgba(34,211,238,0.08)]"
-                          : "text-[#d1d5db] hover:text-white hover:bg-white/[0.06]",
+                          : "text-[var(--text-secondary)] hover:text-[var(--text)] hover:bg-[var(--bg-elevated)]",
                       ].join(" ")}
                     >
                       {item.label}
@@ -255,7 +255,7 @@ export const Header: FC = () => {
               href="https://github.com/dcccrypto/percolator-launch"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex h-8 w-8 items-center justify-center rounded-sm border border-[var(--border)] text-[var(--text-muted)] transition-all hover:border-[var(--border-hover)] hover:text-white hover:bg-white/[0.04]"
+              className="flex h-8 w-8 items-center justify-center rounded-sm border border-[var(--border)] text-[var(--text-muted)] transition-all hover:border-[var(--border-hover)] hover:text-[var(--text)] hover:bg-[var(--bg-elevated)]"
               title="GitHub"
             >
               <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor">
@@ -266,7 +266,7 @@ export const Header: FC = () => {
               href="https://x.com/Percolator_ct"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex h-8 w-8 items-center justify-center rounded-sm border border-[var(--border)] text-[var(--text-muted)] transition-all hover:border-[var(--border-hover)] hover:text-white hover:bg-white/[0.04]"
+              className="flex h-8 w-8 items-center justify-center rounded-sm border border-[var(--border)] text-[var(--text-muted)] transition-all hover:border-[var(--border-hover)] hover:text-[var(--text)] hover:bg-[var(--bg-elevated)]"
               title="X / Twitter"
             >
               <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">

--- a/app/components/marketing/HeroHeadline.tsx
+++ b/app/components/marketing/HeroHeadline.tsx
@@ -32,12 +32,12 @@ export function HeroHeadline() {
         style={{ fontFamily: "var(--font-heading)" }}
       >
         <span
-          className={`hero-line block text-white ${prefersReduced ? '' : 'gsap-fade'}`}
+          className={`hero-line block text-[var(--text)] ${prefersReduced ? '' : 'gsap-fade'}`}
         >
           Any Token.
         </span>
         <span
-          className={`hero-line block text-white ${prefersReduced ? '' : 'gsap-fade'}`}
+          className={`hero-line block text-[var(--text)] ${prefersReduced ? '' : 'gsap-fade'}`}
         >
           Any Market.
         </span>

--- a/app/components/marketing/HeroStats.tsx
+++ b/app/components/marketing/HeroStats.tsx
@@ -40,20 +40,20 @@ export function HeroStats({
     {
       label: "Volume 24h",
       value: volume === 0
-        ? <span className="font-semibold text-white/40">{isDevnet ? "devnet" : "N/A"}</span>
-        : <span className="font-semibold text-white">{formatVolume(volume)}{isDevnet && <span className="ml-1 text-white/25">(devnet)</span>}</span>,
+        ? <span className="font-semibold text-[var(--text-muted)]">{isDevnet ? "devnet" : "N/A"}</span>
+        : <span className="font-semibold text-[var(--text)]">{formatVolume(volume)}{isDevnet && <span className="ml-1 text-[var(--text-muted)]">(devnet)</span>}</span>,
     },
     {
       label: "Markets",
-      value: <AnimatedNumber value={markets} duration={1.2} className="font-semibold text-white" />,
+      value: <AnimatedNumber value={markets} duration={1.2} className="font-semibold text-[var(--text)]" />,
     },
     {
       label: "Traders",
-      value: <AnimatedNumber value={traders} duration={1.2} className="font-semibold text-white" />,
+      value: <AnimatedNumber value={traders} duration={1.2} className="font-semibold text-[var(--text)]" />,
     },
     {
       label: "Fills",
-      value: <span className="font-semibold text-white">&lt; 400ms</span>,
+      value: <span className="font-semibold text-[var(--text)]">&lt; 400ms</span>,
     },
   ];
 
@@ -66,7 +66,7 @@ export function HeroStats({
       {stats.map((s, i) => (
         <div key={s.label} className="flex items-center gap-2 text-[13px] font-medium tracking-[0.01em]">
           {i > 0 && (
-            <span className="mr-2 hidden text-white/10 md:inline">|</span>
+            <span className="mr-2 hidden text-[var(--border)] md:inline">|</span>
           )}
           <span className="font-medium text-[#9ca3af]">{s.label}</span>
           {s.value}

--- a/app/components/ui/GradientText.tsx
+++ b/app/components/ui/GradientText.tsx
@@ -10,9 +10,12 @@ interface GradientTextProps {
   variant?: "solana" | "muted" | "bright";
 }
 
+// GH#1837: "muted" variant used to start at #E1E2E8 (near-white), which was
+// invisible in light mode. Updated to start at #9945FF (same as solana variant)
+// so it's readable on both dark and light backgrounds.
 const GRADIENTS = {
   solana: "linear-gradient(135deg, #B97AFF 0%, #9945FF 40%, #14F195 100%)",
-  muted: "linear-gradient(135deg, #E1E2E8 0%, #9945FF 100%)",
+  muted: "linear-gradient(135deg, #9945FF 0%, #B97AFF 100%)",
   bright: "linear-gradient(135deg, #C4A0FF 0%, #9945FF 30%, #14F195 100%)",
 };
 


### PR DESCRIPTION
## Summary
Fixes GH#1837. Hero headings, stats, and layout hover states used hardcoded `text-white` / near-white colors, making them invisible on the light mode background.

## Changes

| File | Change |
|------|--------|
| `HeroHeadline.tsx` | `text-white` → `text-[var(--text)]` on 'Any Token.' + 'Any Market.' h1 spans |
| `HeroStats.tsx` | `text-white`, `text-white/40`, `text-white/25`, `text-white/10` → CSS vars |
| `GradientText.tsx` | 'muted' variant gradient start `#E1E2E8` (near-white) → `#9945FF` (brand purple) |
| `Header.tsx` | Mobile nav + social icon hover: `text-white`/`bg-white/x` → theme-aware CSS vars |
| `Footer.tsx` | Social icon hover: `text-white`/`bg-white/x` → theme-aware CSS vars |

## Testing
- TypeScript: clean (tsc --noEmit)
- Tests: 1696/1730 passing (2 test files skipped for unrelated bigint bindings)

## Closes
GH#1837