### PR TITLE
fix: trim KEEPER_REGISTER_SECRET; whitespace-only disables register

### DIFF
--- a/app/__tests__/api/gh1692-timing-safe-keeper-auth.test.ts
+++ b/app/__tests__/api/gh1692-timing-safe-keeper-auth.test.ts
@@ -95,6 +95,27 @@ describe("GH#1692: oracle-keeper/register timing-safe auth", () => {
     expect(res.status).toBe(503);
   });
 
+  it("rejects when KEEPER_REGISTER_SECRET is whitespace-only (treated as unset)", async () => {
+    process.env.KEEPER_REGISTER_SECRET = "  \t\n  ";
+    vi.resetModules();
+    process.env.KEEPER_INTERNAL_URL = "http://localhost:8081";
+    const { POST } = await import("@/app/api/oracle-keeper/register/route");
+    const res = await POST(
+      new NextRequest("http://localhost/api/oracle-keeper/register", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-keeper-secret": "any-value",
+        },
+        body: JSON.stringify({
+          slabAddress: "11111111111111111111111111111111",
+          mainnetCA: "22222222222222222222222222222222",
+        }),
+      }),
+    );
+    expect(res.status).toBe(503);
+  });
+
   it("passes auth with correct secret (proceeds to validation)", async () => {
     const { POST } = await import("@/app/api/oracle-keeper/register/route");
     // Correct secret but invalid pubkeys → 400, not 401

--- a/app/app/api/oracle-keeper/register/route.ts
+++ b/app/app/api/oracle-keeper/register/route.ts
@@ -11,6 +11,8 @@
  *
  * The keeper service URL is read from KEEPER_INTERNAL_URL env (default: http://localhost:8081).
  * Non-fatal if keeper is unreachable — market will be auto-discovered on next cycle.
+ *
+ * KEEPER_REGISTER_SECRET is trimmed; empty or whitespace-only disables the route (503).
  */
 
 import { NextRequest, NextResponse } from "next/server";
@@ -21,7 +23,8 @@ import { PublicKey } from "@solana/web3.js";
 export const dynamic = "force-dynamic";
 
 const KEEPER_URL = process.env.KEEPER_INTERNAL_URL ?? "http://localhost:8081";
-const REGISTER_SECRET = process.env.KEEPER_REGISTER_SECRET ?? "";
+/** Trimmed — whitespace-only env counts as unset (same idea as set-price-cap / ADMIN_API_SECRET). */
+const REGISTER_SECRET = (process.env.KEEPER_REGISTER_SECRET ?? "").trim();
 
 export async function POST(req: NextRequest) {
   // Auth: require shared secret to prevent unauthorized oracle source manipulation (#780)


### PR DESCRIPTION
﻿## Summary
`KEEPER_REGISTER_SECRET` is now **trimmed** when the module loads. **Empty or whitespace-only** values disable `POST /api/oracle-keeper/register` with **503** (same operational pattern as `ADMIN_API_SECRET` on set-price-cap).

The timing-safe header check is unchanged; only normalization of the configured secret is tightened.

## Tests
Extended `gh1692-timing-safe-keeper-auth.test.ts` with a whitespace-only env case.
