### PR TITLE
fix(PERC-8215,GH#1862): /api/markets graceful fallback — network column missing

### DIFF
--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -162,17 +162,43 @@ export async function GET(request: NextRequest) {
     // they have slab=null, mainnet_ca=null, vault_balance=null and cannot be indexed.
     // Filtering at the query level prevents them polluting the response even if
     // the JS-layer zombie/blocklist guards don't catch them (Set.has(null) → false).
-    // PERC-8195: filter by network so devnet and mainnet rows don't mix
-    const { data, error } = await supabase
+    // PERC-8195: filter by network so devnet and mainnet rows don't mix.
+    // PERC-8215: Graceful fallback — if the network column is missing (migration not yet
+    // applied to this Supabase instance), retry without the filter to restore service.
+    // The column absence causes a hard 500; we detect it by error message and degrade
+    // gracefully rather than keeping the endpoint broken for all users.
+    const SELECT_FIELDS =
+      "slab_address,mint_address,symbol,name,decimals,deployer,logo_url,max_leverage,trading_fee_bps," +
+      "last_price,mark_price,index_price,volume_24h,trade_count_24h,open_interest_long,open_interest_short,total_open_interest," +
+      "insurance_fund,insurance_balance,total_accounts,funding_rate,net_lp_pos,lp_sum_abs,c_tot," +
+      "vault_balance,created_at,stats_updated_at,oracle_mode,dex_pool_address,mainnet_ca,oracle_authority";
+
+    let { data, error } = await supabase
       .from("markets_with_stats")
-      .select(
-        "slab_address,mint_address,symbol,name,decimals,deployer,logo_url,max_leverage,trading_fee_bps," +
-        "last_price,mark_price,index_price,volume_24h,trade_count_24h,open_interest_long,open_interest_short,total_open_interest," +
-        "insurance_fund,insurance_balance,total_accounts,funding_rate,net_lp_pos,lp_sum_abs,c_tot," +
-        "vault_balance,created_at,stats_updated_at,oracle_mode,dex_pool_address,mainnet_ca,oracle_authority"
-      )
+      .select(SELECT_FIELDS)
       .eq("network", getServerNetwork())
       .not("slab_address", "is", null);
+
+    // PERC-8215: Fallback — migration 20260329180000 not yet applied; `network` column
+    // does not exist in markets_with_stats view. Retry without the network filter so the
+    // endpoint stays up. Logs a Sentry warning so the missing migration is visible on-call.
+    if (error && error.message?.includes("network")) {
+      Sentry.captureMessage(
+        "PERC-8215: markets_with_stats.network column missing — migration not applied. " +
+        "Falling back to unfiltered query. Apply 20260329180000_add_network_column.sql to fix.",
+        {
+          level: "warning",
+          tags: { endpoint: "/api/markets", method: "GET", degraded: "true" },
+          fingerprint: ["perc-8215-network-column-missing"],
+        }
+      );
+      const fallback = await supabase
+        .from("markets_with_stats")
+        .select(SELECT_FIELDS)
+        .not("slab_address", "is", null);
+      data = fallback.data;
+      error = fallback.error;
+    }
 
     if (error) {
       Sentry.captureException(error, {


### PR DESCRIPTION
## Problem
`/api/markets` returns HTTP 500 with `column markets_with_stats.network does not exist`.

The Supabase migration `20260329180000_add_network_column.sql` was merged (PR#1835, PERC-8192) but **not applied to the live database**. The `.eq('network', getServerNetwork())` filter added by PERC-8195 crashes at query time because the column doesn't exist in the `markets_with_stats` view on the live instance.

**Impact:** /markets, /trade/[slab], /earn, /api/stats all returning 0 markets or 500.

## Fix
Detect the `network` column-missing error by message and retry without the filter. This restores service immediately while the migration is pending.

A Sentry warning fires (fingerprinted to one issue) so the migration is visibly outstanding.

## Long-term Fix (Khubair action required)
Apply `supabase/migrations/20260329180000_add_network_column.sql` via Supabase dashboard SQL editor:
1. Open https://supabase.com/dashboard/project/ygvbajglkrwkbjdjyhxi/sql/new
2. Paste contents of the migration file
3. Run — idempotent (`IF NOT EXISTS`), backfills all rows to `network='devnet'`

Once migration is applied, the fallback branch is never reached.

## Testing
```bash
curl https://percolatorlaunch.com/api/markets | jq '.total'
# Should return > 0 (was returning 500)
```

Closes GH#1862