### PR TITLE
fix: GH#1874-1875 network-column fallback + dashboard hardcoded devnet explorer fix

### DIFF
--- a/app/components/dashboard/TradeHistory.tsx
+++ b/app/components/dashboard/TradeHistory.tsx
@@ -11,6 +11,7 @@
 
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useWalletCompat } from "@/hooks/useWalletCompat";
+import { explorerTxUrl } from "@/lib/config";
 import type { TraderTradeEntry } from "@/app/api/trader/[wallet]/trades/route";
 
 type TradeType = "all" | "long" | "short";
@@ -243,7 +244,7 @@ export function TradeHistory() {
                   <td className="px-3 py-2.5 text-center">
                     {trade.tx_signature ? (
                       <a
-                        href={`https://explorer.solana.com/tx/${trade.tx_signature}?cluster=devnet`}
+                        href={explorerTxUrl(trade.tx_signature)}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="text-[var(--text-dim)] transition-colors hover:text-[var(--accent)]"


### PR DESCRIPTION
## Summary

Two fixes in this PR:

### 1. GH#1874-1875 — Network column fallback (already committed by previous session)
When the `network` column migration (PERC-8215 / `20260329180000_add_network_column.sql`) hasn't been applied yet, `/api/stats` and `/api/trader/:wallet/trades` fall back to unfiltered queries instead of erroring. This keeps the trades panel showing data while waiting for Khubair to apply the migration.

### 2. Dashboard TradeHistory hardcoded devnet Explorer URL
`app/components/dashboard/TradeHistory.tsx` was linking to:
```
https://explorer.solana.com/tx/{sig}?cluster=devnet
```
This always appends `?cluster=devnet` — breaking on mainnet. Fixed to use `explorerTxUrl()` from `lib/config` which correctly reads `NEXT_PUBLIC_DEFAULT_NETWORK` and only appends devnet cluster param when actually on devnet.

## Root Cause (GH#1895 / trades 500)

Root cause is the missing `network` column on the `trades` Supabase table. Khubair must apply `20260329180000_add_network_column.sql` at:
https://supabase.com/dashboard/project/ygvbajglkrwkbjdjyhxi/sql/new

This PR provides a graceful UX fallback so existing users aren't blocked.

## Test

- Trades panel should show data (not crash) before AND after migration
- Dashboard explorer links should work on mainnet (no `?cluster=devnet` appended)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved transaction link generation in Trade History by adopting a centralized URL helper function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->