### PR TITLE
fix: protect GET /api/applications with admin session

### DIFF
--- a/app/app/api/admin/bugs/route.ts
+++ b/app/app/api/admin/bugs/route.ts
@@ -19,58 +19,16 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { createServerClient } from "@supabase/ssr";
 import { getServiceClient } from "@/lib/supabase";
-import { cookies } from "next/headers";
+import { requireAdminSession } from "@/lib/admin-session";
 
 export const dynamic = "force-dynamic";
 
-async function getSessionUser(req: NextRequest) {
-  const cookieStore = await cookies();
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        getAll() {
-          return cookieStore.getAll();
-        },
-        setAll(cookiesToSet) {
-          // read-only in Route Handlers — no-op
-        },
-      },
-    },
-  );
+export async function GET() {
+  const auth = await requireAdminSession();
+  if (!auth.ok) return auth.response;
 
-  const {
-    data: { user },
-    error,
-  } = await supabase.auth.getUser();
-  if (error || !user) return null;
-  return user;
-}
-
-export async function GET(req: NextRequest) {
-  // 1. Verify session
-  const user = await getSessionUser(req);
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  // 2. Verify admin
-  if (!user.email) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
   const sb = getServiceClient();
-  const { data: adminRow } = await (sb as any)
-    .from("admin_users")
-    .select("id")
-    .eq("email", user.email)
-    .maybeSingle();
-
-  if (!adminRow) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
 
   // 3. Fetch all bug_reports columns using service role (bypasses column GRANT restrictions)
   const { data, error: fetchError } = await (sb as any)
@@ -88,26 +46,10 @@ export async function GET(req: NextRequest) {
 }
 
 export async function PATCH(req: NextRequest) {
-  // 1. Verify session
-  const user = await getSessionUser(req);
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const auth = await requireAdminSession();
+  if (!auth.ok) return auth.response;
 
-  // 2. Verify admin
-  if (!user.email) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
   const sb = getServiceClient();
-  const { data: adminRow } = await (sb as any)
-    .from("admin_users")
-    .select("id")
-    .eq("email", user.email)
-    .maybeSingle();
-
-  if (!adminRow) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
 
   // 3. Parse body
   const body = await req.json().catch(() => null);

--- a/app/app/api/applications/route.ts
+++ b/app/app/api/applications/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServiceClient } from "@/lib/supabase";
-import { requireAuth, UNAUTHORIZED } from "@/lib/api-auth";
+import { requireAdminSession } from "@/lib/admin-session";
 
 export const dynamic = 'force-dynamic';
 
@@ -24,8 +24,13 @@ function sanitize(str: string): string {
 
 const TABLE = "job_applications";
 
-export async function GET(req: NextRequest) {
-  if (!requireAuth(req)) return UNAUTHORIZED;
+/**
+ * Lists job applications (full PII). **Auth:** Supabase session + `admin_users` row
+ * (same model as `GET /api/admin/bugs`). Not gated by `INDEXER_API_KEY`.
+ */
+export async function GET() {
+  const auth = await requireAdminSession();
+  if (!auth.ok) return auth.response;
 
   try {
     const sb = getServiceClient();

--- a/app/lib/admin-session.ts
+++ b/app/lib/admin-session.ts
@@ -1,0 +1,65 @@
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+import type { User } from "@supabase/supabase-js";
+import { NextResponse } from "next/server";
+import { getServiceClient } from "@/lib/supabase";
+
+export type AdminSessionResult =
+  | { ok: true; user: User }
+  | { ok: false; response: NextResponse };
+
+/**
+ * Verify Supabase Auth session (cookies) and membership in `admin_users`.
+ * For Route Handlers that return PII using `getServiceClient()`.
+ */
+export async function requireAdminSession(): Promise<AdminSessionResult> {
+  const cookieStore = await cookies();
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll() {
+          /* read-only in Route Handlers */
+        },
+      },
+    },
+  );
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+  if (error || !user) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    };
+  }
+  if (!user.email) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    };
+  }
+
+  const sb = getServiceClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: adminRow } = await (sb as any)
+    .from("admin_users")
+    .select("id")
+    .eq("email", user.email)
+    .maybeSingle();
+
+  if (!adminRow) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    };
+  }
+
+  return { ok: true, user };
+}


### PR DESCRIPTION
﻿## Summary
`GET /api/applications` returned full job-application PII (email, CV metadata, etc.) when the caller presented `x-api-key` matching `INDEXER_API_KEY` (`requireAuth`). That key is intended for indexer/automation use, not for HR/admin PII access, and is a broader blast radius than an explicit admin login.

## Changes
- Add `lib/admin-session.ts` with `requireAdminSession()`: Supabase Auth cookie + `admin_users` membership.
- `GET /api/applications` now uses that helper (same trust model as `GET/PATCH /api/admin/bugs`).
- Refactor `admin/bugs` to call the shared helper (no behavior change for bug admin routes).

## Migration / ops
- Any workflow that listed applications with only `INDEXER_API_KEY` must sign in as a user whose email is in `admin_users` and use the session cookie (e.g. browser or cookie-aware client). Public `POST /api/applications` is unchanged.
