### PR TITLE
fix: don't zombie markets with live price or real accounts

### DIFF
--- a/app/lib/activeMarketFilter.ts
+++ b/app/lib/activeMarketFilter.ts
@@ -102,7 +102,10 @@ export function isZombieMarket(row: {
   // In that case, fall through to the vault_balance=0 zombie check below.
   if (cTot !== null && cTot > 0 && hasActivity) return false;
 
-  if (vaultBal !== null && vaultBal === 0) return true;
+  // GH#2029: vault_balance=0 only means zombie when there's zero evidence of life.
+  // The 7T1E mainnet market has vault_balance=0 (collateral in slab) but last_price=79.5
+  // (keeper is cranking). Without this guard, live markets get hidden as zombies.
+  if (vaultBal !== null && vaultBal === 0 && !hasActivity) return true;
   if (vaultBal === null) {
     // GH#1502: OI intentionally excluded from hasNoStats check (same logic as hasActivity above).
     // OI without accounts is phantom per GH#1290 — a null-vault market with phantom OI


### PR DESCRIPTION
## Problem
The new 7T1E mainnet market (SOL-PERP) returns `total: 0, zombieCount: 1` — hidden from the frontend.

**Root cause:** `vault_balance=0` in market_stats (collateral stored in slab struct, not engine.vault). The zombie filter hits `vaultBal === 0 → return true` without checking if the market has a live price (`79.5`).

## Fix
`vault_balance === 0` only triggers zombie when there's **no evidence of life** (no price, no accounts, no volume). Uses the same `hasActivity` check from the c_tot exemption.

## Impact
- 7T1E appears on mainnet.percolatorlaunch.com after deploy
- FF7K keeper markets (vault=0, c_tot>0, prices) already pass the c_tot exemption — no change
- Dead markets (vault=0, no price, no accounts) still correctly zombied

## Related
- Pairs with percolator-indexer#63 (auto-close stale markets)
- PR #2029/#2046 already filters indexer_excluded at DB + API level

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced zombie market detection for markets with zero vault balance. Rather than automatically marking these as inactive, the system now evaluates relevant activity signals such as price movements, trading volume, or existing account activity before making this determination. Markets exhibiting these signals are now correctly classified and displayed as active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->