### PR TITLE
fix: trim backend URL env var to fix price charts 500 (GH#1933)

### DIFF
--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -208,7 +208,7 @@ export function getBackendUrl(): string {
       "No hardcoded fallback is provided — ensure your environment configuration is correct."
     );
   }
-  return url;
+  return url.trim();
 }
 
 /** Build an explorer URL for a transaction */


### PR DESCRIPTION
## Problem
`/api/markets/[slab]/prices` returns 500 on production. The proxy path was fixed in PR#1929, but the backend URL itself contained a trailing newline from the Vercel env var (`NEXT_PUBLIC_API_URL`), causing all fetch requests to the backend to fail.

## Fix
Add `.trim()` to `getBackendUrl()` in `app/lib/config.ts`. Other env var getters in the same file already trim — this was the only one missing.

## Testing
- Verified backend API works directly: `curl https://percolator-api-production.up.railway.app/prices/484DG...prices` → 200 with data
- Frontend proxy fails because URL has `\n` appended

Fixes GH#1933