### PR TITLE
fix: validate markets/[slab]/trades limit (1-200) and document proxies

### DIFF
--- a/app/app/api/markets/[slab]/prices/route.ts
+++ b/app/app/api/markets/[slab]/prices/route.ts
@@ -9,8 +9,10 @@ export const dynamic = "force-dynamic";
  *
  * Proxies to percolator-api GET /markets/:slab/prices
  * Removed standalone Supabase impl (GH#1066 — arch cleanup).
- * 
- * MEDIUM-003: Added slab parameter validation.
+ *
+ * **Slab:** `validateSlabParam` (base58 pubkey) — path segment only; no SQL in this layer.
+ * Query string is forwarded unchanged. **Ordering**, resolution, and row caps are enforced in
+ * percolator-api `routes/prices.ts` (see repo README “Price history for charting”).
  */
 export async function GET(
   req: NextRequest,

--- a/app/app/api/markets/[slab]/trades/route.ts
+++ b/app/app/api/markets/[slab]/trades/route.ts
@@ -1,16 +1,22 @@
 import { type NextRequest } from "next/server";
 import { proxyToApi } from "@/lib/api-proxy";
-import { validateSlabParam } from "@/lib/route-validators";
+import { validateNumericParam, validateSlabParam } from "@/lib/route-validators";
 
 export const dynamic = "force-dynamic";
+
+/** Matches percolator-api / README contract for GET /markets/:slab/trades */
+const TRADES_LIMIT_MAX = 200;
 
 /**
  * GET /api/markets/[slab]/trades
  *
  * Proxies to percolator-api GET /markets/:slab/trades
  * Removed standalone Supabase impl (GH#1066 — arch cleanup).
- * 
- * MEDIUM-003: Added slab parameter validation.
+ *
+ * **Slab:** `validateSlabParam` (base58 pubkey) — not concatenated into raw SQL here.
+ * **`limit`:** optional query, integers **1–200**; invalid → 400. Other query
+ * keys forwarded unchanged. **Ordering** (e.g. newest first) is defined upstream in
+ * `routes/trades.ts`.
  */
 export async function GET(
   req: NextRequest,
@@ -25,5 +31,17 @@ export async function GET(
   }
   const validSlab = validation.slab;
 
-  return proxyToApi(req, `/markets/${validSlab}/trades`);
+  const qs = new URLSearchParams(req.nextUrl.searchParams);
+  const limitRaw = qs.get("limit");
+  if (limitRaw !== null) {
+    const lim = validateNumericParam(limitRaw, { min: 1, max: TRADES_LIMIT_MAX });
+    if (!lim.valid) {
+      return lim.response;
+    }
+    qs.set("limit", String(lim.value));
+  }
+
+  return proxyToApi(req, `/markets/${validSlab}/trades`, undefined, {
+    queryString: qs.toString(),
+  });
 }

--- a/app/lib/api-proxy.ts
+++ b/app/lib/api-proxy.ts
@@ -28,6 +28,11 @@ export interface ProxyOptions {
    * When omitted, the upstream Cache-Control is forwarded (or "no-store" as default).
    */
   cacheControl?: string;
+  /**
+   * Use this query string instead of `req.nextUrl` (e.g. after validating `limit`).
+   * Empty string means no query segment. When omitted, the incoming URL's search is forwarded.
+   */
+  queryString?: string;
 }
 
 /**
@@ -54,10 +59,12 @@ export async function proxyToApi(
     );
   }
 
-  // Forward query string from original request
-  const searchParams = req.nextUrl.searchParams.toString();
-  const targetUrl = searchParams
-    ? `${backendUrl}${apiPath}?${searchParams}`
+  const forwardQs =
+    options?.queryString !== undefined
+      ? options.queryString
+      : req.nextUrl.searchParams.toString();
+  const targetUrl = forwardQs
+    ? `${backendUrl}${apiPath}?${forwardQs}`
     : `${backendUrl}${apiPath}`;
 
   // Optionally read and forward the request body for mutation methods


### PR DESCRIPTION
﻿## Summary
Prompt 19 review: **`GET /api/markets/[slab]/trades`** and **`/prices`** are thin proxies to percolator-api (no SQL here). Slab is validated with **`validateSlabParam`** before use in the path.

## Changes
- **`limit`** on trades: validate as integer **1–200** (matches README / API contract for recent trades). Bad values return **400** instead of forwarding garbage upstream.
- **`proxyToApi`**: optional **`queryString`** so routes can forward a normalized query after validation.
- **JSDoc**: document that ordering and full row caps live in **`routes/trades.ts`** / **`routes/prices.ts`**; clarify no SQL injection surface in the Next layer (parameterized queries are on the API service).

## Note
**`/prices`** has no `limit` in current app callers; query string is still forwarded as before for future/edge use.
