### PR TITLE
security: pin oracle-keeper Dockerfile base image to SHA256 digest

### DIFF
--- a/Dockerfile.oracle-keeper
+++ b/Dockerfile.oracle-keeper
@@ -1,5 +1,5 @@
 # PERC-380: Oracle Keeper — mirrors Binance spot prices to Percolator devnet markets
-FROM node:22-slim AS base
+FROM node:22-slim@sha256:80fdb3f57c815e1b638d221f30a826823467c4a56c8f6a8d7aa091cd9b1675ea AS base
 WORKDIR /app
 
 # Install pnpm + curl for healthcheck


### PR DESCRIPTION
## What was fixed
The oracle-keeper Dockerfile used an unpinned `node:22-slim` base image tag while the other Dockerfiles (api, indexer) already pin `node:22-alpine` with SHA256 digests. Pinned the oracle-keeper image to its current SHA256 digest to prevent silent supply-chain substitution.

## Vulnerability details
- **Severity:** MEDIUM
- **Type:** Supply chain / container image integrity
- **Location:** `Dockerfile.oracle-keeper:2`
- **Attack vector:** A compromised or tampered `node:22-slim` tag pushed to Docker Hub would be silently pulled on the next build. Since the oracle-keeper service holds `CRANK_KEYPAIR` (the server-side signing key), a malicious base image could exfiltrate the key.

## Root cause
The Dockerfile used a floating tag instead of a content-addressable digest:
```dockerfile
# Before (vulnerable)
FROM node:22-slim AS base
```

## Fix approach
Pin to the current SHA256 digest, matching the security pattern used by `Dockerfile.api` and `Dockerfile.indexer`:
```dockerfile
# After (fixed)
FROM node:22-slim@sha256:80fdb3f57c815e1b638d221f30a826823467c4a56c8f6a8d7aa091cd9b1675ea AS base
```

## Verification
1. Run `docker build -f Dockerfile.oracle-keeper .` — build succeeds with pinned image
2. Compare digest: `docker inspect --format='{{index .RepoDigests 0}}' node:22-slim` matches pinned hash
3. All three Dockerfiles now use SHA256-pinned base images

## Impact if left unfixed
A supply-chain attack via Docker Hub could compromise the oracle-keeper service, which holds the `CRANK_KEYPAIR`. This key signs oracle price pushes and crank transactions — an attacker could push malicious prices to manipulate markets or drain the insurance fund.

## Checklist
- [x] Fix is minimal — no unrelated changes
- [x] No new dependencies introduced
- [x] No secrets introduced or exposed
- [x] Tested on devnet config
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image reference to use a pinned version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->