### PR TITLE
fix(security): magic-byte verify market/token logo uploads

### DIFF
--- a/app/__tests__/unit/raster-image-bytes.test.ts
+++ b/app/__tests__/unit/raster-image-bytes.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { Buffer } from "node:buffer";
+import { detectRasterImage } from "@/lib/raster-image-bytes";
+
+describe("detectRasterImage", () => {
+  it("detects PNG signature", () => {
+    const buf = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0]);
+    expect(detectRasterImage(buf)).toEqual({ ext: "png", contentType: "image/png" });
+  });
+
+  it("detects JPEG signature", () => {
+    const buf = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    expect(detectRasterImage(buf)).toEqual({ ext: "jpg", contentType: "image/jpeg" });
+  });
+
+  it("detects WebP (RIFF…WEBP)", () => {
+    const buf = Buffer.alloc(12);
+    buf.write("RIFF", 0, "ascii");
+    buf.write("WEBP", 8, "ascii");
+    expect(detectRasterImage(buf)).toEqual({ ext: "webp", contentType: "image/webp" });
+  });
+
+  it("rejects random bytes", () => {
+    expect(detectRasterImage(Buffer.from("not an image"))).toBeNull();
+  });
+
+  it("rejects too-short buffer", () => {
+    expect(detectRasterImage(Buffer.from([0xff, 0xd8]))).toBeNull();
+  });
+});

--- a/app/app/api/markets/[slab]/logo/route.ts
+++ b/app/app/api/markets/[slab]/logo/route.ts
@@ -1,8 +1,10 @@
+import { Buffer } from "node:buffer";
 import { NextRequest, NextResponse } from "next/server";
 import { getServiceClient } from "@/lib/supabase";
 import { PublicKey } from "@solana/web3.js";
 import { validateSlabParam } from "@/lib/route-validators";
 import { requireAuth, UNAUTHORIZED } from "@/lib/api-auth";
+import { detectRasterImage } from "@/lib/raster-image-bytes";
 
 export const dynamic = "force-dynamic";
 
