### PR TITLE
fix: trim INDEXER_API_KEY and clamp markets trades limit

### DIFF
--- a/app/app/api/markets/[slab]/trades/route.ts
+++ b/app/app/api/markets/[slab]/trades/route.ts
@@ -1,15 +1,20 @@
 import { type NextRequest } from "next/server";
 import { proxyToApi } from "@/lib/api-proxy";
-import { validateSlabParam } from "@/lib/route-validators";
+import { validateNumericParam, validateSlabParam } from "@/lib/route-validators";
 
 export const dynamic = "force-dynamic";
+
+/** README / percolator-api contract: GET /markets/:slab/trades */
+const TRADES_LIMIT_MAX = 200;
 
 /**
  * GET /api/markets/[slab]/trades
  *
  * Proxies to percolator-api GET /markets/:slab/trades
  * Removed standalone Supabase impl (GH#1066 — arch cleanup).
- * 
+ *
+ * **limit** query: optional, integers **1–200**; other params forwarded unchanged.
+ *
  * MEDIUM-003: Added slab parameter validation.
  */
 export async function GET(
@@ -25,5 +30,17 @@ export async function GET(
   }
   const validSlab = validation.slab;
 
-  return proxyToApi(req, `/markets/${validSlab}/trades`);
+  const qs = new URLSearchParams(req.nextUrl.searchParams);
+  const limitRaw = qs.get("limit");
+  if (limitRaw !== null) {
+    const lim = validateNumericParam(limitRaw, { min: 1, max: TRADES_LIMIT_MAX });
+    if (!lim.valid) {
+      return lim.response;
+    }
+    qs.set("limit", String(lim.value));
+  }
+
+  return proxyToApi(req, `/markets/${validSlab}/trades`, undefined, {
+    queryString: qs.toString(),
+  });
 }

--- a/app/lib/api-auth.ts
+++ b/app/lib/api-auth.ts
@@ -8,9 +8,11 @@ import { NextRequest, NextResponse } from "next/server";
  * R2-S9: In production without a configured key, rejects all requests.
  */
 export function requireAuth(req: NextRequest): boolean {
-  const expectedKey = process.env.INDEXER_API_KEY;
+  const raw = process.env.INDEXER_API_KEY;
+  const expectedKey = typeof raw === "string" ? raw.trim() : "";
   if (!expectedKey) {
     // R2-S9: In production, reject all requests if auth key is not configured
+    // Whitespace-only env counts as unset — avoids accidental "configured" state.
     if (process.env.NODE_ENV === "production") return false;
     return true; // No key configured = open (dev mode only)
   }

--- a/app/lib/api-proxy.ts
+++ b/app/lib/api-proxy.ts
@@ -28,6 +28,11 @@ export interface ProxyOptions {
    * When omitted, the upstream Cache-Control is forwarded (or "no-store" as default).
    */
   cacheControl?: string;
+  /**
+   * Replace the forwarded query string (e.g. after validating `limit`).
+   * Empty string means no query segment. When omitted, the request URL search is used.
+   */
+  queryString?: string;
 }
 
 /**
@@ -54,10 +59,12 @@ export async function proxyToApi(
     );
   }
 
-  // Forward query string from original request
-  const searchParams = req.nextUrl.searchParams.toString();
-  const targetUrl = searchParams
-    ? `${backendUrl}${apiPath}?${searchParams}`
+  const forwardQs =
+    options?.queryString !== undefined
+      ? options.queryString
+      : req.nextUrl.searchParams.toString();
+  const targetUrl = forwardQs
+    ? `${backendUrl}${apiPath}?${forwardQs}`
     : `${backendUrl}${apiPath}`;
 
   // Optionally read and forward the request body for mutation methods


### PR DESCRIPTION
﻿## Summary
- **`INDEXER_API_KEY`:** Trim the env value before use. Whitespace-only is treated as unset: production keeps fail-closed behavior (`requireAuth` false), avoiding a fake sense that an indexer key is configured.
- **Markets trades proxy:** Validate optional **`limit`** query as an integer **1–200** (README / API contract) at the Next edge; reject garbage with **400** instead of forwarding to Railway.
- **`proxyToApi`:** Optional **`queryString`** so routes can forward a normalized query after validation.

## Notes
- Hash comparison for `x-api-key` is unchanged (SHA-256 + `timingSafeEqual`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved authentication reliability by properly normalizing environment variable handling, treating whitespace-only keys as unset.

* **New Features**
  * Trade endpoint queries now support a validated limit parameter (1–200 results) for controlled result fetching.

* **Improvements**
  * Enhanced API request proxy with more flexible query parameter forwarding capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->