### PR TITLE
feat(ui): improve scrollbar visibility and add brand-aligned styling

### DIFF
--- a/app/app/globals.css
+++ b/app/app/globals.css
@@ -523,10 +523,37 @@ input[type="range"]:focus-visible::-webkit-slider-thumb {
 }
 
 /* ─── Scrollbar ─── */
-::-webkit-scrollbar { width: 5px; height: 5px; }
-::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; transition: background 200ms; }
-::-webkit-scrollbar-thumb:hover { background: rgba(153, 69, 255, 0.3); }
+::-webkit-scrollbar { width: 16px; height: 16px; }
+::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.03);
+  border-left: 1px solid var(--border);
+}
+@keyframes scrollbar-shimmer {
+  0%, 100% { background: rgba(153, 69, 255, 0.35); }
+  50%      { background: rgba(153, 69, 255, 0.55); }
+}
+::-webkit-scrollbar-thumb {
+  background: rgba(153, 69, 255, 0.35);
+  border-radius: 8px;
+  border: 3px solid transparent;
+  background-clip: padding-box;
+  animation: scrollbar-shimmer 2.4s ease-in-out infinite;
+  transition: background 350ms ease, box-shadow 350ms ease;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(153, 69, 255, 0.9) !important;
+  background-clip: padding-box;
+  animation: none;
+  box-shadow: 0 0 8px rgba(153, 69, 255, 0.5), inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+}
+::-webkit-scrollbar-thumb:active {
+  background: rgba(153, 69, 255, 1) !important;
+  background-clip: padding-box;
+  animation: none;
+}
+::-webkit-scrollbar-corner { background: transparent; }
+/* Firefox */
+* { scrollbar-width: auto; scrollbar-color: rgba(153, 69, 255, 0.5) rgba(255, 255, 255, 0.03); }
 
 /* ─── Selection ─── */
 ::selection {

--- a/app/app/globals.css
+++ b/app/app/globals.css
@@ -537,8 +537,18 @@ input[type="range"]:focus-visible::-webkit-slider-thumb {
   border-radius: 8px;
   border: 3px solid transparent;
   background-clip: padding-box;
-  animation: scrollbar-shimmer 2.4s ease-in-out infinite;
+  animation: none;
   transition: background 350ms ease, box-shadow 350ms ease;
+}
+@media (prefers-reduced-motion: no-preference) {
+  ::-webkit-scrollbar-thumb {
+    animation: scrollbar-shimmer 2.4s ease-in-out infinite;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  ::-webkit-scrollbar-thumb {
+    transition: none;
+  }
 }
 ::-webkit-scrollbar-thumb:hover {
   background: rgba(153, 69, 255, 0.9) !important;


### PR DESCRIPTION
## Why
The default scrollbar was hard to see — only 5px wide with a thumb colored \`var(--border)\` (~#1C1F2E), which blends into the dark theme. On many monitors users could not tell that pages were scrollable, and the thumb was too narrow to comfortably grab.

## What changed
\`app/app/globals.css\` — \`::-webkit-scrollbar\` rules and Firefox \`scrollbar-*\` tokens:

| | Before | After |
|---|---|---|
| Width | **5px** | **16px** |
| Track | fully transparent | subtle white tint + left border so the lane is visible |
| Thumb color | \`var(--border)\` (low-contrast grey) | brand purple \`#9945FF\` |
| Thumb opacity (rest) | 100% (but on a near-invisible color) | **35%** with a 2.4s shimmer pulsing to 55% |
| Hover | bg → \`rgba(153,69,255,0.30)\` | smooth 350ms transition to **90%** + outer purple glow + thin inner white highlight |
| Active (drag) | none | **100%** purple |
| Edge spacing | none | 3px transparent padding via \`background-clip: padding-box\` so the thumb has breathing room from the track |
| Firefox | not styled | matched \`scrollbar-color\` tokens, \`scrollbar-width: auto\` |

## Visual behavior
- At rest: thumb gently shimmers between 35% and 55% purple — visible but not loud
- On hover: smoothly fades to bright purple with a glow, signaling interactivity
- While dragging: solid full-color purple

## Test plan
- [x] Scroll any long page (markets, /create, /portfolio) — scrollbar is clearly visible at rest
- [x] Hover the scrollbar — thumb fades to bright purple + glow
- [x] Drag the thumb — color goes solid
- [x] Tested on Chrome (Webkit rules) — works as expected
- [ ] Verify on Firefox (uses \`scrollbar-color\` fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)