### PR TITLE
fix(GH#1950): allowlist-only network guard in mobile/create-market

### DIFF
--- a/app/__tests__/api/create-market-network-guard.test.ts
+++ b/app/__tests__/api/create-market-network-guard.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for network guard in /api/mobile/create-market (GH#1950).
+ *
+ * The endpoint uses an allowlist approach: only NEXT_PUBLIC_DEFAULT_NETWORK === "devnet"
+ * is accepted. All other values (mainnet, staging, unset) must be rejected with 403.
+ */
+
+import { describe, it, expect } from "vitest";
+
+/**
+ * Mirror of the network guard logic in route.ts.
+ * Returns null if allowed, or an error message if denied.
+ */
+function checkNetworkGuard(network: string | undefined): string | null {
+  if (network !== "devnet") {
+    return (
+      "Mobile create-market is only available on devnet. " +
+      `Current network: ${network ?? "unset"}.`
+    );
+  }
+  return null;
+}
+
+describe("create-market network guard (GH#1950)", () => {
+  it("allows devnet", () => {
+    expect(checkNetworkGuard("devnet")).toBeNull();
+  });
+
+  it("blocks mainnet", () => {
+    expect(checkNetworkGuard("mainnet")).toMatch(/only available on devnet/);
+    expect(checkNetworkGuard("mainnet")).toMatch(/mainnet/);
+  });
+
+  it("blocks undefined / unset env var", () => {
+    expect(checkNetworkGuard(undefined)).toMatch(/only available on devnet/);
+    expect(checkNetworkGuard(undefined)).toMatch(/unset/);
+  });
+
+  it("blocks staging env", () => {
+    expect(checkNetworkGuard("staging")).toMatch(/only available on devnet/);
+  });
+
+  it("blocks empty string", () => {
+    expect(checkNetworkGuard("")).toMatch(/only available on devnet/);
+  });
+
+  it("is case-sensitive — Devnet (capital D) is rejected", () => {
+    expect(checkNetworkGuard("Devnet")).toMatch(/only available on devnet/);
+  });
+
+  it("is case-sensitive — DEVNET (all caps) is rejected", () => {
+    expect(checkNetworkGuard("DEVNET")).toMatch(/only available on devnet/);
+  });
+});

--- a/app/app/api/mobile/create-market/route.ts
+++ b/app/app/api/mobile/create-market/route.ts
@@ -17,8 +17,9 @@
  *  6. Mobile calls POST /api/markets to register the new market in the dashboard DB
  *
  * Security: server keypairs are ephemeral (never persisted). The deployer field is
- * validated as a valid Solana pubkey. When NEXT_PUBLIC_DEFAULT_NETWORK (or
- * NEXT_PUBLIC_SOLANA_NETWORK) is mainnet, POST returns 403 — devnet/beta only.
+ * validated as a valid Solana pubkey. The endpoint uses an allowlist guard — only
+ * NEXT_PUBLIC_DEFAULT_NETWORK (or NEXT_PUBLIC_SOLANA_NETWORK) === "devnet" is
+ * accepted; all other values (mainnet, staging, unset) return 403 (GH#1950).
  */
 import { NextRequest, NextResponse } from "next/server";
 import {
@@ -123,12 +124,19 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  // GH#1950: allowlist-only guard — only devnet is permitted.
+  // Reject any network that is not explicitly "devnet" (catches mainnet, staging,
+  // misconfigured envs, and undefined deployments).
   const network =
     process.env.NEXT_PUBLIC_DEFAULT_NETWORK?.trim() ??
     process.env.NEXT_PUBLIC_SOLANA_NETWORK?.trim();
-  if (network === "mainnet") {
+  if (network !== "devnet") {
     return NextResponse.json(
-      { error: "Mobile create-market is not enabled on mainnet." },
+      {
+        error:
+          "Mobile create-market is only available on devnet. " +
+          `Current network: ${network ?? "unset"}.`,
+      },
       { status: 403 },
     );
   }


### PR DESCRIPTION
## Summary
Closes GH#1950

**Before:** blocklist check — only `network === 'mainnet'` was blocked.
**After:** allowlist check — only `network === 'devnet'` is allowed; all other values (mainnet, staging, unset, empty, mixed-case) return 403.

## Root Cause
The old guard relied on env being explicitly set to `mainnet`. A misconfigured or unset deployment could still reach this devnet-only path.

## Changes
- `app/app/api/mobile/create-market/route.ts`: change guard from `=== 'mainnet'` to `!== 'devnet'`, update JSDoc comment
- `app/__tests__/api/create-market-network-guard.test.ts`: 7 unit tests for guard logic

## Test Results
All 1751 tests pass (144/146 files, 2 skipped due to bigint native bindings)

## Security
Reviewed by: pending QA + security

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated create-market endpoint to only allow requests on devnet.
  * Enhanced error messages to clarify network availability requirements.

* **Tests**
  * Added network guard validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->