### PR TITLE
feat: add rate limit event logging for monitoring

### DIFF
--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -352,6 +352,17 @@ export async function middleware(request: NextRequest) {
     // fires one request too early" in single-instance envs and "never fires"
     // in distributed Edge (each isolate has its own in-memory counter at 0).
     if (!allowed) {
+      // GH#1819: Log rate limit events for monitoring and alerting
+      const logContext = {
+        ip,
+        path: request.nextUrl.pathname,
+        rpcLimit: isRpc,
+        limit,
+        remaining,
+        reset,
+      };
+      console.warn("[RateLimit] Request blocked:", JSON.stringify(logContext));
+
       return new NextResponse(
         JSON.stringify({ error: "Too many requests. Please try again later." }),
         {


### PR DESCRIPTION
- Log rate limit rejections (429) with request context (IP, path, limits)
- Enables visibility into DDoS/abuse attempts
- Logs to console for aggregation into monitoring/alerting systems
- Useful for debugging rate limit tuning and detection

Fixes OBSERV-002: Rate limit events not logged or monitored