### PR TITLE
fix(db): restrict ideas UPDATE RLS to service_role

### DIFF
--- a/supabase/migrations/20260330120000_ideas_update_rls_service_role.sql
+++ b/supabase/migrations/20260330120000_ideas_update_rls_service_role.sql
@@ -1,0 +1,20 @@
+-- Migration: Restrict ideas UPDATE to service_role (parity with job_applications in 044).
+--
+-- Problem (Prompt 81 / GH follow-up):
+--   Migration 019 defines "Service can update ideas" as
+--     FOR UPDATE USING (true)
+--   with no TO clause — PostgreSQL applies that to PUBLIC, so any role that holds
+--   UPDATE on public.ideas could pass RLS. PostgREST + a permissive table GRANT
+--   would allow mass updates from the anon/authenticated key.
+--
+-- Fix:
+--   Same pattern as 044 "Service can update applications" — recreate policy with
+--   TO service_role only. Backend routes use getServiceClient() (service_role),
+--   which bypasses RLS; this closes the policy surface for other roles.
+
+DROP POLICY IF EXISTS "Service can update ideas" ON ideas;
+
+CREATE POLICY "Service can update ideas"
+  ON ideas FOR UPDATE
+  TO service_role
+  USING (true);


### PR DESCRIPTION
## Summary
Aligns \ideas\ table UPDATE policy with \job_applications\ (already fixed in \

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined database security permissions to ensure proper access control for the ideas feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->