### PR TITLE
fix(PERC-8334): add /api/adl-leaderboard compatibility alias for /api/adl/rankings

### DIFF
--- a/app/app/api/adl-leaderboard/route.ts
+++ b/app/app/api/adl-leaderboard/route.ts
@@ -1,0 +1,33 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { proxyToApi } from "@/lib/api-proxy";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/adl-leaderboard
+ *
+ * Compatibility alias for GET /api/adl/rankings.
+ *
+ * PERC-8334: QA regression tests and external callers referenced this URL before
+ * the canonical proxy was introduced at /api/adl/rankings (PERC-8295, PR#1930).
+ * This route ensures those callers receive valid JSON instead of an HTML 404.
+ *
+ * Query string is forwarded unchanged (?slab=, ?limit=, etc.).
+ *
+ * @see /api/adl/rankings/route.ts — canonical upstream route
+ */
+export async function GET(req: NextRequest) {
+  const url = req.nextUrl.clone();
+
+  // If this is a direct browser navigation (accepts HTML), redirect to the
+  // canonical path so bookmarks and browser history stay consistent.
+  const acceptsHtml = req.headers.get("accept")?.includes("text/html") ?? false;
+  if (acceptsHtml) {
+    url.pathname = "/api/adl/rankings";
+    return NextResponse.redirect(url, 301);
+  }
+
+  // For programmatic callers (curl, fetch, SDK): proxy directly so they get
+  // JSON without an extra round-trip.
+  return proxyToApi(req, `/api/adl/rankings`);
+}


### PR DESCRIPTION
## Summary

QA verified at 03:14 UTC (2026-03-31) that `/api/adl-leaderboard` returns HTML 404 despite PERC-8305 being marked done. The canonical endpoint is `/api/adl/rankings` (added in PERC-8295/PR#1930), but the old URL path was never wired up.

## Fix

Created `app/app/api/adl-leaderboard/route.ts` as a compatibility alias:
- **Browser navigation** (Accept: text/html) → 301 redirect to `/api/adl/rankings`
- **Programmatic callers** (curl, fetch, SDK) → proxy directly to `/api/adl/rankings` to return JSON without extra round-trip

No data logic changes — delegates entirely to the existing proxy route.

## Testing

```bash
# Before: HTML 404
curl https://percolatorlaunch.com/api/adl-leaderboard

# After: JSON (proxied to /api/adl/rankings)
curl https://percolatorlaunch.com/api/adl-leaderboard?slab=<valid_slab>
# → { traders: [...] }

# Invalid slab:
curl https://percolatorlaunch.com/api/adl-leaderboard?slab=bad
# → { error: 'Invalid slab address' } (400)
```

## Related
- Fixes: PERC-8334
- Canonical route: PERC-8295/PR#1930
- GH#1941 (closed as invalid — but QA test suite still references the old URL)