### PR TITLE
fix: align GET /api/markets/[slab] Cache-Control with list route

### DIFF
--- a/app/app/api/markets/[slab]/route.ts
+++ b/app/app/api/markets/[slab]/route.ts
@@ -6,6 +6,11 @@ import { SLUG_ALIASES } from "@/lib/symbol-utils";
 import { isBlockedSlab } from "@/lib/blocklist";
 import * as Sentry from "@sentry/nextjs";
 
+/** Success responses only — matches GET /api/markets (errors omit this to avoid caching 404/500). */
+const MARKETS_CACHE_HEADERS = {
+  "Cache-Control": "public, s-maxage=10, stale-while-revalidate=30",
+} as const;
+
 /**
  * GH#1405: Sanitize price fields from the DB. Returns null for corrupt/garbage values.
  * Matches the MAX_SANE_PRICE_USD guard in /api/markets route.ts ($1M ceiling).
@@ -197,14 +202,11 @@ export async function GET(
       index_price: sanitizePrice(data.index_price),
     };
 
-    return NextResponse.json({ market: sanitized });
+    return NextResponse.json({ market: sanitized }, { headers: MARKETS_CACHE_HEADERS });
   } catch (error) {
     Sentry.captureException(error, {
       tags: { endpoint: "/api/markets/[slab]", method: "GET", slab },
     });
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }


### PR DESCRIPTION
﻿## Summary
`GET /api/markets` already returns `Cache-Control: public, s-maxage=10, stale-while-revalidate=30` on success. `GET /api/markets/[slab]` had no explicit cache header on 200 responses.

Add the same directive **only for successful** `{ market: ... }` responses. Error responses (400 from `validateSlabParam`, 404, 500) are unchanged so CDNs are less likely to cache transient failures.

## Rationale
Keeps list and detail market reads consistent for edge caching behavior without changing response bodies or query logic.
