### PR TITLE
fix(PERC-8309): sanitize warmup API 500 error response (GH#1948)

### DIFF
--- a/app/app/api/warmup/[slab]/[accountIdx]/route.ts
+++ b/app/app/api/warmup/[slab]/[accountIdx]/route.ts
@@ -76,9 +76,10 @@ export async function GET(
       lockedAmount: lockedAmount.toString(),
     });
   } catch (err) {
+    // GH#1948: never expose raw error messages to callers (internal implementation details)
     console.error("[Warmup API] Error:", err);
     return NextResponse.json(
-      { error: err instanceof Error ? err.message : "Failed to fetch warmup data" },
+      { error: "Failed to fetch warmup data" },
       { status: 500 }
     );
   }


### PR DESCRIPTION
## GH#1948 — Warmup API leaks raw internal error messages

### Problem
`GET /api/warmup/[slab]/[accountIdx]` returned `err.message` directly in 500 responses. Under RPC failure/invalid data conditions this can expose internal Helius endpoint details, program error codes, and SDK internals to unauthenticated callers.

### Fix
Return a generic `"Failed to fetch warmup data"` message on 500. Full error is still logged server-side via `console.error`.

### Testing
- `pnpm tsc --noEmit` — clean ✅
- One-line change in catch block

Closes #1948