### PR TITLE
fix: no-store Cache-Control on /api/prices routes

### DIFF
--- a/app/app/api/prices/[slab]/route.ts
+++ b/app/app/api/prices/[slab]/route.ts
@@ -5,6 +5,8 @@ import * as Sentry from "@sentry/nextjs";
 
 export const dynamic = "force-dynamic";
 
+const NO_STORE = { "Cache-Control": "private, no-store" } as const;
+
 /**
  * GET /api/prices/[slab]
  *
@@ -46,7 +48,7 @@ export async function GET(
     if (!res.ok) {
       return NextResponse.json(
         { error: `Backend returned ${res.status}` },
-        { status: res.status }
+        { status: res.status, headers: NO_STORE },
       );
     }
 
@@ -56,7 +58,7 @@ export async function GET(
 
     const prices = data.prices ?? [];
     if (prices.length === 0) {
-      return NextResponse.json({ stats: null });
+      return NextResponse.json({ stats: null }, { headers: NO_STORE });
     }
 
     // Prices are sorted desc (newest first). Find entries within last 24h.
@@ -83,15 +85,21 @@ export async function GET(
         ? (Number(latest - oldest) / Number(oldest)) * 100
         : 0;
 
-    return NextResponse.json({
-      stats: {
-        change24h,
-        high24h: high.toString(),
-        low24h: low.toString(),
+    return NextResponse.json(
+      {
+        stats: {
+          change24h,
+          high24h: high.toString(),
+          low24h: low.toString(),
+        },
       },
-    });
+      { headers: NO_STORE },
+    );
   } catch (err) {
     Sentry.captureException(err, { tags: { endpoint: "/api/prices/[slab]" } });
-    return NextResponse.json({ error: "Failed to fetch price stats" }, { status: 502 });
+    return NextResponse.json(
+      { error: "Failed to fetch price stats" },
+      { status: 502, headers: NO_STORE },
+    );
   }
 }

--- a/app/app/api/prices/markets/route.ts
+++ b/app/app/api/prices/markets/route.ts
@@ -4,6 +4,8 @@ import * as Sentry from "@sentry/nextjs";
 
 export const dynamic = "force-dynamic";
 
+const NO_STORE = { "Cache-Control": "private, no-store" } as const;
+
 /**
  * GET /api/prices/markets
  *
@@ -27,7 +29,7 @@ export async function GET() {
     if (!res.ok) {
       return NextResponse.json(
         { error: `Backend returned ${res.status}` },
-        { status: res.status }
+        { status: res.status, headers: NO_STORE },
       );
     }
 
@@ -52,9 +54,12 @@ export async function GET() {
       }
     }
 
-    return NextResponse.json(result);
+    return NextResponse.json(result, { headers: NO_STORE });
   } catch (err) {
     Sentry.captureException(err, { tags: { endpoint: "/api/prices/markets" } });
-    return NextResponse.json({ error: "Failed to fetch prices" }, { status: 502 });
+    return NextResponse.json(
+      { error: "Failed to fetch prices" },
+      { status: 502, headers: NO_STORE },
+    );
   }
 }

--- a/app/app/api/prices/route.ts
+++ b/app/app/api/prices/route.ts
@@ -5,6 +5,9 @@ import * as Sentry from "@sentry/nextjs";
 
 export const dynamic = "force-dynamic";
 
+/** Mutable marks — discourage shared caches from serving stale prices (GH#1574 area). */
+const NO_STORE = { "Cache-Control": "private, no-store" } as const;
+
 /**
  * GET /api/prices
  *
@@ -37,7 +40,7 @@ export async function GET() {
   if (network === "mainnet-beta" || network === "mainnet") {
     return NextResponse.json(
       { error: "prices endpoint not available on mainnet" },
-      { status: 403 }
+      { status: 403, headers: NO_STORE },
     );
   }
 
@@ -77,7 +80,7 @@ export async function GET() {
             }
           }
         }
-        return NextResponse.json({ prices });
+        return NextResponse.json({ prices }, { headers: NO_STORE });
       }
     }
 
@@ -89,13 +92,13 @@ export async function GET() {
     });
 
     if (!res.ok) {
-      return NextResponse.json({ prices: {} }, { status: res.status });
+      return NextResponse.json({ prices: {} }, { status: res.status, headers: NO_STORE });
     }
 
     const data = await res.json();
-    return NextResponse.json(data);
+    return NextResponse.json(data, { headers: NO_STORE });
   } catch (err) {
     Sentry.captureException(err, { tags: { endpoint: "/api/prices" } });
-    return NextResponse.json({ prices: {} }, { status: 502 });
+    return NextResponse.json({ prices: {} }, { status: 502, headers: NO_STORE });
   }
 }


### PR DESCRIPTION
﻿## Summary
Adds `Cache-Control: private, no-store` to every JSON response from:

- `GET /api/prices`
- `GET /api/prices/markets`
- `GET /api/prices/[slab]`

These payloads are mutable oracle/mark data; without explicit headers, some intermediaries may still cache GET responses.

## Notes
- `/api/prices` remains **mainnet-blocked** (403) per GH#1574; Supabase path still filters `market_stats` by `getServerNetwork()`.
- No change to query limits or backend contracts; pagination/row caps unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cache handling on API price endpoints to ensure consistent response behavior across requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->