### PR TITLE
fix(security): cross-check oracle_authority against on-chain slab config

### DIFF
--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -911,6 +911,24 @@ export async function POST(req: NextRequest) {
           { status: 400 },
         );
       }
+
+      // Cross-check oracle_authority against on-chain slab config.
+      // Without this, a deployer could register a false oracle_authority in the DB,
+      // misleading off-chain tooling (admin dashboards, keeper configs) that reads
+      // markets.oracle_authority instead of querying the chain directly.
+      const onChainOracleAuth = config.oracleAuthority.toBase58();
+      const resolvedOracleAuth = oracle_authority || deployer;
+      const SYSTEM_PROGRAM = "11111111111111111111111111111111";
+      // Only enforce when on-chain authority is set (non-zero / non-system-program)
+      if (onChainOracleAuth !== SYSTEM_PROGRAM && onChainOracleAuth !== resolvedOracleAuth) {
+        return NextResponse.json(
+          {
+            error: `oracle_authority does not match on-chain oracle authority. ` +
+              `On-chain: ${onChainOracleAuth}. Provided: ${resolvedOracleAuth}`,
+          },
+          { status: 400 },
+        );
+      }
     } catch {
       // CR fix (GH#1987): parseConfig failure must fail closed — an unparseable slab
       // cannot be verified, so reject registration rather than silently falling through.


### PR DESCRIPTION
## Summary
- `POST /api/markets` validates `deployer` against on-chain `header.admin` and `mint_address` against on-chain `config.collateralMint`, but `oracle_authority` was only validated as a valid PublicKey format — never cross-checked against `config.oracleAuthority`
- A deployer could register their slab with a **false oracle_authority** pointing to any pubkey
- Off-chain tooling reading `markets.oracle_authority` from the DB (admin dashboards, keeper configs) would be misled

## Vulnerability details
- **Severity:** MEDIUM
- **Type:** Metadata tampering / trust boundary violation
- **Location:** `app/app/api/markets/route.ts` lines 803-814, 951
- **Attack vector:** Legitimate deployer registers their slab with `oracle_authority` pointing to an attacker-controlled pubkey. Any off-chain system trusting the DB field (instead of querying on-chain) could be tricked into authorizing the wrong key for price pushes.

## Fix
After the existing `collateralMint` cross-check (which already calls `parseConfig`), add a check comparing the provided `oracle_authority` against `config.oracleAuthority`. Skipped when on-chain authority is the system program (zero address), indicating no authority is set yet.

## Test plan
- [ ] Register a market with correct oracle_authority — succeeds as before
- [ ] Register a market with mismatched oracle_authority — returns 400 with descriptive error
- [ ] Register a market with no oracle_authority (defaults to deployer) — checked against on-chain
- [ ] Register a market where on-chain oracle_authority is system program (zero) — skip check, allow registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)