### PR TITLE
fix: best-effort auto_fund_log after auto-fund success

### DIFF
--- a/app/app/api/auto-fund/route.ts
+++ b/app/app/api/auto-fund/route.ts
@@ -175,14 +175,22 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    // Log the funding event (analytics — gate handles rate limiting)
+    // Log the funding event (analytics — gate handles rate limiting). Best-effort:
+    // do not 500 after successful on-chain funding if logging fails (same as /api/faucet USDC path).
     if (results.sol_airdropped || results.usdc_minted) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await (supabase as any).from("auto_fund_log").insert({
-        wallet: walletAddress,
-        sol_airdropped: results.sol_airdropped,
-        usdc_minted: results.usdc_minted,
-      });
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (supabase as any).from("auto_fund_log").insert({
+          wallet: walletAddress,
+          sol_airdropped: results.sol_airdropped,
+          usdc_minted: results.usdc_minted,
+        });
+      } catch (logErr) {
+        Sentry.captureException(logErr, {
+          tags: { endpoint: "/api/auto-fund", step: "auto_fund_log" },
+          extra: { wallet: walletAddress },
+        });
+      }
     } else {
       // Nothing funded (already had sufficient balance) — release gate so user can retry
       if (gate.claimId) await releaseFaucetClaim(supabase, gate.claimId);


### PR DESCRIPTION
## Summary
Wrap `auto_fund_log` insert in try/catch with Sentry after successful SOL/USDC funding on `POST /api/auto-fund`. Matches the pattern used on `/api/faucet` USDC path so analytics/DB issues do not turn a successful mint/airdrop into a 500 or confuse clients.

## Context
Prompt 9 review: devnet-only gate, per-wallet 24h `tryFaucetGate(..., "

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-fund operations are now more resilient to logging failures and will continue processing even if logging encounters issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->