### PR TITLE
fix(security): bind market challenge redemption to client ip

### DIFF
--- a/app/__tests__/api/markets-challenge-ip-binding.test.ts
+++ b/app/__tests__/api/markets-challenge-ip-binding.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("POST /api/markets challenge IP binding", () => {
+  it("requires challenge claim to match issuing client_ip", () => {
+    const source = readFileSync(
+      resolve(__dirname, "../../app/api/markets/route.ts"),
+      "utf8",
+    );
+
+    expect(source).toContain('import { getClientIp } from "@/lib/get-client-ip"');
+    expect(source).toContain("const clientIp = getClientIp(req);");
+    expect(source).toContain('.eq("client_ip", clientIp)');
+  });
+});

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -12,6 +12,7 @@ import { computeDisplayOiUsd } from "@/lib/oi-display";
 import { computeMarketHealthFromStats } from "@/lib/health";
 import { BLOCKED_SLAB_ADDRESSES } from "@/lib/blocklist";
 import { SLUG_ALIASES } from "@/lib/symbol-utils";
+import { getClientIp } from "@/lib/get-client-ip";
 
 /**
  * GH#1526: Map frontend oracle_mode filter values to DB-stored values.
@@ -729,12 +730,14 @@ export async function POST(req: NextRequest) {
     // the same nonce, only one UPDATE can match (used_at IS NULL), the other gets count=0.
     const supabaseAuth = getServiceClient();
     const now = new Date();
+    const clientIp = getClientIp(req);
 
     const { count: consumed, error: claimErr } = await (supabaseAuth as ReturnType<typeof getServiceClient>)
       .from("market_challenges" as never)
       .update({ used_at: now.toISOString() } as never, { count: "exact" } as never)
       .eq("nonce", nonce)
       .eq("deployer", deployer)
+      .eq("client_ip", clientIp)
       .is("used_at", null)
       .gt("expires_at", now.toISOString())
       .select("nonce" as never) as { count: number | null; error: unknown };


### PR DESCRIPTION
Hardens POST /api/markets auth by requiring nonce claim redemption to match the issuing challenge client_ip (from GET /api/markets/challenge). This reduces replay risk when nonce/signature pairs are intercepted or reused from different clients. Includes focused test coverage in app/__tests__/api/markets-challenge-ip-binding.test.ts.