### PR TITLE
fix(security): trust proxy depth when forwarding bug reporter IP

### DIFF
--- a/app/__tests__/api/bugs-trusted-client-ip.test.ts
+++ b/app/__tests__/api/bugs-trusted-client-ip.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("POST /api/bugs trusted client IP forwarding", () => {
+  it("uses getClientIp rather than parsing first forwarded hop", () => {
+    const source = readFileSync(
+      resolve(__dirname, "../../app/api/bugs/route.ts"),
+      "utf8",
+    );
+
+    expect(source).toContain('import { getClientIp } from "@/lib/get-client-ip"');
+    expect(source).toContain("const ip = getClientIp(req);");
+    expect(source).not.toContain('x-forwarded-for")?.split(",")[0]');
+  });
+});

--- a/app/app/api/bugs/route.ts
+++ b/app/app/api/bugs/route.ts
@@ -15,6 +15,7 @@
 import { NextRequest } from "next/server";
 import { requireAuth, UNAUTHORIZED } from "@/lib/api-auth";
 import { proxyToApi } from "@/lib/api-proxy";
+import { getClientIp } from "@/lib/get-client-ip";
 
 export const dynamic = "force-dynamic";
 
@@ -26,12 +27,9 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  // Extract real client IP from Vercel/proxy forwarded headers and pass it to
-  // percolator-api so that the per-IP rate limiter operates on the actual client.
-  const ip =
-    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
-    req.headers.get("x-real-ip") ??
-    "unknown";
+  // Pass the trusted-proxy-aware client IP so backend rate limiting cannot be
+  // bypassed by spoofing the leftmost x-forwarded-for value.
+  const ip = getClientIp(req);
 
   return proxyToApi(req, "/bugs", { "x-real-ip": ip }, { includeBody: true });
 }


### PR DESCRIPTION
## What was vulnerable
POST /api/bugs forwarded x-real-ip to the backend by taking the leftmost x-forwarded-for hop. That value is user-influenced in many proxy chains and can be spoofed to evade backend per-IP bug-report throttling.

## Why this fix works
The route now uses the shared trusted-proxy-aware resolver (getClientIp), which respects TRUSTED_PROXY_DEPTH and derives client identity consistently with other hardened endpoints.

## Before vs After
Before:
- IP forwarded to backend could be spoofed via first-hop x-forwarded-for values.

After:
- IP forwarded to backend is derived using trusted proxy-depth logic.

## Security impact
- Improves integrity of backend rate-limit keys for public bug submissions.
- Reduces practical abuse bypass via header spoofing.

## Tests
Added focused test asserting the route uses getClientIp and no longer relies on first-hop x-forwarded-for splitting.