### PR TITLE
fix(security): harden admin session assumptions

### DIFF
--- a/app/__tests__/lib/admin-session-security-v2.test.ts
+++ b/app/__tests__/lib/admin-session-security-v2.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("admin session security checks", () => {
+  it("fails closed if admin auth env vars are missing", () => {
+    const source = readFileSync(
+      resolve(__dirname, "../../lib/admin-session.ts"),
+      "utf8",
+    );
+
+    expect(source).toContain("Admin auth is not configured");
+    expect(source).toContain("{ status: 503 }");
+  });
+
+  it("requires confirmed email before admin_users lookup", () => {
+    const source = readFileSync(
+      resolve(__dirname, "../../lib/admin-session.ts"),
+      "utf8",
+    );
+
+    expect(source).toContain("if (!user.email_confirmed_at)");
+    expect(source).toContain('response: NextResponse.json({ error: "Unauthorized" }, { status: 401 })');
+  });
+
+  it("normalizes email before service-role admin query", () => {
+    const source = readFileSync(
+      resolve(__dirname, "../../lib/admin-session.ts"),
+      "utf8",
+    );
+
+    expect(source).toContain("function normalizeEmail(value: string): string");
+    expect(source).toContain("const email = normalizeEmail(user.email);");
+    expect(source).toContain('.eq("email", email)');
+  });
+});

--- a/app/lib/admin-session.ts
+++ b/app/lib/admin-session.ts
@@ -8,15 +8,28 @@ export type AdminSessionResult =
   | { ok: true; user: User }
   | { ok: false; response: NextResponse };
 
+function normalizeEmail(value: string): string {
+  return value.trim().toLowerCase();
+}
+
 /**
  * Verify Supabase Auth session (cookies) and membership in `admin_users`.
  * For Route Handlers that return PII using `getServiceClient()`.
  */
 export async function requireAdminSession(): Promise<AdminSessionResult> {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!supabaseUrl || !supabaseAnonKey) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Admin auth is not configured" }, { status: 503 }),
+    };
+  }
+
   const cookieStore = await cookies();
   const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    supabaseUrl,
+    supabaseAnonKey,
     {
       cookies: {
         getAll() {
@@ -46,12 +59,21 @@ export async function requireAdminSession(): Promise<AdminSessionResult> {
     };
   }
 
+  if (!user.email_confirmed_at) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    };
+  }
+
+  const email = normalizeEmail(user.email);
+
   const sb = getServiceClient();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data: adminRow } = await (sb as any)
     .from("admin_users")
     .select("id")
-    .eq("email", user.email)
+    .eq("email", email)
     .maybeSingle();
 
   if (!adminRow) {


### PR DESCRIPTION
Hardens admin session checks by failing closed when Supabase auth env vars are missing, requiring email_confirmed_at before admin_users lookup, and normalizing email before comparison. Includes focused tests in app/__tests__/lib/admin-session-security-v2.test.ts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced admin session security with mandatory email confirmation verification
  * Improved error handling for missing service configuration 
  * Admin user lookup now performs case-insensitive and trimmed email matching

* **Tests**
  * Added comprehensive test suite for admin session security validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->