### PR TITLE
fix(security): trust proxy depth for ideas and applications rate limits

### DIFF
--- a/app/__tests__/api/trusted-ip-rate-limit-headers.test.ts
+++ b/app/__tests__/api/trusted-ip-rate-limit-headers.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("trusted proxy-aware rate-limit identity", () => {
+  it("uses getClientIp in /api/ideas POST", () => {
+    const source = readFileSync(
+      resolve(__dirname, "../../app/api/ideas/route.ts"),
+      "utf8",
+    );
+
+    expect(source).toContain('import { getClientIp } from "@/lib/get-client-ip"');
+    expect(source).toContain("const ip = getClientIp(req);");
+    expect(source).not.toContain('x-forwarded-for")?.split(",")[0]');
+  });
+
+  it("uses getClientIp in /api/applications POST", () => {
+    const source = readFileSync(
+      resolve(__dirname, "../../app/api/applications/route.ts"),
+      "utf8",
+    );
+
+    expect(source).toContain('import { getClientIp } from "@/lib/get-client-ip"');
+    expect(source).toContain("const ip = getClientIp(req);");
+    expect(source).not.toContain('x-forwarded-for")?.split(",")[0]');
+  });
+});

--- a/app/app/api/applications/route.ts
+++ b/app/app/api/applications/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServiceClient } from "@/lib/supabase";
 import { requireAdminSession } from "@/lib/admin-session";
+import { getClientIp } from "@/lib/get-client-ip";
 
 export const dynamic = 'force-dynamic';
 
@@ -55,10 +56,7 @@ export async function GET() {
 
 export async function POST(req: NextRequest) {
   try {
-    const ip =
-      req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
-      req.headers.get("x-real-ip") ??
-      "unknown";
+    const ip = getClientIp(req);
 
     if (isRateLimited(ip)) {
       return NextResponse.json(

--- a/app/app/api/ideas/route.ts
+++ b/app/app/api/ideas/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServiceClient } from "@/lib/supabase";
+import { getClientIp } from "@/lib/get-client-ip";
 
 export const dynamic = 'force-dynamic';
 
@@ -54,10 +55,7 @@ export async function GET() {
 
 export async function POST(req: NextRequest) {
   try {
-    const ip =
-      req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
-      req.headers.get("x-real-ip") ??
-      "unknown";
+    const ip = getClientIp(req);
 
     if (isRateLimited(ip)) {
       return NextResponse.json(


### PR DESCRIPTION
## What was vulnerable\nTwo public mutation endpoints identified client IP using the leftmost value in x-forwarded-for. Attackers can spoof this header to rotate fake IPs and bypass per-IP throttling.\n\n- POST /api/ideas\n- POST /api/applications\n\n## Why this fix works\nBoth routes now use the shared trusted-proxy-aware resolver (getClientIp) that honors TRUSTED_PROXY_DEPTH and selects the correct hop from the forwarding chain. This aligns them with the middleware and other hardened endpoints.\n\n## Before vs After\nBefore:\n- Rate limits keyed on a spoofable header position (first forwarded IP).\n\nAfter:\n- Rate limits keyed on trusted client IP derivation based on configured proxy depth.\n\n## Security impact\n- Reduces practical bypass of abuse controls for public POST endpoints.\n- Improves consistency of IP identity handling across API surfaces.\n\n## Tests\nAdded a focused test file asserting both endpoints use getClientIp and no longer parse x-forwarded-for via first-hop split logic.\n- pp/__tests__/api/trusted-ip-rate-limit-headers.test.ts\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite validating rate-limit header handling for API routes

* **Refactor**
  * Improved client IP detection in API rate-limiting logic for better proxy support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->