### PR TITLE
fix(security): bump lodash override to >=4.18.0 (GHSA-r5fr-rjxr-66jc)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
       "ajv": ">=6.14.0",
       "axios": ">=1.13.5",
       "bn.js": ">=5.2.3",
-      "lodash": ">=4.17.21",
+      "lodash": ">=4.18.0",
       "minimatch": ">=10.2.3",
       "rollup": "4.59.0",
       "serialize-javascript": ">=7.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   ajv: '>=6.14.0'
   axios: '>=1.13.5'
   bn.js: '>=5.2.3'
-  lodash: '>=4.17.21'
+  lodash: '>=4.18.0'
   minimatch: '>=10.2.3'
   rollup: 4.59.0
   serialize-javascript: '>=7.0.5'
@@ -5386,8 +5386,8 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -8191,7 +8191,7 @@ snapshots:
       '@types/debug': 4.1.12
       '@types/lodash': 4.17.23
       debug: 4.4.3
-      lodash: 4.17.23
+      lodash: 4.18.1
       pony-cause: 2.1.11
       semver: 7.7.4
       uuid: 9.0.1
@@ -13742,7 +13742,7 @@ snapshots:
 
   extension-port-stream@3.0.0:
     dependencies:
-      readable-stream: 3.6.2
+      readable-stream: 4.7.0
       webextension-polyfill: 0.10.0
 
   eyes@0.1.8: {}
@@ -14543,7 +14543,7 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   loose-envify@1.4.0:
     dependencies:


### PR DESCRIPTION
Bumps lodash pnpm override from >=4.17.21 to >=4.18.0 to resolve GHSA-r5fr-rjxr-66jc (code injection via _.template key names). Transitive dep via @privy-io/react-auth chain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated lodash dependency to minimum version 4.18.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->