### PR TITLE
hardening(ci): add explicit permissions to workflow files

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 # Cancel in-progress runs on same PR
 concurrency:
   group: pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -2,6 +2,10 @@ name: Post-Deploy Smoke Test
 
 # Runs automatically after Vercel production deployments via workflow_call,
 # or can be triggered manually targeting any URL.
+
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 # Cancel in-progress runs on same branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- `test.yml`, `pr-check.yml`, and `smoke-test.yml` lacked top-level `permissions:` blocks
- Without explicit scoping, workflows may inherit `write-all` on private repos or certain org configurations
- A compromised or malicious step could use the elevated `GITHUB_TOKEN` to push code, create releases, or modify packages
- `deploy.yml` already scopes permissions correctly — this aligns the other three

## Details
- **Severity:** MEDIUM (hardening recommendation)
- **Type:** Least-privilege CI configuration
- **Location:** `.github/workflows/test.yml`, `.github/workflows/pr-check.yml`, `.github/workflows/smoke-test.yml`
- **Context:** GitHub's default token permissions depend on repo visibility and org settings. Public repos with `pull_request` triggers get read-only tokens by default, but this is not guaranteed across all configurations. Explicit `permissions: contents: read` ensures least-privilege regardless of org settings.

## Fix
Add `permissions: contents: read` at the top level of each workflow file. This is the minimum permission needed for checkout and build/test steps. Any future step requiring write access can declare it at the job level.

## Test plan
- [ ] All three workflows still trigger and pass on PRs
- [ ] `gh api repos/dcccrypto/percolator-launch/actions/permissions` confirms org-level settings
- [ ] Verify no existing step requires write permissions (none do — they only build, test, and report)

🤖 Generated with [Claude Code](https://claude.com/claude-code)