### PR TITLE
fix(social): update X handle to @PercolatorTrade

### DIFF
--- a/app/components/layout/Footer.tsx
+++ b/app/components/layout/Footer.tsx
@@ -56,7 +56,7 @@ export const Footer: FC = () => {
               </svg>
             </a>
             <a
-              href="https://x.com/Percolator_ct"
+              href="https://x.com/PercolatorTrade"
               target="_blank"
               rel="noopener noreferrer"
               className="flex h-7 w-7 items-center justify-center rounded-sm border border-[var(--border)] text-[var(--text-muted)] transition-all hover:border-[var(--border-hover)] hover:text-[var(--text)] hover:bg-[var(--bg-elevated)]"

--- a/app/components/layout/Header.tsx
+++ b/app/components/layout/Header.tsx
@@ -263,7 +263,7 @@ export const Header: FC = () => {
               </svg>
             </a>
             <a
-              href="https://x.com/Percolator_ct"
+              href="https://x.com/PercolatorTrade"
               target="_blank"
               rel="noopener noreferrer"
               className="flex h-8 w-8 items-center justify-center rounded-sm border border-[var(--border)] text-[var(--text-muted)] transition-all hover:border-[var(--border-hover)] hover:text-[var(--text)] hover:bg-[var(--bg-elevated)]"


### PR DESCRIPTION
## Summary
The X / Twitter account was renamed from \`@Percolator_ct\` to \`@PercolatorTrade\`. The old URL now 404s. Update both icon links to point to the live account.

## Files changed
- \`app/components/layout/Footer.tsx\` — desktop footer X icon
- \`app/components/layout/Header.tsx\` — mobile menu X icon

## Test plan
- [x] Hover the X icon in the footer — URL preview shows \`x.com/PercolatorTrade\`
- [x] Same for the mobile menu in the header
- [x] No remaining references to \`Percolator_ct\` in the codebase (verified with grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)