### PR TITLE
fix: rate-limit POST /api/launch and scope limiter keys

### DIFF
--- a/app/__tests__/api/create-market-rate-limit.test.ts
+++ b/app/__tests__/api/create-market-rate-limit.test.ts
@@ -108,6 +108,39 @@ describe("checkCreateMarketRateLimit (in-memory fallback)", () => {
   });
 });
 
+describe("checkLaunchRateLimit vs checkCreateMarketRateLimit (in-memory)", () => {
+  let checkCreateMarketRateLimit: (ip: string) => Promise<{
+    allowed: boolean;
+    remaining: number;
+    retryAfterSecs: number;
+  }>;
+  let checkLaunchRateLimit: (ip: string) => Promise<{
+    allowed: boolean;
+    remaining: number;
+    retryAfterSecs: number;
+  }>;
+  let CREATE_MARKET_RATE_LIMIT: number;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    const mod = await import("@/lib/create-market-rate-limit");
+    checkCreateMarketRateLimit = mod.checkCreateMarketRateLimit;
+    checkLaunchRateLimit = mod.checkLaunchRateLimit;
+    CREATE_MARKET_RATE_LIMIT = mod.CREATE_MARKET_RATE_LIMIT;
+  });
+
+  it("exhausting create-market bucket does not block launch for the same IP", async () => {
+    const ip = "10.0.3.1";
+    for (let i = 0; i <= CREATE_MARKET_RATE_LIMIT; i++) {
+      await checkCreateMarketRateLimit(ip);
+    }
+    expect((await checkCreateMarketRateLimit(ip)).allowed).toBe(false);
+    expect((await checkLaunchRateLimit(ip)).allowed).toBe(true);
+  });
+});
+
 // ── X-RateLimit-Reset header convention ───────────────────────────────────
 describe("X-RateLimit-Reset header", () => {
   it("is seconds-until-reset (≤ 60), not an epoch timestamp", async () => {

--- a/app/app/api/launch/route.ts
+++ b/app/app/api/launch/route.ts
@@ -2,6 +2,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { PublicKey } from "@solana/web3.js";
 import { SLAB_TIERS, type SlabTierKey } from "@percolator/sdk";
 import { getRpcEndpoint } from "@/lib/config";
+import { getClientIp } from "@/lib/get-client-ip";
+import {
+  checkLaunchRateLimit,
+  CREATE_MARKET_RATE_LIMIT,
+} from "@/lib/create-market-rate-limit";
+import * as Sentry from "@sentry/nextjs";
 
 export const dynamic = 'force-dynamic';
 
@@ -45,6 +51,25 @@ interface LaunchConfig {
  */
 export async function POST(req: NextRequest) {
   try {
+    const clientIp = getClientIp(req);
+    const rl = await checkLaunchRateLimit(clientIp);
+    if (!rl.allowed) {
+      return NextResponse.json(
+        {
+          error: `Rate limit exceeded — max ${CREATE_MARKET_RATE_LIMIT} launch requests per minute`,
+        },
+        {
+          status: 429,
+          headers: {
+            "Retry-After": String(rl.retryAfterSecs),
+            "X-RateLimit-Limit": String(CREATE_MARKET_RATE_LIMIT),
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": String(Math.max(0, rl.retryAfterSecs)),
+          },
+        },
+      );
+    }
+
     const body = await req.json();
     const { mint, slabTier = "small" } = body as { mint: string; slabTier?: SlabTierKey };
 
@@ -240,6 +265,9 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json(config);
   } catch (err) {
+    Sentry.captureException(err, {
+      tags: { endpoint: "/api/launch", method: "POST" },
+    });
     return NextResponse.json(
       { error: err instanceof Error ? err.message : "Unknown error" },
       { status: 500 },

--- a/app/lib/create-market-rate-limit.ts
+++ b/app/lib/create-market-rate-limit.ts
@@ -1,12 +1,13 @@
 /**
- * Distributed sliding-window rate limiter for POST /api/mobile/create-market.
+ * Distributed sliding-window rate limiter for market-creation–adjacent POST routes:
+ * `/api/mobile/create-market` and `/api/launch` (prep / pool detection).
  *
  * Primary: Upstash Redis + @upstash/ratelimit (UPSTASH_REDIS_REST_URL /
  *          UPSTASH_REDIS_REST_TOKEN env vars must be set).
  * Fallback: in-memory sliding window (dev / CI / when Redis is unconfigured).
  *           Per-serverless-instance — not suitable for horizontal mainnet scaling.
  *
- * Limit: CREATE_MARKET_RATE_LIMIT requests per CREATE_MARKET_RATE_WINDOW_MS.
+ * Limit: CREATE_MARKET_RATE_LIMIT requests per CREATE_MARKET_RATE_WINDOW_MS per route bucket.
  */
 
 import { Redis } from "@upstash/redis";
@@ -43,7 +44,7 @@ function getRatelimiter(): Ratelimit | null {
 // ── In-memory sliding-window fallback ─────────────────────────────────────
 const _localMap = new Map<string, number[]>();
 
-function checkLocalRateLimit(ip: string): {
+function checkLocalRateLimit(rateKey: string): {
   allowed: boolean;
   remaining: number;
   retryAfterMs: number;
@@ -51,10 +52,10 @@ function checkLocalRateLimit(ip: string): {
   const now = Date.now();
   const windowStart = now - CREATE_MARKET_RATE_WINDOW_MS;
 
-  // Prune expired timestamps for this IP
-  let timestamps = (_localMap.get(ip) ?? []).filter((t) => t > windowStart);
+  // Prune expired timestamps for this rate key (IP scoped per route via key prefix)
+  let timestamps = (_localMap.get(rateKey) ?? []).filter((t) => t > windowStart);
   timestamps.push(now);
-  _localMap.set(ip, timestamps);
+  _localMap.set(rateKey, timestamps);
 
   // Periodic full cleanup (~0.1% of requests)
   if (Math.random() < 0.001) {
@@ -86,11 +87,11 @@ export interface RateLimitResult {
   retryAfterSecs: number;
 }
 
-export async function checkCreateMarketRateLimit(ip: string): Promise<RateLimitResult> {
+async function rateLimitByKey(rateKey: string): Promise<RateLimitResult> {
   const limiter = getRatelimiter();
 
   if (limiter) {
-    const result = await limiter.limit(ip);
+    const result = await limiter.limit(rateKey);
     return {
       allowed: result.success,
       remaining: result.remaining,
@@ -100,11 +101,20 @@ export async function checkCreateMarketRateLimit(ip: string): Promise<RateLimitR
     };
   }
 
-  // In-memory fallback
-  const local = checkLocalRateLimit(ip);
+  const local = checkLocalRateLimit(rateKey);
   return {
     allowed: local.allowed,
     remaining: local.remaining,
     retryAfterSecs: Math.ceil(local.retryAfterMs / 1000),
   };
+}
+
+/** POST /api/mobile/create-market — 5 req/min per IP (bucket separate from launch). */
+export async function checkCreateMarketRateLimit(ip: string): Promise<RateLimitResult> {
+  return rateLimitByKey(`create-market:${ip}`);
+}
+
+/** POST /api/launch — same numeric limit, independent bucket (RPC + DexScreener cost). */
+export async function checkLaunchRateLimit(ip: string): Promise<RateLimitResult> {
+  return rateLimitByKey(`launch:${ip}`);
 }


### PR DESCRIPTION
﻿## Summary
- Add `checkLaunchRateLimit` using the same Upstash sliding-window limiter as mobile create-market, with a separate rate key (`launch:` vs `create-market:`) so buckets stay independent.
- Apply it at the start of `POST /api/launch` (before JSON/RPC work) with `Retry-After` / `X-RateLimit-*` headers aligned with `/api/mobile/create-market`.
- Report unexpected handler errors to Sentry (consistent with other API routes).

## Notes
- `/api/launch` does not write to Supabase; it returns config for client-signed transactions.
