### PR TITLE
fix(sdk): add bounds validation to encU8, encU16, encU32

### DIFF
--- a/packages/core/src/abi/encode.ts
+++ b/packages/core/src/abi/encode.ts
@@ -4,13 +4,19 @@ import { PublicKey } from "@solana/web3.js";
  * Encode u8 (1 byte)
  */
 export function encU8(val: number): Uint8Array {
-  return new Uint8Array([val & 0xff]);
+  if (val < 0 || val > 255 || !Number.isInteger(val)) {
+    throw new Error(`encU8: value ${val} out of range (0–255)`);
+  }
+  return new Uint8Array([val]);
 }
 
 /**
  * Encode u16 little-endian (2 bytes)
  */
 export function encU16(val: number): Uint8Array {
+  if (val < 0 || val > 65535 || !Number.isInteger(val)) {
+    throw new Error(`encU16: value ${val} out of range (0–65535)`);
+  }
   const buf = new Uint8Array(2);
   new DataView(buf.buffer).setUint16(0, val, true);
   return buf;
@@ -20,6 +26,9 @@ export function encU16(val: number): Uint8Array {
  * Encode u32 little-endian (4 bytes)
  */
 export function encU32(val: number): Uint8Array {
+  if (val < 0 || val > 0xffffffff || !Number.isInteger(val)) {
+    throw new Error(`encU32: value ${val} out of range (0–4294967295)`);
+  }
   const buf = new Uint8Array(4);
   new DataView(buf.buffer).setUint32(0, val, true);
   return buf;


### PR DESCRIPTION
## Summary
- `encU8` silently masked with `& 0xff` — `encU8(256)` produced `0`
- `encU16` silently truncated via `DataView.setUint16` — `encU16(65537)` produced `1`
- `encU32` had the same silent truncation issue
- Compare with `encU64`/`encI64`/`encU128`/`encI128` which already throw on out-of-range values

## Vulnerability details
- **Severity:** HIGH
- **Type:** Silent integer truncation / wrong-account targeting
- **Location:** `packages/core/src/abi/encode.ts` lines 6-26
- **Attack vector:** A buggy or malicious SDK consumer passes `userIdx: 65537` to any instruction encoder. `encU16(65537)` silently encodes as `1`, targeting account slot 1 instead of the intended slot. This affects `encodeDepositCollateral`, `encodeWithdrawCollateral`, `encodeTradeNoCpi`, `encodeLiquidateAtOracle`, `encodeCloseAccount`, and all other instructions taking index parameters. Similarly, `encU16(-1)` produces `65535` — targeting the highest account slot.

## Fix
Add explicit bounds and integer checks to `encU8`, `encU16`, and `encU32`, matching the validation pattern already used by the bigint encoders. All three now throw with a descriptive error on negative, non-integer, or out-of-range values.

## Test plan
- [ ] `encU8(0)`, `encU8(255)` — succeed as before
- [ ] `encU8(256)`, `encU8(-1)`, `encU8(1.5)` — now throw
- [ ] `encU16(0)`, `encU16(65535)` — succeed as before
- [ ] `encU16(65536)`, `encU16(-1)` — now throw
- [ ] `encU32(0)`, `encU32(0xffffffff)` — succeed as before
- [ ] `encU32(0x100000000)`, `encU32(-1)` — now throw
- [ ] Existing SDK tests pass (no current callers pass out-of-range values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Integer encoding functions now include comprehensive input validation and strict range checking. Invalid or out-of-range values trigger clear error messages, preventing silent failures and unexpected behavior during encoding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->