### PR TITLE
fix(test): align rpc-allowlist tests with sendTransaction re-enablement

### DIFF
--- a/app/__tests__/api/rpc-allowlist.test.ts
+++ b/app/__tests__/api/rpc-allowlist.test.ts
@@ -17,19 +17,19 @@ describe("/api/rpc allowlist", () => {
     "utf-8"
   );
 
-  // PERC-8308: mutating methods must NOT be in the public allowlist
-  it("does NOT allow sendTransaction (PERC-8308 security fix)", () => {
-    // sendTransaction must not appear inside ALLOWED_RPC_METHODS
-    // The comment referencing it (as excluded) is okay, but the string literal in the Set must not exist
-    expect(routeSource).not.toMatch(/ALLOWED_RPC_METHODS[^;]*"sendTransaction"/s);
+  // PERC-8308 originally removed sendTransaction/simulateTransaction.
+  // a70eebd1: Khubair re-added them — origin guard makes them safe for
+  // user-signed transactions without exposing the Helius key to abuse.
+  // Tests now verify they ARE allowed (policy change) and origin guard exists.
+  it("allows sendTransaction (re-enabled with origin guard)", () => {
+    expect(routeSource).toMatch(/ALLOWED_RPC_METHODS[^;]*"sendTransaction"/s);
   });
 
-  it("does NOT allow simulateTransaction (PERC-8308 security fix)", () => {
-    expect(routeSource).not.toMatch(/ALLOWED_RPC_METHODS[^;]*"simulateTransaction"/s);
+  it("allows simulateTransaction (re-enabled with origin guard)", () => {
+    expect(routeSource).toMatch(/ALLOWED_RPC_METHODS[^;]*"simulateTransaction"/s);
   });
 
-  it("returns 403 for sendTransaction (documented in route source)", () => {
-    // Route source should document the exclusion with a PERC-8308 reference
+  it("references PERC-8308 security decision", () => {
     expect(routeSource).toContain("PERC-8308");
   });
 

--- a/app/app/api/rpc/route.ts
+++ b/app/app/api/rpc/route.ts
@@ -125,9 +125,9 @@ function getRpcUrl(networkOverride?: "mainnet" | "devnet"): string {
  * Allowlist of JSON-RPC methods that may be proxied to Helius.
  * Prevents abuse of the API key for unauthorized operations.
  *
- * PERC-8308: sendTransaction and simulateTransaction are intentionally EXCLUDED.
- * Mutating RPC methods must not be exposed publicly — clients should submit
- * transactions via their own RPC connection or a dedicated authenticated endpoint.
+ * PERC-8308: sendTransaction and simulateTransaction were originally excluded.
+ * Re-enabled (a70eebd1) — origin guard prevents external abuse of the Helius
+ * key while allowing user-signed transactions from the app.
  */
 const ALLOWED_RPC_METHODS = new Set([
   // Health & cluster


### PR DESCRIPTION
## Problem
CI on main failing: `rpc-allowlist.test.ts` asserts `sendTransaction` and `simulateTransaction` must NOT be in `ALLOWED_RPC_METHODS`, but a70eebd1 intentionally re-added them with origin guard protection.

## Fix
- Updated test assertions to verify methods ARE allowed (matching current policy)
- Updated route.ts JSDoc comment to reflect the policy change
- Origin guard test remains in place

## Testing
All 1795 tests pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Re-enabled transaction sending functionality (`sendTransaction` and `simulateTransaction` methods) with security improvements.

* **Documentation**
  * Updated API documentation to reflect that transaction methods are now available with origin-based access controls to protect against unauthorized external use while allowing user-signed transactions within the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->