### PR TITLE
fix(chart): oracle price history seconds vs milliseconds

### DIFF
--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -36,6 +36,12 @@ const TIMEFRAME_MS: Record<Timeframe, number> = {
 
 const CANDLE_INTERVAL_MS = 5 * 60 * 1000;
 
+/** Oracle price history uses unix seconds; external chart candles use ms (Prompt 89). */
+function pricePointTimestampToMs(t: number): number {
+  if (!Number.isFinite(t) || t <= 0) return Date.now();
+  return t < 100_000_000_000 ? t * 1000 : t;
+}
+
 // PERC-8090: removed 7d/30d from TIMEFRAMES — too exotic for a perps UI
 const VISIBLE_TIMEFRAMES: Timeframe[] = ["1m", "5m", "15m", "1h", "4h", "1d"];
 
@@ -126,7 +132,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
       .then((r) => r.json())
       .then((d) => {
         const apiPrices = (d.prices ?? []).map((p: { price_e6: string; timestamp: number }) => ({
-          timestamp: p.timestamp,
+          timestamp: pricePointTimestampToMs(p.timestamp),
           price: parseInt(p.price_e6) / 1e6,
         }));
         setOraclePrices(apiPrices);


### PR DESCRIPTION
## Why (Prompt 89)
Oracle rows and \/api/prices/[slab]\ treat \	imestamp\ as **unix seconds**. \TradingChart\ compared those values to \Date.now()\ (ms) for timeframe filtering, and passed them to lightweight-charts as \	ime = floor(ts/1000)\, which is wrong when \	s\ is already seconds (dates near 1970 / empty windows).

External Gecko candles already use **ms** per \/api/chart\ types.

## What
Normalize oracle history points: values \< 1e11\ are treated as seconds and multiplied by 1000 so internal \PricePoint\s stay in ms, matching \Date.now()\ live ticks.

## Risk
If a future API ever sends ms-scale timestamps (\>= 1e11\ ms), they pass through unchanged.


Made with [Cursor](https://cursor.com)