### PR TITLE
fix(security): use timing-safe comparison for INTERNAL_API_SECRET in RPC proxy

### DIFF
--- a/app/app/api/rpc/route.ts
+++ b/app/app/api/rpc/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getRpcEndpoint } from "@/lib/config";
-import { createHash } from "crypto";
+import { createHash, timingSafeEqual } from "crypto";
 
 export const dynamic = "force-dynamic";
 
@@ -70,7 +70,11 @@ function validateNetworkOverride(
       console.warn("[/api/rpc] PERC-8310: network override blocked (INTERNAL_API_SECRET not set)");
       return { error: "Network override requires authentication", status: 403 };
     }
-    if (authHeader !== secret) {
+    // Use timing-safe comparison to prevent side-channel brute-force of the secret.
+    // Hash both values to equalise buffer lengths (timingSafeEqual requires same length).
+    const expected = createHash("sha256").update(secret).digest();
+    const provided = createHash("sha256").update(authHeader ?? "").digest();
+    if (!timingSafeEqual(expected, provided)) {
       console.warn("[/api/rpc] PERC-8310: network override blocked (invalid secret)");
       return { error: "Network override requires authentication", status: 403 };
     }


### PR DESCRIPTION
## Summary
- The network-override auth check in `/api/rpc` used plain `!==` string comparison for `INTERNAL_API_SECRET`, enabling timing side-channel attacks to brute-force the secret character by character
- Other auth checks in the codebase (`set-price-cap`, `api-auth.ts`) already use `timingSafeEqual` correctly — this was the only holdout

## Vulnerability details
- **Severity:** LOW-MEDIUM
- **Type:** Timing side-channel / credential brute-force
- **Location:** `app/app/api/rpc/route.ts` line 73
- **Attack vector:** Attacker sends many requests with incrementally correct secret prefixes, measuring response time differences to determine each character. Successful brute-force enables network routing override (e.g., routing devnet traffic to mainnet).

## Fix
Hash both the expected secret and the provided header value with SHA-256 to equalise buffer lengths, then compare with `crypto.timingSafeEqual`. This matches the pattern already used in `app/lib/api-auth.ts` lines 22-24.

## Test plan
- [ ] Valid `X-Internal-Token` header with correct secret — network override works
- [ ] Invalid `X-Internal-Token` header — returns 403
- [ ] Missing `X-Internal-Token` header on cross-network request — returns 403
- [ ] No `INTERNAL_API_SECRET` configured — returns 403 (fail-closed behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)