### PR TITLE
fix(security): drop stale permissive UPDATE/INSERT policies on bug_reports

### DIFF
--- a/supabase/migrations/20260402180000_drop_stale_bug_reports_update_policy.sql
+++ b/supabase/migrations/20260402180000_drop_stale_bug_reports_update_policy.sql
@@ -1,0 +1,23 @@
+-- Drop stale permissive UPDATE policy on bug_reports from migration 006.
+--
+-- PROBLEM:
+--   Migration 006 created "Service can update bug reports" FOR UPDATE USING (true)
+--   with NO `TO` clause — PostgreSQL treats this as applying to the PUBLIC pseudo-role
+--   (all roles, including anon). Migration 016 added a proper admin-email-gated UPDATE
+--   policy, but never dropped the old one. PostgreSQL OR's permissive policies, so the
+--   old wide-open policy still grants UPDATE to everyone — including anon callers using
+--   only NEXT_PUBLIC_SUPABASE_ANON_KEY.
+--
+--   An attacker could UPDATE any bug_reports row to change bounty_wallet (redirect
+--   bounty payments), status, or admin_notes.
+--
+-- FIX:
+--   Drop the stale policy. The admin-gated policy from 016 remains as the sole UPDATE
+--   policy. Service_role bypasses RLS entirely, so backend routes are unaffected.
+
+DROP POLICY IF EXISTS "Service can update bug reports" ON bug_reports;
+
+-- Also drop the stale INSERT policy from 006 (no TO clause → PUBLIC).
+-- Migration 015 already created "Anyone can submit bugs" TO anon, authenticated
+-- which is the intentional public-insert policy with proper role scoping.
+DROP POLICY IF EXISTS "Service can insert bug reports" ON bug_reports;


### PR DESCRIPTION
## Summary
- Migration 006 created `"Service can update bug reports"` and `"Service can insert bug reports"` with **no `TO` clause** — PostgreSQL treats this as applying to the PUBLIC pseudo-role (all roles including `anon`)
- Migration 016 added a properly scoped admin-email-gated UPDATE policy but **never dropped the originals**
- PostgreSQL OR's permissive policies — the old wide-open UPDATE policy still grants `anon` users the ability to modify any bug report row

## Vulnerability details
- **Severity:** HIGH
- **Type:** Broken access control / RLS policy stacking
- **Location:** `supabase/migrations/006_bug_reports.sql` lines 44-49
- **Attack vector:** Using only the public `NEXT_PUBLIC_SUPABASE_ANON_KEY`, an attacker can call Supabase PostgREST directly to UPDATE any `bug_reports` row — changing `bounty_wallet` (redirect payments), `status`, or `admin_notes`

## Fix
Drop both stale policies by their exact names from migration 006. The admin-gated UPDATE from migration 016 and the role-scoped INSERT from migration 015 remain as the sole write policies. Service_role bypasses RLS entirely, so backend routes are unaffected.

## Verification
After running the migration:
```sql
SELECT policyname, cmd, roles FROM pg_policies WHERE tablename = 'bug_reports';
```
Expected: no policies with `roles = {public}` for INSERT or UPDATE.

## Test plan
- [ ] Run migration against devnet Supabase
- [ ] Verify `pg_policies` output shows no PUBLIC-role write policies
- [ ] Confirm admin can still update bug reports via the admin dashboard
- [ ] Confirm anon POST /api/bugs still works (uses service_role client server-side)
- [ ] Confirm direct PostgREST UPDATE with anon key is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)