### PR TITLE
fix(chart): remove 10-bar gate on Percolator tier-0 source

### DIFF
--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -196,10 +196,12 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
     volume: c.volume,
   }));
 
-  // Only use Percolator as the chart source once the market has enough volume
-  // to form at least 10 bars — otherwise fall back to Pyth to avoid a sparse,
-  // gap-filled chart that looks worse than Pyth's deep history.
-  const hasPercolatorData = percolatorStatus === "success" && percolatorCandles.length >= 10;
+  // Use Percolator as the chart source as soon as ANY internal-trade candle
+  // is available. Previously this was gated at >=10 bars to avoid rendering a
+  // sparse chart that looked worse than Pyth's deep history, but that's a bad
+  // default for the "market was just created" case — the chart should
+  // immediately reflect OUR data once it exists, however thin.
+  const hasPercolatorData = percolatorStatus === "success" && percolatorCandles.length > 0;
   const hasPythData = !hasPercolatorData && pythStatus === "success" && pythCandles.length > 0;
   const hasExternalData = !hasPercolatorData && !hasPythData && externalStatus === "success" && externalCandles.length > 0;
 


### PR DESCRIPTION
## Summary
Simplifies the chart data-source cascade. Previously we required ≥10 Percolator candles before preferring our internal data over tier-1 Pyth. That gate was meant to prevent a sparse chart, but it delays OUR data from appearing on the chart for markets that are actively trading at low density.

New behaviour: any PERC candle → chart uses PERC. Zero PERC → falls to Pyth naturally.

## Test plan
- [x] \`pnpm tsc --noEmit\` clean
- [x] Full suite: 1844 passed / 2 skipped (no regressions)
- [ ] Visual verify post-deploy: our SOL/USDC market still shows Pyth (0 PERC candles) — expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trading chart now displays internal-trade candles immediately upon availability instead of waiting for multiple data points to accumulate, improving chart responsiveness and data source prioritization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->