### PR TITLE
fix(api): GH#1928 correct proxy path for /api/markets/[slab]/prices

### DIFF
--- a/app/app/api/markets/[slab]/prices/route.ts
+++ b/app/app/api/markets/[slab]/prices/route.ts
@@ -7,12 +7,14 @@ export const dynamic = "force-dynamic";
 /**
  * GET /api/markets/[slab]/prices
  *
- * Proxies to percolator-api GET /markets/:slab/prices
+ * Proxies to percolator-api GET /prices/:slab
  * Removed standalone Supabase impl (GH#1066 — arch cleanup).
+ * Fixed GH#1928: route was incorrectly proxying to /markets/:slab/prices (404→500);
+ * correct backend path is /prices/:slab (registered in priceRoutes()).
  *
  * **Slab:** `validateSlabParam` (base58 pubkey) — path segment only; no SQL in this layer.
  * Query string is forwarded unchanged. **Ordering**, resolution, and row caps are enforced in
- * percolator-api `routes/prices.ts` (see repo README “Price history for charting”).
+ * percolator-api `routes/prices.ts` (see repo README "Price history for charting").
  */
 export async function GET(
   req: NextRequest,
@@ -27,5 +29,5 @@ export async function GET(
   }
   const validSlab = validation.slab;
 
-  return proxyToApi(req, `/markets/${validSlab}/prices`);
+  return proxyToApi(req, `/prices/${validSlab}`);
 }


### PR DESCRIPTION
## Problem
The Next.js route `/api/markets/[slab]/prices` was proxying to `/markets/:slab/prices` on the backend, but percolator-api registers price history under `/prices/:slab` (via `priceRoutes()`). This caused a 404 from the backend which returned as 500 with `{"error":"Failed to fetch price history"}`.

## Root Cause
Route mismatch introduced during GH#1066 arch cleanup — the proxy path wasn't updated to match the actual backend route structure.

## Fix
One-line change: `proxyToApi(req, `/markets/${validSlab}/prices`)` → `proxyToApi(req, `/prices/${validSlab}`)`

Also updated the JSDoc comment to reflect the correct backend path.

## Testing
```bash
curl https://percolatorlaunch.com/api/markets/CixbiFBpC79Xwuq4yd7bqhyPGBHrvSi2GdqHhUPVdrKL/prices
# Expected: 200 with { prices: [...] }
```

## Impact
- Trade page price chart will load correctly
- Browser console 500 error eliminated

Closes #1928

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the API proxy endpoint for market price lookups to route requests to the proper backend service path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->