### PR TITLE
fix: advance-phase devnet guard uses NEXT_PUBLIC_DEFAULT_NETWORK first

### DIFF
--- a/app/__tests__/api/oracle-advance-phase.test.ts
+++ b/app/__tests__/api/oracle-advance-phase.test.ts
@@ -101,6 +101,7 @@ afterEach(() => {
   process.env.NEXT_PUBLIC_SOLANA_NETWORK = "devnet";
   process.env.CRANK_KEYPAIR = FAKE_KEYPAIR_JSON;
   delete process.env.DEVNET_MINT_AUTHORITY_KEYPAIR;
+  delete process.env.NEXT_PUBLIC_DEFAULT_NETWORK;
 });
 
 // --- Tests ---
@@ -138,6 +139,7 @@ describe("POST /api/oracle/advance-phase", () => {
   // ── Network guard ─────────────────────────────────────────────────────
 
   it("returns skipped:true on mainnet (rate limiter not called)", async () => {
+    delete process.env.NEXT_PUBLIC_DEFAULT_NETWORK;
     process.env.NEXT_PUBLIC_SOLANA_NETWORK = "mainnet";
     const res = await POST(makeRequest({ slabAddress: VALID_SLAB }));
     const json = await res.json();
@@ -145,6 +147,27 @@ describe("POST /api/oracle/advance-phase", () => {
     expect(json.reason).toBe("not devnet");
     // Rate limit check should not fire for no-op network guard
     expect(mockCheckRateLimit).not.toHaveBeenCalled();
+  });
+
+  it("prefers NEXT_PUBLIC_DEFAULT_NETWORK over NEXT_PUBLIC_SOLANA_NETWORK", async () => {
+    process.env.NEXT_PUBLIC_DEFAULT_NETWORK = "mainnet";
+    process.env.NEXT_PUBLIC_SOLANA_NETWORK = "devnet";
+    const res = await POST(makeRequest({ slabAddress: VALID_SLAB }));
+    const json = await res.json();
+    expect(json.skipped).toBe(true);
+    expect(json.reason).toBe("not devnet");
+    expect(mockCheckRateLimit).not.toHaveBeenCalled();
+  });
+
+  it("uses NEXT_PUBLIC_DEFAULT_NETWORK=devnet when NEXT_PUBLIC_SOLANA_NETWORK is unset", async () => {
+    delete process.env.NEXT_PUBLIC_SOLANA_NETWORK;
+    process.env.NEXT_PUBLIC_DEFAULT_NETWORK = "devnet";
+    mockSendAndConfirm.mockResolvedValue("sig_default_network");
+    const res = await POST(makeRequest({ slabAddress: VALID_SLAB }));
+    const json = await res.json();
+    expect(mockCheckRateLimit).toHaveBeenCalled();
+    expect(json.success).toBe(true);
+    expect(json.signature).toBe("sig_default_network");
   });
 
   // ── GH#1124: Rate limiting ─────────────────────────────────────────────

--- a/app/app/api/oracle/advance-phase/route.ts
+++ b/app/app/api/oracle/advance-phase/route.ts
@@ -9,7 +9,7 @@
  * "Confirm transaction" modal that was firing on every trade page load.
  *
  * AdvanceOraclePhase is a permissionless instruction (any fee payer works).
- * Only runs on devnet; silently no-ops on mainnet.
+ * Only runs on devnet; silently no-ops when network is not devnet (see env vars below).
  *
  * PERC-799 / GH#1124: Rate limited to 60 req/IP/min (Upstash or in-memory).
  * PERC-799 / GH#1125: CRANK_KEYPAIR is required — no fallback to mint authority.
@@ -64,8 +64,10 @@ function isValidBase58(s: string): boolean {
 }
 
 export async function POST(req: NextRequest) {
-  // Only active on devnet — on mainnet/mainnet-fork this is a no-op
-  const network = process.env.NEXT_PUBLIC_SOLANA_NETWORK?.trim() ?? "mainnet";
+  // Only active on devnet — align with NEXT_PUBLIC_DEFAULT_NETWORK first (GH#1375 / auto-fund).
+  const network =
+    process.env.NEXT_PUBLIC_DEFAULT_NETWORK?.trim() ??
+    process.env.NEXT_PUBLIC_SOLANA_NETWORK?.trim();
   if (network !== "devnet") {
     return NextResponse.json({ skipped: true, reason: "not devnet" });
   }


### PR DESCRIPTION
﻿## Summary
`POST /api/oracle/advance-phase` only ran when `NEXT_PUBLIC_SOLANA_NETWORK === "devnet"`. Deployments that set **`NEXT_PUBLIC_DEFAULT_NETWORK=devnet`** (and leave the legacy var unset) are treated as devnet elsewhere but previously **skipped** this route.

Resolve network with **`NEXT_PUBLIC_DEFAULT_NETWORK` first**, then **`NEXT_PUBLIC_SOLANA_NETWORK`** (same pattern as `/api/auto-fund`). If neither is `devnet`, keep the existing `{ skipped: true, reason: "not devnet" }` behavior.

## Tests
- `oracle-advance-phase.test.ts`: clear `NEXT_PUBLIC_DEFAULT_NETWORK` in the mainnet skip case; assert `DEFAULT` wins over `SOLANA`; assert `DEFAULT=devnet` works when `SOLANA` is unset.

CI / local: `npm run test -- __tests__/api/oracle-advance-phase.test.ts` from `app/` (workspace install).
