### PR TITLE
fix: add explicit type guards for devnet mirror mint validation

### DIFF
--- a/app/app/api/devnet-pre-fund/route.ts
+++ b/app/app/api/devnet-pre-fund/route.ts
@@ -184,7 +184,13 @@ export async function POST(req: NextRequest) {
             });
           }
           const mirrorRow = mirrorRows?.[0];
-          finallyPermitted = !!mirrorRow?.devnet_mint;
+          // GH#1816: Explicit type guard — verify mirrorRow structure
+          finallyPermitted = !!(
+            mirrorRow &&
+            typeof mirrorRow === "object" &&
+            "devnet_mint" in mirrorRow &&
+            typeof (mirrorRow as Record<string, unknown>).devnet_mint === "string"
+          );
         } catch (e) {
           Sentry.captureException(e, {
             tags: { endpoint: "/api/devnet-pre-fund", phase: "dynamic-mint-check" },
@@ -209,7 +215,16 @@ export async function POST(req: NextRequest) {
           });
         }
         const mirrorRow = mirrorRows?.[0];
-        finallyPermitted = !!mirrorRow?.devnet_mint;
+        // GH#1816: Explicit type guard — verify mirrorRow has required devnet_mint property.
+        // Previously !!mirrorRow?.devnet_mint would correctly fail-closed (undefined → false),
+        // but being explicit about structure validation is clearer and prevents subtle bugs
+        // if the schema changes or malformed data is returned from DB.
+        finallyPermitted = !!(
+          mirrorRow &&
+          typeof mirrorRow === "object" &&
+          "devnet_mint" in mirrorRow &&
+          typeof (mirrorRow as Record<string, unknown>).devnet_mint === "string"
+        );
       } catch (e) {
         Sentry.captureException(e, {
           tags: { endpoint: "/api/devnet-pre-fund", phase: "dynamic-mint-check" },


### PR DESCRIPTION
- Add explicit null/undefined checks and type validation for mirrorRow
- Verify devnet_mint property exists and is a string before using
- Improves code clarity; maintains fail-closed security (returns false on invalid data)
- Applies fix to both static allowlist and dynamic DB lookup paths

Improves VAL-003: Missing null/undefined checks on critical paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the devnet pre-fund eligibility verification logic for improved reliability and consistency across different check pathways.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->