### PR TITLE
fix: PublicKey-validate mint before DexScreener pool search

### DIFF
--- a/app/hooks/useDexPoolSearch.ts
+++ b/app/hooks/useDexPoolSearch.ts
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useState, useRef } from "react";
+import { PublicKey } from "@solana/web3.js";
+import { SUPPORTED_DEX_IDS } from "@/lib/dex-constants";
 
 export interface DexPoolResult {
   poolAddress: string;
@@ -10,11 +12,21 @@ export interface DexPoolResult {
   priceUsd: number;
 }
 
-import { SUPPORTED_DEX_IDS } from "@/lib/dex-constants";
+function isValidSolanaMint(mint: string): boolean {
+  try {
+    new PublicKey(mint);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Search DexScreener for DEX pools containing a given token mint.
  * Filters to supported DEXes (PumpSwap, Raydium, Meteora) and sorts by liquidity.
+ *
+ * Mint must be a valid Solana address before any browser fetch — avoids noisy calls
+ * and leaking malformed input to a third-party API (Prompt 87).
  */
 export function useDexPoolSearch(mint: string | null) {
   const [pools, setPools] = useState<DexPoolResult[]>([]);
@@ -23,7 +35,8 @@ export function useDexPoolSearch(mint: string | null) {
 
   useEffect(() => {
     setPools([]);
-    if (!mint || mint.length < 32) return;
+    const trimmed = mint?.trim() ?? "";
+    if (!trimmed || !isValidSolanaMint(trimmed)) return;
 
     abortRef.current?.abort();
     const controller = new AbortController();
@@ -33,7 +46,7 @@ export function useDexPoolSearch(mint: string | null) {
 
     (async () => {
       try {
-        const url = `https://api.dexscreener.com/latest/dex/tokens/${mint}`;
+        const url = `https://api.dexscreener.com/latest/dex/tokens/${trimmed}`;
         const resp = await fetch(url, {
           signal: controller.signal,
           headers: { "User-Agent": "percolator-app/1.0" },


### PR DESCRIPTION
## Why
\useDexPoolSearch\ only checked \mint.length < 32\, so malformed base58 could still trigger a browser fetch to DexScreener (noise + pointless third-party traffic).

## What
- Trim mint and require \
ew PublicKey(mint)\ to succeed before fetching.
- Document in hook (Prompt 87).

## Risk
Low — invalid mints now skip fetch; valid mints unchanged.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of Solana mint addresses in pool search functionality to prevent network requests with invalid inputs and improve search reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->