### PR TITLE
review(security): flag WebSocket price feed auth gap for mainnet decision

### DIFF
--- a/app/hooks/useLivePrice.ts
+++ b/app/hooks/useLivePrice.ts
@@ -19,6 +19,22 @@ import { useSlabState } from "@/components/providers/SlabProvider";
 import { applyInvert, resolveMarketPriceE6, sanitizePriceE6 } from "@/lib/oraclePrice";
 import { getBackendUrl } from "@/lib/config";
 
+// ── SECURITY REVIEW (mainnet) ─────────────────────────────────────────────
+// The WS price feed client sends NO authentication token when connecting.
+// If WS_AUTH_REQUIRED=false on the server (current default per SECURITY.md),
+// any external caller can open unauthenticated connections, subscribe to any
+// slab's live prices, and enumerate active markets. Per-IP connection limits
+// (default 5) are the only protection against abuse.
+//
+// If WS_AUTH_REQUIRED=true on the server, this client will fail to
+// authenticate and silently fall back to 30s REST polling — the WS feature
+// becomes a no-op with no user-visible indication.
+//
+// Before mainnet: decide whether the price feed is intentionally public
+// (document it, set aggressive per-IP limits) or requires auth (implement
+// HMAC token generation here matching the scheme in SECURITY.md).
+// ──────────────────────────────────────────────────────────────────────────
+
 // Derive WebSocket URL from API URL: https://... → wss://...
 function getWsUrl(): string {
   const explicit = process.env.NEXT_PUBLIC_WS_URL;


### PR DESCRIPTION
## Summary
The WebSocket price feed client in `useLivePrice.ts` sends **no authentication token** when connecting or subscribing. This needs an explicit team decision before mainnet.

## Current behavior
- Client opens `new WebSocket(WS_URL)` and sends `{ type: "subscribe", slabAddress }` with no auth (line 209-220)
- Server docs say `WS_AUTH_REQUIRED` defaults to `false` (per SECURITY.md)
- Per-IP connection limit (default 5) is the only abuse protection

## Two possible states on mainnet

### If WS_AUTH_REQUIRED=false (current default)
- Any external caller can connect and subscribe to any slab's live price feed
- Attackers can enumerate all active markets and monitor prices in real-time
- Only per-IP limits prevent connection flooding (easily rotated with proxies)
- The price data itself is not secret (also available via REST), but unauthenticated WS access enables high-frequency monitoring at zero cost to the attacker

### If WS_AUTH_REQUIRED=true
- The client has no auth implementation — connections will be rejected
- Users silently fall back to 30s REST polling with **no visible indication** that WebSocket is broken
- Live price updates degrade from sub-second to 30-second intervals without any user feedback

## What needs to happen
1. **Decide:** Is the price feed intentionally public? (Most exchanges treat live prices as public data)
2. **If public:** Document it explicitly, set aggressive per-IP connection limits on the WS server, and consider adding a lightweight API key to prevent casual scraping
3. **If private:** Implement HMAC token generation in the client matching the scheme documented in SECURITY.md, and add a visible fallback indicator when WS auth fails

## This PR
Adds a `SECURITY REVIEW` comment block to `useLivePrice.ts` documenting the gap and the decision needed. No behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)