### PR TITLE
fix: lazy-resolve stake program ID — unblocks mainnet build

### DIFF
--- a/app/app/api/stake/pools/route.ts
+++ b/app/app/api/stake/pools/route.ts
@@ -157,9 +157,6 @@ export const dynamic = "force-dynamic";
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
-/** Percolator Stake program — resolved for current network via env var or network constant. */
-const STAKE_PROGRAM_ID = getStakeProgramId();
-
 /** Expected on-chain size of a StakePool account (must match Rust struct). */
 const STAKE_POOL_SIZE = 352;
 
@@ -265,10 +262,22 @@ function calcPoolValue(p: ParsedStakePool): bigint {
 
 export async function GET() {
   try {
+    // Resolve lazily inside try/catch so mainnet builds don't crash
+    // when the stake program hasn't been deployed yet.
+    let stakeProgramId: PublicKey;
+    try {
+      stakeProgramId = getStakeProgramId();
+    } catch {
+      // Stake program not available on this network — return empty pools
+      return NextResponse.json({ pools: [] }, {
+        headers: { "Cache-Control": "public, s-maxage=30, stale-while-revalidate=60" },
+      });
+    }
+
     const connection = new Connection(getRpcEndpoint(), "confirmed");
 
     // 1. Fetch all on-chain StakePool accounts
-    const rawAccounts = await connection.getProgramAccounts(STAKE_PROGRAM_ID, {
+    const rawAccounts = await connection.getProgramAccounts(stakeProgramId, {
       filters: [{ dataSize: STAKE_POOL_SIZE }],
     });
 


### PR DESCRIPTION
## Problem
Vercel production build fails during page data collection:
```
Error: Stake program not deployed on mainnet. Set STAKE_PROGRAM_ID env var...
```
`getStakeProgramId()` was called at module top-level (outside try/catch), so when `NEXT_PUBLIC_DEFAULT_NETWORK=mainnet` and no mainnet stake program exists, the build crashes.

## Fix
- Removed top-level `const STAKE_PROGRAM_ID = getStakeProgramId()`
- Moved resolution inside `GET()` handler's try/catch
- Returns `{ pools: [] }` gracefully when stake program isn't available on the current network

## Testing
- Mainnet build will pass (no more throw at page data collection)
- Devnet unchanged (stake program exists there)