### PR TITLE
fix(PERC-8388): detect Lighthouse error in JSON format (Custom:6400)

### DIFF
--- a/app/__tests__/unit/lighthouse-detection.test.ts
+++ b/app/__tests__/unit/lighthouse-detection.test.ts
@@ -9,6 +9,9 @@ describe("Lighthouse 0x1900 detection", () => {
     "Transaction simulation failed: custom program error: 0x1900",
     "failed to send transaction: Transaction simulation failed: Error processing Instruction 3: custom program error: 0x1900",
     "Program L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95 consumed 12345 of 200000 compute units",
+    // JSON format from RPC — 6400 decimal = 0x1900 hex
+    '{"InstructionError":[3,{"Custom":6400}]}',
+    'Transaction simulation failed: Error processing Instruction 3: {"InstructionError":[3,{"Custom":6400}]}',
   ];
 
   const NON_LIGHTHOUSE = [
@@ -20,7 +23,8 @@ describe("Lighthouse 0x1900 detection", () => {
 
   const isLighthouse = (msg: string) =>
     /custom program error:\s*0x1900\b/i.test(msg) ||
-    /L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95/i.test(msg);
+    /L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95/i.test(msg) ||
+    (/"Custom"\s*:\s*6400/.test(msg) && /InstructionError/.test(msg));
 
   test.each(LIGHTHOUSE_PATTERNS)("detects Lighthouse error: %s", (msg) => {
     expect(isLighthouse(msg)).toBe(true);
@@ -30,7 +34,7 @@ describe("Lighthouse 0x1900 detection", () => {
     expect(isLighthouse(msg)).toBe(false);
   });
 
-  test("user-facing message for 0x1900", () => {
+  test("user-facing message for 0x1900 hex format", () => {
     const is0x1900 = /custom program error:\s*0x1900\b/i.test(
       "custom program error: 0x1900"
     );
@@ -44,5 +48,13 @@ describe("Lighthouse 0x1900 detection", () => {
 
     expect(userMsg).toContain("Blowfish");
     expect(userMsg).toContain("Backpack");
+  });
+
+  test("user-facing message for JSON Custom:6400 format", () => {
+    const raw = '{"InstructionError":[3,{"Custom":6400}]}';
+    const is0x1900 =
+      /custom program error:\s*0x1900\b/i.test(raw) ||
+      (/"Custom"\s*:\s*6400/.test(raw) && /InstructionError/.test(raw));
+    expect(is0x1900).toBe(true);
   });
 });

--- a/app/hooks/useInitUser.ts
+++ b/app/hooks/useInitUser.ts
@@ -94,7 +94,8 @@ export function useInitUser(slabAddress: string) {
           // itself validates correctly without Lighthouse assertions.
           const isLighthouse =
             /custom program error:\s*0x1900\b/i.test(errMsg) ||
-            /L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95/i.test(errMsg);
+            /L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95/i.test(errMsg) ||
+            (/"Custom"\s*:\s*6400/.test(errMsg) && /InstructionError/.test(errMsg));
 
           if (isLighthouse) {
             console.warn(
@@ -119,7 +120,9 @@ export function useInitUser(slabAddress: string) {
         // PERC-8388: Lighthouse/Blowfish 0x1900 — wallet middleware assertion failure.
         // If the skipPreflight retry in the try block above also failed, surface
         // a more helpful message than the raw Lighthouse error code.
-        const is0x1900 = /custom program error:\s*0x1900\b/i.test(raw);
+        const is0x1900 =
+          /custom program error:\s*0x1900\b/i.test(raw) ||
+          (/"Custom"\s*:\s*6400/.test(raw) && /InstructionError/.test(raw));
         const userMsg = is0x4
           ? "This market uses an older format that's incompatible with the current program version. " +
             "The market creator needs to re-initialize it. Please try a different market or contact support."


### PR DESCRIPTION
## Problem
The Lighthouse/Blowfish wallet middleware error comes in two formats:
- **Hex**: `custom program error: 0x1900`
- **JSON**: `{"InstructionError":[3,{"Custom":6400}]}`

The skipPreflight retry logic only matched the hex format, so when the RPC returns the JSON format (which is the actual format Khubair is seeing), the retry never triggers.

## Fix
Added JSON format detection: `/"Custom"\s*:\s*6400/.test(errMsg) && /InstructionError/.test(errMsg)`

Applied to both:
1. The inner try/catch (triggers skipPreflight retry)
2. The outer catch (user-facing error message)

## Testing
- 11/11 unit tests pass including 2 new JSON format test cases
- `pnpm test:app -- __tests__/unit/lighthouse-detection.test.ts`

Closes PERC-8388