### PR TITLE
fix(api): ideas GET returns 503 on errors; show feed errors in UI

### DIFF
--- a/app/app/api/ideas/route.ts
+++ b/app/app/api/ideas/route.ts
@@ -33,15 +33,22 @@ export async function GET() {
       .limit(50);
 
     if (error) {
-      // Table might not exist yet
+      // Table might not exist yet — empty feed is accurate
       if (error.code === "42P01") return NextResponse.json([]);
-      throw error;
+      console.error("GET /api/ideas Supabase error:", error);
+      return NextResponse.json(
+        { error: "Ideas feed temporarily unavailable." },
+        { status: 503 },
+      );
     }
 
     return NextResponse.json(data ?? []);
   } catch (err) {
     console.error("GET /api/ideas error:", err);
-    return NextResponse.json([], { status: 200 });
+    return NextResponse.json(
+      { error: "Ideas feed temporarily unavailable." },
+      { status: 503 },
+    );
   }
 }
 

--- a/app/components/agent-hub/ConsoleLog.tsx
+++ b/app/components/agent-hub/ConsoleLog.tsx
@@ -9,10 +9,19 @@ interface Idea {
   created_at: string;
 }
 
-const fetcher = (url: string) => fetch(url).then((r) => r.json());
+async function ideasFetcher(url: string): Promise<Idea[]> {
+  const r = await fetch(url);
+  const j = await r.json();
+  if (!r.ok) {
+    const msg = typeof j?.error === "string" ? j.error : "Feed unavailable";
+    throw new Error(msg);
+  }
+  if (!Array.isArray(j)) throw new Error("Invalid feed response");
+  return j;
+}
 
 export default function ConsoleLog() {
-  const { data, isLoading } = useSWR<Idea[]>("/api/ideas", fetcher, {
+  const { data, error, isLoading } = useSWR<Idea[]>("/api/ideas", ideasFetcher, {
     refreshInterval: 5000,
   });
 
@@ -41,7 +50,12 @@ export default function ConsoleLog() {
               connecting to feed...
             </p>
           )}
-          {!isLoading && (!data || data.length === 0) && (
+          {error && (
+            <p className="text-[var(--short)] text-xs">
+              {error.message || "Feed unavailable — try again later."}
+            </p>
+          )}
+          {!isLoading && !error && (!data || data.length === 0) && (
             <p className="text-[#5a6382]">
               no activity yet — be the first to submit an idea ↓
             </p>


### PR DESCRIPTION
## Why (Prompt 92)
GET /api/ideas caught failures and returned HTTP 200 with [], so the agent hub looked empty during outages.

## What
- Return 503 with { error } for unexpected errors; keep [] only for missing table (42P01) or successful empty query.
- ConsoleLog SWR fetcher throws on non-OK; UI shows an error line instead of the empty-state copy.
