### PR TITLE
fix(security): fail closed on malformed launch JSON

### DIFF
--- a/app/__tests__/api/launch-invalid-json-guard.test.ts
+++ b/app/__tests__/api/launch-invalid-json-guard.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+async function loadPostHandler() {
+  vi.resetModules();
+
+  vi.doMock("@/lib/create-market-rate-limit", () => ({
+    CREATE_MARKET_RATE_LIMIT: 5,
+    checkLaunchRateLimit: vi.fn().mockResolvedValue({ allowed: true, retryAfterSecs: 0 }),
+  }));
+
+  vi.doMock("@/lib/get-client-ip", () => ({
+    getClientIp: () => "1.2.3.4",
+  }));
+
+  const mod = await import("@/app/api/launch/route");
+  return mod.POST as (req: NextRequest) => Promise<Response>;
+}
+
+describe("POST /api/launch invalid JSON guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 for malformed JSON", async () => {
+    const POST = await loadPostHandler();
+    const req = new NextRequest("http://localhost/api/launch", {
+      method: "POST",
+      body: "{",
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/Invalid JSON body/i);
+  });
+});

--- a/app/app/api/launch/route.ts
+++ b/app/app/api/launch/route.ts
@@ -70,7 +70,12 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const body = await req.json();
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
     const { mint, slabTier = "small" } = body as { mint: string; slabTier?: SlabTierKey };
 
     // Validate mint


### PR DESCRIPTION
Adds explicit malformed-JSON handling in POST /api/launch so invalid request bodies return 400 instead of falling into the generic 500 handler. This prevents noisy error-path abuse and keeps input validation behavior deterministic. Includes focused test coverage in app/__tests__/api/launch-invalid-json-guard.test.ts.