### PR TITLE
fix(api): remove next.config.ts prices rewrite that bypassed route.ts (GH#1936)

### DIFF
--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -62,7 +62,9 @@ const nextConfig: NextConfig = {
     return [
       // Data routes → API service
       { source: "/api/markets/:slab/trades", destination: `${API_URL}/markets/:slab/trades` },
-      { source: "/api/markets/:slab/prices", destination: `${API_URL}/markets/:slab/prices` },
+      // NOTE: Do NOT rewrite /api/markets/:slab/prices — route.ts handles it (proxies to /prices/:slab).
+      // A rewrite here would bypass route.ts and hit the wrong Railway path (/markets/:slab/prices → 404→500).
+      // GH#1936 / PERC-8302 root cause fix.
       { source: "/api/markets/:slab/stats", destination: `${API_URL}/markets/:slab/stats` },
       { source: "/api/markets/:slab/volume", destination: `${API_URL}/markets/:slab/volume` },
       // NOTE: Do NOT rewrite /api/markets/:slab/logo — that stays in Next.js (file upload)


### PR DESCRIPTION
## Problem
GH#1936 / PERC-8302: All 178 market price charts returning 500.

**Root cause:** `next.config.ts` had a rewrite rule:
```
{ source: "/api/markets/:slab/prices", destination: `${API_URL}/markets/:slab/prices` }
```
This bypassed the Next.js `route.ts` entirely and sent requests directly to Railway at path `/markets/:slab/prices` — which does not exist. Railway returns 404, Next.js wraps it as 500.

## Fix
Remove the rewrite. `app/api/markets/[slab]/prices/route.ts` already exists and correctly proxies to `/prices/:slab` via `proxyToApi()`. Letting Next.js handle the route end-to-end is the right path.

## Testing
- [ ] `/api/markets/<slab>/prices` returns 200 with OHLCV data
- [ ] Price charts render on all market pages
- [ ] No regression on other `/api/markets/:slab/*` routes

## References
- Closes GH#1936
- PERC-8302
- Related: PR#1929 (fixed route.ts), PR#1935 (fixed trailing newline in API_URL)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected API route configuration to ensure proper request handling without conflicting rewrites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->