### PR TITLE
fix: CodeRabbit nitpicks from #1888/#1889 — queryString normalize + u64 bound + test cleanup

### DIFF
--- a/app/__tests__/api/oracle-set-price-cap.test.ts
+++ b/app/__tests__/api/oracle-set-price-cap.test.ts
@@ -65,6 +65,7 @@ beforeEach(() => {
 afterEach(() => {
   delete process.env.ADMIN_API_SECRET;
   delete process.env.CRANK_KEYPAIR;
+  delete process.env.NEXT_PUBLIC_SOLANA_RPC_URL;
 });
 
 describe("POST /api/oracle/set-price-cap", () => {

--- a/app/app/api/oracle/set-price-cap/route.ts
+++ b/app/app/api/oracle/set-price-cap/route.ts
@@ -100,7 +100,14 @@ export async function POST(req: NextRequest) {
       }
       maxChangeE2bps = BigInt(raw);
     } else if (typeof raw === "string" && /^\d+$/.test(raw)) {
-      maxChangeE2bps = BigInt(raw);
+      const parsed = BigInt(raw);
+      if (parsed > 0xffff_ffff_ffff_ffffn) {
+        return NextResponse.json(
+          { error: "maxChangeE2bps exceeds u64 max" },
+          { status: 400 },
+        );
+      }
+      maxChangeE2bps = parsed;
     } else {
       return NextResponse.json(
         { error: "maxChangeE2bps must be a non-negative integer" },

--- a/app/lib/api-proxy.ts
+++ b/app/lib/api-proxy.ts
@@ -61,7 +61,7 @@ export async function proxyToApi(
 
   const forwardQs =
     options?.queryString !== undefined
-      ? options.queryString
+      ? options.queryString.replace(/^\?+/, "")
       : req.nextUrl.searchParams.toString();
   const targetUrl = forwardQs
     ? `${backendUrl}${apiPath}?${forwardQs}`


### PR DESCRIPTION
## Summary
Addresses CodeRabbit nitpick comments from the recently merged PR batch.

## Changes

**api-proxy.ts** (from #1888/#1891 nitpick):
- Strip leading `?` from `queryString` option → prevents malformed `??foo=bar` URLs if callers accidentally include it

**oracle/set-price-cap/route.ts** (from #1889 nitpick):
- Reject `maxChangeE2bps` > `u64::MAX` with a clear 400 error instead of letting `encU64` throw an opaque SDK error
- Pattern: `if (parsed > 0xffff_ffff_ffff_ffffn) → 400`

**oracle-set-price-cap.test.ts** (from #1889 nitpick):
- Clean `NEXT_PUBLIC_SOLANA_RPC_URL` in `afterEach` for better test isolation

## Risk
Low — all changes are validation/normalization only, no auth or logic changes.