### PR TITLE
docs: add CONTRIBUTING merge check guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+## Required merge checks
+
+Pull requests to `main` run two GitHub Actions workflows:
+
+| Workflow        | File                      | What it runs |
+|----------------|---------------------------|--------------|
+| **PR Check**   | `.github/workflows/pr-check.yml`  | Builds `@percolator/sdk`, shared, api, keeper, indexer, and the Next.js app. Runs package tests for shared, api, keeper, and indexer. **Does not** run the `app` Vitest suite. |
+| **Test Suite** | `.github/workflows/test.yml`      | Runs the same package tests **and** `pnpm --filter app test`, plus other jobs defined in that workflow. |
+
+Branch protection should require the **Test Suite** workflow (or its unit-test job) to pass before merging. Treating **PR Check** alone as sufficient can allow merges while frontend unit tests are failing.


### PR DESCRIPTION
Documents that PR Check does not run app Vitest; Test Suite does. Suggests requiring the Test Suite workflow in branch protection.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidelines documenting merge check requirements and continuous integration workflow specifications for pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->