### PR TITLE
fix: markets page load errors and POST observability

### DIFF
--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -771,7 +771,7 @@ export async function POST(req: NextRequest) {
   if (mainnet_ca && process.env.KEEPER_REGISTER_SECRET) {
     try {
       const keeperRegisterUrl = `${process.env.NEXT_PUBLIC_BASE_URL ?? ""}/api/oracle-keeper/register`;
-      await fetch(keeperRegisterUrl, {
+      const res = await fetch(keeperRegisterUrl, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -779,8 +779,19 @@ export async function POST(req: NextRequest) {
         },
         body: JSON.stringify({ slabAddress: slab_address, mainnetCA: mainnet_ca }),
         signal: AbortSignal.timeout(5000),
-      }).catch(() => {});
-    } catch {
+      }).catch((e: unknown) => {
+        console.warn("[api/markets POST] keeper hot-register fetch failed", e);
+        return null;
+      });
+      if (res && !res.ok) {
+        console.warn(
+          "[api/markets POST] keeper hot-register non-OK",
+          res.status,
+          await res.text().catch(() => ""),
+        );
+      }
+    } catch (e) {
+      console.warn("[api/markets POST] keeper hot-register failed", e);
       // Non-fatal — oracle keeper will discover via Supabase polling
     }
   }
@@ -806,7 +817,8 @@ export async function POST(req: NextRequest) {
         },
         { onConflict: "mainnet_ca", ignoreDuplicates: true },
       );
-    } catch {
+    } catch (e) {
+      console.warn("[api/markets POST] devnet_mints upsert failed", e);
       // Non-fatal — devnet-airdrop has fallback via markets table
     }
   }

--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -109,8 +109,13 @@ function MarketsPageInner() {
   }, []);
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { markets: discovered, loading: discoveryLoading } = useMarketDiscovery();
-  const { statsMap, loading: statsLoading } = useAllMarketStats();
+  const { markets: discovered, loading: discoveryLoading, error: discoveryError } = useMarketDiscovery();
+  const { statsMap, loading: statsLoading, error: statsError } = useAllMarketStats();
+
+  const loadErrorMessage = useMemo(() => {
+    const parts = [discoveryError, statsError].filter(Boolean) as string[];
+    return parts.length ? parts.join(" · ") : null;
+  }, [discoveryError, statsError]);
 
   // NOTE: totalActiveMarkets (Supabase-only count) removed — was inconsistent with
   // activeMarkets.length which includes on-chain discovered markets (#847).
@@ -504,6 +509,7 @@ function MarketsPageInner() {
 
   const displayedMarkets = filtered.slice(0, displayCount);
   const loading = discoveryLoading || statsLoading;
+  const showDegradedBanner = Boolean(loadErrorMessage && !loading && filtered.length > 0);
 
   // P-MED-4: Separate clear functions
   const clearFilters = () => {
@@ -721,6 +727,22 @@ function MarketsPageInner() {
           </div>
         </ScrollReveal>
 
+        {showDegradedBanner && (
+          <ScrollReveal delay={0.15}>
+            <div
+              role="alert"
+              className="mb-4 rounded-sm border px-4 py-3 text-center text-sm font-mono"
+              style={{
+                background: "rgba(239,68,68,0.06)",
+                borderColor: "rgba(239,68,68,0.3)",
+                color: "#f87171",
+              }}
+            >
+              Partial market data: {loadErrorMessage}
+            </div>
+          </ScrollReveal>
+        )}
+
         {/* Table */}
         <ErrorBoundary label="Markets Table">
           <ScrollReveal delay={0.2}>
@@ -736,6 +758,21 @@ function MarketsPageInner() {
                 <>
                   <h3 className="text-base font-semibold text-white">nothing here.</h3>
                   <p className="mt-1 text-sm text-[var(--text-secondary)]">try a different search or filter.</p>
+                </>
+              ) : loadErrorMessage ? (
+                <>
+                  <h3 className="text-base font-semibold text-white">couldn&apos;t load markets.</h3>
+                  <p className="mt-2 text-sm text-[var(--text-secondary)]">{loadErrorMessage}</p>
+                  <div className="mt-6 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+                    <GlowButton type="button" onClick={() => window.location.reload()}>
+                      reload page
+                    </GlowButton>
+                    <Link href="/create">
+                      <GlowButton variant="secondary" size="sm">
+                        launch market
+                      </GlowButton>
+                    </Link>
+                  </div>
                 </>
               ) : (
                 <>


### PR DESCRIPTION
Markets page now reads discovery and Supabase stats errors: degraded banner when some rows still render, dedicated empty state with reload when both sources fail. /api/markets POST logs keeper hot-register fetch failures and devnet_mints upsert failures instead of swallowing them silently.

Made with [Cursor](https://cursor.com)