### PR TITLE
fix(mainnet): correct programId to Percolator's deployed program

### DIFF
--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -108,7 +108,7 @@ export function getWsEndpoint(): string {
 const CONFIGS = {
   mainnet: {
     get rpcUrl() { return getRpcEndpoint(); },
-    programId: "GM8zjJ8LTBMv9xEsverh6H6wLyevgMHEJXcEzyY3rY24",
+    programId: "ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv",
     matcherProgramId: "DHP6DtwXP1yJsz8YzfoeigRFPB979gzmumkmCxDLSkUX",
     crankWallet: "8y7sXswvGo6fWa4daCnxaE3znaFoBs6QJXLTzCLYXotV",  // mainnet keeper crank wallet
     explorerUrl: "https://solscan.io",

--- a/packages/core/src/config/program-ids.ts
+++ b/packages/core/src/config/program-ids.ts
@@ -28,7 +28,7 @@ export const PROGRAM_IDS = {
     matcher: "GTRgyTDfrMvBubALAqtHuQwT8tbGyXid7svXZKtWfC9k",
   },
   mainnet: {
-    percolator: "GM8zjJ8LTBMv9xEsverh6H6wLyevgMHEJXcEzyY3rY24",
+    percolator: "ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv",
     matcher: "DHP6DtwXP1yJsz8YzfoeigRFPB979gzmumkmCxDLSkUX",
   },
 } as const;

--- a/packages/core/src/solana/__tests__/stake.test.ts
+++ b/packages/core/src/solana/__tests__/stake.test.ts
@@ -242,7 +242,7 @@ describe('Instruction encoders', () => {
 
 describe('Account builders', () => {
   const admin = Keypair.generate().publicKey;
-  const percolatorProgram = new PublicKey('GM8zjJ8LTBMv9xEsverh6H6wLyevgMHEJXcEzyY3rY24');
+  const percolatorProgram = new PublicKey('ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv');
 
   it('initPoolAccounts returns 11 accounts in correct order', () => {
     const [pool] = deriveStakePool(slab);

--- a/packages/core/src/solana/static-markets.ts
+++ b/packages/core/src/solana/static-markets.ts
@@ -41,14 +41,13 @@ export interface StaticMarketEntry {
  * Known mainnet market slab addresses.
  *
  * These are the markets deployed to the mainnet Percolator program
- * (`GM8zjJ8LTBMv9xEsverh6H6wLyevgMHEJXcEzyY3rY24`).
+ * (`ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv`).
  *
- * **Last updated:** 2026-04-04 (pre-mainnet launch, populated from devnet
- * deployment addresses as placeholders — update with real mainnet addresses
- * once mainnet markets are live).
+ * **Last updated:** 2026-04-08 (mainnet SOL-PERP slab from migration
+ * 20260330000000, verified on-chain 2026-03-30).
  */
 const MAINNET_MARKETS: StaticMarketEntry[] = [
-  { slabAddress: "CBMzT1jxdmFnhT9UiHbgDkFhdsCuKwYSGXxcE8NnFFBn", symbol: "SOL-PERP", name: "SOL/USDC Perpetual" },
+  { slabAddress: "8NY7rvQJXNTinJkAQG1GUV8NQ1hQzdtF7iWNjK9p7tQN", symbol: "SOL-PERP", name: "SOL/USDC Perpetual" },
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Mainnet `programId` was still set to `GM8zjJ8...` (Toly's large-slab-only program) instead of `ESa89R5...` (Percolator's own deployed mainnet program)
- The live mainnet SOL-PERP slab (`8NY7rvQ...`) is owned by `ESa89R5...`, confirmed in migration `20260330000000` and the `create-market.ts` deployment script
- This caused `getProgramAccounts`-based market discovery to return zero results on mainnet, and all PDA derivations (vault, LP slot, keeper fund) to target the wrong program
- Production deployments masked this via `PROGRAM_ID` env var overrides, but the hardcoded fallback was wrong
- Also updated the static markets registry with the real mainnet SOL-PERP slab address

## Files changed
- `app/lib/config.ts` — mainnet `programId` → `ESa89R5...`
- `packages/core/src/config/program-ids.ts` — mainnet `percolator` → `ESa89R5...`
- `packages/core/src/solana/static-markets.ts` — mainnet SOL-PERP slab → `8NY7rvQ...` (real on-chain address, verified 2026-03-30), updated comment
- `packages/core/src/solana/__tests__/stake.test.ts` — updated test constant

## Test plan
- [x] All 163 app test files pass (1838 tests, 0 failures)
- [x] Core package failures (5 files, 21 tests) verified as pre-existing and unrelated
- [x] No remaining references to `GM8zjJ8...` in source `.ts` files (only in `dist/` build artifacts and docs)
- [ ] Verify on mainnet staging: `getProgramAccounts` returns the SOL-PERP slab
- [ ] Verify PDA derivations match on-chain state (vault, keeper fund addresses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mainnet Percolator program configuration and market registry metadata to reflect current deployment state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->