@@ -22,7 +24,7 @@ export async function GET(
   if (!validation.valid) {
     return validation.response;
   }
-  const validSlab = validation.slab;
+  const validSlab = new PublicKey(validation.slab).toBase58();
 
   const supabase = getServiceClient();
   const { data, error } = await supabase
@@ -54,7 +56,7 @@ export async function POST(
   if (!validation.valid) {
     return validation.response;
   }
-  const validSlab = validation.slab;
+  const validSlab = new PublicKey(validation.slab).toBase58();
 
   // Rate limit
   const lastUpload = uploadTimestamps.get(validSlab) ?? 0;
@@ -69,9 +71,9 @@ export async function POST(
     return NextResponse.json({ error: "No file provided. Use 'logo' field." }, { status: 400 });
   }
 
-  // Only allow safe raster formats — NO SVG (XSS vector)
-  const allowedTypes = ["image/png", "image/jpeg", "image/webp", "image/gif"];
-  if (!allowedTypes.includes(file.type)) {
+  // Reject declared non-raster types early (SVG, etc.); real format verified by magic bytes below.
+  const allowedTypes = ["image/png", "image/jpeg", "image/webp", "image/gif", "image/jpg", ""];
+  if (file.type && !allowedTypes.includes(file.type)) {
     return NextResponse.json(
       { error: `Invalid file type. Allowed: PNG, JPEG, WebP, GIF` },
       { status: 400 }
@@ -89,7 +91,7 @@ export async function POST(
   const { data: market, error: marketError } = await supabase
     .from("markets")
     .select("slab_address")
-    .eq("slab_address", slab)
+    .eq("slab_address", validSlab)
     .single();
 
   if (marketError || !market) {
@@ -97,15 +99,21 @@ export async function POST(
   }
 
   try {
-    const ext = file.type === "image/png" ? "png" : file.type === "image/webp" ? "webp" : file.type === "image/gif" ? "gif" : "jpg";
-    const filePath = `market-logos/${slab}.${ext}`;
-
     const arrayBuffer = await file.arrayBuffer();
     const buffer = Buffer.from(arrayBuffer);
+    const detected = detectRasterImage(buffer);
+    if (!detected) {
+      return NextResponse.json(
+        { error: "Invalid image file. Upload a valid PNG, JPEG, WebP, or GIF (contents do not match)." },
+        { status: 400 }
+      );
+    }
+
+    const filePath = `market-logos/${validSlab}.${detected.ext}`;
 
     const { error: uploadError } = await supabase.storage
       .from("logos")
-      .upload(filePath, buffer, { contentType: file.type, upsert: true });
+      .upload(filePath, buffer, { contentType: detected.contentType, upsert: true });
 
     if (uploadError) {
       console.error("Storage upload error:", uploadError);
@@ -118,14 +126,14 @@ export async function POST(
     const { error: updateError } = await supabase
       .from("markets")
       .update({ logo_url: publicUrl })
-      .eq("slab_address", slab);
+      .eq("slab_address", validSlab);
 
     if (updateError) {
       console.error("DB update error:", updateError);
       return NextResponse.json({ error: `DB update failed: ${updateError.message}` }, { status: 500 });
     }
 
-    uploadTimestamps.set(slab, Date.now());
+    uploadTimestamps.set(validSlab, Date.now());
 
     return NextResponse.json({ logo_url: publicUrl }, { status: 200 });
   } catch (error) {

--- a/app/app/api/tokens/[mint]/logo/route.ts
+++ b/app/app/api/tokens/[mint]/logo/route.ts
@@ -1,7 +1,9 @@
+import { Buffer } from "node:buffer";
 import { NextRequest, NextResponse } from "next/server";
 import { getServiceClient } from "@/lib/supabase";
 import { PublicKey } from "@solana/web3.js";
 import { requireAuth, UNAUTHORIZED } from "@/lib/api-auth";
+import { detectRasterImage } from "@/lib/raster-image-bytes";
 
 export const dynamic = "force-dynamic";
 
@@ -15,8 +17,9 @@ export async function GET(
 ) {
   const { mint } = await params;
 
+  let canonicalMint: string;
   try {
-    new PublicKey(mint);
+    canonicalMint = new PublicKey(mint).toBase58();
   } catch {
     return NextResponse.json({ error: "Invalid mint address" }, { status: 400 });
   }
@@ -26,11 +29,11 @@ export async function GET(
   // Check all possible extensions
   const extensions = ["png", "jpg", "webp", "gif"];
   for (const ext of extensions) {
-    const filePath = `token-logos/${mint}.${ext}`;
+    const filePath = `token-logos/${canonicalMint}.${ext}`;
     const { data } = supabase.storage.from("logos").getPublicUrl(filePath);
     // Try a HEAD-like check by listing
     const { data: files } = await supabase.storage.from("logos").list("token-logos", {
-      search: `${mint}.${ext}`,
+      search: `${canonicalMint}.${ext}`,
       limit: 1,
     });
     if (files && files.length > 0) {
@@ -52,14 +55,15 @@ export async function POST(
 
   const { mint } = await params;
 
+  let canonicalMint: string;
   try {
-    new PublicKey(mint);
+    canonicalMint = new PublicKey(mint).toBase58();
   } catch {
     return NextResponse.json({ error: "Invalid mint address" }, { status: 400 });
   }
 
   // Rate limit
-  const lastUpload = uploadTimestamps.get(mint) ?? 0;
+  const lastUpload = uploadTimestamps.get(canonicalMint) ?? 0;
   if (Date.now() - lastUpload < RATE_LIMIT_MS) {
     return NextResponse.json({ error: "Rate limited. Try again in 30s." }, { status: 429 });
   }
@@ -71,8 +75,8 @@ export async function POST(
     return NextResponse.json({ error: "No file provided. Use 'logo' field." }, { status: 400 });
   }
 
-  const allowedTypes = ["image/png", "image/jpeg", "image/webp", "image/gif"];
-  if (!allowedTypes.includes(file.type)) {
+  const allowedTypes = ["image/png", "image/jpeg", "image/webp", "image/gif", "image/jpg", ""];
+  if (file.type && !allowedTypes.includes(file.type)) {
     return NextResponse.json({ error: "Invalid file type. Allowed: PNG, JPEG, WebP, GIF" }, { status: 400 });
   }
 
@@ -83,15 +87,21 @@ export async function POST(
   const supabase = getServiceClient();
 
   try {
-    const ext = file.type === "image/png" ? "png" : file.type === "image/webp" ? "webp" : file.type === "image/gif" ? "gif" : "jpg";
-    const filePath = `token-logos/${mint}.${ext}`;
-
     const arrayBuffer = await file.arrayBuffer();
     const buffer = Buffer.from(arrayBuffer);
+    const detected = detectRasterImage(buffer);
+    if (!detected) {
+      return NextResponse.json(
+        { error: "Invalid image file. Upload a valid PNG, JPEG, WebP, or GIF (contents do not match)." },
+        { status: 400 }
+      );
+    }
+
+    const filePath = `token-logos/${canonicalMint}.${detected.ext}`;
 
     const { error: uploadError } = await supabase.storage
       .from("logos")
-      .upload(filePath, buffer, { contentType: file.type, upsert: true });
+      .upload(filePath, buffer, { contentType: detected.contentType, upsert: true });
 
     if (uploadError) {
       console.error("Storage upload error:", uploadError);
@@ -105,9 +115,9 @@ export async function POST(
     await supabase
       .from("markets")
       .update({ logo_url: publicUrl })
-      .eq("mint_address", mint);
+      .eq("mint_address", canonicalMint);
 
-    uploadTimestamps.set(mint, Date.now());
+    uploadTimestamps.set(canonicalMint, Date.now());
 
     return NextResponse.json({ logo_url: publicUrl }, { status: 200 });
   } catch (error) {

--- a/app/lib/raster-image-bytes.ts
+++ b/app/lib/raster-image-bytes.ts
@@ -1,0 +1,44 @@
+import { Buffer } from "node:buffer";
+
+/**
+ * Sniff raster image format from file contents (not Content-Type / File.type).
+ * Blocks polyglots and non-images that claim image/* (Prompt 91).
+ */
+export type RasterFormat = {
+  ext: "png" | "jpg" | "webp" | "gif";
+  contentType: "image/png" | "image/jpeg" | "image/webp" | "image/gif";
+};
+
+function hasPrefix(buf: Buffer, prefix: readonly number[], offset = 0): boolean {
+  if (buf.length < offset + prefix.length) return false;
+  for (let i = 0; i < prefix.length; i++) {
+    if (buf[offset + i] !== prefix[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * Returns detected raster format or null if bytes are not a supported image signature.
+ */
+export function detectRasterImage(buffer: Buffer): RasterFormat | null {
+  if (buffer.length < 3) return null;
+
+  if (hasPrefix(buffer, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) {
+    return { ext: "png", contentType: "image/png" };
+  }
+  if (hasPrefix(buffer, [0xff, 0xd8, 0xff])) {
+    return { ext: "jpg", contentType: "image/jpeg" };
+  }
+  if (hasPrefix(buffer, [0x47, 0x46, 0x38, 0x37, 0x61]) || hasPrefix(buffer, [0x47, 0x46, 0x38, 0x39, 0x61])) {
+    return { ext: "gif", contentType: "image/gif" };
+  }
+  if (
+    buffer.length >= 12 &&
+    buffer.subarray(0, 4).toString("ascii") === "RIFF" &&
+    buffer.subarray(8, 12).toString("ascii") === "WEBP"
+  ) {
+    return { ext: "webp", contentType: "image/webp" };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Why (Prompt 91)
Browser \File.type\ is spoofable. A non-image or SVG could claim \image/png\ and still be stored/served from the public \logos\ bucket.

## What
- New \detectRasterImage\ helper (PNG/JPEG/GIF/WebP signatures) + unit tests.
- Logo POST routes use detected MIME/extension for Storage \contentType\ and path.
- Canonical \PublicKey(...).toBase58()\ for slab/mint in paths, rate-limit keys, and DB filters.

## Notes
\LogoUpload.tsx\ already restricts picker types and size; server remains the trust boundary.


Made with [Cursor](https://cursor.com)