### PR TITLE
fix: return appropriate HTTP status codes from health endpoint

### DIFF
--- a/app/app/api/health/route.ts
+++ b/app/app/api/health/route.ts
@@ -48,9 +48,15 @@ export async function GET() {
 
   const status = apiOk && rpcOk ? "online" : apiOk ? "degraded" : "offline";
 
+  // GH#1820: Return appropriate HTTP status codes based on service health.
+  // - 200 OK: All services online
+  // - 503 Service Unavailable: API or RPC offline/unhealthy
+  const statusCode = apiOk && rpcOk ? 200 : 503;
+
   return NextResponse.json(
     { status, api: apiOk, rpc: rpcOk, ts: Date.now() },
     {
+      status: statusCode,
       headers: {
         "Cache-Control": "no-store, max-age=0",
       },


### PR DESCRIPTION
- Return 200 OK when all services (API + RPC) are online
- Return 503 Service Unavailable when API or RPC is offline
- Enables monitoring systems to properly detect service degradation
- Health status still available in JSON response body

Fixes OBSERV-001: Health check endpoint incomplete