### PR TITLE
fix(security): require explicit bypass flag for markets auth

### DIFF
--- a/app/__tests__/api/markets-bypass-explicit-flag.test.ts
+++ b/app/__tests__/api/markets-bypass-explicit-flag.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("POST /api/markets bypass explicit flag", () => {
+  it("requires MARKETS_AUTH_BYPASS_ENABLED=true in addition to secret", () => {
+    const source = readFileSync(
+      resolve(__dirname, "../../app/api/markets/route.ts"),
+      "utf8",
+    );
+
+    expect(source).toContain("const bypassEnabled = process.env.MARKETS_AUTH_BYPASS_ENABLED === \"true\"");
+    expect(source).toContain("const isBypass = !isProd && bypassEnabled && bypassSecret && bypassHeader === bypassSecret;");
+  });
+});

--- a/app/__tests__/api/markets-deployer-auth.test.ts
+++ b/app/__tests__/api/markets-deployer-auth.test.ts
@@ -229,7 +229,9 @@ describe("POST /api/markets — PERC-8332 deployer auth", () => {
 
   it("bypass header skips sig check (dev env only)", async () => {
     const originalNodeEnv = process.env.NODE_ENV;
+    const originalBypassEnabled = process.env.MARKETS_AUTH_BYPASS_ENABLED;
     process.env.NODE_ENV = "test"; // ensure not "production" so bypass is honoured
+    process.env.MARKETS_AUTH_BYPASS_ENABLED = "true";
     process.env.MARKETS_AUTH_BYPASS_SECRET = "dev-bypass-secret-123";
     try {
       (getServiceClient as ReturnType<typeof vi.fn>).mockReturnValue(buildMockSupabase(0));
@@ -250,6 +252,7 @@ describe("POST /api/markets — PERC-8332 deployer auth", () => {
       expect(body.error).not.toMatch(/nonce|signature/i);
     } finally {
       process.env.NODE_ENV = originalNodeEnv;
+      process.env.MARKETS_AUTH_BYPASS_ENABLED = originalBypassEnabled;
       delete process.env.MARKETS_AUTH_BYPASS_SECRET;
     }
   });

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -667,8 +667,12 @@ export async function POST(req: NextRequest) {
   // This proves cryptographic ownership of the deployer key instead of trusting
   // the deployer string from the body (which attackers can set to any observed pubkey).
   //
-  // Bypass: MARKETS_AUTH_BYPASS_SECRET env var allows internal tooling / migration
-  // scripts to skip the sig check. MUST NEVER be set in production.
+  // Bypass: internal tooling can skip sig checks only when BOTH are set:
+  // - MARKETS_AUTH_BYPASS_ENABLED=true
+  // - MARKETS_AUTH_BYPASS_SECRET matches x-markets-bypass header
+  // This extra opt-in flag prevents accidental bypass activation from a leftover secret.
+  // MUST NEVER be enabled in production.
+  const bypassEnabled = process.env.MARKETS_AUTH_BYPASS_ENABLED === "true";
   const bypassSecret = process.env.MARKETS_AUTH_BYPASS_SECRET;
   const bypassHeader = req.headers.get("x-markets-bypass");
   // Security: bypass is only permitted in non-production environments.
@@ -685,7 +689,7 @@ export async function POST(req: NextRequest) {
       }
     );
   }
-  const isBypass = !isProd && bypassSecret && bypassHeader === bypassSecret;
+  const isBypass = !isProd && bypassEnabled && bypassSecret && bypassHeader === bypassSecret;
 
   if (!isBypass) {
     if (!nonce || !signature) {


### PR DESCRIPTION
Fixes a security regression in POST /api/markets by requiring explicit MARKETS_AUTH_BYPASS_ENABLED=true in addition to MARKETS_AUTH_BYPASS_SECRET (and non-production mode) before auth bypass is allowed. This prevents accidental bypass activation from leftover secrets. Includes updated deployer-auth test and focused source assertion test.