### PR TITLE
fix(PERC-8211,GH#1851): light mode text-white → CSS vars in trade + earn components

### DIFF
--- a/app/components/earn/OiCapMeter.tsx
+++ b/app/components/earn/OiCapMeter.tsx
@@ -115,13 +115,13 @@ export function OiCapMeter({
         <div className="flex items-center gap-4">
           <span className="text-[var(--text-secondary)]">
             Current:{' '}
-            <span className="text-white font-mono tabular-nums">
+            <span className="text-[var(--text)] font-mono tabular-nums">
               ${formatCompact(currentOI)}
             </span>
           </span>
           <span className="text-[var(--text-secondary)]">
             Max:{' '}
-            <span className="text-white font-mono tabular-nums">
+            <span className="text-[var(--text)] font-mono tabular-nums">
               ${formatCompact(maxOI)}
             </span>
           </span>

--- a/app/components/earn/VaultCard.tsx
+++ b/app/components/earn/VaultCard.tsx
@@ -33,7 +33,7 @@ export function VaultCard({ vault }: VaultCardProps) {
                 {vault.symbol.slice(0, 2)}
               </div>
               <div>
-                <h3 className="text-sm font-semibold text-white">
+                <h3 className="text-sm font-semibold text-[var(--text)]">
                   {vault.symbol}-PERP
                 </h3>
                 <p className="text-[10px] text-[var(--text-secondary)]">
@@ -101,7 +101,7 @@ function MetricCell({ label, value }: { label: string; value: string }) {
       <div className="text-[9px] uppercase tracking-[0.15em] text-[var(--text-secondary)] mb-0.5">
         {label}
       </div>
-      <div className="text-sm font-mono tabular-nums text-white">{value}</div>
+      <div className="text-sm font-mono tabular-nums text-[var(--text)]">{value}</div>
     </div>
   );
 }

--- a/app/components/earn/VaultGrid.tsx
+++ b/app/components/earn/VaultGrid.tsx
@@ -90,7 +90,7 @@ export function VaultGrid({ markets, loading }: VaultGridProps) {
             placeholder="Search markets..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full h-9 px-3 pl-8 text-[13px] bg-[var(--panel-bg)] border border-[var(--border)] rounded-sm text-white placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)]/30 transition-colors"
+            className="w-full h-9 px-3 pl-8 text-[13px] bg-[var(--panel-bg)] border border-[var(--border)] rounded-sm text-[var(--text)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)]/30 transition-colors"
           />
           <svg
             className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-[var(--text-muted)]"

--- a/app/components/trade/TradeHistoryTable.tsx
+++ b/app/components/trade/TradeHistoryTable.tsx
@@ -188,7 +188,7 @@ export function TradeHistoryTable({
               {/* Market (slab short address) */}
               <div className="sm:truncate">
                 <p
-                  className="text-[11px] font-medium text-white"
+                  className="text-[11px] font-medium text-[var(--text)]"
                   style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}
                   title={trade.slab_address}
                 >
@@ -212,7 +212,7 @@ export function TradeHistoryTable({
               {/* Size */}
               <div>
                 <p
-                  className="text-[11px] text-white"
+                  className="text-[11px] text-[var(--text)]"
                   style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}
                 >
                   {formatSize(trade.size, tradeDecimals)}


### PR DESCRIPTION
## Summary

Fixes PERC-8211 (P1) — stats panel white text regression on trade page in light mode.

### Root Cause
PR#1848 was closed without merge during git-filter-repo force push. The MarketStatsCard fix was recovered in PR#1857. However, additional `text-white` instances in `TradeHistoryTable` and earn components were missed.

### Changes
- `TradeHistoryTable.tsx`: market label (line 191) + trade size (line 215) — `text-white` → `text-[var(--text)]`
- `VaultCard.tsx`: vault name heading + stat value cells — `text-white` → `text-[var(--text)]`
- `OiCapMeter.tsx`: Current/Max OI numeric values — `text-white` → `text-[var(--text)]`
- `VaultGrid.tsx`: search input text — `text-white` → `text-[var(--text)]`

All button/CTA `text-white` instances on colored backgrounds are intentionally unchanged.

### Not Changed
MarketStatsCard.tsx was already fixed via PR#1857 — confirmed on main.

### Tests
- 1696/1730 passing, tsc clean

Closes GH#1851

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text color styling to use CSS theme variables instead of hardcoded colors in multiple earn and trade display components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->