### PR TITLE
fix(security): trust proxy depth for stats and trader rate limits (v2)

### DIFF
--- a/app/__tests__/api/stats-trader-trusted-ip-rate-limit.test.ts
+++ b/app/__tests__/api/stats-trader-trusted-ip-rate-limit.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("trusted proxy-aware IPs for rate-limited public endpoints", () => {
+  it("stats endpoint uses getClientIp", () => {
+    const source = readFileSync(
+      resolve(__dirname, "../../app/api/stats/route.ts"),
+      "utf8",
+    );
+
+    expect(source).toContain('import { getClientIp } from "@/lib/get-client-ip"');
+    expect(source).toContain("const ip = getClientIp(request);");
+    expect(source).not.toContain('x-forwarded-for")?.split(",")[0]');
+  });
+
+  it("trader stats endpoint uses getClientIp", () => {
+    const source = readFileSync(
+      resolve(__dirname, "../../app/api/trader/[wallet]/stats/route.ts"),
+      "utf8",
+    );
+
+    expect(source).toContain('import { getClientIp } from "@/lib/get-client-ip"');
+    expect(source).toContain("const ip = getClientIp(request);");
+    expect(source).not.toContain('x-forwarded-for")?.split(",")[0]');
+  });
+
+  it("trader trades endpoint uses getClientIp", () => {
+    const source = readFileSync(
+      resolve(__dirname, "../../app/api/trader/[wallet]/trades/route.ts"),
+      "utf8",
+    );
+
+    expect(source).toContain('import { getClientIp } from "@/lib/get-client-ip"');
+    expect(source).toContain("const ip = getClientIp(_request);");
+    expect(source).not.toContain('x-forwarded-for")?.split(",")[0]');
+  });
+});

--- a/app/app/api/stats/route.ts
+++ b/app/app/api/stats/route.ts
@@ -8,6 +8,7 @@ import { getServiceClient, getServerNetwork } from "@/lib/supabase";
 import { isActiveMarket, isSaneMarketValue, isZombieMarket } from "@/lib/activeMarketFilter";
 import { isPhantomOpenInterest } from "@/lib/phantom-oi";
 import { BLOCKED_SLAB_ADDRESSES } from "@/lib/blocklist";
+import { getClientIp } from "@/lib/get-client-ip";
 import type { Database } from "@/lib/database.types";
 export const dynamic = "force-dynamic";
 
@@ -53,9 +54,7 @@ function isRateLimited(ip: string): boolean {
  * Rate limited: 60 req/min per IP (PERC-660, security issue #1031).
  */
 export async function GET(request: NextRequest) {
-  const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim()
-    ?? request.headers.get("x-real-ip")
-    ?? "unknown";
+  const ip = getClientIp(request);
   if (isRateLimited(ip)) {
     return NextResponse.json(
       { error: "Rate limited. Max 60 requests per minute." },

--- a/app/app/api/trader/[wallet]/stats/route.ts
+++ b/app/app/api/trader/[wallet]/stats/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServiceClient, getServerNetwork } from "@/lib/supabase";
 import { PublicKey } from "@solana/web3.js";
+import { getClientIp } from "@/lib/get-client-ip";
 
 /**
  * GET /api/trader/:wallet/stats
@@ -79,10 +80,7 @@ export async function GET(
   { params }: { params: Promise<{ wallet: string }> },
 ) {
   // Rate limiting
-  const ip =
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
-    request.headers.get("x-real-ip") ??
-    "unknown";
+  const ip = getClientIp(request);
   if (isRateLimited(ip)) {
     return NextResponse.json(
       { error: "Too many requests — max 30 per minute" },

--- a/app/app/api/trader/[wallet]/trades/route.ts
+++ b/app/app/api/trader/[wallet]/trades/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServiceClient, getServerNetwork } from "@/lib/supabase";
 import { PublicKey } from "@solana/web3.js";
 import { validateNumericParam } from "@/lib/route-validators";
+import { getClientIp } from "@/lib/get-client-ip";
 
 /**
  * GET /api/trader/:wallet/trades?limit=20&offset=0&slab=<optional>
@@ -54,10 +55,7 @@ export async function GET(
   { params }: { params: Promise<{ wallet: string }> },
 ) {
   // Rate limiting — 60 req/min per IP (fixes #700)
-  const ip =
-    _request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
-    _request.headers.get("x-real-ip") ??
-    "unknown";
+  const ip = getClientIp(_request);
   if (isRateLimited(ip)) {
     return NextResponse.json(
       { error: "Too many requests — max 60 per minute" },


### PR DESCRIPTION
Replacement for #1997 (GitHub had persistent merge-conflict bug on original PR despite clean rebase).

Same change: Replace manual x-forwarded-for header parsing with `getClientIp()` utility across stats, trader/stats, and trader/trades endpoints.

QA approved, Security approved on original PR. All CI was green.

Closes #1997