### PR TITLE
fix(security): harden devnet register-mint abuse controls

### DIFF
--- a/app/__tests__/api/devnet-register-mint-abuse-guards.test.ts
+++ b/app/__tests__/api/devnet-register-mint-abuse-guards.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockUpsert = vi.fn();
+
+async function loadPostHandler() {
+  vi.resetModules();
+
+  vi.doMock("@/lib/supabase", () => ({
+    getServiceClient: () => ({
+      from: () => ({
+        upsert: mockUpsert,
+      }),
+    }),
+  }));
+
+  vi.doMock("@/lib/get-client-ip", () => ({
+    getClientIp: () => "1.2.3.4",
+  }));
+
+  const mod = await import("@/app/api/devnet-register-mint/route");
+  return mod.POST as (req: NextRequest) => Promise<Response>;
+}
+
+describe("POST /api/devnet-register-mint abuse guards", () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_SOLANA_NETWORK = "devnet";
+    mockUpsert.mockReset();
+    mockUpsert.mockResolvedValue({ error: null });
+  });
+
+  it("rejects invalid JSON body", async () => {
+    const POST = await loadPostHandler();
+    const req = new NextRequest("http://localhost/api/devnet-register-mint", {
+      method: "POST",
+      body: "{",
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/Invalid JSON body/i);
+  });
+
+  it("rejects invalid symbol format", async () => {
+    const POST = await loadPostHandler();
+    const req = new NextRequest("http://localhost/api/devnet-register-mint", {
+      method: "POST",
+      body: JSON.stringify({
+        mintAddress: "So11111111111111111111111111111111111111112",
+        symbol: "bad symbol!",
+      }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects out-of-range decimals", async () => {
+    const POST = await loadPostHandler();
+    const req = new NextRequest("http://localhost/api/devnet-register-mint", {
+      method: "POST",
+      body: JSON.stringify({
+        mintAddress: "So11111111111111111111111111111111111111112",
+        decimals: 99,
+      }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("rate limits repeated requests from same IP", async () => {
+    const POST = await loadPostHandler();
+
+    let lastStatus = 0;
+    for (let i = 0; i < 21; i++) {
+      const req = new NextRequest("http://localhost/api/devnet-register-mint", {
+        method: "POST",
+        body: JSON.stringify({
+          mintAddress: "So11111111111111111111111111111111111111112",
+        }),
+        headers: { "content-type": "application/json" },
+      });
+      const res = await POST(req);
+      lastStatus = res.status;
+    }
+
+    expect(lastStatus).toBe(429);
+  });
+});

--- a/app/app/api/devnet-register-mint/route.ts
+++ b/app/app/api/devnet-register-mint/route.ts
@@ -14,10 +14,36 @@ import { NextRequest, NextResponse } from "next/server";
 import { PublicKey } from "@solana/web3.js";
 import * as Sentry from "@sentry/nextjs";
 import { getServiceClient } from "@/lib/supabase";
+import { getClientIp } from "@/lib/get-client-ip";
 
 export const dynamic = "force-dynamic";
 
 const NETWORK = process.env.NEXT_PUBLIC_SOLANA_NETWORK?.trim() ?? "mainnet";
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+const RATE_LIMIT_MAX = 20;
+const requestCounts = new Map<string, { count: number; resetAt: number }>();
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const current = requestCounts.get(ip);
+
+  if (!current || now > current.resetAt) {
+    requestCounts.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return false;
+  }
+
+  if (current.count >= RATE_LIMIT_MAX) return true;
+  current.count++;
+  return false;
+}
+
+function isPrintableName(value: string): boolean {
+  return /^[\w\s._-]{1,64}$/.test(value);
+}
+
+function isTicker(value: string): boolean {
+  return /^[A-Z0-9._-]{1,12}$/.test(value);
+}
 
 export async function POST(req: NextRequest) {
   if (NETWORK !== "devnet") {
@@ -25,7 +51,21 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const body = await req.json();
+    const ip = getClientIp(req);
+    if (isRateLimited(ip)) {
+      return NextResponse.json(
+        { error: "Rate limited - max 20 register-mint requests per hour" },
+        { status: 429 },
+      );
+    }
+
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
     const { mintAddress, name, symbol, decimals } = body as {
       mintAddress?: string;
       name?: string;
@@ -43,20 +83,43 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Invalid mintAddress" }, { status: 400 });
     }
 
+    const safeName = name?.trim() || `Token ${mintAddress.slice(0, 6)}`;
+    if (!isPrintableName(safeName)) {
+      return NextResponse.json(
+        { error: "Invalid name (1-64 chars; letters, numbers, space, ._- only)" },
+        { status: 400 },
+      );
+    }
+
+    const rawSymbol = symbol?.trim().toUpperCase() || mintAddress.slice(0, 4).toUpperCase();
+    if (!isTicker(rawSymbol)) {
+      return NextResponse.json(
+        { error: "Invalid symbol (1-12 chars; A-Z, 0-9, ._- only)" },
+        { status: 400 },
+      );
+    }
+
+    const safeDecimals = decimals ?? 6;
+    if (!Number.isInteger(safeDecimals) || safeDecimals < 0 || safeDecimals > 18) {
+      return NextResponse.json({ error: "Invalid decimals (must be integer 0-18)" }, { status: 400 });
+    }
+
     const supabase = getServiceClient();
 
     // Upsert: use mintAddress as both mainnet_ca and devnet_mint for native devnet mints.
     // This allows devnet-airdrop to look up by devnet_mint and find the row.
-    await (supabase as any).from("devnet_mints").upsert(
+    const { error } = await (supabase as any).from("devnet_mints").upsert(
       {
         mainnet_ca: mintAddress, // self-referencing for devnet-native mints
         devnet_mint: mintAddress,
-        name: name ?? `Token ${mintAddress.slice(0, 6)}`,
-        symbol: symbol ?? mintAddress.slice(0, 4).toUpperCase(),
-        decimals: decimals ?? 6,
+        name: safeName,
+        symbol: rawSymbol,
+        decimals: safeDecimals,
       },
       { onConflict: "mainnet_ca", ignoreDuplicates: true },
     );
+
+    if (error) throw error;
 
     return NextResponse.json({ status: "registered", mintAddress });
   } catch (error) {


### PR DESCRIPTION
## What was vulnerable\nPOST /api/devnet-register-mint accepted unbounded/weakly validated input and had no per-IP abuse throttle. While devnet-only, this still enables low-cost endpoint spam and noisy DB writes (untrusted metadata payloads, repeated upserts).\n\n## Why this fix works\nThis patch adds lightweight, localized abuse controls:\n- Trusted-proxy-aware IP extraction (getClientIp)\n- Per-IP rate limit: 20 requests/hour\n- Strict JSON parsing guard\n- Input constraints for 
ame, symbol, and decimals\n- Explicit DB error handling on upsert\n\n## Before vs After\nBefore:\n- No rate limit on this public mutation endpoint\n- Weak optional field validation\n- Upsert errors were not checked explicitly\n\nAfter:\n- Repeated same-IP abuse is throttled\n- Metadata fields are constrained to safe formats/ranges\n- DB write failures surface as errors instead of implicit success\n\n## Security impact\n- Reduces practical API abuse and data pollution on devnet infra\n- Improves integrity guarantees of registered mint metadata\n- Keeps behavior localized with no protocol-level changes\n\n## Tests\nAdded targeted tests for:\n- Invalid JSON rejection\n- Invalid symbol rejection\n- Invalid decimals rejection\n- Same-IP rate-limit enforcement\n\nFile: pp/__tests__/api/devnet-register-mint-abuse-guards.test.ts\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * IP-based rate limiting added to devnet-register-mint endpoint (20 requests per 60-minute window per IP).

* **Bug Fixes**
  * Improved error handling for invalid JSON and input validation failures with clearer error responses.

* **Tests**
  * Added test suite validating abuse guard behaviors including rate limiting and input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->