### PR TITLE
fix(PERC-8328,PERC-8329): abort on oracle price fetch failure; remove secret key from localStorage

### DIFF
--- a/app/__tests__/hooks/useTrade.test.ts
+++ b/app/__tests__/hooks/useTrade.test.ts
@@ -108,6 +108,14 @@ describe("useTrade", () => {
     ( useWalletCompat as any).mockReturnValue(mockWallet);
     (useSlabState as any).mockReturnValue(mockSlabState);
     (sendTx as any).mockResolvedValue({ signature: "mock-signature" });
+
+    // Mock fetch for backend price API (PERC-8328: price required, no fallback allowed)
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        [mockSlabAddress]: { priceE6: "1500000" },
+      }),
+    });
   });
 
   afterEach(() => {

--- a/app/__tests__/hooks/useWithdraw.test.ts
+++ b/app/__tests__/hooks/useWithdraw.test.ts
@@ -355,37 +355,70 @@ describe("useWithdraw", () => {
       );
     });
 
-    it("should fallback to existing price if backend fetch fails", async () => {
+    it("should abort withdrawal if backend fetch fails (PERC-8328: no hardcoded fallback)", async () => {
+      // PERC-8328 / GH#1966: When price fetch fails, we must NOT fall back to a hardcoded
+      // price (e.g. $1). The withdrawal must abort to prevent catastrophic oracle mispricing.
       mockSlabState.config.oracleAuthority = mockWalletPubkey;
       (global.fetch as any).mockRejectedValue(new Error("Network error"));
 
       const { result } = renderHook(() => useWithdraw(mockSlabAddress));
 
       await act(async () => {
-        await result.current.withdraw({
-          userIdx: 1,
-          amount: 1000000n,
-        });
+        await expect(
+          result.current.withdraw({
+            userIdx: 1,
+            amount: 1000000n,
+          })
+        ).rejects.toThrow("Cannot push oracle price");
       });
 
-      // Should still complete with fallback price
-      expect(sendTx).toHaveBeenCalled();
+      // sendTx must NOT have been called — tx was aborted before reaching the network
+      expect(sendTx).not.toHaveBeenCalled();
+      expect(result.current.error).toContain("Cannot push oracle price");
     });
 
-    it("should use minimum price of 1 SOL if price is invalid", async () => {
+    it("should abort withdrawal if backend returns no price for this market (PERC-8328)", async () => {
+      // Backend returned 200 but the specific market has no price entry — must abort.
       mockSlabState.config.oracleAuthority = mockWalletPubkey;
-      mockSlabState.config.authorityPriceE6 = 0n; // Invalid price
+      (global.fetch as any).mockResolvedValue({
+        ok: true,
+        json: async () => ({}), // Empty — no entry for this slab
+      });
 
       const { result } = renderHook(() => useWithdraw(mockSlabAddress));
 
       await act(async () => {
-        await result.current.withdraw({
-          userIdx: 1,
-          amount: 1000000n,
-        });
+        await expect(
+          result.current.withdraw({
+            userIdx: 1,
+            amount: 1000000n,
+          })
+        ).rejects.toThrow("Cannot push oracle price");
       });
 
-      expect(sendTx).toHaveBeenCalled();
+      expect(sendTx).not.toHaveBeenCalled();
+    });
+
+    it("should abort withdrawal if price is zero or negative (PERC-8328)", async () => {
+      // Even if backend returns a price, reject zero/negative values.
+      mockSlabState.config.oracleAuthority = mockWalletPubkey;
+      (global.fetch as any).mockResolvedValue({
+        ok: true,
+        json: async () => ({ [mockSlabAddress]: { priceE6: "0" } }),
+      });
+
+      const { result } = renderHook(() => useWithdraw(mockSlabAddress));
+
+      await act(async () => {
+        await expect(
+          result.current.withdraw({
+            userIdx: 1,
+            amount: 1000000n,
+          })
+        ).rejects.toThrow("Invalid oracle price");
+      });
+
+      expect(sendTx).not.toHaveBeenCalled();
     });
   });
 

--- a/app/hooks/useCreateMarket.ts
+++ b/app/hooks/useCreateMarket.ts
@@ -187,21 +187,11 @@ export function useCreateMarket() {
     insuranceMintFailed: false,
   });
 
-  // Persist slab keypair across retries so we can resume from any step
+  // PERC-8329 / GH#1964: Slab keypair is kept in-memory ONLY — never in localStorage.
+  // Persisting a secret key in localStorage is unsafe: any same-origin script (including
+  // browser extensions) can read it. If the user refreshes mid-flow, they must start over.
+  // The in-memory ref is sufficient for the single-session retry path (step resume).
   const slabKpRef = useRef<Keypair | null>(null);
-
-  // Load persisted keypair from localStorage on mount
-  useEffect(() => {
-    const persisted = localStorage.getItem("percolator-pending-slab-keypair");
-    if (persisted) {
-      try {
-        const secretKey = Uint8Array.from(JSON.parse(persisted));
-        slabKpRef.current = Keypair.fromSecretKey(secretKey);
-      } catch {
-        localStorage.removeItem("percolator-pending-slab-keypair");
-      }
-    }
-  }, []);
 
   const create = useCallback(
     async (params: CreateMarketParams, retryFromStep?: number) => {
@@ -269,7 +259,8 @@ export function useCreateMarket() {
         ...(startStep === 0 ? { txSigs: [], slabAddress: null } : {}),
       }));
 
-      // Persist slab keypair in ref and localStorage so retries can reuse it even after page refresh
+      // PERC-8329: Slab keypair lives in memory only — no localStorage persistence.
+      // Retries within the same session reuse slabKpRef.current. Page refresh requires restart.
       let slabKp: Keypair;
       let slabPk: PublicKey;
       let vaultAta: PublicKey;
@@ -278,11 +269,8 @@ export function useCreateMarket() {
         slabKp = Keypair.generate();
         slabKpRef.current = slabKp;
         slabPk = slabKp.publicKey;
-        // Persist to localStorage for retry after page refresh
-        localStorage.setItem(
-          "percolator-pending-slab-keypair",
-          JSON.stringify(Array.from(slabKp.secretKey))
-        );
+        // PERC-8329: Do NOT persist secret key to localStorage — keep in memory only.
+        // If the user refreshes before completing all steps, they must start over.
       } else if (slabKpRef.current) {
         // Retry with persisted keypair — full functionality
         slabKp = slabKpRef.current;
@@ -324,14 +312,10 @@ export function useCreateMarket() {
               `(${existingAccount.data.length}B, expected ${expectedSlabSize}B). ` +
               `Abandoning orphan and generating fresh keypair.`,
             );
-            localStorage.removeItem("percolator-pending-slab-keypair");
+            // PERC-8329: No localStorage cleanup needed — key was never stored there.
             slabKp = Keypair.generate();
             slabKpRef.current = slabKp;
             slabPk = slabKp.publicKey;
-            localStorage.setItem(
-              "percolator-pending-slab-keypair",
-              JSON.stringify(Array.from(slabKp.secretKey)),
-            );
             // Recompute PDA and ATA for new slab keypair
             [vaultPda] = deriveVaultAuthority(programId, slabPk);
             vaultAta = await getAssociatedTokenAddress(params.mint, vaultPda, true);
@@ -1038,8 +1022,8 @@ export function useCreateMarket() {
           }
         }
 
-        // Done! Clear persisted keypair from localStorage
-        localStorage.removeItem("percolator-pending-slab-keypair");
+        // Done! Clear in-memory keypair ref (PERC-8329: no localStorage to clean up).
+        slabKpRef.current = null;
         setState((s) => ({
           ...s,
           loading: false,
@@ -1059,7 +1043,8 @@ export function useCreateMarket() {
 
   const reset = useCallback(() => {
     slabKpRef.current = null;
-    localStorage.removeItem("percolator-pending-slab-keypair");
+    // PERC-8329: Clear any stale key that may have been stored by old code (defensive cleanup).
+    try { localStorage.removeItem("percolator-pending-slab-keypair"); } catch { /* ignore */ }
     setState({
       step: 0,
       stepLabel: "",

--- a/app/hooks/useTrade.ts
+++ b/app/hooks/useTrade.ts
@@ -74,22 +74,31 @@ export function useTrade(slabAddress: string) {
         const instructions = [];
 
         // For admin oracle markets where user IS the oracle authority,
-        // push a fresh price before cranking (crank needs fresh oracle data)
+        // push a fresh price before cranking (crank needs fresh oracle data).
+        // PERC-8328 / GH#1966: NEVER fall back to a hardcoded price — if we can't get
+        // a valid, fresh price from the backend, abort the trade entirely. Pushing a
+        // fabricated oracle price (e.g. $1) would cause catastrophic mispricing.
         const userIsOracleAuth = useAdminOracle && mktConfig.oracleAuthority.equals(wallet.publicKey);
         if (userIsOracleAuth) {
-          // Fetch current price from backend or use last known
-          let priceE6 = mktConfig.authorityPriceE6 ?? 1_000_000n;
+          // Fetch the authoritative price from the backend. Fail hard if unavailable.
+          let priceE6: bigint;
           try {
             const resp = await fetch(`/api/prices/markets`);
-            if (resp.ok) {
-              const prices = await resp.json();
-              const entry = prices[slabAddress];
-              if (entry?.priceE6) {
-                try { priceE6 = BigInt(entry.priceE6); } catch { /* keep existing price */ }
-              }
-            }
-          } catch { /* use existing price */ }
-          if (priceE6 <= 0n) priceE6 = 1_000_000n;
+            if (!resp.ok) throw new Error(`Price fetch failed: HTTP ${resp.status}`);
+            const prices = await resp.json();
+            const entry = prices[slabAddress];
+            if (!entry?.priceE6) throw new Error("No price available for this market from backend");
+            priceE6 = BigInt(entry.priceE6);
+          } catch (fetchErr) {
+            // Do NOT fall back to a hardcoded price — abort to prevent mispricing.
+            throw new Error(
+              `Cannot push oracle price: ${fetchErr instanceof Error ? fetchErr.message : String(fetchErr)}. ` +
+              `Retry when the price service is available.`
+            );
+          }
+          if (priceE6 <= 0n) {
+            throw new Error(`Invalid oracle price: ${priceE6}. Price must be positive. Aborting to prevent mispricing.`);
+          }
 
           // Use on-chain slot time instead of client Date.now() to avoid clock drift
           // between client and validator causing signature verification failures

--- a/app/hooks/useWithdraw.ts
+++ b/app/hooks/useWithdraw.ts
@@ -60,21 +60,31 @@ export function useWithdraw(slabAddress: string) {
 
         const instructions = [];
 
-        // If user is oracle authority, push price first
+        // If user is oracle authority, push price first.
+        // PERC-8328 / GH#1966: NEVER fall back to a hardcoded price — if we can't get
+        // a valid, fresh price from the backend, abort the withdrawal entirely. Pushing a
+        // fabricated oracle price (e.g. $1) would cause catastrophic mispricing.
         const userIsOracleAuth = useAdminOracle && mktConfig.oracleAuthority.equals(wallet.publicKey);
         if (userIsOracleAuth) {
-          let priceE6 = mktConfig.authorityPriceE6 ?? 1_000_000n;
+          // Fetch the authoritative price from the backend. Fail hard if unavailable.
+          let priceE6: bigint;
           try {
             const resp = await fetch(`/api/prices/markets`);
-            if (resp.ok) {
-              const prices = await resp.json();
-              const entry = prices[slabAddress];
-              if (entry?.priceE6) {
-                try { priceE6 = BigInt(entry.priceE6); } catch { /* keep existing price */ }
-              }
-            }
-          } catch { /* use existing */ }
-          if (priceE6 <= 0n) priceE6 = 1_000_000n;
+            if (!resp.ok) throw new Error(`Price fetch failed: HTTP ${resp.status}`);
+            const prices = await resp.json();
+            const entry = prices[slabAddress];
+            if (!entry?.priceE6) throw new Error("No price available for this market from backend");
+            priceE6 = BigInt(entry.priceE6);
+          } catch (fetchErr) {
+            // Do NOT fall back to a hardcoded price — abort to prevent mispricing.
+            throw new Error(
+              `Cannot push oracle price: ${fetchErr instanceof Error ? fetchErr.message : String(fetchErr)}. ` +
+              `Retry when the price service is available.`
+            );
+          }
+          if (priceE6 <= 0n) {
+            throw new Error(`Invalid oracle price: ${priceE6}. Price must be positive. Aborting to prevent mispricing.`);
+          }
           // Use on-chain slot time instead of client Date.now() to avoid clock drift
           // between client and validator causing signature verification failures
           let oracleTimestamp: bigint;


### PR DESCRIPTION
## Summary

Two security fixes bundled together (both in admin-oracle flow):

### PERC-8328 / GH#1966 — CRITICAL: Oracle $1 fallback price

**Problem:** `useTrade.ts` and `useWithdraw.ts` fell back to a hardcoded `priceE6 = 1_000_000n` ($1.00) when the backend price API failed or returned no entry. This fabricated price was then pushed as an oracle update on-chain before the trade/withdraw. In any admin-oracle market, a transient backend/RPC failure during a user action could trigger a mass liquidation cascade.

**Fix:** Remove all hardcoded fallback. If `/api/prices/markets` fails, returns non-200, or has no entry for this market, throw immediately with a user-readable error. The transaction is never built.

**Tests:** Old "fallback" tests replaced with assertions that the operation fails hard (sendTx not called) when fetch fails, returns empty, or returns zero price.

### PERC-8329 / GH#1964 — HIGH: Secret key in localStorage

**Problem:** `useCreateMarket.ts` persisted the generated slab keypair as a JSON array in `localStorage['percolator-pending-slab-keypair']`. Any same-origin script (XSS, browser extension) could read and exfiltrate the secret key during the market creation window.

**Fix:** Remove all `localStorage.setItem` for the keypair. The keypair now lives in `slabKpRef.current` (in-memory React ref) only. Session retries still work; page refresh requires starting over. Added a defensive `removeItem` in `reset()` to clean up any key stored by old code.

## Files changed
- `app/hooks/useTrade.ts` — fail-hard on fetch error  
- `app/hooks/useWithdraw.ts` — fail-hard on fetch error
- `app/hooks/useCreateMarket.ts` — remove localStorage key persistence
- `app/__tests__/hooks/useTrade.test.ts` — add global.fetch mock, keep passing
- `app/__tests__/hooks/useWithdraw.test.ts` — update fallback tests to assert abort

## Test Results
✅ 1743 passed | 34 skipped | 0 failed (146 test files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Oracle price validation now enforces valid backend responses; trades and withdrawals will fail if prices cannot be reliably obtained instead of using fallback values.
  * Slab keypair data no longer persists between sessions, improving security and requiring re-entry after browser refresh.

* **Tests**
  * Updated test expectations for oracle price handling failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->