### PR TITLE
fix(tests): align zombie test assertions with GH#2029 vault=0 live-market logic

### DIFF
--- a/app/__tests__/api/gh1535-1536-active-count-alignment.test.ts
+++ b/app/__tests__/api/gh1535-1536-active-count-alignment.test.ts
@@ -116,7 +116,7 @@ describe("GH#1535 — /api/stats activeTotal must match /api/markets activeTotal
   it("zombies are excluded before isActiveMarket check in both paths", () => {
     const markets = [
       makeMarket({ slab_address: "active", last_price: 50, vault_balance: 5_000_000, total_accounts: 3 }),
-      makeMarket({ slab_address: "zombie", last_price: 148, vault_balance: 0, total_accounts: 5, c_tot: null }),
+      makeMarket({ slab_address: "zombie", last_price: null, vault_balance: 0, total_accounts: 0, c_tot: null, volume_24h: null }),
     ];
     const statsTotal = deriveStatsActiveTotal(markets);
     const marketsTotal = deriveMarketsActiveTotal(markets);

--- a/app/__tests__/api/markets-price-sanitize.test.ts
+++ b/app/__tests__/api/markets-price-sanitize.test.ts
@@ -293,7 +293,7 @@ describe("GET /api/markets — price sanitization (#856)", () => {
   describe("PERC-816 — phantom OI suppression for dust vault_balance", () => {
     it("excludes vault_balance=0 markets by default (GH#1420 zombie filter)", async () => {
       mockMarkets = [
-        mkMarket({ symbol: "ZERO_VAULT", vault_balance: 0, total_open_interest: 2_000_000_000_000, last_price: 1.0 }),
+        mkMarket({ symbol: "ZERO_VAULT", vault_balance: 0, total_open_interest: 2_000_000_000_000, last_price: null, volume_24h: null, total_accounts: 0 }),
         mkMarket({ symbol: "HEALTHY", vault_balance: 5_000_000_000, total_open_interest: 1_000_000_000, last_price: 100.0 }),
       ];
       vi.resetModules();

--- a/app/__tests__/api/markets-zombie-string-coercion.test.ts
+++ b/app/__tests__/api/markets-zombie-string-coercion.test.ts
@@ -91,12 +91,27 @@ describe("isZombieMarket with Supabase NUMERIC string coercion (GH#1494)", () =>
     ).toBe(false);
   });
 
-  it("is_zombie=true for string '0' vault_balance even with stale price (GH#1494 main case)", () => {
-    // This is the production case: vault=0, stale last_price still in DB
+  it("is_zombie=false for string '0' vault_balance with live price (GH#2029)", () => {
+    // GH#2029: vault=0 + live price means keeper is cranking → NOT a zombie.
+    // Previously (pre-GH#2029) this was true, but markets like 7T1E proved
+    // that vault=0 markets with live prices are genuinely active (collateral in slab).
     expect(
       isZombieMarket({
         vault_balance: numericOrNull("0"),
         last_price: numericOrNull("148"),
+        volume_24h: numericOrNull("0"),
+        total_open_interest: numericOrNull("0"),
+        total_accounts: numericOrNull("0"),
+      }),
+    ).toBe(false);
+  });
+
+  it("is_zombie=true for string '0' vault_balance with NO price (GH#1494 + GH#2029)", () => {
+    // vault=0, no price, no activity → genuine zombie
+    expect(
+      isZombieMarket({
+        vault_balance: numericOrNull("0"),
+        last_price: null,
         volume_24h: numericOrNull("0"),
         total_open_interest: numericOrNull("0"),
         total_accounts: numericOrNull("0"),


### PR DESCRIPTION
## What

Fixes CI failure on `main` caused by PR #2049 (GH#2029) changing `isZombieMarket` behavior without updating all test assertions.

## Problem

GH#2029 correctly changed `isZombieMarket` to NOT treat vault=0 markets as zombies when they have live prices (e.g. 7T1E mainnet market with collateral in slab). Three test files still asserted the old behavior where vault=0 always meant zombie.

## Changes

- **markets-zombie-string-coercion.test.ts**: vault=0 + price=148 → now expects `false` (not zombie). Added new test: vault=0 + no price → `true` (zombie).
- **markets-price-sanitize.test.ts**: `ZERO_VAULT` test market now has `last_price: null, total_accounts: 0` to be a genuine zombie.
- **gh1535-1536-active-count-alignment.test.ts**: zombie test market now has null price and zero accounts.

## Testing

All 149 test files pass (1795 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for zombie market detection and filtering logic with updated test scenarios for markets displaying zero vault balance and null pricing data, ensuring accurate identification of inactive markets across various data conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->