### PR TITLE
fix(PERC-8225,GH#1867): graceful fallback for missing network column in /api/markets/[slab]

### DIFF
--- a/app/app/api/markets/[slab]/route.ts
+++ b/app/app/api/markets/[slab]/route.ts
@@ -69,12 +69,34 @@ export async function GET(
 
     if (isValidPublicKey(slab)) {
       // Standard lookup by slab address
-      const { data: row, error } = await supabase
+      // PERC-8225: Graceful fallback — if the network column is missing (migration not yet
+      // applied), retry without the filter to restore service. Mirrors the pattern in
+      // /api/markets/route.ts (PERC-8215).
+      let { data: row, error } = await supabase
         .from("markets_with_stats")
         .select("*")
         .eq("slab_address", slab)
         .eq("network", network)
         .maybeSingle();
+
+      if (error && error.message?.includes("network")) {
+        Sentry.captureMessage(
+          "PERC-8225: markets_with_stats.network column missing in [slab] route — migration not applied. " +
+          "Falling back to unfiltered query. Apply 20260329180000_add_network_column.sql to fix.",
+          {
+            level: "warning",
+            tags: { endpoint: "/api/markets/[slab]", method: "GET", degraded: "true" },
+            fingerprint: ["perc-8225-network-column-missing-slab"],
+          }
+        );
+        const fallback = await supabase
+          .from("markets_with_stats")
+          .select("*")
+          .eq("slab_address", slab)
+          .maybeSingle();
+        row = fallback.data;
+        error = fallback.error;
+      }
 
       if (error) {
         Sentry.captureException(error, {
@@ -88,10 +110,30 @@ export async function GET(
       const slugNorm = slab.toUpperCase().replace(/-PERP$/, "");
 
       // Fetch all markets and filter in JS to avoid needing ilike + function indexes
-      const { data: rows, error } = await supabase
+      // PERC-8225: Graceful fallback — if the network column is missing (migration not yet
+      // applied), retry without the filter to restore service. Mirrors the pattern in
+      // /api/markets/route.ts (PERC-8215).
+      let { data: rows, error } = await supabase
         .from("markets_with_stats")
         .select("*")
         .eq("network", network);
+
+      if (error && error.message?.includes("network")) {
+        Sentry.captureMessage(
+          "PERC-8225: markets_with_stats.network column missing in [slab] slug route — migration not applied. " +
+          "Falling back to unfiltered query. Apply 20260329180000_add_network_column.sql to fix.",
+          {
+            level: "warning",
+            tags: { endpoint: "/api/markets/[slab]", method: "GET", degraded: "true", lookup: "slug" },
+            fingerprint: ["perc-8225-network-column-missing-slug"],
+          }
+        );
+        const fallback = await supabase
+          .from("markets_with_stats")
+          .select("*");
+        rows = fallback.data;
+        error = fallback.error;
+      }
 
       if (error) {
         Sentry.captureException(error, {


### PR DESCRIPTION
## Problem
GH#1867 / PERC-8225 — Trade pages returning HTTP 500.

PR#1865 fixed the `/api/markets` list endpoint with a network-column fallback, but
the single-market `/api/markets/[slab]` route still used `.eq("network", network)`
without any fallback. When the Supabase migration 20260329180000 is not yet applied
to a given environment, this hard-crashes with a 500.

## Fix
Applies the identical graceful-fallback pattern from PERC-8215:
- Detect `network` in the Supabase error message
- Retry without the `.eq("network")` filter
- Log Sentry warning with a stable fingerprint (`perc-8225-network-column-missing-slab` / `-slug`)

Both lookup paths are covered:
1. **Public-key lookup** (`.eq("slab_address", slab)`)
2. **Slug resolution** (fetch all + JS filter)

## Verification
```bash
curl https://percolatorlaunch.com/api/markets/9Av38ug3FE1goNB4JanwjqdHVvF5JeQbHV6jUVEvvocB
# Before: HTTP 500
# After:  HTTP 200 { market: {...} }
```

## Fixes
Fixes: https://github.com/dcccrypto/percolator-launch/issues/1867