### PR TITLE
fix(security): rate limit markets challenge by client IP

### DIFF
--- a/app/__tests__/api/markets-challenge-ip-rate-limit.test.ts
+++ b/app/__tests__/api/markets-challenge-ip-rate-limit.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("GET /api/markets/challenge IP rate limiting", () => {
+  it("defines and applies per-IP challenge request limit", () => {
+    const source = readFileSync(
+      resolve(__dirname, "../../app/api/markets/challenge/route.ts"),
+      "utf8",
+    );
+
+    expect(source).toContain("MAX_CHALLENGES_PER_IP_PER_MINUTE = 30");
+    expect(source).toContain("function isIpRateLimited(ip: string): boolean");
+    expect(source).toContain("if (isIpRateLimited(clientIp))");
+    expect(source).toContain("Rate limited — max 30 challenge requests per minute per IP");
+  });
+});

--- a/app/app/api/markets/challenge/route.ts
+++ b/app/app/api/markets/challenge/route.ts
@@ -22,10 +22,40 @@ export const dynamic = "force-dynamic";
 
 const CHALLENGE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 const MAX_PENDING_PER_DEPLOYER = 10;
+const MAX_CHALLENGES_PER_IP_PER_MINUTE = 30;
+
+const ipRateMap = new Map<string, { count: number; resetAt: number }>();
+
+function isIpRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const entry = ipRateMap.get(ip);
+  if (!entry || now > entry.resetAt) {
+    ipRateMap.set(ip, { count: 1, resetAt: now + 60_000 });
+    return false;
+  }
+  if (entry.count >= MAX_CHALLENGES_PER_IP_PER_MINUTE) return true;
+  entry.count++;
+  return false;
+}
 
 export async function GET(req: NextRequest) {
   try {
     const deployer = req.nextUrl.searchParams.get("deployer");
+    const clientIp = getClientIp(req);
+
+    if (isIpRateLimited(clientIp)) {
+      return NextResponse.json(
+        { error: "Rate limited — max 30 challenge requests per minute per IP" },
+        {
+          status: 429,
+          headers: {
+            "Retry-After": "60",
+            "X-RateLimit-Limit": String(MAX_CHALLENGES_PER_IP_PER_MINUTE),
+            "X-RateLimit-Window": "60s",
+          },
+        },
+      );
+    }
 
     if (!deployer) {
       return NextResponse.json(
@@ -47,8 +77,6 @@ export async function GET(req: NextRequest) {
     const supabase = getServiceClient();
     const now = new Date();
     const expiresAt = new Date(now.getTime() + CHALLENGE_TTL_MS);
-    const clientIp = getClientIp(req);
-
     // Prune expired challenges lazily (cap query to avoid long-running cleanup)
     await (supabase as ReturnType<typeof getServiceClient>)
       .from("market_challenges" as never)


### PR DESCRIPTION
Adds per-IP throttling to GET /api/markets/challenge (30 requests/minute/IP) using trusted proxy-aware IP extraction. This reduces challenge-flood abuse that can pressure nonce storage and supports stronger protection around market registration auth flows. Includes focused test coverage.