### PR TITLE
fix(security): require verified email for admin session

### DIFF
--- a/app/__tests__/lib/admin-session-security.test.ts
+++ b/app/__tests__/lib/admin-session-security.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("admin session security checks", () => {
+  it("requires confirmed email before admin_users lookup", () => {
+    const source = readFileSync(
+      resolve(__dirname, "../../lib/admin-session.ts"),
+      "utf8",
+    );
+
+    expect(source).toContain("if (!user.email_confirmed_at)");
+    expect(source).toContain("response: NextResponse.json({ error: \"Unauthorized\" }, { status: 401 })");
+  });
+
+  it("normalizes email before service-role admin query", () => {
+    const source = readFileSync(
+      resolve(__dirname, "../../lib/admin-session.ts"),
+      "utf8",
+    );
+
+    expect(source).toContain("function normalizedEmail(value: string): string");
+    expect(source).toContain("const email = normalizedEmail(user.email);");
+    expect(source).toContain(".eq(\"email\", email)");
+  });
+});

--- a/app/lib/admin-session.ts
+++ b/app/lib/admin-session.ts
@@ -8,6 +8,10 @@ export type AdminSessionResult =
   | { ok: true; user: User }
   | { ok: false; response: NextResponse };
 
+function normalizedEmail(value: string): string {
+  return value.trim().toLowerCase();
+}
+
 /**
  * Verify Supabase Auth session (cookies) and membership in `admin_users`.
  * For Route Handlers that return PII using `getServiceClient()`.
@@ -46,12 +50,23 @@ export async function requireAdminSession(): Promise<AdminSessionResult> {
     };
   }
 
+  // Do not trust unverified email claims for service-role admin lookups.
+  // This keeps admin elevation tied to verified identity state.
+  if (!user.email_confirmed_at) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    };
+  }
+
+  const email = normalizedEmail(user.email);
+
   const sb = getServiceClient();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data: adminRow } = await (sb as any)
     .from("admin_users")
     .select("id")
-    .eq("email", user.email)
+    .eq("email", email)
     .maybeSingle();
 
   if (!adminRow) {


### PR DESCRIPTION
Hardens Supabase service-role admin authorization assumptions by requiring user.email_confirmed_at before checking dmin_users membership, and normalizing email before lookup. This reduces risk of admin elevation from unverified/ambiguous email claims when route handlers bypass RLS via service role. Includes focused tests in app/__tests__/lib/admin-session-security.test.ts.