### PR TITLE
fix(api): GH#1874 + GH#1875 — network column fallback for /api/stats and /api/trader/:wallet/trades

### DIFF
--- a/app/app/api/stats/route.ts
+++ b/app/app/api/stats/route.ts
@@ -70,15 +70,42 @@ export async function GET(request: NextRequest) {
     // GH#1297: include vault_balance + total_accounts to apply phantom OI guard (consistent with /api/markets)
     // GH#1419: include stats_updated_at to filter stale volume_24h (markets not updated in >48h)
     // PERC-8195: filter by network so devnet/mainnet rows don't mix
+    // GH#1874: Graceful fallback — if network column is missing (PERC-8215 migration
+    // not yet applied), retry without the filter to keep stats endpoint alive.
     supabase.from("markets_with_stats").select("slab_address, volume_24h, trade_count_24h, open_interest_long, open_interest_short, total_open_interest, last_price, decimals, vault_balance, c_tot, total_accounts, stats_updated_at").eq("network", getServerNetwork()).limit(500),
     supabase.from("trades").select("trader").eq("network", getServerNetwork()).limit(5000),
   ]);
+
+  // GH#1874: Network column fallback — if the migration hasn't been applied yet,
+  // the .eq("network", ...) filter causes Supabase to return an error (column not found).
+  // Retry without the filter so the endpoint returns data rather than all zeros.
+  // GH#1874: Network column fallback — if the migration hasn't been applied yet,
+  // the .eq("network", ...) filter causes Supabase to return an error (column not found).
+  // Retry without the filter so the endpoint returns data rather than all zeros.
+  let statsData_raw = statsRes.data;
+  let tradersData_raw = tradersRes.data;
+
+  if (statsRes.error && statsRes.error.message?.includes("network")) {
+    console.warn(
+      "[/api/stats] PERC-8215: network column missing on markets_with_stats — falling back to unfiltered query. " +
+      "Apply 20260329180000_add_network_column.sql to fix."
+    );
+    const fallback = await supabase.from("markets_with_stats").select("slab_address, volume_24h, trade_count_24h, open_interest_long, open_interest_short, total_open_interest, last_price, decimals, vault_balance, c_tot, total_accounts, stats_updated_at").limit(500);
+    statsData_raw = fallback.data;
+  }
+  if (tradersRes.error && tradersRes.error.message?.includes("network")) {
+    console.warn(
+      "[/api/stats] PERC-8215: network column missing on trades — falling back to unfiltered query."
+    );
+    const fallback = await supabase.from("trades").select("trader").limit(5000);
+    tradersData_raw = fallback.data;
+  }
 
   // GH#1218: filter blocked slabs before aggregating — mirrors /api/markets behaviour.
   // Previously this endpoint had no blocklist filter, allowing corrupt markets (e.g. NL
   // with 9e12 raw OI → $89.2M false open interest) to pollute global stats.
   // GH#1539: Use unified BLOCKED_SLAB_ADDRESSES (includes env var overrides).
-  const statsData = (statsRes.data ?? []).filter(
+  const statsData = (statsData_raw ?? []).filter(
     (m) => !BLOCKED_SLAB_ADDRESSES.has((m as Record<string, unknown>).slab_address as string ?? ""),
   );
 
@@ -209,7 +236,7 @@ export async function GET(request: NextRequest) {
     0
   );
   const uniqueTraders = new Set(
-    (tradersRes.data ?? []).map((r) => r.trader)
+    (tradersData_raw ?? []).map((r) => r.trader)
   ).size;
   // GH#1265: trades table count query (head:true) returns 0 — likely a column name mismatch
   // or supabase HEAD count limitation. Use trade_count_24h from markets_with_stats instead,

--- a/app/app/api/trader/[wallet]/trades/route.ts
+++ b/app/app/api/trader/[wallet]/trades/route.ts
@@ -109,7 +109,33 @@ export async function GET(
       if (safeSlab) query = query.eq("slab_address", safeSlab);
     }
 
-    const { data, error, count } = await query;
+    let { data, error, count } = await query;
+
+    // GH#1875: Graceful fallback — if the network column doesn't exist yet
+    // (PERC-8215 migration not applied), retry without the network filter.
+    if (error && error.message?.includes("network")) {
+      console.warn(
+        "[trader-trades] PERC-8215: network column missing on trades table — " +
+        "falling back to unfiltered query. Apply 20260329180000_add_network_column.sql to fix."
+      );
+      let fallbackQuery = supabase
+        .from("trades")
+        .select("id, slab_address, trader, side, size, price, fee, tx_signature, created_at", { count: "exact" })
+        .eq("trader", walletKey)
+        .order("created_at", { ascending: false })
+        .range(offset, offset + limit - 1);
+
+      if (slabFilter) {
+        const safeSlab = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(slabFilter) ? slabFilter : null;
+        if (safeSlab) fallbackQuery = fallbackQuery.eq("slab_address", safeSlab);
+      }
+
+      const fallback = await fallbackQuery;
+      data = fallback.data;
+      error = fallback.error;
+      count = fallback.count;
+    }
+
     if (error) throw error;
 
     const trades: TraderTradeEntry[] = (data ?? []).map((row) => ({


### PR DESCRIPTION
## What
Adds PERC-8215 network column fallback to two endpoints that were missing it:

### GH#1874: /api/stats returns all zeros
- `.eq('network', getServerNetwork())` on `markets_with_stats` fails when the network column migration hasn't been applied
- Stats endpoint returned all zeros (totalMarkets:0, volume:0, etc.) making the homepage look dead
- **Fix:** Retry without network filter on column-missing error (matches existing /api/markets pattern)

### GH#1875: /api/trader/:wallet/trades returns 500
- Same `.eq('network', ...)` on `trades` table causes a hard 500 error
- Portfolio trade history shows 'Failed to fetch trade history'
- **Fix:** Same fallback pattern — retry without network filter, log warning

## Root cause
Both blocked on PERC-8215 (Supabase migration `20260329180000_add_network_column.sql` not yet applied by Khubair). This PR makes both endpoints resilient to the missing column.

## How to test
1. Without migration: `curl /api/stats` should return real market counts instead of zeros
2. Without migration: `curl /api/trader/<wallet>/trades` should return trades instead of 500
3. With migration applied: no behavior change (network filter works normally)

Closes #1874
Closes #1875

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability of stats and trader trades API endpoints with fallback mechanisms to ensure consistent data retrieval under various database conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->