### PR TITLE
fix(sdk): clamp short entry price to prevent underflow at high fee bps

### DIFF
--- a/packages/core/src/math/trading.ts
+++ b/packages/core/src/math/trading.ts
@@ -209,7 +209,12 @@ export function computeEstimatedEntryPrice(
 ): bigint {
   if (oracleE6 === 0n) return 0n;
   const feeImpact = (oracleE6 * tradingFeeBps) / 10000n;
-  return direction === "long" ? oracleE6 + feeImpact : oracleE6 - feeImpact;
+  if (direction === "long") return oracleE6 + feeImpact;
+  // Clamp to 1 to prevent underflow — a zero or negative entry price is nonsensical
+  // and would cause computePreTradeLiqPrice to report "no liquidation risk" (liqPrice=0)
+  // when fee >= 100%, misleading the UI.
+  const shortEntry = oracleE6 - feeImpact;
+  return shortEntry > 0n ? shortEntry : 1n;
 }
 
 /**


### PR DESCRIPTION
## Summary
- `computeEstimatedEntryPrice` for short direction subtracts `feeImpact` from `oracleE6`
- When `tradingFeeBps >= 10000` (fee >= 100%), the result goes to zero or negative
- This feeds into `computePreTradeLiqPrice` which returns `liqPrice = 0`, causing the UI to display **"no liquidation risk"** when there is actually extreme risk

## Vulnerability details
- **Severity:** MEDIUM
- **Type:** Misleading UI / risk miscalculation
- **Location:** `packages/core/src/math/trading.ts` lines 205-213
- **Attack vector:** A market creator sets `tradingFeeBps >= 10000` (fee >= 100%). The pre-trade liquidation price estimate for short positions shows 0, making it appear safe. Users open shorts believing they have no liquidation risk and get immediately liquidated. This could also affect any downstream tooling that relies on `computePreTradeLiqPrice` for risk checks.

## Fix
Clamp the short entry price to a minimum of `1n`. This preserves correct behavior for all normal fee ranges (0-9999 bps) while preventing the zero/negative underflow for adversarial configurations. Long direction is unaffected (fee impact is additive, not subtractive).

## Test plan
- [ ] Normal fees (e.g., 30 bps): short entry price unchanged
- [ ] Fee = 10000 bps (100%): short entry price clamps to `1n` instead of `0n`
- [ ] Fee = 15000 bps (150%): short entry price clamps to `1n` instead of going negative
- [ ] Long direction: unchanged for all fee values
- [ ] `computePreTradeLiqPrice` returns a non-zero liq price for extreme fee scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)