### PR TITLE
security: sanitize raw error messages in 6 remaining API routes

### DIFF
--- a/app/app/api/devnet-mint-token/route.ts
+++ b/app/app/api/devnet-mint-token/route.ts
@@ -401,7 +401,7 @@ export async function POST(req: NextRequest) {
       tags: { endpoint: "/api/devnet-mint-token", method: "POST" },
     });
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Internal server error" },
+      { error: "Token minting failed. Please try again later." },
       { status: 500 },
     );
   }

--- a/app/app/api/launch/route.ts
+++ b/app/app/api/launch/route.ts
@@ -269,7 +269,7 @@ export async function POST(req: NextRequest) {
       tags: { endpoint: "/api/launch", method: "POST" },
     });
     return NextResponse.json(
-      { error: err instanceof Error ? err.message : "Unknown error" },
+      { error: "Failed to generate launch config. Please try again later." },
       { status: 500 },
     );
   }

--- a/app/app/api/markets/[slab]/route.ts
+++ b/app/app/api/markets/[slab]/route.ts
@@ -107,7 +107,7 @@ export async function GET(
         Sentry.captureException(error, {
           tags: { endpoint: "/api/markets/[slab]", method: "GET", slab },
         });
-        return NextResponse.json({ error: error.message }, { status: 500 });
+        return NextResponse.json({ error: "Failed to load market. Please try again later." }, { status: 500 });
       }
       data = row;
     } else {
@@ -144,7 +144,7 @@ export async function GET(
         Sentry.captureException(error, {
           tags: { endpoint: "/api/markets/[slab]", method: "GET", slab },
         });
-        return NextResponse.json({ error: error.message }, { status: 500 });
+        return NextResponse.json({ error: "Failed to load market. Please try again later." }, { status: 500 });
       }
 
       // Sort to prefer the most active slab when multiple markets share the same

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -204,7 +204,7 @@ export async function GET(request: NextRequest) {
       Sentry.captureException(error, {
         tags: { endpoint: "/api/markets", method: "GET" },
       });
-      return NextResponse.json({ error: error.message }, { status: 500 });
+      return NextResponse.json({ error: "Failed to load markets. Please try again later." }, { status: 500 });
     }
 
     // Sanitize funding_rate: raw DB values from uninitialized slabs can be

--- a/app/app/api/oracle/advance-phase/route.ts
+++ b/app/app/api/oracle/advance-phase/route.ts
@@ -152,6 +152,6 @@ export async function POST(req: NextRequest) {
       });
     }
 
-    return NextResponse.json({ success: false, skipped: true, reason: msg });
+    return NextResponse.json({ success: false, skipped: true, reason: "Oracle phase advance failed." });
   }
 }

--- a/app/app/api/oracle/set-price-cap/route.ts
+++ b/app/app/api/oracle/set-price-cap/route.ts
@@ -196,7 +196,7 @@ export async function POST(req: NextRequest) {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[set-price-cap] Failed for ${slabAddress}:`, msg);
-      results.push({ slabAddress, status: "error", error: msg });
+      results.push({ slabAddress, status: "error", error: "Price cap update failed." });
     }
   }
 


### PR DESCRIPTION
## Summary
Completes the error sanitization started in PR #2023 (which covers faucet, airdrop, and create-market). These 6 routes were still returning raw `error.message` to clients:

| Route | What leaked |
|---|---|
| `/api/launch` | `err.message` (raw exception text) |
| `/api/markets` GET | Supabase `error.message` (table/column names) |
| `/api/markets/[slab]` GET (2 locations) | Supabase `error.message` |
| `/api/devnet-mint-token` | `error.message` (SDK/RPC internals) |
| `/api/oracle/advance-phase` | Raw Solana program error (hex codes, simulation details) |
| `/api/oracle/set-price-cap` | Raw error in results array |

## Vulnerability details
- **Severity:** MEDIUM
- **Type:** Information disclosure via error messages
- **Attack vector:** Attacker sends malformed or edge-case requests to trigger errors, extracting Supabase table/column names, RPC endpoint URLs, on-chain program error codes, and SDK version information from the response body. This is reconnaissance fuel for deeper attacks.

## Fix
Replace all raw `error.message` in response bodies with generic, user-safe messages. All errors are already captured by `Sentry.captureException()` — clients do not need the raw text for debugging.

## Test plan
- [ ] Trigger an error on each route (e.g., malformed request, DB unavailable)
- [ ] Verify response body contains generic message, not internal details
- [ ] Verify Sentry still captures full error context
- [ ] Normal (non-error) responses unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)