### PR TITLE
fix(PERC-8311): admin UI authority pre-flight check before privileged txs (GH#1951)

### DIFF
--- a/app/__tests__/hooks/useAdminActions.test.ts
+++ b/app/__tests__/hooks/useAdminActions.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PublicKey } from "@solana/web3.js";
+
+/**
+ * PERC-8311 — useAdminActions authority pre-flight checks.
+ *
+ * Verifies that privileged admin/oracle actions throw descriptive errors when
+ * the connected wallet does not hold the required role, preventing sign-doomed-tx UX.
+ */
+
+// ─── Minimal DiscoveredMarket mock ───────────────────────────────────────────
+
+const ADMIN_PK = new PublicKey("3BTomn4cTCcTXaGWnvTxU4ArQWq9spfSZ2KAcaXHPFX6");
+const ORACLE_PK = new PublicKey("C2okXiWSM6S68Cx1ZyRbUzF7chMG8Sixo8JfqRkyHMWz");
+const SLAB_PK = new PublicKey("27kaERB4L51djBQoQtLYURQNML5naZGaATuj2oB6kL1d");
+const PROGRAM_PK = new PublicKey("D5Fnzt2XCP7xbavWjqdRRJvGxB7uTtmzemaFX1PWnyVu");
+const COLLATERAL_PK = new PublicKey("B34xF8mQ9DQ7jHY7mZpVE6SknMw9d8SRHjrcYYfZaYPG");
+const VAULT_PK = new PublicKey("45ie9QT16AE1MekYjKu2Z2mKat6eeGqQoL96dnFmxYNP");
+const STRANGER_PK = new PublicKey("9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin");
+
+function makeMarket(adminOverride?: PublicKey, oracleOverride?: PublicKey) {
+  return {
+    slabAddress: SLAB_PK,
+    programId: PROGRAM_PK,
+    header: {
+      admin: adminOverride ?? ADMIN_PK,
+      paused: false,
+    },
+    config: {
+      oracleAuthority: oracleOverride ?? ORACLE_PK,
+      collateralMint: COLLATERAL_PK,
+      vaultPubkey: VAULT_PK,
+    },
+  } as any;
+}
+
+// ─── Import the pure helper functions directly ────────────────────────────────
+// We extract the validation logic by reading the source to confirm the functions exist
+// and test them through the hook behavior using mocking.
+
+// Mock the heavy deps so we can import the hook in a test environment
+vi.mock("@/hooks/useWalletCompat", () => ({
+  useWalletCompat: vi.fn(),
+  useConnectionCompat: vi.fn(() => ({ connection: {} })),
+}));
+vi.mock("@/lib/tx", () => ({
+  sendTx: vi.fn().mockResolvedValue({ signature: "abc123" }),
+}));
+vi.mock("@percolator/sdk", async () => {
+  const actual = await vi.importActual("@percolator/sdk");
+  return {
+    ...actual,
+    encodeSetOracleAuthority: vi.fn(() => Buffer.from([])),
+    encodePushOraclePrice: vi.fn(() => Buffer.from([])),
+    encodeSetOraclePriceCap: vi.fn(() => Buffer.from([])),
+    encodeTopUpInsurance: vi.fn(() => Buffer.from([])),
+    encodeRenounceAdmin: vi.fn(() => Buffer.from([])),
+    encodeCreateInsuranceMint: vi.fn(() => Buffer.from([])),
+    encodeSetRiskThreshold: vi.fn(() => Buffer.from([])),
+    encodePauseMarket: vi.fn(() => Buffer.from([])),
+    encodeUnpauseMarket: vi.fn(() => Buffer.from([])),
+    buildAccountMetas: vi.fn(() => []),
+    buildIx: vi.fn(() => ({ programId: PROGRAM_PK, keys: [], data: Buffer.from([]) })),
+    deriveVaultAuthority: vi.fn(() => [VAULT_PK]),
+    deriveInsuranceLpMint: vi.fn(() => [VAULT_PK]),
+  };
+});
+
+import { useWalletCompat } from "@/hooks/useWalletCompat";
+import { renderHook } from "@testing-library/react";
+import { useAdminActions } from "@/hooks/useAdminActions";
+
+function mockWallet(pubkey: PublicKey) {
+  (useWalletCompat as any).mockReturnValue({
+    publicKey: pubkey,
+    signTransaction: vi.fn(),
+  });
+}
+
+describe("useAdminActions — PERC-8311 authority pre-flight checks", () => {
+  describe("setOracleAuthority", () => {
+    it("throws when wallet is not oracle authority", async () => {
+      mockWallet(STRANGER_PK);
+      const { result } = renderHook(() => useAdminActions());
+      await expect(
+        result.current.setOracleAuthority(makeMarket(), ORACLE_PK.toBase58()),
+      ).rejects.toThrow(/not the oracle authority/i);
+    });
+
+    it("succeeds when wallet IS oracle authority", async () => {
+      mockWallet(ORACLE_PK);
+      const { result } = renderHook(() => useAdminActions());
+      await expect(
+        result.current.setOracleAuthority(makeMarket(), ORACLE_PK.toBase58()),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe("pushPrice", () => {
+    it("throws when wallet is not oracle authority", async () => {
+      mockWallet(STRANGER_PK);
+      const { result } = renderHook(() => useAdminActions());
+      await expect(
+        result.current.pushPrice(makeMarket(), "50000000000"),
+      ).rejects.toThrow(/not the oracle authority/i);
+    });
+
+    it("succeeds when wallet IS oracle authority", async () => {
+      mockWallet(ORACLE_PK);
+      const { result } = renderHook(() => useAdminActions());
+      await expect(
+        result.current.pushPrice(makeMarket(), "50000000000"),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe("pauseMarket", () => {
+    it("throws when wallet is not admin", async () => {
+      mockWallet(STRANGER_PK);
+      const { result } = renderHook(() => useAdminActions());
+      await expect(
+        result.current.pauseMarket(makeMarket()),
+      ).rejects.toThrow(/not the market admin/i);
+    });
+
+    it("succeeds when wallet IS admin", async () => {
+      mockWallet(ADMIN_PK);
+      const { result } = renderHook(() => useAdminActions());
+      await expect(
+        result.current.pauseMarket(makeMarket()),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe("unpauseMarket", () => {
+    it("throws when wallet is not admin", async () => {
+      mockWallet(STRANGER_PK);
+      const { result } = renderHook(() => useAdminActions());
+      await expect(
+        result.current.unpauseMarket(makeMarket()),
+      ).rejects.toThrow(/not the market admin/i);
+    });
+
+    it("succeeds when wallet IS admin", async () => {
+      mockWallet(ADMIN_PK);
+      const { result } = renderHook(() => useAdminActions());
+      await expect(
+        result.current.unpauseMarket(makeMarket()),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe("renounceAdmin", () => {
+    it("throws when wallet is not admin", async () => {
+      mockWallet(STRANGER_PK);
+      const { result } = renderHook(() => useAdminActions());
+      await expect(
+        result.current.renounceAdmin(makeMarket()),
+      ).rejects.toThrow(/not the market admin/i);
+    });
+
+    it("succeeds when wallet IS admin", async () => {
+      mockWallet(ADMIN_PK);
+      const { result } = renderHook(() => useAdminActions());
+      await expect(
+        result.current.renounceAdmin(makeMarket()),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe("resetRiskGate", () => {
+    it("throws when wallet is not admin", async () => {
+      mockWallet(STRANGER_PK);
+      const { result } = renderHook(() => useAdminActions());
+      await expect(
+        result.current.resetRiskGate(makeMarket()),
+      ).rejects.toThrow(/not the market admin/i);
+    });
+  });
+
+  describe("createInsuranceMint", () => {
+    it("throws when wallet is not admin", async () => {
+      mockWallet(STRANGER_PK);
+      const { result } = renderHook(() => useAdminActions());
+      await expect(
+        result.current.createInsuranceMint(makeMarket()),
+      ).rejects.toThrow(/not the market admin/i);
+    });
+  });
+
+  describe("topUpInsurance", () => {
+    it("does NOT require admin authority (any token holder can top up)", async () => {
+      mockWallet(STRANGER_PK);
+      const { result } = renderHook(() => useAdminActions());
+      // Should NOT throw authority error (may throw for other reasons like ATA in test env)
+      try {
+        await result.current.topUpInsurance(makeMarket(), 1000n);
+      } catch (err) {
+        expect((err as Error).message).not.toMatch(/not the market admin/i);
+        expect((err as Error).message).not.toMatch(/not the oracle authority/i);
+      }
+    });
+  });
+
+  describe("error message quality", () => {
+    it("includes truncated wallet address in error message", async () => {
+      mockWallet(STRANGER_PK);
+      const { result } = renderHook(() => useAdminActions());
+      await expect(
+        result.current.pauseMarket(makeMarket()),
+      ).rejects.toThrow(STRANGER_PK.toBase58().slice(0, 8));
+    });
+
+    it("includes truncated admin address in error message", async () => {
+      mockWallet(STRANGER_PK);
+      const { result } = renderHook(() => useAdminActions());
+      await expect(
+        result.current.pauseMarket(makeMarket()),
+      ).rejects.toThrow(ADMIN_PK.toBase58().slice(0, 8));
+    });
+  });
+});

--- a/app/hooks/useAdminActions.ts
+++ b/app/hooks/useAdminActions.ts
@@ -30,6 +30,55 @@ import {
 import { sendTx } from "@/lib/tx";
 import type { DiscoveredMarket } from "@percolator/sdk";
 
+/**
+ * PERC-8311 — Authority pre-flight helpers.
+ *
+ * These checks verify the connected wallet holds the required role BEFORE building
+ * any privileged instruction. The on-chain program still enforces authority as the
+ * final gate, but these client-side checks prevent:
+ *  - Confusing "sign a doomed transaction" prompts for non-admin users
+ *  - Unnecessary signature requests that will always fail on-chain
+ *  - Phishing surface where users are tricked into signing predictably-failing txs
+ */
+
+/**
+ * Asserts the connected wallet is the market admin.
+ * Throws a descriptive error if it isn't, so the caller can surface it to the UI.
+ */
+function requireAdminAuthority(
+  walletKey: PublicKey,
+  market: DiscoveredMarket,
+  action: string,
+): void {
+  const admin = market.header.admin.toBase58();
+  const wallet = walletKey.toBase58();
+  if (admin !== wallet) {
+    throw new Error(
+      `[${action}] Connected wallet (${wallet.slice(0, 8)}…) is not the market admin ` +
+      `(${admin.slice(0, 8)}…). Connect the admin wallet to perform this action.`,
+    );
+  }
+}
+
+/**
+ * Asserts the connected wallet is the market oracle authority.
+ * Throws a descriptive error if it isn't.
+ */
+function requireOracleAuthority(
+  walletKey: PublicKey,
+  market: DiscoveredMarket,
+  action: string,
+): void {
+  const oracle = market.config.oracleAuthority.toBase58();
+  const wallet = walletKey.toBase58();
+  if (oracle !== wallet) {
+    throw new Error(
+      `[${action}] Connected wallet (${wallet.slice(0, 8)}…) is not the oracle authority ` +
+      `(${oracle.slice(0, 8)}…). Connect the oracle authority wallet to perform this action.`,
+    );
+  }
+}
+
 export function useAdminActions() {
   const { connection } = useConnectionCompat();
   const wallet = useWalletCompat();
@@ -38,6 +87,8 @@ export function useAdminActions() {
   const setOracleAuthority = useCallback(
     async (market: DiscoveredMarket, newAuthority: string) => {
       if (!wallet.publicKey || !wallet.signTransaction) throw new Error("Wallet not connected");
+      // PERC-8311: Pre-flight authority check — must be current oracle authority
+      requireOracleAuthority(wallet.publicKey, market, "setOracleAuthority");
       setLoading("setOracleAuthority");
       try {
         const data = encodeSetOracleAuthority({ newAuthority: new PublicKey(newAuthority) });
@@ -57,6 +108,8 @@ export function useAdminActions() {
   const pushPrice = useCallback(
     async (market: DiscoveredMarket, priceE6: string) => {
       if (!wallet.publicKey || !wallet.signTransaction) throw new Error("Wallet not connected");
+      // PERC-8311: Pre-flight authority check — must be oracle authority to push prices
+      requireOracleAuthority(wallet.publicKey, market, "pushPrice");
       setLoading("pushPrice");
       try {
         const instructions = [];
@@ -94,6 +147,7 @@ export function useAdminActions() {
   const topUpInsurance = useCallback(
     async (market: DiscoveredMarket, amount: bigint) => {
       if (!wallet.publicKey || !wallet.signTransaction) throw new Error("Wallet not connected");
+      // topUpInsurance is permissioned by token balance, not admin role — no authority pre-check needed.
       setLoading("topUpInsurance");
       try {
         const { getAssociatedTokenAddress } = await import("@solana/spl-token");
@@ -118,6 +172,8 @@ export function useAdminActions() {
   const createInsuranceMint = useCallback(
     async (market: DiscoveredMarket) => {
       if (!wallet.publicKey || !wallet.signTransaction) throw new Error("Wallet not connected");
+      // PERC-8311: Pre-flight authority check — must be admin to create insurance mint
+      requireAdminAuthority(wallet.publicKey, market, "createInsuranceMint");
       setLoading("createInsuranceMint");
       try {
         const [vaultAuth] = deriveVaultAuthority(market.programId, market.slabAddress);
@@ -146,6 +202,8 @@ export function useAdminActions() {
   const renounceAdmin = useCallback(
     async (market: DiscoveredMarket) => {
       if (!wallet.publicKey || !wallet.signTransaction) throw new Error("Wallet not connected");
+      // PERC-8311: Pre-flight authority check — must be admin to renounce admin role
+      requireAdminAuthority(wallet.publicKey, market, "renounceAdmin");
       setLoading("renounceAdmin");
       try {
         const data = encodeRenounceAdmin();
@@ -165,6 +223,8 @@ export function useAdminActions() {
   const resetRiskGate = useCallback(
     async (market: DiscoveredMarket) => {
       if (!wallet.publicKey || !wallet.signTransaction) throw new Error("Wallet not connected");
+      // PERC-8311: Pre-flight authority check — must be admin to reset risk gate
+      requireAdminAuthority(wallet.publicKey, market, "resetRiskGate");
       setLoading("resetRiskGate");
       try {
         const data = encodeSetRiskThreshold({ newThreshold: 0n });
@@ -184,6 +244,8 @@ export function useAdminActions() {
   const pauseMarket = useCallback(
     async (market: DiscoveredMarket) => {
       if (!wallet.publicKey || !wallet.signTransaction) throw new Error("Wallet not connected");
+      // PERC-8311: Pre-flight authority check — must be admin to pause a market
+      requireAdminAuthority(wallet.publicKey, market, "pauseMarket");
       setLoading("pauseMarket");
       try {
         const data = encodePauseMarket();
@@ -203,6 +265,8 @@ export function useAdminActions() {
   const unpauseMarket = useCallback(
     async (market: DiscoveredMarket) => {
       if (!wallet.publicKey || !wallet.signTransaction) throw new Error("Wallet not connected");
+      // PERC-8311: Pre-flight authority check — must be admin to unpause a market
+      requireAdminAuthority(wallet.publicKey, market, "unpauseMarket");
       setLoading("unpauseMarket");
       try {
         const data = encodeUnpauseMarket();


### PR DESCRIPTION
## GH#1951 — Admin UI authority pre-flight check

### Problem
`useAdminActions` built privileged instructions (pause/unpause market, set oracle authority, renounce admin, etc.) without first verifying the connected wallet holds the required role. Users saw wallet signing prompts for transactions that would always fail on-chain — confusing UX and phishing surface.

### Fix
Added two guard functions in `useAdminActions.ts`:
- `requireAdminAuthority(wallet, market, action)` — throws before building if wallet ≠ `market.header.admin`
- `requireOracleAuthority(wallet, market, action)` — throws before building if wallet ≠ `market.config.oracleAuthority`

Applied to:
| Action | Guard |
|--------|-------|
| setOracleAuthority | oracle |
| pushPrice | oracle |
| createInsuranceMint | admin |
| renounceAdmin | admin |
| resetRiskGate | admin |
| pauseMarket | admin |
| unpauseMarket | admin |
| topUpInsurance | none (token balance permission) |

Error messages include truncated wallet and expected authority address for actionable UX.

### Testing
- `pnpm tsc --noEmit` — clean ✅
- `__tests__/hooks/useAdminActions.test.ts` — 15 new tests covering all authority paths
- 1725 unit tests pass, 0 failures

### Notes
On-chain enforcement is unchanged — this is a UX improvement, not a security bypass. Final authority check still lives in the program.

Closes #1951