### PR TITLE
fix: reject unsupported oracle_mode in mobile create-market (closes #1989)

### DIFF
--- a/app/app/api/mobile/create-market/route.ts
+++ b/app/app/api/mobile/create-market/route.ts
@@ -96,9 +96,9 @@ interface MobileCreateMarketBody {
   tier?: SlabTierKey;
   /** Human-readable market name. */
   name?: string;
-  /** Oracle mode. Only "admin" is supported for devnet beta. */
-  oracle_mode?: "admin" | "hyperp" | "pyth";
-  /** DEX pool address (base58). Required for hyperp mode; ignored for admin. */
+  /** Oracle mode. Only "admin" is implemented — "hyperp"/"pyth" are rejected (GH#1989). */
+  oracle_mode?: string;
+  /** DEX pool address (base58). Reserved for future hyperp mode; currently unused. */
   dex_pool_address?: string | null;
   /** Initial mark price in e6 format (price × 1_000_000). Default: "1000000" ($1.00). */
   initial_price_e6?: string;
@@ -196,10 +196,18 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const validOracleModes = ["admin", "hyperp", "pyth"] as const;
-    if (!validOracleModes.includes(oracle_mode as typeof validOracleModes[number])) {
+    // GH#1989: Only "admin" oracle mode is implemented on-chain. Accepting
+    // "hyperp" or "pyth" would write those values to DB metadata while the
+    // actual on-chain instructions always build an admin-oracle market,
+    // creating a trust-model mismatch between metadata and execution.
+    if (oracle_mode !== "admin") {
       return NextResponse.json(
-        { error: `Invalid oracle_mode. Must be one of: ${validOracleModes.join(", ")}` },
+        {
+          error:
+            `Unsupported oracle_mode "${oracle_mode}". ` +
+            `Only "admin" is currently supported for on-chain market initialization. ` +
+            `"hyperp" and "pyth" modes are not yet implemented.`,
+        },
         { status: 400 },
       );
     }


### PR DESCRIPTION
## Summary
- Fixes the oracle_mode metadata/on-chain mismatch reported in #1989
- The endpoint now rejects `oracle_mode` values other than `"admin"` with a clear 400 error
- Previously, `"hyperp"` and `"pyth"` were accepted by validation but silently ignored during transaction construction, causing the DB registration to record an oracle mode that didn't match on-chain reality

## What was fixed
The `POST /api/mobile/create-market` endpoint validated `oracle_mode` against `["admin", "hyperp", "pyth"]` but **always** built admin-oracle transactions regardless:
- `indexFeedId` was hardcoded to `ADMIN_ORACLE_FEED` (all-zero 64-char hex)
- Oracle authority was always set to the deployer wallet
- Keeper crank instructions always used `slabPk` as the oracle account (admin-oracle pattern)

A client sending `oracle_mode="pyth"` would get a market that is admin-oracle on-chain but labeled "pyth" in the dashboard DB, causing:
- Incorrect oracle trust assumptions by traders and operators
- Broken automation that behaves differently per oracle mode
- Monitoring systems that expect Pyth/DEX oracle behavior from an admin-oracle market

## Root cause
```typescript
// Before — accepted but ignored
const validOracleModes = ["admin", "hyperp", "pyth"] as const;
if (!validOracleModes.includes(oracle_mode)) { return 400; }
// ...then always used ADMIN_ORACLE_FEED regardless of oracle_mode
```

## Fix approach
Reject non-admin modes explicitly since they are not implemented:
```typescript
// After — fail-closed on unimplemented modes
if (oracle_mode !== "admin") {
  return NextResponse.json({
    error: `Unsupported oracle_mode "${oracle_mode}". Only "admin" is currently supported.`
  }, { status: 400 });
}
```

## Test plan
- [ ] `POST /api/mobile/create-market` with `oracle_mode: "admin"` → succeeds as before
- [ ] `POST /api/mobile/create-market` with `oracle_mode: "pyth"` → returns 400 with clear message
- [ ] `POST /api/mobile/create-market` with `oracle_mode: "hyperp"` → returns 400 with clear message
- [ ] `POST /api/mobile/create-market` with no `oracle_mode` → defaults to "admin", succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for oracle mode selection when creating markets via mobile endpoint
  * Improved error messages to clearly communicate which oracle modes are unsupported for on-chain market initialization
  * Market creation requests with unsupported oracle modes are now properly rejected

<!-- end of auto-generated comment: release notes by coderabbit.ai -->