### PR TITLE
ci: enforce high-severity pnpm audit with allowlist

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -273,9 +273,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # Run audit at high severity only.
-      # GHSA-3gc7-fjrx-p6mg (bigint-buffer): transitive via @solana/spl-token,
-      # no patched version exists upstream — ignored until Solana publishes a fix.
+      # Fail on high+ severity. Accepted findings are listed in root package.json
+      # pnpm.auditConfig (must match SECURITY-DEPS.md).
       - name: Build SDK package
         run: pnpm --filter @percolator/sdk build
 
@@ -283,7 +282,7 @@ jobs:
         run: pnpm --filter @percolator/shared build
 
       - name: Run security audit
-        run: pnpm audit --audit-level=high || true
+        run: pnpm audit --audit-level=high
 
       - name: Run security tests (shared)
         run: pnpm --filter @percolator/shared test

--- a/SECURITY-DEPS.md
+++ b/SECURITY-DEPS.md
@@ -1,6 +1,6 @@
 # Security Dependency Risk Register
 
-> Last updated: 2026-02-20 (PERC-038)
+> Last updated: 2026-03-29
 > Audited by: security agent
 
 ## Summary
@@ -102,11 +102,24 @@ Verified linting still passes with the override.
 - **Decision:** ACCEPT — dev-only, no production impact, no realistic exploit
   path.
 
+## CI enforcement
+
+The **Security Tests** job in `.github/workflows/test.yml` runs `pnpm audit --audit-level=high` and **fails the workflow** on any high-or-critical advisory that is not explicitly ignored.
+
+Accepted-risk items (currently **bigint-buffer** / GHSA-3gc7-fjrx-p6mg) must be mirrored in root `package.json` under `pnpm.auditConfig.ignoreGhsas` / `ignoreCves` so the audit passes while the register below stays authoritative.
+
+## In-memory rate limits (API routes)
+
+Several routes use **in-process** counters (e.g. ideas submission, mobile create-market). That is correct for a single Node instance but **does not coordinate across** multiple serverless instances or cold starts. For strict global limits, use a shared store (e.g. Redis) or an edge/WAF rate limiter; until then, treat in-memory limits as **best-effort abuse throttling**.
+
 ## Audit Commands
 
 ```bash
-# Full audit
+# Full audit (respects pnpm.auditConfig ignores)
 pnpm audit
+
+# Fail CI-equivalent check locally
+pnpm audit --audit-level=high
 
 # Check specific package
 pnpm why <package-name>

--- a/package.json
+++ b/package.json
@@ -50,6 +50,10 @@
     "pg": "^8.18.0"
   },
   "pnpm": {
+    "auditConfig": {
+      "ignoreCves": ["CVE-2025-3194"],
+      "ignoreGhsas": ["GHSA-3gc7-fjrx-p6mg"]
+    },
     "overrides": {
       "ajv": ">=6.14.0",
       "axios": ">=1.13.5",


### PR DESCRIPTION
Security Tests now fail on pnpm audit high+ findings. bigint-buffer (GHSA-3gc7-fjrx-p6mg / CVE-2025-3194) remains ignored via root package.json pnpm.auditConfig, documented in SECURITY-DEPS.md. Also documents CI behavior, in-memory rate limit caveats, and local audit command.

Made with [Cursor](https://cursor.com)