### PR TITLE
fix: trim INDEXER_API_KEY whitespace in requireAuth (PERC-8244)

### DIFF
--- a/app/lib/api-auth.ts
+++ b/app/lib/api-auth.ts
@@ -8,7 +8,7 @@ import { NextRequest, NextResponse } from "next/server";
  * R2-S9: In production without a configured key, rejects all requests.
  */
 export function requireAuth(req: NextRequest): boolean {
-  const expectedKey = process.env.INDEXER_API_KEY;
+  const expectedKey = process.env.INDEXER_API_KEY?.trim() || undefined;
   if (!expectedKey) {
     // R2-S9: In production, reject all requests if auth key is not configured
     if (process.env.NODE_ENV === "production") return false;


### PR DESCRIPTION
## Summary
Cherry-pick of the unique change from PR#1891.

PR#1891 conflicted on merge because it shared `trades/route.ts` and `api-proxy.ts` changes with PR#1888 (merged first per QA order). The unique contribution — trimming `INDEXER_API_KEY` — is extracted here.

## Change
- `app/lib/api-auth.ts`: `process.env.INDEXER_API_KEY?.trim() || undefined`
- Whitespace-only key → treated as unset → fail-closed in prod (same pattern as ADMIN_API_SECRET, KEEPER_REGISTER_SECRET)

## Review
- Security APPROVED #1891 ✅ (covers this change explicitly)
- QA APPROVED #1891 ✅ (covers this change explicitly)

Closes: #1891 (superseded — unique change extracted here)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key validation to properly handle whitespace in configuration, ensuring authentication behaves correctly when keys contain leading or trailing spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->