### PR TITLE
fix(security): add buffer size validation for Pyth oracle data parsing

### DIFF
--- a/app/app/api/oracle/publishers/route.ts
+++ b/app/app/api/oracle/publishers/route.ts
@@ -181,7 +181,20 @@ async function fetchPythPublishers(feedIdHex: string): Promise<PublishersRespons
     };
   }
 
-  const data = Buffer.from(json.result.value.data[0], "base64");
+  // GH#1814: Validate buffer size before decoding to prevent OOM attacks.
+  // Pyth price accounts are typically ~5-10KB; reject anything larger than 1MB.
+  const b64Data = json.result.value.data[0];
+  if (typeof b64Data === "string" && Buffer.byteLength(b64Data, "base64") > 1_000_000) {
+    console.warn("[oracle/publishers] Pyth account data too large (>1MB), rejecting");
+    return {
+      mode: "pyth-pinned",
+      publisherCount: null,
+      publisherTotal: null,
+      publishers: [],
+    };
+  }
+
+  const data = Buffer.from(b64Data, "base64");
 
   const magic = data.readUInt32LE(0);
   if (magic !== PYTH_MAGIC) {


### PR DESCRIPTION
- Add 1MB size limit to base64 oracle account data before Buffer.from()
- Prevents potential OOM attacks from malicious RPC responses
- Gracefully returns empty publisher list if data is oversized
- Pyth price accounts are ~5-10KB; 1MB allows reasonable headroom

Fixes SEC-006: Buffer overflow potential in oracle data parsing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced the publisher data endpoint with size validation to safely handle large data responses. When publisher data exceeds safe processing limits, the service now returns gracefully with an empty publishers list instead of attempting full processing, helping prevent potential performance issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->