### PR TITLE
test: set MARKETS_AUTH_BYPASS_ENABLED in leverage-guard tests

### DIFF
--- a/app/__tests__/api/markets-post-leverage-guard.test.ts
+++ b/app/__tests__/api/markets-post-leverage-guard.test.ts
@@ -58,6 +58,7 @@ vi.mock("@solana/web3.js", async (importOriginal) => {
 // migration script that already has the bypass secret configured.
 const BYPASS_SECRET = "test-bypass-secret";
 process.env.MARKETS_AUTH_BYPASS_SECRET = BYPASS_SECRET;
+process.env.MARKETS_AUTH_BYPASS_ENABLED = "true";
 
 function buildRequest(body: Record<string, unknown>): Request {
   return new Request("http://localhost/api/markets", {


### PR DESCRIPTION
The leverage-guard tests use the bypass header to skip challenge-response auth but only set `MARKETS_AUTH_BYPASS_SECRET`. PRs requiring explicit `MARKETS_AUTH_BYPASS_ENABLED=true` (e.g. #2001, #2007, #2010) cause these tests to fail.

This adds the missing env var so the existing tests are forward-compatible.

**Merge this first**, then #2001 (or similar) can be rebased on top with green CI.

Closes no issue — test-only fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated authentication bypass test configuration to validate leverage guard behavior under alternative authentication states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->