### PR TITLE
fix(security): drop stale permissive RLS policies on core financial tables

### DIFF
--- a/supabase/migrations/20260402180100_drop_stale_core_table_rls_policies.sql
+++ b/supabase/migrations/20260402180100_drop_stale_core_table_rls_policies.sql
@@ -1,0 +1,45 @@
+-- Drop stale permissive INSERT/UPDATE policies on core financial tables.
+--
+-- PROBLEM:
+--   schema.sql (the reference file sometimes run via Supabase SQL Editor) created
+--   INSERT/UPDATE policies on markets, market_stats, trades, and oracle_prices
+--   with NO `TO` clause — defaulting to the PUBLIC pseudo-role (all roles including anon).
+--   Policy names: "Service can insert markets", "Service can update markets", etc.
+--
+--   Migration 021 attempted to fix this by dropping and recreating as service_role-only,
+--   but used wrong policy names ("markets_insert", "markets_update") that never existed.
+--   The DROP POLICY IF EXISTS calls were silent no-ops.
+--
+--   If schema.sql was ever run against the database, the old permissive policies still
+--   coexist with the service_role-only policies from 021. PostgreSQL OR's permissive
+--   policies — if ANY policy grants access, access is granted. An attacker with the
+--   public anon key could INSERT fake markets/trades or UPDATE market_stats/oracle_prices.
+--
+-- FIX:
+--   Drop every known stale policy name from both schema.sql and migration 001.
+--   Uses DROP IF EXISTS so this is safe even if the policies don't exist.
+--   The service_role-only policies from migration 021 remain as the sole write policies.
+
+-- markets
+DROP POLICY IF EXISTS "Service can insert markets" ON markets;
+DROP POLICY IF EXISTS "Service can update markets" ON markets;
+
+-- market_stats
+DROP POLICY IF EXISTS "Service can insert stats" ON market_stats;
+DROP POLICY IF EXISTS "Service can update stats" ON market_stats;
+
+-- trades
+DROP POLICY IF EXISTS "Service can insert trades" ON trades;
+
+-- oracle_prices
+DROP POLICY IF EXISTS "Service can insert prices" ON oracle_prices;
+
+-- Also drop the wrong-name policies that migration 021 tried to drop
+-- (in case some other path created them under those names)
+DROP POLICY IF EXISTS "markets_insert" ON markets;
+DROP POLICY IF EXISTS "markets_update" ON markets;
+DROP POLICY IF EXISTS "market_stats_insert" ON market_stats;
+DROP POLICY IF EXISTS "market_stats_update" ON market_stats;
+DROP POLICY IF EXISTS "trades_insert" ON trades;
+DROP POLICY IF EXISTS "oracle_prices_insert" ON oracle_prices;
+DROP POLICY IF EXISTS "oracle_prices_update" ON oracle_prices;


### PR DESCRIPTION
## Summary
- `schema.sql` (the reference file, sometimes run via Supabase SQL Editor for initial setup) created INSERT/UPDATE policies on `markets`, `market_stats`, `trades`, and `oracle_prices` with **no `TO` clause** — defaulting to PUBLIC (all roles including `anon`)
- Migration 021 attempted to replace them with service_role-only policies but **dropped wrong policy names** (`"markets_insert"` instead of actual `"Service can insert markets"`) — the `DROP POLICY IF EXISTS` calls were silent no-ops
- If `schema.sql` was ever run against the database, anon callers could INSERT fake markets/trades or UPDATE market_stats/oracle_prices

## Vulnerability details
- **Severity:** CRITICAL (conditional — depends on whether schema.sql was run)
- **Type:** Broken access control / RLS policy name mismatch
- **Location:** `supabase/schema.sql` lines 108-113, `supabase/migrations/021_fix_rls_policies.sql` lines 5-11
- **Attack vector:** Using the public `NEXT_PUBLIC_SUPABASE_ANON_KEY` via PostgREST to INSERT/UPDATE core financial tables

## Fix
Defensively drop all known stale policy names from both `schema.sql` and migration 021's wrong names. Uses `DROP POLICY IF EXISTS` so this is safe regardless of whether schema.sql was previously run. The service_role-only policies from migration 021 remain as the sole write policies.

## Verification
**Run this query against both devnet and mainnet Supabase before and after:**
```sql
SELECT policyname, tablename, cmd, roles
FROM pg_policies
WHERE tablename IN ('markets','market_stats','trades','oracle_prices')
ORDER BY tablename, cmd;
```
After migration: only `*_service_only` and `*_select_anon` / `"Public read access"` policies should remain.

## Test plan
- [ ] Run `pg_policies` query before migration to check if stale policies exist
- [ ] Run migration against devnet Supabase
- [ ] Run `pg_policies` query after — confirm no PUBLIC-role write policies remain
- [ ] Verify API routes (GET /api/markets, POST /api/markets) still work
- [ ] Verify direct PostgREST INSERT with anon key is rejected on markets table

🤖 Generated with [Claude Code](https://claude.com/claude-code)