### PR TITLE
fix(security): validate feedId hex format in oracle publishers endpoint

### DIFF
--- a/app/app/api/oracle/publishers/route.ts
+++ b/app/app/api/oracle/publishers/route.ts
@@ -79,9 +79,16 @@ export async function GET(req: NextRequest) {
 
     switch (mode) {
       case "pyth-pinned":
-        if (!feedId) {
+        if (!feedId || !/^(0x)?[0-9a-fA-F]+$/.test(feedId)) {
           return NextResponse.json(
-            { error: "Missing feedId for pyth-pinned mode" },
+            { error: "Missing or invalid feedId for pyth-pinned mode" },
+            { status: 400 },
+          );
+        }
+        // Pyth feed IDs are 32 bytes = 64 hex chars (+ optional 0x prefix)
+        if (feedId.replace(/^0x/, "").length > 128) {
+          return NextResponse.json(
+            { error: "feedId too long" },
             { status: 400 },
           );
         }


### PR DESCRIPTION
## Summary
- `GET /api/oracle/publishers?mode=pyth-pinned&feedId=...` only checked if `feedId` was non-empty before passing it to `hexToBytes()`
- An attacker could send non-hex characters (producing `NaN` bytes via `parseInt`), extremely long strings (CPU/memory exhaustion in the byte array allocation), or crafted values to poison the in-memory cache (keyed on raw unsanitized `feedId`)
- Now validates `feedId` against strict hex regex (`/^(0x)?[0-9a-fA-F]+$/`) and enforces 128-char max (64 bytes)

## Vulnerability details
- **Severity:** MODERATE
- **Type:** Input validation / denial of service / cache poisoning
- **Location:** `app/app/api/oracle/publishers/route.ts` lines 82-88, 311-318
- **Attack vector:** `GET /api/oracle/publishers?mode=pyth-pinned&feedId=AAAA...` (megabytes of non-hex data) causes large `Uint8Array` allocation and CPU burn in `hexToBytes()`. Distinct junk values also pollute the 5-minute in-memory cache with useless entries.

## Test plan
- [ ] Valid 64-char hex feedId — returns publisher data as before
- [ ] Valid feedId with `0x` prefix — accepted
- [ ] Non-hex characters (`feedId=ZZZZ`) — returns 400
- [ ] Empty feedId — returns 400
- [ ] Oversized feedId (>128 hex chars) — returns 400
- [ ] Existing cache behavior unchanged for valid feeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced API request validation for feed IDs. Feed identifiers are now validated to ensure they follow the correct hex format with an optional 0x prefix and do not exceed the maximum allowed length. Missing or improperly formatted feed IDs will be rejected with a 400 error response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->