### PR TITLE
fix(PERC-8216,GH#1863): light mode text-white regressions on secondary pages

### DIFF
--- a/app/app/admin/page.tsx
+++ b/app/app/admin/page.tsx
@@ -117,7 +117,7 @@ const card =
 const labelStyle =
   "text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-muted)]";
 const inputStyle =
-  "w-full rounded-none border border-[var(--border)] bg-[#0D0D14] px-3 py-2 text-[12px] text-white placeholder:text-[var(--text-dim)] focus:border-[var(--accent)] focus:outline-none transition-colors";
+  "w-full rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] px-3 py-2 text-[12px] text-[var(--text)] placeholder:text-[var(--text-dim)] focus:border-[var(--accent)] focus:outline-none transition-colors";
 
 // ─── Small helpers ─────────────────────────────────────────────────────────────
 
@@ -261,7 +261,7 @@ function BarRow({
     >
       <div className="flex items-center justify-between mb-1">
         <span
-          className="text-[11px] font-medium capitalize group-hover:text-white transition-colors"
+          className="text-[11px] font-medium capitalize group-hover:text-[var(--text)] transition-colors"
           style={{ color }}
         >
           {label.replace("_", " ")}
@@ -470,7 +470,7 @@ export default function AdminDashboard() {
       <div className="flex items-center justify-between mb-8">
         <div>
           <div className={`${labelStyle} mb-1`}>Admin Dashboard</div>
-          <h1 className="text-xl font-bold text-white">Percolator Admin</h1>
+          <h1 className="text-xl font-bold text-[var(--text)]">Percolator Admin</h1>
         </div>
         <div className="flex items-center gap-3">
           <span className="hidden sm:inline text-[11px] text-[var(--text-muted)]">
@@ -478,7 +478,7 @@ export default function AdminDashboard() {
           </span>
           <button
             onClick={signOut}
-            className="rounded-none border border-[var(--border)] px-3 py-1.5 text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-secondary)] hover:text-white hover:border-[var(--border-hover)] transition-colors"
+            className="rounded-none border border-[var(--border)] px-3 py-1.5 text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-secondary)] hover:text-[var(--text)] hover:border-[var(--border-hover)] transition-colors"
           >
             Sign Out
           </button>
@@ -528,7 +528,7 @@ export default function AdminDashboard() {
 
           <div className={`${card} p-4`}>
             <div className={labelStyle}>Total Reports</div>
-            <div className="text-3xl font-bold mt-1 text-white">
+            <div className="text-3xl font-bold mt-1 text-[var(--text)]">
               {bugs.length}
             </div>
             <div className="text-[11px] text-[var(--text-muted)] mt-1">
@@ -630,7 +630,7 @@ export default function AdminDashboard() {
                           {r.paid}✓
                         </span>
                       )}
-                      <span className="text-[12px] font-bold text-white w-5 text-right">
+                      <span className="text-[12px] font-bold text-[var(--text)] w-5 text-right">
                         {r.total}
                       </span>
                     </div>
@@ -681,7 +681,7 @@ export default function AdminDashboard() {
                     />
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2 flex-wrap">
-                        <span className="text-[12px] text-white truncate max-w-[220px] group-hover:text-[var(--accent)] transition-colors">
+                        <span className="text-[12px] text-[var(--text)] truncate max-w-[220px] group-hover:text-[var(--accent)] transition-colors">
                           {bug.title}
                         </span>
                         <span
@@ -850,7 +850,7 @@ export default function AdminDashboard() {
               setStatusFilter("all");
               setSeverityFilter("all");
             }}
-            className="rounded-none border border-[var(--border)] px-3 py-2 text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-dim)] hover:text-white hover:border-[var(--border-hover)] transition-colors"
+            className="rounded-none border border-[var(--border)] px-3 py-2 text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-dim)] hover:text-[var(--text)] hover:border-[var(--border-hover)] transition-colors"
           >
             Clear
           </button>
@@ -859,7 +859,7 @@ export default function AdminDashboard() {
               fetchBugs();
               fetchPlatformStats();
             }}
-            className="rounded-none border border-[var(--border)] px-3 py-2 text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-secondary)] hover:text-white hover:border-[var(--accent)] transition-colors"
+            className="rounded-none border border-[var(--border)] px-3 py-2 text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-secondary)] hover:text-[var(--text)] hover:border-[var(--accent)] transition-colors"
           >
             Refresh
           </button>
@@ -908,7 +908,7 @@ export default function AdminDashboard() {
                             "var(--text-muted)"
                           }
                         />
-                        <span className="text-[13px] font-medium text-white truncate">
+                        <span className="text-[13px] font-medium text-[var(--text)] truncate">
                           {bug.title}
                         </span>
                       </div>
@@ -963,7 +963,7 @@ export default function AdminDashboard() {
                     {selectedBug.severity}
                   </span>
                 </div>
-                <h2 className="text-[15px] font-bold text-white leading-tight mb-2">
+                <h2 className="text-[15px] font-bold text-[var(--text)] leading-tight mb-2">
                   {selectedBug.title}
                 </h2>
                 <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px]">
@@ -1081,8 +1081,8 @@ export default function AdminDashboard() {
                       disabled={saving || selectedBug.status === s}
                       className={`rounded-none border px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.1em] transition-colors ${
                         selectedBug.status === s
-                          ? "bg-[var(--accent-subtle)] border-[var(--accent)] text-white"
-                          : "border-[var(--border)] text-[var(--text-muted)] hover:text-white hover:border-[var(--border-hover)]"
+                          ? "bg-[var(--accent-subtle)] border-[var(--accent)] text-[var(--text)]"
+                          : "border-[var(--border)] text-[var(--text-muted)] hover:text-[var(--text)] hover:border-[var(--border-hover)]"
                       }`}
                     >
                       {s.replace("_", " ")}

--- a/app/app/agents/page.tsx
+++ b/app/app/agents/page.tsx
@@ -5,7 +5,7 @@ import { ScrollReveal } from "@/components/ui/ScrollReveal";
 import { CodeBlock } from "@/components/ui/CodeBlock";
 
 const card = "rounded-sm bg-[var(--panel-bg)] border border-[var(--border)] p-6";
-const h2Style = "text-lg font-bold text-white mb-4";
+const h2Style = "text-lg font-bold text-[var(--text)] mb-4";
 const h3Style = "text-sm font-semibold text-[var(--accent)] mb-2 uppercase tracking-wider";
 const textMuted = "text-[13px] leading-relaxed text-[var(--text-secondary)]";
 const badge = "inline-block rounded-sm px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider";
@@ -22,8 +22,8 @@ export default function AgentsPage() {
               <div className="mb-2 text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--accent)]/60">
                 // contribute
               </div>
-              <h1 className="text-xl font-medium tracking-[-0.01em] text-white sm:text-2xl" style={{ fontFamily: "var(--font-heading)" }}>
-                <span className="font-normal text-white/50">Agent </span>Contribution Guide
+              <h1 className="text-xl font-medium tracking-[-0.01em] text-[var(--text)] sm:text-2xl" style={{ fontFamily: "var(--font-heading)" }}>
+                <span className="font-normal text-[var(--text-muted)]">Agent </span>Contribution Guide
               </h1>
               <p className="mt-2 text-[13px] text-[var(--text-secondary)]">
                 Use your AI agent to improve Percolator Launch. Fork, build, submit PRs.
@@ -34,7 +34,7 @@ export default function AgentsPage() {
                 href="https://github.com/dcccrypto/percolator-launch"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="border border-[var(--border)] px-4 py-2 text-xs font-medium text-white transition-colors hover:bg-[var(--accent)]/10"
+                className="border border-[var(--border)] px-4 py-2 text-xs font-medium text-[var(--text)] transition-colors hover:bg-[var(--accent)]/10"
               >
                 View on GitHub
               </a>
@@ -57,28 +57,28 @@ export default function AgentsPage() {
             <div className="flex gap-4">
               <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-sm bg-[var(--accent)]/10 text-sm font-bold text-[var(--accent)]">1</div>
               <div>
-                <p className="text-sm font-medium text-white">Fork the repository</p>
+                <p className="text-sm font-medium text-[var(--text)]">Fork the repository</p>
                 <p className={textMuted}>Clone dcccrypto/percolator-launch to your own GitHub</p>
               </div>
             </div>
             <div className="flex gap-4">
               <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-sm bg-[var(--accent)]/10 text-sm font-bold text-[var(--accent)]">2</div>
               <div>
-                <p className="text-sm font-medium text-white">Point your agent at the code</p>
+                <p className="text-sm font-medium text-[var(--text)]">Point your agent at the code</p>
                 <p className={textMuted}>Give it the architecture context and a specific task</p>
               </div>
             </div>
             <div className="flex gap-4">
               <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-sm bg-[var(--accent)]/10 text-sm font-bold text-[var(--accent)]">3</div>
               <div>
-                <p className="text-sm font-medium text-white">Agent builds on a feature branch</p>
+                <p className="text-sm font-medium text-[var(--text)]">Agent builds on a feature branch</p>
                 <p className={textMuted}>TypeScript must compile clean. Follow the design system.</p>
               </div>
             </div>
             <div className="flex gap-4">
               <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-sm bg-[var(--accent)]/10 text-sm font-bold text-[var(--accent)]">4</div>
               <div>
-                <p className="text-sm font-medium text-white">Submit a PR</p>
+                <p className="text-sm font-medium text-[var(--text)]">Submit a PR</p>
                 <p className={textMuted}>Main branch is protected. All changes go through review.</p>
               </div>
             </div>
@@ -119,7 +119,7 @@ Key concepts:
             <div className="rounded-sm border border-[var(--border)] p-4">
               <div className="mb-2 flex items-center gap-2">
                 <span className={`${badge} bg-[var(--long)]/20 text-[var(--long)]`}>Easy</span>
-                <h3 className="text-sm font-medium text-white">Bug Fixes</h3>
+                <h3 className="text-sm font-medium text-[var(--text)]">Bug Fixes</h3>
               </div>
               <p className={textMuted}>
                 Fix console errors, null rendering, missing loading states, TypeScript issues, mobile layout
@@ -128,7 +128,7 @@ Key concepts:
             <div className="rounded-sm border border-[var(--border)] p-4">
               <div className="mb-2 flex items-center gap-2">
                 <span className={`${badge} bg-[var(--long)]/20 text-[var(--long)]`}>Easy</span>
-                <h3 className="text-sm font-medium text-white">UI Polish</h3>
+                <h3 className="text-sm font-medium text-[var(--text)]">UI Polish</h3>
               </div>
               <p className={textMuted}>
                 Better skeletons, animations, accessibility, responsive design, performance
@@ -137,7 +137,7 @@ Key concepts:
             <div className="rounded-sm border border-[var(--border)] p-4">
               <div className="mb-2 flex items-center gap-2">
                 <span className={`${badge} bg-[var(--warning)]/20 text-[var(--warning)]`}>Medium</span>
-                <h3 className="text-sm font-medium text-white">Backend Features</h3>
+                <h3 className="text-sm font-medium text-[var(--text)]">Backend Features</h3>
               </div>
               <p className={textMuted}>
                 Trade history indexing, market stats, WebSocket reliability, monitoring dashboards
@@ -146,7 +146,7 @@ Key concepts:
             <div className="rounded-sm border border-[var(--border)] p-4">
               <div className="mb-2 flex items-center gap-2">
                 <span className={`${badge} bg-[var(--short)]/20 text-[var(--short)]`}>Hard</span>
-                <h3 className="text-sm font-medium text-white">Solana Program</h3>
+                <h3 className="text-sm font-medium text-[var(--text)]">Solana Program</h3>
               </div>
               <p className={textMuted}>
                 Gas optimization, new instructions, security hardening. Requires Rust + BPF toolchain.
@@ -243,7 +243,7 @@ npx tsx tests/t1-market-boot.ts`}</CodeBlock>
         <div className="text-center">
           <Link
             href="/"
-            className="inline-flex items-center gap-2 text-sm text-[var(--text-muted)] transition-colors hover:text-white"
+            className="inline-flex items-center gap-2 text-sm text-[var(--text-muted)] transition-colors hover:text-[var(--text)]"
           >
             <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M19 12H5M12 19l-7-7 7-7" />

--- a/app/app/guide/page.tsx
+++ b/app/app/guide/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { ScrollReveal } from "@/components/ui/ScrollReveal";
 
 const sectionHeader = "mb-2 text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--accent)]/60";
-const sectionTitle = "text-lg font-semibold tracking-[-0.01em] text-white sm:text-xl";
+const sectionTitle = "text-lg font-semibold tracking-[-0.01em] text-[var(--text)] sm:text-xl";
 const cardClass = "border border-[var(--border)] bg-[var(--panel-bg)]";
 const cellClass = "px-4 py-3 text-[12px]";
 const thClass = "px-4 py-3 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-muted)] text-left";
@@ -43,10 +43,10 @@ export default function GuidePage() {
             // documentation
           </div>
           <h1
-            className="text-xl font-medium tracking-[-0.01em] text-white sm:text-2xl"
+            className="text-xl font-medium tracking-[-0.01em] text-[var(--text)] sm:text-2xl"
             style={{ fontFamily: "var(--font-heading)" }}
           >
-            <span className="font-normal text-white/50">Percolator </span>Guide
+            <span className="font-normal text-[var(--text-muted)]">Percolator </span>Guide
           </h1>
           <p className="mt-2 text-[13px] text-[var(--text-secondary)]">
             Everything you need to know about launching and trading perpetual futures markets on Solana.
@@ -57,7 +57,7 @@ export default function GuidePage() {
       {/* P-MED-6: Table of Contents */}
       <ScrollReveal>
         <nav className={`${cardClass} p-5`}>
-          <h2 className="text-sm font-semibold text-white mb-3 uppercase tracking-wider">Contents</h2>
+          <h2 className="text-sm font-semibold text-[var(--text)] mb-3 uppercase tracking-wider">Contents</h2>
           <ul className="space-y-2">
             {sections.map((section) => (
               <li key={section.id}>
@@ -81,7 +81,7 @@ export default function GuidePage() {
         <div className={cardClass}>
           <div className="p-5 space-y-3">
             <p className="text-[13px] leading-relaxed text-[var(--text-secondary)]">
-              Percolator is <span className="text-white font-medium">pump.fun for perps</span> — anyone can launch a perpetual futures market for any Solana token in one click. No approvals, no gatekeepers.
+              Percolator is <span className="text-[var(--text)] font-medium">pump.fun for perps</span> — anyone can launch a perpetual futures market for any Solana token in one click. No approvals, no gatekeepers.
             </p>
             <p className="text-[13px] leading-relaxed text-[var(--text-secondary)]">
               Paste a token address, set your terms, and your market goes live on-chain instantly. Traders can open leveraged long/short positions using the token itself as collateral.
@@ -110,7 +110,7 @@ export default function GuidePage() {
                 ["Markets", "Anyone can create (free, 3 tiers)", "Anyone can create (0.45–7 SOL rent deposit)"],
               ].map(([aspect, devnet, mainnet]) => (
                 <tr key={aspect} className="transition-colors hover:bg-[var(--bg-elevated)]">
-                  <td className={`${cellClass} font-medium text-white`}>{aspect}</td>
+                  <td className={`${cellClass} font-medium text-[var(--text)]`}>{aspect}</td>
                   <td className={`${cellClass} text-[var(--warning)]`}>{devnet}</td>
                   <td className={`${cellClass} text-[var(--cyan)]`}>{mainnet}</td>
                 </tr>
@@ -142,7 +142,7 @@ export default function GuidePage() {
             },
           ].map((item) => (
             <div key={item.title} className="bg-[var(--panel-bg)] p-5 transition-colors hover:bg-[var(--bg-elevated)]">
-              <h3 className="text-[13px] font-semibold text-white mb-2">{item.title}</h3>
+              <h3 className="text-[13px] font-semibold text-[var(--text)] mb-2">{item.title}</h3>
               <p className="text-[12px] leading-relaxed text-[var(--text-secondary)]">{item.desc}</p>
             </div>
           ))}
@@ -179,7 +179,7 @@ export default function GuidePage() {
               />
               <div>
                 <div className="flex items-center gap-2">
-                  <h3 className="text-[13px] font-semibold text-white">{item.mode}</h3>
+                  <h3 className="text-[13px] font-semibold text-[var(--text)]">{item.mode}</h3>
                   <span
                     className="px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider border"
                     style={{ color: item.color, borderColor: `color-mix(in srgb, ${item.color} 30%, transparent)` }}
@@ -219,7 +219,7 @@ export default function GuidePage() {
                 ["Large", "4,096", "~$1,000 (~7 SOL)", "available"],
               ].map(([tier, slots, cost, status]) => (
                 <tr key={tier} className="transition-colors hover:bg-[var(--bg-elevated)]">
-                  <td className={`${cellClass} font-medium text-white`}>{tier}</td>
+                  <td className={`${cellClass} font-medium text-[var(--text)]`}>{tier}</td>
                   <td className={`${cellClass} text-[var(--text-secondary)]`}>{slots}</td>
                   <td className={`${cellClass} text-[var(--text-secondary)]`}>{cost}</td>
                   <td className={cellClass}>
@@ -255,7 +255,7 @@ export default function GuidePage() {
                 {item.step}
               </span>
               <div>
-                <h3 className="text-[13px] font-semibold text-white">{item.title}</h3>
+                <h3 className="text-[13px] font-semibold text-[var(--text)]">{item.title}</h3>
                 <p className="mt-1 text-[12px] leading-relaxed text-[var(--text-secondary)]">{item.desc}</p>
               </div>
             </div>
@@ -293,7 +293,7 @@ export default function GuidePage() {
             },
           ].map((item, idx) => (
             <details key={idx} className="bg-[var(--panel-bg)] group">
-              <summary className="cursor-pointer px-5 py-4 text-[13px] font-medium text-white transition-colors hover:bg-[var(--bg-elevated)] list-none flex items-center justify-between focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/50">
+              <summary className="cursor-pointer px-5 py-4 text-[13px] font-medium text-[var(--text)] transition-colors hover:bg-[var(--bg-elevated)] list-none flex items-center justify-between focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/50">
                 {item.q}
                 <svg className="h-3 w-3 text-[var(--text-muted)] transition-transform group-open:rotate-180" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />

--- a/app/app/join/page.tsx
+++ b/app/app/join/page.tsx
@@ -5,13 +5,13 @@ import Link from "next/link";
 import { ScrollReveal } from "@/components/ui/ScrollReveal";
 
 const card = "rounded-sm bg-[var(--panel-bg)] border border-[var(--border)] p-6";
-const h2Style = "text-lg font-bold text-white mb-4";
+const h2Style = "text-lg font-bold text-[var(--text)] mb-4";
 const textMuted = "text-[13px] leading-relaxed text-[var(--text-secondary)]";
 const labelStyle = "block text-[11px] font-medium uppercase tracking-[0.15em] text-[var(--text-muted)] mb-1.5";
 const inputStyle =
-  "w-full rounded-sm border border-[var(--border)] bg-[#0D0D14] px-3 py-2.5 text-[13px] text-white placeholder:text-[var(--text-dim)] focus:border-[var(--accent)] focus:outline-none transition-colors";
+  "w-full rounded-sm border border-[var(--border)] bg-[var(--bg-elevated)] px-3 py-2.5 text-[13px] text-[var(--text)] placeholder:text-[var(--text-dim)] focus:border-[var(--accent)] focus:outline-none transition-colors";
 const textareaStyle =
-  "w-full rounded-sm border border-[var(--border)] bg-[#0D0D14] px-3 py-2.5 text-[13px] text-white placeholder:text-[var(--text-dim)] focus:border-[var(--accent)] focus:outline-none transition-colors resize-none";
+  "w-full rounded-sm border border-[var(--border)] bg-[var(--bg-elevated)] px-3 py-2.5 text-[13px] text-[var(--text)] placeholder:text-[var(--text-dim)] focus:border-[var(--accent)] focus:outline-none transition-colors resize-none";
 
 const ROLE_OPTIONS = [
   { value: "developer", label: "Developer", desc: "Smart contracts, frontend, backend" },
@@ -139,7 +139,7 @@ export default function JoinPage() {
                 <path d="M20 6L9 17l-5-5" />
               </svg>
             </div>
-            <h2 className="text-lg font-bold text-white mb-2">Application Submitted</h2>
+            <h2 className="text-lg font-bold text-[var(--text)] mb-2">Application Submitted</h2>
             <p className={textMuted}>
               Thanks {form.name} — we&apos;ll review your application and reach out via @{form.twitter_handle.replace(/^@/, "")} or email.
             </p>
@@ -162,7 +162,7 @@ export default function JoinPage() {
                   });
                   setCvFile(null);
                 }}
-                className="border border-[var(--border)] px-4 py-2 text-xs font-medium text-white transition-colors hover:bg-[var(--accent)]/10"
+                className="border border-[var(--border)] px-4 py-2 text-xs font-medium text-[var(--text)] transition-colors hover:bg-[var(--accent)]/10"
               >
                 Submit Another
               </button>
@@ -189,9 +189,9 @@ export default function JoinPage() {
             <div className="mb-2 text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--accent)]/60">
               // careers
             </div>
-            <h1 className="text-xl font-medium tracking-[-0.01em] text-white sm:text-2xl" style={{ fontFamily: "var(--font-heading)" }}>
+            <h1 className="text-xl font-medium tracking-[-0.01em] text-[var(--text)] sm:text-2xl" style={{ fontFamily: "var(--font-heading)" }}>
               <span className="font-bold">Join</span>{" "}
-              <span className="font-normal text-white/50">Us</span>
+              <span className="font-normal text-[var(--text-muted)]">Us</span>
             </h1>
             <p className="mt-2 text-[13px] text-[var(--text-secondary)]">
               Help build the future of perpetual futures on Solana.
@@ -286,7 +286,7 @@ export default function JoinPage() {
                             : "border-[var(--border)] hover:border-[var(--border-hover)]"
                         }`}
                       >
-                        <span className="text-[12px] font-medium text-white">{opt.label}</span>
+                        <span className="text-[12px] font-medium text-[var(--text)]">{opt.label}</span>
                         <p className="mt-0.5 text-[10px] text-[var(--text-dim)]">{opt.desc}</p>
                       </button>
                     ))}
@@ -301,8 +301,8 @@ export default function JoinPage() {
                         onClick={() => update("experience_level", opt.value)}
                         className={`rounded-sm border px-4 py-1.5 text-[11px] font-medium transition-all ${
                           form.experience_level === opt.value
-                            ? "border-[var(--accent)] bg-[var(--accent)]/10 text-white"
-                            : "border-[var(--border)] text-[var(--text-muted)] hover:border-[var(--border-hover)] hover:text-white"
+                            ? "border-[var(--accent)] bg-[var(--accent)]/10 text-[var(--text)]"
+                            : "border-[var(--border)] text-[var(--text-muted)] hover:border-[var(--border-hover)] hover:text-[var(--text)]"
                         }`}
                       >
                         {opt.label}
@@ -367,7 +367,7 @@ export default function JoinPage() {
                     />
                     {cvFile ? (
                       <div>
-                        <p className="text-[13px] text-white font-medium">{cvFile.name}</p>
+                        <p className="text-[13px] text-[var(--text)] font-medium">{cvFile.name}</p>
                         <button
                           onClick={(e) => { e.stopPropagation(); setCvFile(null); }}
                           className="mt-1 text-[11px] text-[var(--text-muted)] hover:text-[var(--short)] transition-colors"
@@ -402,8 +402,8 @@ export default function JoinPage() {
                         onClick={() => update("availability", opt.value)}
                         className={`rounded-sm border px-4 py-1.5 text-[11px] font-medium transition-all ${
                           form.availability === opt.value
-                            ? "border-[var(--accent)] bg-[var(--accent)]/10 text-white"
-                            : "border-[var(--border)] text-[var(--text-muted)] hover:border-[var(--border-hover)] hover:text-white"
+                            ? "border-[var(--accent)] bg-[var(--accent)]/10 text-[var(--text)]"
+                            : "border-[var(--border)] text-[var(--text-muted)] hover:border-[var(--border-hover)] hover:text-[var(--text)]"
                         }`}
                       >
                         {opt.label}
@@ -436,7 +436,7 @@ export default function JoinPage() {
             <div className="flex items-center justify-between">
               <Link
                 href="/"
-                className="inline-flex items-center gap-2 text-sm text-[var(--text-muted)] transition-colors hover:text-white"
+                className="inline-flex items-center gap-2 text-sm text-[var(--text-muted)] transition-colors hover:text-[var(--text)]"
               >
                 <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M19 12H5M12 19l-7-7 7-7" />
@@ -468,7 +468,7 @@ export default function JoinPage() {
                   <li key={item.title} className="flex items-start gap-3">
                     <span className="mt-1.5 h-1.5 w-1.5 shrink-0 bg-[var(--accent)]" />
                     <div>
-                      <p className="text-[12px] font-medium text-white">{item.title}</p>
+                      <p className="text-[12px] font-medium text-[var(--text)]">{item.title}</p>
                       <p className="text-[11px] text-[var(--text-secondary)]">{item.desc}</p>
                     </div>
                   </li>

--- a/app/app/report-bug/page.tsx
+++ b/app/app/report-bug/page.tsx
@@ -5,13 +5,13 @@ import Link from "next/link";
 import { ScrollReveal } from "@/components/ui/ScrollReveal";
 
 const card = "rounded-sm bg-[var(--panel-bg)] border border-[var(--border)] p-6";
-const h2Style = "text-lg font-bold text-white mb-4";
+const h2Style = "text-lg font-bold text-[var(--text)] mb-4";
 const textMuted = "text-[13px] leading-relaxed text-[var(--text-secondary)]";
 const labelStyle = "block text-[11px] font-medium uppercase tracking-[0.15em] text-[var(--text-muted)] mb-1.5";
 const inputStyle =
-  "w-full rounded-sm border border-[var(--border)] bg-[#0D0D14] px-3 py-2.5 text-[13px] text-white placeholder:text-[var(--text-dim)] focus:border-[var(--accent)] focus:outline-none transition-colors";
+  "w-full rounded-sm border border-[var(--border)] bg-[var(--bg-elevated)] px-3 py-2.5 text-[13px] text-[var(--text)] placeholder:text-[var(--text-dim)] focus:border-[var(--accent)] focus:outline-none transition-colors";
 const textareaStyle =
-  "w-full rounded-sm border border-[var(--border)] bg-[#0D0D14] px-3 py-2.5 text-[13px] text-white placeholder:text-[var(--text-dim)] focus:border-[var(--accent)] focus:outline-none transition-colors resize-none";
+  "w-full rounded-sm border border-[var(--border)] bg-[var(--bg-elevated)] px-3 py-2.5 text-[13px] text-[var(--text)] placeholder:text-[var(--text-dim)] focus:border-[var(--accent)] focus:outline-none transition-colors resize-none";
 
 const SEVERITY_OPTIONS = [
   { value: "low", label: "Low", color: "var(--text-muted)", desc: "Minor visual glitch or cosmetic issue" },
@@ -98,7 +98,7 @@ export default function ReportBugPage() {
                 <path d="M20 6L9 17l-5-5" />
               </svg>
             </div>
-            <h2 className="text-lg font-bold text-white mb-2">Bug Report Submitted</h2>
+            <h2 className="text-lg font-bold text-[var(--text)] mb-2">Bug Report Submitted</h2>
             <p className={textMuted}>
               Thanks @{form.twitter_handle.replace(/^@/, "")} — we&apos;ll review this and reach out on X if we need more info.
             </p>
@@ -121,7 +121,7 @@ export default function ReportBugPage() {
                     browser: "",
                   });
                 }}
-                className="border border-[var(--border)] px-4 py-2 text-xs font-medium text-white transition-colors hover:bg-[var(--accent)]/10"
+                className="border border-[var(--border)] px-4 py-2 text-xs font-medium text-[var(--text)] transition-colors hover:bg-[var(--accent)]/10"
               >
                 Submit Another
               </button>
@@ -149,8 +149,8 @@ export default function ReportBugPage() {
               <div className="mb-2 text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--accent)]/60">
                 // report
               </div>
-              <h1 className="text-xl font-medium tracking-[-0.01em] text-white sm:text-2xl" style={{ fontFamily: "var(--font-heading)" }}>
-                <span className="font-normal text-white/50">Bug </span>Report
+              <h1 className="text-xl font-medium tracking-[-0.01em] text-[var(--text)] sm:text-2xl" style={{ fontFamily: "var(--font-heading)" }}>
+                <span className="font-normal text-[var(--text-muted)]">Bug </span>Report
               </h1>
               <p className="mt-2 text-[13px] text-[var(--text-secondary)]">
                 Found something broken? Help us fix it. Be as detailed as possible.
@@ -168,7 +168,7 @@ export default function ReportBugPage() {
               </svg>
             </div>
             <div>
-              <p className="text-[13px] font-medium text-white">Bug bounties paid from creator rewards</p>
+              <p className="text-[13px] font-medium text-[var(--text)]">Bug bounties paid from creator rewards</p>
               <p className="mt-1 text-[11px] leading-relaxed text-[var(--text-secondary)]">
                 Valid bug reports are eligible for bounties. We allocate a portion of creator rewards to pay community members who help us find and document bugs. The more detailed your report, the higher the bounty.
               </p>
@@ -269,7 +269,7 @@ export default function ReportBugPage() {
                         className="h-2 w-2 rounded-full"
                         style={{ backgroundColor: opt.color }}
                       />
-                      <span className="text-[12px] font-medium text-white">{opt.label}</span>
+                      <span className="text-[12px] font-medium text-[var(--text)]">{opt.label}</span>
                     </div>
                     <p className="mt-0.5 text-[10px] text-[var(--text-dim)]">{opt.desc}</p>
                   </button>
@@ -287,8 +287,8 @@ export default function ReportBugPage() {
                     onClick={() => update("page", form.page === p ? "" : p)}
                     className={`rounded-sm border px-3 py-1.5 text-[11px] font-medium transition-all ${
                       form.page === p
-                        ? "border-[var(--accent)] bg-[var(--accent)]/10 text-white"
-                        : "border-[var(--border)] text-[var(--text-muted)] hover:border-[var(--border-hover)] hover:text-white"
+                        ? "border-[var(--accent)] bg-[var(--accent)]/10 text-[var(--text)]"
+                        : "border-[var(--border)] text-[var(--text-muted)] hover:border-[var(--border-hover)] hover:text-[var(--text)]"
                     }`}
                   >
                     {p}
@@ -380,7 +380,7 @@ export default function ReportBugPage() {
         <div className="flex items-center justify-between">
           <Link
             href="/"
-            className="inline-flex items-center gap-2 text-sm text-[var(--text-muted)] transition-colors hover:text-white"
+            className="inline-flex items-center gap-2 text-sm text-[var(--text-muted)] transition-colors hover:text-[var(--text)]"
           >
             <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M19 12H5M12 19l-7-7 7-7" />

--- a/app/app/stake/page.tsx
+++ b/app/app/stake/page.tsx
@@ -149,7 +149,7 @@ function StakeHero({ pools, totalUserDeposited }: { pools: StakePool[]; totalUse
             className="mb-4 text-3xl font-medium tracking-[-0.02em] sm:text-4xl lg:text-[56px]"
             style={{ fontFamily: "var(--font-heading)" }}
           >
-            <span className="text-white">Stake. Earn.</span>
+            <span className="text-[var(--text)]">Stake. Earn.</span>
             <br />
             <span className="text-[var(--cyan)]">Back the Fund.</span>
           </h1>
@@ -232,7 +232,7 @@ function YourPositionPanel({
         <p className="mt-1 text-[10px] text-[var(--text-dim)]">Deposit into a pool to get started</p>
         <a
           href="#deposit"
-          className="mt-3 inline-block text-[11px] font-medium text-[var(--accent)] transition-colors hover:text-white"
+          className="mt-3 inline-block text-[11px] font-medium text-[var(--accent)] transition-colors hover:text-[var(--text)]"
         >
           Deposit Now →
         </a>
@@ -253,17 +253,17 @@ function YourPositionPanel({
         <div className="grid grid-cols-2 gap-3 text-[12px]">
           <div>
             <span className="text-[var(--text-secondary)]">Pool</span>
-            <p className="font-medium text-white">{position.poolName}</p>
+            <p className="font-medium text-[var(--text)]">{position.poolName}</p>
           </div>
           <div>
             <span className="text-[var(--text-secondary)]">LP Balance</span>
-            <p className="font-medium text-white tabular-nums" style={{ fontFamily: "var(--font-mono)" }}>
+            <p className="font-medium text-[var(--text)] tabular-nums" style={{ fontFamily: "var(--font-mono)" }}>
               {position.lpBalance.toLocaleString(undefined, { maximumFractionDigits: 4 })} LP
             </p>
           </div>
           <div>
             <span className="text-[var(--text-secondary)]">Est. Value</span>
-            <p className="font-medium text-white tabular-nums" style={{ fontFamily: "var(--font-mono)" }}>
+            <p className="font-medium text-[var(--text)] tabular-nums" style={{ fontFamily: "var(--font-mono)" }}>
               {formatUsd(position.estimatedValue)}
             </p>
           </div>
@@ -410,7 +410,7 @@ function DepositWidget({
           <select
             value={selectedPool}
             onChange={(e) => { setSelectedPool(e.target.value); setTxStatus(null); }}
-            className="w-full border border-[var(--border)] bg-[var(--bg-surface)] px-3 py-2.5 text-[13px] text-white outline-none transition-colors focus:border-[var(--accent)]/50"
+            className="w-full border border-[var(--border)] bg-[var(--bg-surface)] px-3 py-2.5 text-[13px] text-[var(--text)] outline-none transition-colors focus:border-[var(--accent)]/50"
             style={{ fontFamily: "var(--font-mono)" }}
           >
             {pools.map((p) => (
@@ -443,7 +443,7 @@ function DepositWidget({
               placeholder="0.00"
               min="0"
               step="any"
-              className="flex-1 border border-[var(--border)] bg-[var(--bg-surface)] px-3 py-2.5 text-[13px] text-white placeholder:text-[var(--text-muted)] outline-none transition-colors focus:border-[var(--accent)]/50 tabular-nums"
+              className="flex-1 border border-[var(--border)] bg-[var(--bg-surface)] px-3 py-2.5 text-[13px] text-[var(--text)] placeholder:text-[var(--text-muted)] outline-none transition-colors focus:border-[var(--accent)]/50 tabular-nums"
               style={{ fontFamily: "var(--font-mono)" }}
             />
             <button
@@ -460,7 +460,7 @@ function DepositWidget({
         {amountNum > 0 && (
           <div className="text-[12px] text-[var(--text-secondary)]">
             You will receive ≈{" "}
-            <span className="font-medium text-white tabular-nums" style={{ fontFamily: "var(--font-mono)" }}>
+            <span className="font-medium text-[var(--text)] tabular-nums" style={{ fontFamily: "var(--font-mono)" }}>
               {lpEstimate.toLocaleString(undefined, { maximumFractionDigits: 4 })} LP
             </span>
           </div>
@@ -532,7 +532,7 @@ function PoolCard({ pool }: { pool: StakePool }) {
             💧
           </div>
           <div>
-            <h3 className="text-[13px] font-semibold text-white">{pool.symbol}</h3>
+            <h3 className="text-[13px] font-semibold text-[var(--text)]">{pool.symbol}</h3>
             <p className="text-[10px] text-[var(--text-muted)]">POOL</p>
           </div>
         </div>
@@ -541,7 +541,7 @@ function PoolCard({ pool }: { pool: StakePool }) {
       <div className="space-y-2 text-[12px]">
         <div className="flex justify-between">
           <span className="text-[var(--text-secondary)]">TVL</span>
-          <span className="font-medium text-white tabular-nums" style={{ fontFamily: "var(--font-mono)" }}>{formatUsd(pool.tvl)}</span>
+          <span className="font-medium text-[var(--text)] tabular-nums" style={{ fontFamily: "var(--font-mono)" }}>{formatUsd(pool.tvl)}</span>
         </div>
         <div className="flex justify-between">
           <span className="text-[var(--text-secondary)]">APR</span>


### PR DESCRIPTION
## Problem

GH#1863: 6 secondary pages missed in the PERC-8210/8211 sweep. All have hardcoded `text-white` on content elements — invisible in light mode.

## Pages Fixed
- `/guide` — sectionTitle const + 8 heading/cell fixes
- `/report-bug` — h2Style const + inputs (bg-[#0D0D14] → bg-[var(--bg-elevated)]) + headings + labels
- `/join` — same pattern, plus file name and role tag labels
- `/stake` — hero heading, position names/values, inputs, pool stats
- `/agents` — page heading, step descriptions, section headings
- `/admin` — h1/h2 headings, stat values, market list items, tab selected state

## Rule Applied
- Content text: `text-[var(--text)]` (inverts dark/light automatically)
- Button/CTA text on dark backgrounds: `text-white` kept intentionally
- Hover states: `hover:text-[var(--text)]` not `hover:text-white`
- Input backgrounds: `bg-[var(--bg-elevated)]` not `bg-[#0D0D14]`

## Tests
- 141/141 passing
- tsc clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Unified text color styling across six pages—admin dashboard, agents, guide, onboarding, bug reporting, and staking—using consistent theme variables instead of hardcoded values. Updated input field backgrounds to align with the application's theme system for improved visual consistency throughout the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->