### PR TITLE
fix: align oracle resolve price and source with DexScreener-first

### DIFF
--- a/app/app/api/oracle/resolve/[ca]/route.ts
+++ b/app/app/api/oracle/resolve/[ca]/route.ts
@@ -254,11 +254,12 @@ export async function GET(
   } else if (jupResult || dexResult) {
     // PERC-470: No Pyth feed — use hyperp mode if we have a supported DEX pool
     const hasPool = !!bestPool;
+    // Align price + source with priceSource above (DexScreener preferred over Jupiter).
     result = {
       feedId: null,
       symbol: symbolFromPrice ?? ca.slice(0, 6),
-      price: (jupResult?.price ?? dexResult?.price) || 0,
-      source: jupResult ? "jupiter" : "dexscreener",
+      price,
+      source: dexResult ? "dexscreener" : "jupiter",
       dexPoolAddress: bestPool,
       dexType: bestDexType,
       oracleMode: hasPool ? "hyperp" : "admin",


### PR DESCRIPTION
﻿## Summary
In `GET /api/oracle/resolve/[ca]`, when the mint is not in the static Pyth map but both Jupiter and DexScreener return a price, the handler already picked **DexScreener first** for `priceSource` (symbol + primary price). The JSON body still used **Jupiter-first** `price` and set `source` to `jupiter` whenever Jupiter succeeded, so clients could see a **symbol from one venue and a price from another**.

Use the existing `price` variable and set `source` to `dexscreener` when DexScreener data exists, otherwise `jupiter`.

## Testing
Not run (small logic alignment; no new deps).
