### PR TITLE
feat(chart): add candle style variants and on-chart display toggles

### DIFF
--- a/app/__tests__/components/trade/ChartDisplayMenu.test.tsx
+++ b/app/__tests__/components/trade/ChartDisplayMenu.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi } from "vitest";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ChartDisplayMenu } from "@/components/trade/ChartDisplayMenu";
+import {
+  DEFAULT_OVERLAY_PREFS,
+  OVERLAY_DISPLAY_ORDER,
+  OVERLAY_LABELS,
+} from "@/lib/chart-overlays";
+
+const allOn = { ...DEFAULT_OVERLAY_PREFS };
+
+describe("ChartDisplayMenu", () => {
+  it("renders a static 'Display' trigger label regardless of pref state", () => {
+    render(<ChartDisplayMenu prefs={allOn} onToggle={() => {}} />);
+    const trigger = screen.getByRole("button", { name: /Display/i });
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    expect(trigger.getAttribute("aria-haspopup")).toBe("true");
+  });
+
+  it("toggles open and closed when the trigger is clicked", () => {
+    render(<ChartDisplayMenu prefs={allOn} onToggle={() => {}} />);
+    const trigger = screen.getByRole("button", { name: /Display/i });
+
+    fireEvent.click(trigger);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.click(trigger);
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("renders every overlay toggle in OVERLAY_DISPLAY_ORDER when open", () => {
+    render(<ChartDisplayMenu prefs={allOn} onToggle={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /Display/i }));
+
+    for (const key of OVERLAY_DISPLAY_ORDER) {
+      expect(
+        screen.getByRole("button", { name: new RegExp(OVERLAY_LABELS[key], "i") }),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("aria-pressed reflects the current value of each overlay pref", () => {
+    render(
+      <ChartDisplayMenu
+        prefs={{ entry: true, liq: false, pnl: true }}
+        onToggle={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Display/i }));
+
+    expect(
+      screen.getByRole("button", { name: new RegExp(OVERLAY_LABELS.entry, "i") })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(
+      screen.getByRole("button", { name: new RegExp(OVERLAY_LABELS.liq, "i") })
+        .getAttribute("aria-pressed"),
+    ).toBe("false");
+    expect(
+      screen.getByRole("button", { name: new RegExp(OVERLAY_LABELS.pnl, "i") })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+  });
+
+  it("calls onToggle with the inverted value when a row is clicked", () => {
+    const onToggle = vi.fn();
+    render(
+      <ChartDisplayMenu
+        prefs={{ entry: true, liq: false, pnl: true }}
+        onToggle={onToggle}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Display/i }));
+
+    // entry is currently true → click should fire onToggle("entry", false)
+    fireEvent.click(screen.getByRole("button", { name: new RegExp(OVERLAY_LABELS.entry, "i") }));
+    expect(onToggle).toHaveBeenLastCalledWith("entry", false);
+
+    // liq is currently false → click should fire onToggle("liq", true)
+    fireEvent.click(screen.getByRole("button", { name: new RegExp(OVERLAY_LABELS.liq, "i") }));
+    expect(onToggle).toHaveBeenLastCalledWith("liq", true);
+  });
+
+  it("does NOT close the menu after toggling a row (multi-toggle UX)", () => {
+    // Unlike ChartStyleMenu (single-select, click → pick → close), the
+    // Display menu is multi-toggle — closing on every click would force the
+    // user to reopen the menu for each overlay they want to flip.
+    const onToggle = vi.fn();
+    render(<ChartDisplayMenu prefs={allOn} onToggle={onToggle} />);
+    const trigger = screen.getByRole("button", { name: /Display/i });
+    fireEvent.click(trigger);
+
+    fireEvent.click(screen.getByRole("button", { name: new RegExp(OVERLAY_LABELS.entry, "i") }));
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("closes when Escape is pressed", () => {
+    render(<ChartDisplayMenu prefs={allOn} onToggle={() => {}} />);
+    const trigger = screen.getByRole("button", { name: /Display/i });
+    fireEvent.click(trigger);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("closes when a mousedown occurs outside the component", () => {
+    render(<ChartDisplayMenu prefs={allOn} onToggle={() => {}} />);
+    const trigger = screen.getByRole("button", { name: /Display/i });
+    fireEvent.click(trigger);
+
+    fireEvent.mouseDown(document.body);
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("hides the popup container from assistive tech when closed", () => {
+    const { container } = render(<ChartDisplayMenu prefs={allOn} onToggle={() => {}} />);
+    // The popup is the only child div with aria-hidden — find it via that attr.
+    const popup = container.querySelector('[aria-hidden="true"]');
+    expect(popup).not.toBeNull();
+  });
+
+  it("flips toggle-row tabIndex between 0 (open) and -1 (closed)", () => {
+    const { container } = render(<ChartDisplayMenu prefs={allOn} onToggle={() => {}} />);
+
+    // Toggle rows live inside the popup; the trigger button is always tabIndex=0.
+    // Filter to the rows by aria-pressed presence (trigger lacks it).
+    const closedRows = container.querySelectorAll('button[aria-pressed]');
+    closedRows.forEach((r) => expect(r.getAttribute("tabindex")).toBe("-1"));
+
+    fireEvent.click(screen.getByRole("button", { name: /Display/i }));
+
+    const openRows = container.querySelectorAll('button[aria-pressed]');
+    openRows.forEach((r) => expect(r.getAttribute("tabindex")).toBe("0"));
+  });
+});

--- a/app/__tests__/components/trade/ChartDisplayMenu.test.tsx
+++ b/app/__tests__/components/trade/ChartDisplayMenu.test.tsx
@@ -43,7 +43,7 @@ describe("ChartDisplayMenu", () => {
   it("aria-pressed reflects the current value of each overlay pref", () => {
     render(
       <ChartDisplayMenu
-        prefs={{ entry: true, liq: false, pnl: true }}
+        prefs={{ ...DEFAULT_OVERLAY_PREFS, entry: true, liq: false, pnl: true }}
         onToggle={() => {}}
       />,
     );
@@ -67,7 +67,7 @@ describe("ChartDisplayMenu", () => {
     const onToggle = vi.fn();
     render(
       <ChartDisplayMenu
-        prefs={{ entry: true, liq: false, pnl: true }}
+        prefs={{ ...DEFAULT_OVERLAY_PREFS, entry: true, liq: false, pnl: true }}
         onToggle={onToggle}
       />,
     );
@@ -116,9 +116,11 @@ describe("ChartDisplayMenu", () => {
 
   it("hides the popup container from assistive tech when closed", () => {
     const { container } = render(<ChartDisplayMenu prefs={allOn} onToggle={() => {}} />);
-    // The popup is the only child div with aria-hidden — find it via that attr.
-    const popup = container.querySelector('[aria-hidden="true"]');
+    const popup = container.querySelector('div[aria-hidden="true"]');
     expect(popup).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Display/i }));
+    expect(container.querySelector('div[aria-hidden="true"]')).toBeNull();
   });
 
   it("flips toggle-row tabIndex between 0 (open) and -1 (closed)", () => {

--- a/app/__tests__/components/trade/ChartStyleMenu.test.tsx
+++ b/app/__tests__/components/trade/ChartStyleMenu.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi } from "vitest";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ChartStyleMenu } from "@/components/trade/ChartStyleMenu";
+import { CHART_STYLE_DISPLAY_ORDER, CHART_STYLE_LABELS } from "@/lib/chart-style";
+
+describe("ChartStyleMenu", () => {
+  it("renders the active style's label in the trigger when closed", () => {
+    render(<ChartStyleMenu value="candle-solid" onChange={() => {}} />);
+    const trigger = screen.getByRole("button", { name: /Candle \(Solid\)/i });
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    expect(trigger.getAttribute("aria-haspopup")).toBe("listbox");
+  });
+
+  it("toggles open and closed when the trigger is clicked", () => {
+    render(<ChartStyleMenu value="line" onChange={() => {}} />);
+    const trigger = screen.getByRole("button", { name: /^Line/i });
+
+    fireEvent.click(trigger);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.click(trigger);
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("renders every style option in CHART_STYLE_DISPLAY_ORDER when open", () => {
+    render(<ChartStyleMenu value="line" onChange={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /^Line/i }));
+
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(CHART_STYLE_DISPLAY_ORDER.length);
+    options.forEach((option, i) => {
+      expect(option).toHaveTextContent(CHART_STYLE_LABELS[CHART_STYLE_DISPLAY_ORDER[i]]);
+    });
+  });
+
+  it("marks the active option with aria-selected=true and the rest with false", () => {
+    render(<ChartStyleMenu value="bar" onChange={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /Bar \(OHLC\)/i }));
+
+    const options = screen.getAllByRole("option");
+    const activeOptions = options.filter((o) => o.getAttribute("aria-selected") === "true");
+    expect(activeOptions).toHaveLength(1);
+    expect(activeOptions[0]).toHaveTextContent("Bar (OHLC)");
+  });
+
+  it("calls onChange with the selected style and closes when an option is clicked", () => {
+    const onChange = vi.fn();
+    render(<ChartStyleMenu value="line" onChange={onChange} />);
+
+    const trigger = screen.getByRole("button", { name: /^Line/i });
+    fireEvent.click(trigger);
+
+    fireEvent.click(screen.getByRole("option", { name: /Candle \(Hollow\)$/i }));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith("candle-hollow");
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("closes when Escape is pressed", () => {
+    render(<ChartStyleMenu value="line" onChange={() => {}} />);
+    const trigger = screen.getByRole("button", { name: /^Line/i });
+    fireEvent.click(trigger);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("closes when a mousedown occurs outside the component", () => {
+    render(<ChartStyleMenu value="line" onChange={() => {}} />);
+    const trigger = screen.getByRole("button", { name: /^Line/i });
+    fireEvent.click(trigger);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.mouseDown(document.body);
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("hides the listbox panel from assistive tech when closed", () => {
+    // The component sets `aria-hidden={!open || undefined}` so the closed
+    // panel is removed from the AT tree. If a future change drops that
+    // attribute, screen-reader users would announce stale options.
+    const { container } = render(<ChartStyleMenu value="line" onChange={() => {}} />);
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(listbox).not.toBeNull();
+    expect(listbox?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("flips option tabIndex between 0 (open) and -1 (closed) so closed options are non-tabbable", () => {
+    // Without this, Tab would land on hidden options when the menu is
+    // closed — breaking the listbox contract.
+    const { container } = render(<ChartStyleMenu value="line" onChange={() => {}} />);
+    const closedOptions = container.querySelectorAll('[role="option"]');
+    closedOptions.forEach((o) => expect(o.getAttribute("tabindex")).toBe("-1"));
+
+    fireEvent.click(screen.getByRole("button", { name: /^Line/i }));
+
+    const openOptions = container.querySelectorAll('[role="option"]');
+    openOptions.forEach((o) => expect(o.getAttribute("tabindex")).toBe("0"));
+  });
+
+  it("does not close when a mousedown occurs inside the component", () => {
+    render(<ChartStyleMenu value="line" onChange={() => {}} />);
+    const trigger = screen.getByRole("button", { name: /^Line/i });
+    fireEvent.click(trigger);
+
+    // Mousedown on an option (still inside the component) must NOT trigger
+    // the outside-click handler — only the option's onClick should fire.
+    const option = screen.getByRole("option", { name: /^Area/i });
+    fireEvent.mouseDown(option);
+
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+  });
+});

--- a/app/__tests__/lib/chart-overlays.test.ts
+++ b/app/__tests__/lib/chart-overlays.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import {
+  isOverlayKey,
+  mergeOverlayPrefs,
+  OVERLAY_LABELS,
+  OVERLAY_DISPLAY_ORDER,
+  DEFAULT_OVERLAY_PREFS,
+  type OverlayKey,
+  type OverlayPrefs,
+} from "../../lib/chart-overlays";
+
+describe("isOverlayKey", () => {
+  it("accepts every member of the OverlayKey union", () => {
+    const all: OverlayKey[] = ["entry", "liq", "pnl"];
+    for (const k of all) expect(isOverlayKey(k)).toBe(true);
+  });
+
+  it("rejects unknown strings, including case-mismatches", () => {
+    for (const v of ["", "Entry", "ENTRY", "mark", "volume", "fee"]) {
+      expect(isOverlayKey(v)).toBe(false);
+    }
+  });
+
+  it("rejects non-string inputs", () => {
+    for (const v of [null, undefined, 0, 1, {}, [], true, false]) {
+      expect(isOverlayKey(v)).toBe(false);
+    }
+  });
+});
+
+describe("mergeOverlayPrefs", () => {
+  it("returns DEFAULT_OVERLAY_PREFS for null / non-object input", () => {
+    for (const v of [null, undefined, 42, "x", []]) {
+      expect(mergeOverlayPrefs(v)).toEqual(DEFAULT_OVERLAY_PREFS);
+    }
+  });
+
+  it("returns a fresh object — does not mutate DEFAULT_OVERLAY_PREFS", () => {
+    const result = mergeOverlayPrefs(null);
+    result.entry = false;
+    expect(DEFAULT_OVERLAY_PREFS.entry).toBe(true);
+  });
+
+  it("falls back to defaults for missing keys (older deploy wrote a smaller set)", () => {
+    expect(mergeOverlayPrefs({ entry: false })).toEqual({
+      entry: false,
+      liq: true,
+      pnl: true,
+    });
+  });
+
+  it("ignores unknown keys (forward-compat: downgraded build sees a future key)", () => {
+    const result = mergeOverlayPrefs({ entry: false, liq: true, pnl: true, future: true });
+    expect(result).toEqual({ entry: false, liq: true, pnl: true });
+    expect("future" in result).toBe(false);
+  });
+
+  it("ignores keys whose values are not boolean", () => {
+    const result = mergeOverlayPrefs({ entry: "no", liq: 0, pnl: true });
+    expect(result).toEqual({ entry: true, liq: true, pnl: true });
+  });
+});
+
+describe("DEFAULT_OVERLAY_PREFS", () => {
+  it("enables every overlay by default — Display menu is opt-OUT not opt-in", () => {
+    for (const key of OVERLAY_DISPLAY_ORDER) {
+      expect(DEFAULT_OVERLAY_PREFS[key]).toBe(true);
+    }
+  });
+});
+
+describe("OVERLAY_LABELS", () => {
+  it("provides a non-empty label for every OverlayKey", () => {
+    for (const key of OVERLAY_DISPLAY_ORDER) {
+      expect(OVERLAY_LABELS[key]).toBeTruthy();
+      expect(OVERLAY_LABELS[key].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("labels are unique", () => {
+    const seen = new Set<string>();
+    for (const key of OVERLAY_DISPLAY_ORDER) {
+      expect(seen.has(OVERLAY_LABELS[key])).toBe(false);
+      seen.add(OVERLAY_LABELS[key]);
+    }
+  });
+});
+
+describe("OVERLAY_DISPLAY_ORDER", () => {
+  it("includes every OverlayKey exactly once", () => {
+    const all: OverlayKey[] = ["entry", "liq", "pnl"];
+    expect(OVERLAY_DISPLAY_ORDER.length).toBe(all.length);
+    for (const key of all) {
+      expect(OVERLAY_DISPLAY_ORDER).toContain(key);
+    }
+  });
+
+  it("prioritises entry → liq → pnl (what a trader watches with an open position)", () => {
+    expect(OVERLAY_DISPLAY_ORDER[0]).toBe("entry");
+    expect(OVERLAY_DISPLAY_ORDER[1]).toBe("liq");
+    expect(OVERLAY_DISPLAY_ORDER[2]).toBe("pnl");
+  });
+});
+
+describe("type integrity", () => {
+  it("OverlayPrefs accepts every OverlayKey as a key", () => {
+    // Compile-time check — body just satisfies the Record contract at runtime.
+    const prefs: OverlayPrefs = { entry: true, liq: false, pnl: true };
+    expect(Object.keys(prefs).sort()).toEqual([...OVERLAY_DISPLAY_ORDER].sort());
+  });
+});

--- a/app/__tests__/lib/chart-overlays.test.ts
+++ b/app/__tests__/lib/chart-overlays.test.ts
@@ -11,12 +11,12 @@ import {
 
 describe("isOverlayKey", () => {
   it("accepts every member of the OverlayKey union", () => {
-    const all: OverlayKey[] = ["entry", "liq", "pnl"];
+    const all: OverlayKey[] = ["position", "entry", "liq", "pnl"];
     for (const k of all) expect(isOverlayKey(k)).toBe(true);
   });
 
   it("rejects unknown strings, including case-mismatches", () => {
-    for (const v of ["", "Entry", "ENTRY", "mark", "volume", "fee"]) {
+    for (const v of ["", "Entry", "ENTRY", "mark", "volume", "fee", "Position"]) {
       expect(isOverlayKey(v)).toBe(false);
     }
   });
@@ -43,6 +43,7 @@ describe("mergeOverlayPrefs", () => {
 
   it("falls back to defaults for missing keys (older deploy wrote a smaller set)", () => {
     expect(mergeOverlayPrefs({ entry: false })).toEqual({
+      position: true,
       entry: false,
       liq: true,
       pnl: true,
@@ -50,14 +51,14 @@ describe("mergeOverlayPrefs", () => {
   });
 
   it("ignores unknown keys (forward-compat: downgraded build sees a future key)", () => {
-    const result = mergeOverlayPrefs({ entry: false, liq: true, pnl: true, future: true });
-    expect(result).toEqual({ entry: false, liq: true, pnl: true });
+    const result = mergeOverlayPrefs({ position: true, entry: false, liq: true, pnl: true, future: true });
+    expect(result).toEqual({ position: true, entry: false, liq: true, pnl: true });
     expect("future" in result).toBe(false);
   });
 
   it("ignores keys whose values are not boolean", () => {
-    const result = mergeOverlayPrefs({ entry: "no", liq: 0, pnl: true });
-    expect(result).toEqual({ entry: true, liq: true, pnl: true });
+    const result = mergeOverlayPrefs({ position: "yes", entry: "no", liq: 0, pnl: true });
+    expect(result).toEqual({ position: true, entry: true, liq: true, pnl: true });
   });
 });
 
@@ -88,24 +89,25 @@ describe("OVERLAY_LABELS", () => {
 
 describe("OVERLAY_DISPLAY_ORDER", () => {
   it("includes every OverlayKey exactly once", () => {
-    const all: OverlayKey[] = ["entry", "liq", "pnl"];
+    const all: OverlayKey[] = ["position", "entry", "liq", "pnl"];
     expect(OVERLAY_DISPLAY_ORDER.length).toBe(all.length);
     for (const key of all) {
       expect(OVERLAY_DISPLAY_ORDER).toContain(key);
     }
   });
 
-  it("prioritises entry → liq → pnl (what a trader watches with an open position)", () => {
-    expect(OVERLAY_DISPLAY_ORDER[0]).toBe("entry");
-    expect(OVERLAY_DISPLAY_ORDER[1]).toBe("liq");
-    expect(OVERLAY_DISPLAY_ORDER[2]).toBe("pnl");
+  it("orders position → entry → liq → pnl (the order a trader thinks about an open position)", () => {
+    expect(OVERLAY_DISPLAY_ORDER[0]).toBe("position");
+    expect(OVERLAY_DISPLAY_ORDER[1]).toBe("entry");
+    expect(OVERLAY_DISPLAY_ORDER[2]).toBe("liq");
+    expect(OVERLAY_DISPLAY_ORDER[3]).toBe("pnl");
   });
 });
 
 describe("type integrity", () => {
   it("OverlayPrefs accepts every OverlayKey as a key", () => {
     // Compile-time check — body just satisfies the Record contract at runtime.
-    const prefs: OverlayPrefs = { entry: true, liq: false, pnl: true };
+    const prefs: OverlayPrefs = { position: true, entry: true, liq: false, pnl: true };
     expect(Object.keys(prefs).sort()).toEqual([...OVERLAY_DISPLAY_ORDER].sort());
   });
 });

--- a/app/__tests__/lib/chart-pnl-format.test.ts
+++ b/app/__tests__/lib/chart-pnl-format.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { formatPnl } from "../../lib/chart-pnl-format";
+
+describe("formatPnl", () => {
+  it("classifies a profit as 'positive' and prepends + signs", () => {
+    const r = formatPnl(120.5, 8.4);
+    expect(r.sign).toBe("positive");
+    expect(r.display).toBe("+$120.50 (+8.40%)");
+  });
+
+  it("classifies a loss as 'negative' and prepends - signs", () => {
+    const r = formatPnl(-15, -1.234);
+    expect(r.sign).toBe("negative");
+    expect(r.display).toBe("-$15.00 (-1.23%)");
+  });
+
+  it("classifies an exact zero as 'zero' with no leading sign", () => {
+    const r = formatPnl(0, 0);
+    expect(r.sign).toBe("zero");
+    expect(r.display).toBe("$0.00 (0.00%)");
+  });
+
+  it("rounds to two decimal places (USD and percent)", () => {
+    expect(formatPnl(1.2349, 3.4567).display).toBe("+$1.23 (+3.46%)");
+  });
+
+  it("preserves a sub-cent loss as 'negative' even when USD rounds to $0.00", () => {
+    // A position with a tiny mark-to-market loss should NOT render green —
+    // the sign tracks the input value, not the rounded display.
+    const r = formatPnl(-0.001, -0.01);
+    expect(r.sign).toBe("negative");
+    expect(r.display).toBe("-$0.00 (-0.01%)");
+  });
+
+  it("preserves a sub-cent profit as 'positive'", () => {
+    const r = formatPnl(0.001, 0.01);
+    expect(r.sign).toBe("positive");
+    expect(r.display).toBe("+$0.00 (+0.01%)");
+  });
+
+  it("handles large values without scientific notation or commas", () => {
+    // toFixed(2) is intentional — no thousands separators on the chart badge
+    // (matches existing PositionPanel formatting; commas would compete with
+    // the live-price ticker font density).
+    expect(formatPnl(12345.67, 250.5).display).toBe("+$12345.67 (+250.50%)");
+  });
+
+  it("does not double-sign when the negative input already produces a minus", () => {
+    // Math.abs in the formatter is the load-bearing guard against "--$15.00".
+    const r = formatPnl(-50.25, -7.5);
+    expect(r.display).not.toContain("--");
+    expect(r.display).toBe("-$50.25 (-7.50%)");
+  });
+});

--- a/app/__tests__/lib/chart-style.test.ts
+++ b/app/__tests__/lib/chart-style.test.ts
@@ -2,9 +2,14 @@ import { describe, it, expect } from "vitest";
 import {
   isChartStyle,
   isCandleStyle,
+  candleStyleOptions,
   DEFAULT_CHART_STYLE,
   type ChartStyle,
 } from "../../lib/chart-style";
+
+const UP = "#22c55e";
+const DOWN = "#ef4444";
+const TRANSPARENT = "rgba(0,0,0,0)";
 
 describe("isChartStyle", () => {
   it("accepts every member of the ChartStyle union", () => {
@@ -51,5 +56,61 @@ describe("DEFAULT_CHART_STYLE", () => {
 
   it("is a candle variant (matches first-paint expectation)", () => {
     expect(isCandleStyle(DEFAULT_CHART_STYLE)).toBe(true);
+  });
+});
+
+describe("candleStyleOptions", () => {
+  it("solid: filled bodies in trend colour, no border", () => {
+    const opts = candleStyleOptions("candle-solid", UP, DOWN);
+    expect(opts.upColor).toBe(UP);
+    expect(opts.downColor).toBe(DOWN);
+    expect(opts.borderUpColor).toBe(UP);
+    expect(opts.borderDownColor).toBe(DOWN);
+    expect(opts.borderVisible).toBe(false);
+  });
+
+  it("hollow: transparent bodies for both directions, borders on", () => {
+    const opts = candleStyleOptions("candle-hollow", UP, DOWN);
+    expect(opts.upColor).toBe(TRANSPARENT);
+    expect(opts.downColor).toBe(TRANSPARENT);
+    expect(opts.borderUpColor).toBe(UP);
+    expect(opts.borderDownColor).toBe(DOWN);
+    expect(opts.borderVisible).toBe(true);
+  });
+
+  it("hollow-up: hollow bullish bars, solid bearish bars", () => {
+    const opts = candleStyleOptions("candle-hollow-up", UP, DOWN);
+    expect(opts.upColor).toBe(TRANSPARENT);
+    expect(opts.downColor).toBe(DOWN);
+    expect(opts.borderUpColor).toBe(UP);
+    expect(opts.borderDownColor).toBe(DOWN);
+    expect(opts.borderVisible).toBe(true);
+  });
+
+  it("hollow-down: solid bullish bars, hollow bearish bars", () => {
+    const opts = candleStyleOptions("candle-hollow-down", UP, DOWN);
+    expect(opts.upColor).toBe(UP);
+    expect(opts.downColor).toBe(TRANSPARENT);
+    expect(opts.borderUpColor).toBe(UP);
+    expect(opts.borderDownColor).toBe(DOWN);
+    expect(opts.borderVisible).toBe(true);
+  });
+
+  it("wick colours always follow the trend colour so direction stays visible", () => {
+    for (const style of ["candle-solid", "candle-hollow", "candle-hollow-up", "candle-hollow-down"] as const) {
+      const opts = candleStyleOptions(style, UP, DOWN);
+      expect(opts.wickUpColor).toBe(UP);
+      expect(opts.wickDownColor).toBe(DOWN);
+    }
+  });
+
+  it("throws via assertNever when a value bypasses the type system", () => {
+    // Simulates a future variant that slipped past the union via an `as` cast
+    // or stale persisted enum. The assertNever sentinel must throw, NOT
+    // silently return base — that would render the unknown variant as solid
+    // and mask the bug.
+    expect(() =>
+      candleStyleOptions("candle-bogus" as unknown as Parameters<typeof candleStyleOptions>[0], UP, DOWN),
+    ).toThrow(/Unexpected value/);
   });
 });

--- a/app/__tests__/lib/chart-style.test.ts
+++ b/app/__tests__/lib/chart-style.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import {
+  isChartStyle,
+  isCandleStyle,
+  DEFAULT_CHART_STYLE,
+  type ChartStyle,
+} from "../../lib/chart-style";
+
+describe("isChartStyle", () => {
+  it("accepts every member of the ChartStyle union", () => {
+    const all: ChartStyle[] = [
+      "line",
+      "candle-solid",
+      "candle-hollow",
+      "candle-hollow-up",
+      "candle-hollow-down",
+    ];
+    for (const s of all) expect(isChartStyle(s)).toBe(true);
+  });
+
+  it("rejects unknown strings, including case-mismatches and dropped variants", () => {
+    for (const v of ["", "candle", "Line", "candle-Solid", "bar", "area", "ohlc"]) {
+      expect(isChartStyle(v)).toBe(false);
+    }
+  });
+
+  it("rejects non-string inputs", () => {
+    for (const v of [null, undefined, 0, 1, {}, [], true, false]) {
+      expect(isChartStyle(v)).toBe(false);
+    }
+  });
+});
+
+describe("isCandleStyle", () => {
+  it("returns true for every candle-* variant", () => {
+    expect(isCandleStyle("candle-solid")).toBe(true);
+    expect(isCandleStyle("candle-hollow")).toBe(true);
+    expect(isCandleStyle("candle-hollow-up")).toBe(true);
+    expect(isCandleStyle("candle-hollow-down")).toBe(true);
+  });
+
+  it("returns false for the line style", () => {
+    expect(isCandleStyle("line")).toBe(false);
+  });
+});
+
+describe("DEFAULT_CHART_STYLE", () => {
+  it("is itself a valid ChartStyle", () => {
+    expect(isChartStyle(DEFAULT_CHART_STYLE)).toBe(true);
+  });
+
+  it("is a candle variant (matches first-paint expectation)", () => {
+    expect(isCandleStyle(DEFAULT_CHART_STYLE)).toBe(true);
+  });
+});

--- a/app/__tests__/lib/chart-style.test.ts
+++ b/app/__tests__/lib/chart-style.test.ts
@@ -6,6 +6,8 @@ import {
   chartDataKind,
   hasRenderableData,
   DEFAULT_CHART_STYLE,
+  CHART_STYLE_LABELS,
+  CHART_STYLE_DISPLAY_ORDER,
   type ChartStyle,
   type ChartSeriesKind,
 } from "../../lib/chart-style";
@@ -204,5 +206,52 @@ describe("ChartSeriesKind", () => {
     // is just to keep vitest happy — the test is the type annotation.
     const kinds: ChartSeriesKind[] = ["Candlestick", "Line", "Area", "Bar"];
     expect(kinds).toHaveLength(4);
+  });
+});
+
+describe("CHART_STYLE_LABELS", () => {
+  it("provides a non-empty label for every ChartStyle", () => {
+    // The Record<ChartStyle, string> type already enforces this at compile
+    // time, but a runtime check guards against an empty-string slipping in
+    // (which would render a blank dropdown trigger and make the menu unusable).
+    for (const style of CHART_STYLE_DISPLAY_ORDER) {
+      expect(CHART_STYLE_LABELS[style]).toBeTruthy();
+      expect(CHART_STYLE_LABELS[style].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("labels are unique — no two styles collide", () => {
+    const seen = new Set<string>();
+    for (const style of CHART_STYLE_DISPLAY_ORDER) {
+      const label = CHART_STYLE_LABELS[style];
+      expect(seen.has(label)).toBe(false);
+      seen.add(label);
+    }
+  });
+});
+
+describe("CHART_STYLE_DISPLAY_ORDER", () => {
+  it("includes every ChartStyle exactly once", () => {
+    const all: ChartStyle[] = [
+      "line",
+      "area",
+      "candle-solid",
+      "candle-hollow",
+      "candle-hollow-up",
+      "candle-hollow-down",
+      "bar",
+    ];
+    expect(CHART_STYLE_DISPLAY_ORDER.length).toBe(all.length);
+    for (const style of all) {
+      expect(CHART_STYLE_DISPLAY_ORDER).toContain(style);
+    }
+  });
+
+  it("orders simplest series first (line/area) then candles then bar", () => {
+    // Validates the intent of the manual ordering — if someone reshuffles
+    // ALL_STYLES they should also rethink whether the menu reads naturally.
+    expect(CHART_STYLE_DISPLAY_ORDER[0]).toBe("line");
+    expect(CHART_STYLE_DISPLAY_ORDER[1]).toBe("area");
+    expect(CHART_STYLE_DISPLAY_ORDER[CHART_STYLE_DISPLAY_ORDER.length - 1]).toBe("bar");
   });
 });

--- a/app/__tests__/lib/chart-style.test.ts
+++ b/app/__tests__/lib/chart-style.test.ts
@@ -3,8 +3,11 @@ import {
   isChartStyle,
   isCandleStyle,
   candleStyleOptions,
+  chartDataKind,
+  hasRenderableData,
   DEFAULT_CHART_STYLE,
   type ChartStyle,
+  type ChartSeriesKind,
 } from "../../lib/chart-style";
 
 const UP = "#22c55e";
@@ -15,16 +18,18 @@ describe("isChartStyle", () => {
   it("accepts every member of the ChartStyle union", () => {
     const all: ChartStyle[] = [
       "line",
+      "area",
       "candle-solid",
       "candle-hollow",
       "candle-hollow-up",
       "candle-hollow-down",
+      "bar",
     ];
     for (const s of all) expect(isChartStyle(s)).toBe(true);
   });
 
-  it("rejects unknown strings, including case-mismatches and dropped variants", () => {
-    for (const v of ["", "candle", "Line", "candle-Solid", "bar", "area", "ohlc"]) {
+  it("rejects unknown strings, including case-mismatches", () => {
+    for (const v of ["", "candle", "Line", "candle-Solid", "ohlc", "heikin-ashi"]) {
       expect(isChartStyle(v)).toBe(false);
     }
   });
@@ -46,6 +51,11 @@ describe("isCandleStyle", () => {
 
   it("returns false for the line style", () => {
     expect(isCandleStyle("line")).toBe(false);
+  });
+
+  it("returns false for area and bar — they are series types but not candle variants", () => {
+    expect(isCandleStyle("area")).toBe(false);
+    expect(isCandleStyle("bar")).toBe(false);
   });
 });
 
@@ -112,5 +122,87 @@ describe("candleStyleOptions", () => {
     expect(() =>
       candleStyleOptions("candle-bogus" as unknown as Parameters<typeof candleStyleOptions>[0], UP, DOWN),
     ).toThrow(/Unexpected value/);
+  });
+});
+
+describe("chartDataKind", () => {
+  it("returns 'ohlc' for every candle variant", () => {
+    expect(chartDataKind("candle-solid")).toBe("ohlc");
+    expect(chartDataKind("candle-hollow")).toBe("ohlc");
+    expect(chartDataKind("candle-hollow-up")).toBe("ohlc");
+    expect(chartDataKind("candle-hollow-down")).toBe("ohlc");
+  });
+
+  it("returns 'ohlc' for bar — bar series consume OHLC, not single-value", () => {
+    expect(chartDataKind("bar")).toBe("ohlc");
+  });
+
+  it("returns 'single' for line and area — both read the closes-only stream", () => {
+    expect(chartDataKind("line")).toBe("single");
+    expect(chartDataKind("area")).toBe("single");
+  });
+
+  it("throws via assertNever when a value bypasses the type system", () => {
+    expect(() =>
+      chartDataKind("heikin-ashi" as unknown as Parameters<typeof chartDataKind>[0]),
+    ).toThrow(/Unexpected value/);
+  });
+});
+
+describe("hasRenderableData", () => {
+  const bar = (t: number) => ({ timestamp: t });
+  const point = (t: number) => ({ timestamp: t });
+
+  it("inspects candleData for ohlc styles, ignores lineData length", () => {
+    // 5 line points must NOT make a candle style 'ready' — that was the
+    // ad-hoc pre-helper bug shape (cross-source inspection).
+    const r = hasRenderableData("candle-solid", [], [point(1), point(2), point(3), point(4), point(5)]);
+    expect(r.ready).toBe(false);
+    expect(r.sparse).toBe(true);
+  });
+
+  it("inspects lineData for single styles, ignores candleData length", () => {
+    const r = hasRenderableData("line", [bar(1), bar(2), bar(3)], []);
+    expect(r.ready).toBe(false);
+    expect(r.sparse).toBe(true);
+  });
+
+  it("treats area as single-value (regression: area used to fall through the sparse predicate)", () => {
+    expect(hasRenderableData("area", [bar(1), bar(2)], []).sparse).toBe(true);
+    expect(hasRenderableData("area", [], [point(1), point(2)]).sparse).toBe(false);
+  });
+
+  it("treats bar as ohlc (regression: bar used to fall through the sparse predicate)", () => {
+    expect(hasRenderableData("bar", [], [point(1), point(2)]).sparse).toBe(true);
+    expect(hasRenderableData("bar", [bar(1), bar(2)], []).sparse).toBe(false);
+  });
+
+  it("ready threshold is >= 1 (so the switch can create the series for a single point)", () => {
+    expect(hasRenderableData("line", [], [point(1)]).ready).toBe(true);
+    expect(hasRenderableData("candle-solid", [bar(1)], []).ready).toBe(true);
+  });
+
+  it("sparse threshold is < 2 (single point still shows 'building…' overlay)", () => {
+    expect(hasRenderableData("line", [], [point(1)]).sparse).toBe(true);
+    expect(hasRenderableData("line", [], [point(1), point(2)]).sparse).toBe(false);
+    expect(hasRenderableData("candle-solid", [bar(1)], []).sparse).toBe(true);
+    expect(hasRenderableData("candle-solid", [bar(1), bar(2)], []).sparse).toBe(false);
+  });
+
+  it("empty arrays yield ready=false, sparse=true for any style", () => {
+    for (const style of ["line", "area", "candle-solid", "candle-hollow", "candle-hollow-up", "candle-hollow-down", "bar"] as const) {
+      const r = hasRenderableData(style, [], []);
+      expect(r.ready).toBe(false);
+      expect(r.sparse).toBe(true);
+    }
+  });
+});
+
+describe("ChartSeriesKind", () => {
+  it("admits exactly the four lightweight-charts series-API discriminator strings", () => {
+    // Compile-time check: every member must be assignable. Runtime expect
+    // is just to keep vitest happy — the test is the type annotation.
+    const kinds: ChartSeriesKind[] = ["Candlestick", "Line", "Area", "Bar"];
+    expect(kinds).toHaveLength(4);
   });
 });

--- a/app/components/trade/ChartDisplayMenu.tsx
+++ b/app/components/trade/ChartDisplayMenu.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { FC, useState, useRef, useEffect, useCallback } from "react";
+import {
+  OVERLAY_LABELS,
+  OVERLAY_DISPLAY_ORDER,
+  type OverlayKey,
+  type OverlayPrefs,
+} from "@/lib/chart-overlays";
+
+interface ChartDisplayMenuProps {
+  prefs: OverlayPrefs;
+  onToggle: (key: OverlayKey, value: boolean) => void;
+}
+
+/** Click-driven popup that exposes an ON/OFF toggle for each chart overlay
+ *  in OVERLAY_DISPLAY_ORDER (Avg Entry price, Liquidation price, Live PnL).
+ *  Sits next to ChartStyleMenu in the chart toolbar.
+ *
+ *  Closes on outside click and Escape. The trigger label is static ("Display")
+ *  rather than reflecting state — counting "3 of 3 enabled" in the trigger
+ *  would be noise when defaults are all-on.
+ *
+ *  ARIA: each toggle is a `<button aria-pressed={value}>` rather than a
+ *  listbox option or menuitemcheckbox. Toggle buttons (`aria-pressed`) are
+ *  the closest native fit for "independent boolean per row" — listbox
+ *  semantics promise single-select, and `role="menuitemcheckbox"` requires
+ *  the WAI-ARIA APG menu keyboard contract (arrow keys, focus management)
+ *  which this component does not implement. The popup container itself
+ *  carries no role; Tab + Space/Enter on each button is the full contract. */
+export const ChartDisplayMenu: FC<ChartDisplayMenuProps> = ({ prefs, onToggle }) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const handleToggle = useCallback(
+    (key: OverlayKey) => {
+      onToggle(key, !prefs[key]);
+    },
+    [onToggle, prefs],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        aria-haspopup="true"
+        className={[
+          "flex items-center gap-1 rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] px-2 py-1 text-xs transition-colors",
+          open
+            ? "text-[var(--accent)]"
+            : "text-[var(--text-secondary)] hover:text-[var(--text)]",
+        ].join(" ")}
+      >
+        <span>Display</span>
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 10 10"
+          fill="none"
+          aria-hidden="true"
+          className={["transition-transform duration-150", open ? "rotate-180" : ""].join(" ")}
+        >
+          <path
+            d="M2.5 3.75L5 6.25L7.5 3.75"
+            stroke="currentColor"
+            strokeWidth="1.25"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+
+      <div
+        aria-hidden={!open || undefined}
+        className={[
+          "absolute left-0 top-full z-20 mt-1 min-w-[200px] rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] py-1 shadow-[0_8px_32px_rgba(0,0,0,0.48)] transition-opacity duration-[120ms] ease-out",
+          open ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none",
+        ].join(" ")}
+      >
+        {OVERLAY_DISPLAY_ORDER.map((key) => {
+          const enabled = prefs[key];
+          return (
+            <button
+              key={key}
+              type="button"
+              aria-pressed={enabled}
+              tabIndex={open ? 0 : -1}
+              onClick={() => handleToggle(key)}
+              className={[
+                "flex w-full items-center justify-between px-3 py-1.5 text-xs transition-colors",
+                enabled
+                  ? "text-[var(--text)]"
+                  : "text-[var(--text-dim)] hover:text-[var(--text-secondary)]",
+              ].join(" ")}
+            >
+              <span>{OVERLAY_LABELS[key]}</span>
+              <span
+                aria-hidden="true"
+                className={[
+                  "inline-flex h-3.5 w-6 items-center rounded-full border transition-colors",
+                  enabled
+                    ? "bg-[var(--accent)] border-[var(--accent)]"
+                    : "bg-transparent border-[var(--border)]",
+                ].join(" ")}
+              >
+                <span
+                  className={[
+                    "h-2.5 w-2.5 rounded-full bg-[var(--bg)] transition-transform",
+                    enabled ? "translate-x-[10px]" : "translate-x-[2px]",
+                  ].join(" ")}
+                />
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/app/components/trade/ChartPnlBadge.tsx
+++ b/app/components/trade/ChartPnlBadge.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { FC } from "react";
+import { computeMarkPnl, computePnlPercent } from "@/lib/trading";
+import { useUserAccount } from "@/hooks/useUserAccount";
+import { useLivePrice } from "@/hooks/useLivePrice";
+import { useMarketConfig } from "@/hooks/useMarketConfig";
+import { useTokenMeta } from "@/hooks/useTokenMeta";
+import { isMockMode } from "@/lib/mock-mode";
+import { isMockSlab, getMockUserAccount } from "@/lib/mock-trade-data";
+import { getEntryPrice } from "@/lib/entry-price";
+import { formatPnl } from "@/lib/chart-pnl-format";
+
+interface ChartPnlBadgeProps {
+  slabAddress: string;
+}
+
+/** Floating badge that displays unrealized PnL on the chart, refreshed on
+ *  every live-price tick. Sits stacked below the PositionSummary badge in
+ *  the top-right corner of the chart container.
+ *
+ *  Returns null when there's no open position, no entry price, or no valid
+ *  mark — the badge should never render with placeholder zeroes since that
+ *  reads as "your position is flat" which is misleading mid-fetch.
+ *
+ *  Math is delegated to `computeMarkPnl` + `computePnlPercent` from the
+ *  trading SDK (already test-covered in phantom-position-pnl.test.ts);
+ *  this component owns only the data plumbing + presentation. */
+export const ChartPnlBadge: FC<ChartPnlBadgeProps> = ({ slabAddress }) => {
+  const realUserAccount = useUserAccount();
+  const mockMode = isMockMode() && isMockSlab(slabAddress);
+  const userAccount = realUserAccount ?? (mockMode ? getMockUserAccount(slabAddress) : null);
+  const { priceE6: livePriceE6, priceUsd } = useLivePrice();
+  const marketConfig = useMarketConfig();
+  const tokenMeta = useTokenMeta(marketConfig?.collateralMint ?? null);
+  const decimals = tokenMeta?.decimals ?? 6;
+
+  if (!userAccount) return null;
+  const { account } = userAccount;
+  if (account.positionSize === 0n) return null;
+  if (livePriceE6 == null || livePriceE6 <= 0n || priceUsd == null) return null;
+
+  // V12_1: entry_price was removed from the on-chain account struct, so
+  // accounts created via the position-NFT path have account.entryPrice == 0n.
+  // Fall back to the locally-saved entry from when the position was opened —
+  // mirrors the resolution PositionPanel does for the same reason.
+  const rawEntryPrice = account.entryPrice ?? 0n;
+  const resolvedEntryPrice =
+    rawEntryPrice > 0n ? rawEntryPrice : getEntryPrice(slabAddress, userAccount.idx);
+  if (resolvedEntryPrice <= 0n) return null;
+
+  const pnlTokens = computeMarkPnl(account.positionSize, resolvedEntryPrice, livePriceE6);
+  const pnlUsd = (Number(pnlTokens) / 10 ** decimals) * priceUsd;
+  const roe = computePnlPercent(pnlTokens, account.capital);
+
+  if (!Number.isFinite(pnlUsd) || !Number.isFinite(roe)) return null;
+
+  const { display, sign } = formatPnl(pnlUsd, roe);
+  const colorClass =
+    sign === "positive" ? "text-green-400" : sign === "negative" ? "text-red-400" : "text-[var(--text-dim)]";
+
+  return (
+    <div className="absolute top-10 right-2 z-10 flex items-center gap-1.5 rounded-none border border-[var(--border)]/60 bg-[var(--bg)]/90 px-2 py-1 backdrop-blur-sm">
+      <span className="text-[9px] font-bold uppercase tracking-[0.12em] text-[var(--text-dim)]">PnL</span>
+      <span className={`text-[10px] font-mono ${colorClass}`}>{display}</span>
+    </div>
+  );
+};

--- a/app/components/trade/ChartStyleMenu.tsx
+++ b/app/components/trade/ChartStyleMenu.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { FC, useState, useRef, useEffect, useCallback } from "react";
+import {
+  CHART_STYLE_LABELS,
+  CHART_STYLE_DISPLAY_ORDER,
+  type ChartStyle,
+} from "@/lib/chart-style";
+
+interface ChartStyleMenuProps {
+  value: ChartStyle;
+  onChange: (style: ChartStyle) => void;
+}
+
+/** Click-driven dropdown that exposes every ChartStyle in
+ *  CHART_STYLE_DISPLAY_ORDER. Replaces the previous 2-button Line/Candle
+ *  toggle in the chart toolbar — the toggle could only express 2 of the 7
+ *  styles the renderer now supports.
+ *
+ *  Closes on outside click and Escape. The trigger always shows the active
+ *  style's label so the user never has to open the menu to read state.
+ *
+ *  ARIA: uses `role="listbox"` + `role="option"` + `aria-selected` rather
+ *  than `role="menu"` + `role="menuitemradio"`. The menu pattern would
+ *  promise arrow-key navigation, Home/End, type-ahead, and managed focus
+ *  per the WAI-ARIA APG menu spec — none of which are implemented here.
+ *  Listbox makes a smaller promise (Tab + Enter is sufficient) so the
+ *  declared semantics match the actual behaviour. If arrow-key navigation
+ *  is added later, swap back to the menu pattern in lockstep. */
+export const ChartStyleMenu: FC<ChartStyleMenuProps> = ({ value, onChange }) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const handleSelect = useCallback(
+    (style: ChartStyle) => {
+      onChange(style);
+      setOpen(false);
+    },
+    [onChange],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        className={[
+          "flex items-center gap-1 rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] px-2 py-1 text-xs transition-colors",
+          open
+            ? "text-[var(--accent)]"
+            : "text-[var(--text-secondary)] hover:text-[var(--text)]",
+        ].join(" ")}
+      >
+        <span>{CHART_STYLE_LABELS[value]}</span>
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 10 10"
+          fill="none"
+          aria-hidden="true"
+          className={["transition-transform duration-150", open ? "rotate-180" : ""].join(" ")}
+        >
+          <path
+            d="M2.5 3.75L5 6.25L7.5 3.75"
+            stroke="currentColor"
+            strokeWidth="1.25"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+
+      <div
+        role="listbox"
+        aria-hidden={!open || undefined}
+        className={[
+          "absolute left-0 top-full z-20 mt-1 min-w-[180px] rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] py-1 shadow-[0_8px_32px_rgba(0,0,0,0.48)] transition-opacity duration-[120ms] ease-out",
+          open ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none",
+        ].join(" ")}
+      >
+        {CHART_STYLE_DISPLAY_ORDER.map((style) => {
+          const active = style === value;
+          return (
+            <button
+              key={style}
+              type="button"
+              role="option"
+              aria-selected={active}
+              tabIndex={open ? 0 : -1}
+              onClick={() => handleSelect(style)}
+              className={[
+                "flex w-full items-center justify-between px-3 py-1.5 text-xs transition-colors",
+                active
+                  ? "text-[var(--accent)] bg-[var(--accent)]/10"
+                  : "text-[var(--text-secondary)] hover:text-[var(--text)] hover:bg-[var(--bg-surface)]",
+              ].join(" ")}
+            >
+              <span>{CHART_STYLE_LABELS[style]}</span>
+              {active && (
+                <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
+                  <path
+                    d="M2 5L4 7L8 3"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -429,7 +429,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
       }
       // Liq price overlay
       const liqPriceNum = liqPriceE6 != null && liqPriceE6 > 0n ? Number(liqPriceE6) / 1e6 : null;
-      if (liqPriceNum != null && liqPriceNum > 0) {
+      if (overlayPrefs.liq && liqPriceNum != null && liqPriceNum > 0) {
         liqLineRef.current = s.createPriceLine({
           price: liqPriceNum,
           color: "#ef4444",
@@ -627,7 +627,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
     return () => {
       chart.unsubscribeCrosshairMove(crosshairHandler);
     };
-  }, [chartStyle, timeframe, candleData, lineData, priceUsd, liqPriceE6, entryPriceNum, chartTheme, hasPythData, hasExternalData, overlayPrefs.entry]);
+  }, [chartStyle, timeframe, candleData, lineData, priceUsd, liqPriceE6, entryPriceNum, chartTheme, hasPythData, hasExternalData, overlayPrefs.entry, overlayPrefs.liq]);
 
   // Update mark price line when live price changes
   useEffect(() => {

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -17,8 +17,9 @@ import { ChartEmptyState } from "./ChartEmptyState";
 import { computeRef24h, computePriceChange } from "@/lib/chart-stats";
 import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab, getMockUserAccount } from "@/lib/mock-trade-data";
+import { useChartStylePref } from "@/hooks/useChartStylePref";
+import { isCandleStyle } from "@/lib/chart-style";
 
-type ChartType = "line" | "candle";
 // Phase 2: added 15m timeframe
 type Timeframe = "1m" | "5m" | "15m" | "1h" | "4h" | "1d" | "7d" | "30d";
 
@@ -119,7 +120,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
   const { config } = useSlabState();
   const { priceUsd } = useLivePrice();
   const chartTheme = useChartTheme();
-  const [chartType, setChartType] = useState<ChartType>("candle");
+  const [chartStyle, setChartStyle] = useChartStylePref();
   const [timeframe, setTimeframe] = useState<Timeframe>("1d");
   const [oraclePrices, setOraclePrices] = useState<PricePoint[]>([]);
 
@@ -275,8 +276,8 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
 
   // GH#1625: sparse-data guard
   const effectiveSparse =
-    (chartType === "candle" && candleData.length < 2) ||
-    (chartType === "line" && lineData.length < 2);
+    (isCandleStyle(chartStyle) && candleData.length < 2) ||
+    (chartStyle === "line" && lineData.length < 2);
 
   // Phase 2: volume has data (used to show empty state in volume pane)
   const hasVolumeData = candleData.some((c) => (c.volume ?? 0) > 0);
@@ -371,7 +372,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
     return Number(ep) / 1e6;
   })();
 
-  // Update series when data or chartType changes
+  // Update series when data or chartStyle changes
   useEffect(() => {
     const chart = chartRef.current;
     if (!chart) return;
@@ -389,7 +390,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
     liqLineRef.current = null;
     entryLineRef.current = null;
 
-    if (chartType === "candle" && candleData.length > 0) {
+    if (isCandleStyle(chartStyle) && candleData.length > 0) {
       const series = chart.addCandlestickSeries({
         upColor: chartTheme.upColor,
         downColor: chartTheme.downColor,
@@ -480,7 +481,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
           title: "Entry",
         });
       }
-    } else if (chartType === "line" && lineData.length > 0) {
+    } else if (chartStyle === "line" && lineData.length > 0) {
       const series = chart.addLineSeries({
         color: chartTheme.upColor,
         lineWidth: 2,
@@ -567,10 +568,16 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
     chart.subscribeCrosshairMove(crosshairHandler);
 
     // Only fit the content to viewport on the FIRST render for the current
-    // (timeframe, chart type, data source) combo. Subsequent polls just
+    // (timeframe, chart kind, data source) combo. Subsequent polls just
     // update-in-place so the user's pan/zoom is preserved.
+    //
+    // Bucket all candle variants under one key so flipping between
+    // candle-solid / candle-hollow / candle-hollow-up / candle-hollow-down
+    // does not reset pan/zoom — the variants share the same OHLC series
+    // and only differ in fill/border styling.
     const source = hasPythData ? "pyth" : hasExternalData ? "dex" : "oracle";
-    const fitKey = `${chartType}:${timeframe}:${source}`;
+    const styleBucket = isCandleStyle(chartStyle) ? "candle" : chartStyle;
+    const fitKey = `${styleBucket}:${timeframe}:${source}`;
     if (fitKeyRef.current !== fitKey) {
       chart.timeScale().fitContent();
       fitKeyRef.current = fitKey;
@@ -579,7 +586,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
     return () => {
       chart.unsubscribeCrosshairMove(crosshairHandler);
     };
-  }, [chartType, timeframe, candleData, lineData, priceUsd, liqPriceE6, entryPriceNum, chartTheme, hasPythData, hasExternalData]);
+  }, [chartStyle, timeframe, candleData, lineData, priceUsd, liqPriceE6, entryPriceNum, chartTheme, hasPythData, hasExternalData]);
 
   // Update mark price line when live price changes
   useEffect(() => {
@@ -656,9 +663,9 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
         <div className="flex flex-wrap items-center gap-2">
           <div className="flex gap-1 rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] p-0.5">
             <button
-              onClick={() => setChartType("line")}
+              onClick={() => setChartStyle("line")}
               className={`rounded-none px-2 py-1 text-xs transition-colors ${
-                chartType === "line"
+                chartStyle === "line"
                   ? "bg-[var(--accent)]/10 text-[var(--accent)]"
                   : "text-[var(--text-dim)] hover:text-[var(--text-secondary)]"
               }`}
@@ -666,9 +673,9 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
               Line
             </button>
             <button
-              onClick={() => setChartType("candle")}
+              onClick={() => setChartStyle("candle-solid")}
               className={`rounded-none px-2 py-1 text-xs transition-colors ${
-                chartType === "candle"
+                isCandleStyle(chartStyle)
                   ? "bg-[var(--accent)]/10 text-[var(--accent)]"
                   : "text-[var(--text-dim)] hover:text-[var(--text-secondary)]"
               }`}
@@ -769,7 +776,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
         )}
 
         {/* Phase 2: Volume no-data overlay — shown when volume pane exists but all volumes are 0 */}
-        {!showEmptyOverlay && chartType === "candle" && !hasVolumeData && (
+        {!showEmptyOverlay && isCandleStyle(chartStyle) && !hasVolumeData && (
           <div className="pointer-events-none absolute bottom-0 left-0 right-0 flex h-[20%] items-center justify-center border-t border-[var(--border)]/30">
             <span className="text-[9px] text-[var(--text-dim)] uppercase tracking-[0.12em]">
               ── Volume (no data) ──

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -15,10 +15,12 @@ import { useLiqPrice } from "@/hooks/useLiqPrice";
 import { useChartTheme } from "@/hooks/useChartTheme";
 import { ChartEmptyState } from "./ChartEmptyState";
 import { ChartStyleMenu } from "./ChartStyleMenu";
+import { ChartDisplayMenu } from "./ChartDisplayMenu";
 import { computeRef24h, computePriceChange } from "@/lib/chart-stats";
 import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab, getMockUserAccount } from "@/lib/mock-trade-data";
 import { useChartStylePref } from "@/hooks/useChartStylePref";
+import { useChartOverlayPrefs } from "@/hooks/useChartOverlayPrefs";
 import {
   isCandleStyle,
   candleStyleOptions,
@@ -129,6 +131,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
   const { priceUsd } = useLivePrice();
   const chartTheme = useChartTheme();
   const [chartStyle, setChartStyle] = useChartStylePref();
+  const [overlayPrefs, setOverlayPref] = useChartOverlayPrefs();
   const [timeframe, setTimeframe] = useState<Timeframe>("1d");
   const [oraclePrices, setOraclePrices] = useState<PricePoint[]>([]);
 
@@ -700,6 +703,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
         {/* Controls */}
         <div className="flex flex-wrap items-center gap-2">
           <ChartStyleMenu value={chartStyle} onChange={setChartStyle} />
+          <ChartDisplayMenu prefs={overlayPrefs} onToggle={setOverlayPref} />
 
           {/* PERC-8090: 1m/5m/15m/1h/4h/1d only — 7d/30d collapsed */}
           <div className="flex gap-1 rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] p-0.5">

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -440,7 +440,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
         });
       }
       // Entry price overlay — cyan dashed when position is open
-      if (entryPriceNum != null && entryPriceNum > 0) {
+      if (overlayPrefs.entry && entryPriceNum != null && entryPriceNum > 0) {
         entryLineRef.current = s.createPriceLine({
           price: entryPriceNum,
           color: "#22d3ee",
@@ -627,7 +627,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
     return () => {
       chart.unsubscribeCrosshairMove(crosshairHandler);
     };
-  }, [chartStyle, timeframe, candleData, lineData, priceUsd, liqPriceE6, entryPriceNum, chartTheme, hasPythData, hasExternalData]);
+  }, [chartStyle, timeframe, candleData, lineData, priceUsd, liqPriceE6, entryPriceNum, chartTheme, hasPythData, hasExternalData, overlayPrefs.entry]);
 
   // Update mark price line when live price changes
   useEffect(() => {

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -18,7 +18,7 @@ import { computeRef24h, computePriceChange } from "@/lib/chart-stats";
 import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab, getMockUserAccount } from "@/lib/mock-trade-data";
 import { useChartStylePref } from "@/hooks/useChartStylePref";
-import { isCandleStyle } from "@/lib/chart-style";
+import { isCandleStyle, candleStyleOptions } from "@/lib/chart-style";
 
 // Phase 2: added 15m timeframe
 type Timeframe = "1m" | "5m" | "15m" | "1h" | "4h" | "1d" | "7d" | "30d";
@@ -392,12 +392,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
 
     if (isCandleStyle(chartStyle) && candleData.length > 0) {
       const series = chart.addCandlestickSeries({
-        upColor: chartTheme.upColor,
-        downColor: chartTheme.downColor,
-        borderDownColor: chartTheme.downColor,
-        borderUpColor: chartTheme.upColor,
-        wickDownColor: chartTheme.downColor,
-        wickUpColor: chartTheme.upColor,
+        ...candleStyleOptions(chartStyle, chartTheme.upColor, chartTheme.downColor),
         // Suppress lightweight-charts' built-in last-price label + horizontal
         // price line. Those show the DEX pool's last candle close (e.g. 84.20)
         // which is NOT our mark price (84.33) — users saw two prices on the

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -14,6 +14,7 @@ import { useEngineState } from "@/hooks/useEngineState";
 import { useLiqPrice } from "@/hooks/useLiqPrice";
 import { useChartTheme } from "@/hooks/useChartTheme";
 import { ChartEmptyState } from "./ChartEmptyState";
+import { ChartStyleMenu } from "./ChartStyleMenu";
 import { computeRef24h, computePriceChange } from "@/lib/chart-stats";
 import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab, getMockUserAccount } from "@/lib/mock-trade-data";
@@ -698,28 +699,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
 
         {/* Controls */}
         <div className="flex flex-wrap items-center gap-2">
-          <div className="flex gap-1 rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] p-0.5">
-            <button
-              onClick={() => setChartStyle("line")}
-              className={`rounded-none px-2 py-1 text-xs transition-colors ${
-                chartStyle === "line"
-                  ? "bg-[var(--accent)]/10 text-[var(--accent)]"
-                  : "text-[var(--text-dim)] hover:text-[var(--text-secondary)]"
-              }`}
-            >
-              Line
-            </button>
-            <button
-              onClick={() => setChartStyle("candle-solid")}
-              className={`rounded-none px-2 py-1 text-xs transition-colors ${
-                isCandleStyle(chartStyle)
-                  ? "bg-[var(--accent)]/10 text-[var(--accent)]"
-                  : "text-[var(--text-dim)] hover:text-[var(--text-secondary)]"
-              }`}
-            >
-              Candle
-            </button>
-          </div>
+          <ChartStyleMenu value={chartStyle} onChange={setChartStyle} />
 
           {/* PERC-8090: 1m/5m/15m/1h/4h/1d only — 7d/30d collapsed */}
           <div className="flex gap-1 rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] p-0.5">

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -16,6 +16,7 @@ import { useChartTheme } from "@/hooks/useChartTheme";
 import { ChartEmptyState } from "./ChartEmptyState";
 import { ChartStyleMenu } from "./ChartStyleMenu";
 import { ChartDisplayMenu } from "./ChartDisplayMenu";
+import { ChartPnlBadge } from "./ChartPnlBadge";
 import { computeRef24h, computePriceChange } from "@/lib/chart-stats";
 import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab, getMockUserAccount } from "@/lib/mock-trade-data";
@@ -832,6 +833,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
         )}
 
         {overlayPrefs.position && <PositionSummary slabAddress={slabAddress} />}
+        {overlayPrefs.pnl && <ChartPnlBadge slabAddress={slabAddress} />}
       </div>
     </div>
   );

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -831,8 +831,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
           </div>
         )}
 
-        {/* Phase 2: Position summary badge overlay */}
-        <PositionSummary slabAddress={slabAddress} />
+        {overlayPrefs.position && <PositionSummary slabAddress={slabAddress} />}
       </div>
     </div>
   );

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -18,7 +18,14 @@ import { computeRef24h, computePriceChange } from "@/lib/chart-stats";
 import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab, getMockUserAccount } from "@/lib/mock-trade-data";
 import { useChartStylePref } from "@/hooks/useChartStylePref";
-import { isCandleStyle, candleStyleOptions } from "@/lib/chart-style";
+import {
+  isCandleStyle,
+  candleStyleOptions,
+  chartDataKind,
+  hasRenderableData,
+  type ChartSeriesKind,
+} from "@/lib/chart-style";
+import { assertNever } from "@/lib/exhaustive";
 
 // Phase 2: added 15m timeframe
 type Timeframe = "1m" | "5m" | "15m" | "1h" | "4h" | "1d" | "7d" | "30d";
@@ -138,7 +145,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
 
   const containerRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<IChartApi | null>(null);
-  const seriesRef = useRef<ISeriesApi<"Candlestick" | "Line"> | null>(null);
+  const seriesRef = useRef<ISeriesApi<ChartSeriesKind> | null>(null);
   const volumeSeriesRef = useRef<ISeriesApi<"Histogram"> | null>(null);
   const priceLineRef = useRef<ReturnType<ISeriesApi<"Candlestick">["createPriceLine"]> | null>(null);
   const liqLineRef = useRef<ReturnType<ISeriesApi<"Candlestick">["createPriceLine"]> | null>(null);
@@ -274,10 +281,10 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
 
   const totalDataPoints = candleData.length + lineData.length;
 
-  // GH#1625: sparse-data guard
-  const effectiveSparse =
-    (isCandleStyle(chartStyle) && candleData.length < 2) ||
-    (chartStyle === "line" && lineData.length < 2);
+  // GH#1625: sparse-data guard. Routes through the SoT helper so area and
+  // bar correctly trigger the overlay too — they used to fall through the
+  // ad-hoc candle+line predicate.
+  const { sparse: effectiveSparse } = hasRenderableData(chartStyle, candleData, lineData);
 
   // Phase 2: volume has data (used to show empty state in volume pane)
   const hasVolumeData = candleData.some((c) => (c.volume ?? 0) > 0);
@@ -390,59 +397,24 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
     liqLineRef.current = null;
     entryLineRef.current = null;
 
-    if (isCandleStyle(chartStyle) && candleData.length > 0) {
-      const series = chart.addCandlestickSeries({
-        ...candleStyleOptions(chartStyle, chartTheme.upColor, chartTheme.downColor),
-        // Suppress lightweight-charts' built-in last-price label + horizontal
-        // price line. Those show the DEX pool's last candle close (e.g. 84.20)
-        // which is NOT our mark price (84.33) — users saw two prices on the
-        // chart and couldn't tell which was authoritative. Our explicit
-        // createPriceLine below draws the mark price as the only price label.
-        lastValueVisible: false,
-        priceLineVisible: false,
-      });
-
-      const formatted = candleData.map((c) => ({
-        time: (Math.floor(c.timestamp / 1000)) as import("lightweight-charts").UTCTimestamp,
-        open: c.open,
-        high: c.high,
-        low: c.low,
-        close: c.close,
-      }));
-      series.setData(formatted);
-      seriesRef.current = series;
-
-      // Volume histogram — only render when the active data source has real
-      // trade volume. Pyth Benchmarks returns v=0 for every bar (it's a price
-      // feed, not a trade tape); painting a sentinel 0.001 for every bar made
-      // the pane render as a meaningless flat red/green band auto-scaled to
-      // fill the full pane. Hide the series entirely in that case and let the
-      // candles reclaim the bottom 10% of vertical space instead.
-      if (hasVolumeData) {
-        const volumeSeries = chart.addHistogramSeries({
-          priceFormat: { type: "volume" },
-          priceScaleId: "volume",
-        });
-        chart.priceScale("volume").applyOptions({
-          scaleMargins: { top: 0.90, bottom: 0 },
-        });
-        const volumeData = candleData.map((c) => ({
-          time: (Math.floor(c.timestamp / 1000)) as import("lightweight-charts").UTCTimestamp,
-          value: c.volume ?? 0,
-          color: c.close >= c.open ? chartTheme.volUpColor : chartTheme.volDownColor,
-        }));
-        volumeSeries.setData(volumeData);
-        volumeSeriesRef.current = volumeSeries;
-      } else {
-        // No volume pane — reclaim the bottom margin for the candle series.
-        series.priceScale().applyOptions({
-          scaleMargins: { top: 0.08, bottom: 0.04 },
-        });
-      }
-
+    // Series selection.
+    //
+    // The switch is exhaustive over ChartStyle: a future variant added to
+    // ALL_STYLES without a matching case here fails the build at the
+    // assertNever default rather than silently rendering nothing.
+    //
+    // All four candle variants share one fall-through body — they all use
+    // addCandlestickSeries with different colour presets via candleStyleOptions.
+    // Bar series also reads OHLC candleData; line and area both read the
+    // single-value lineData stream.
+    //
+    // Overlay lines (Mark / Liq / Entry) are added per series via the local
+    // addOverlayLines() helper to keep each case body small. They use the
+    // generic ISeriesApi.createPriceLine API which all series types support.
+    const addOverlayLines = (s: ISeriesApi<ChartSeriesKind>) => {
       // Mark price line
       if (priceUsd != null) {
-        priceLineRef.current = series.createPriceLine({
+        priceLineRef.current = s.createPriceLine({
           price: priceUsd,
           color: "rgba(255,255,255,0.6)",
           lineWidth: 1,
@@ -451,11 +423,10 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
           title: "Mark",
         });
       }
-
-      // Phase 2: Liq price overlay
+      // Liq price overlay
       const liqPriceNum = liqPriceE6 != null && liqPriceE6 > 0n ? Number(liqPriceE6) / 1e6 : null;
       if (liqPriceNum != null && liqPriceNum > 0) {
-        liqLineRef.current = series.createPriceLine({
+        liqLineRef.current = s.createPriceLine({
           price: liqPriceNum,
           color: "#ef4444",
           lineWidth: 2,
@@ -464,10 +435,9 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
           title: "Liq",
         });
       }
-
       // Entry price overlay — cyan dashed when position is open
       if (entryPriceNum != null && entryPriceNum > 0) {
-        entryLineRef.current = series.createPriceLine({
+        entryLineRef.current = s.createPriceLine({
           price: entryPriceNum,
           color: "#22d3ee",
           lineWidth: 1,
@@ -476,58 +446,131 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
           title: "Entry",
         });
       }
-    } else if (chartStyle === "line" && lineData.length > 0) {
-      const series = chart.addLineSeries({
-        color: chartTheme.upColor,
-        lineWidth: 2,
-        // Same rationale as candle series — only the mark price should show
-        // as a price-axis label. DEX last-close goes away.
-        lastValueVisible: false,
-        priceLineVisible: false,
-      });
-      const formatted = lineData.map((p) => ({
-        time: (Math.floor(p.timestamp / 1000)) as import("lightweight-charts").UTCTimestamp,
-        value: p.price,
-      }));
-      series.setData(formatted);
-      seriesRef.current = series as ISeriesApi<"Candlestick" | "Line">;
+    };
 
-      // Mark price line on line series
-      if (priceUsd != null) {
-        priceLineRef.current = series.createPriceLine({
-          price: priceUsd,
-          color: "rgba(255,255,255,0.6)",
-          lineWidth: 1,
-          lineStyle: LineStyle.Dashed,
-          axisLabelVisible: true,
-          title: "Mark",
+    switch (chartStyle) {
+      case "candle-solid":
+      case "candle-hollow":
+      case "candle-hollow-up":
+      case "candle-hollow-down": {
+        if (!hasRenderableData(chartStyle, candleData, lineData).ready) break;
+        const series = chart.addCandlestickSeries({
+          ...candleStyleOptions(chartStyle, chartTheme.upColor, chartTheme.downColor),
+          // Suppress lightweight-charts' built-in last-price label + horizontal
+          // price line. Those show the DEX pool's last candle close (e.g. 84.20)
+          // which is NOT our mark price (84.33) — users saw two prices on the
+          // chart and couldn't tell which was authoritative. Our explicit
+          // createPriceLine below draws the mark price as the only price label.
+          lastValueVisible: false,
+          priceLineVisible: false,
         });
-      }
 
-      // Liq price on line chart
-      const liqPriceNum = liqPriceE6 != null && liqPriceE6 > 0n ? Number(liqPriceE6) / 1e6 : null;
-      if (liqPriceNum != null && liqPriceNum > 0) {
-        liqLineRef.current = series.createPriceLine({
-          price: liqPriceNum,
-          color: "#ef4444",
+        const formatted = candleData.map((c) => ({
+          time: (Math.floor(c.timestamp / 1000)) as import("lightweight-charts").UTCTimestamp,
+          open: c.open,
+          high: c.high,
+          low: c.low,
+          close: c.close,
+        }));
+        series.setData(formatted);
+        seriesRef.current = series;
+
+        // Volume histogram — only render when the active data source has real
+        // trade volume. Pyth Benchmarks returns v=0 for every bar (it's a price
+        // feed, not a trade tape); painting a sentinel 0.001 for every bar made
+        // the pane render as a meaningless flat red/green band auto-scaled to
+        // fill the full pane. Hide the series entirely in that case and let the
+        // candles reclaim the bottom 10% of vertical space instead.
+        if (hasVolumeData) {
+          const volumeSeries = chart.addHistogramSeries({
+            priceFormat: { type: "volume" },
+            priceScaleId: "volume",
+          });
+          chart.priceScale("volume").applyOptions({
+            scaleMargins: { top: 0.90, bottom: 0 },
+          });
+          const volumeData = candleData.map((c) => ({
+            time: (Math.floor(c.timestamp / 1000)) as import("lightweight-charts").UTCTimestamp,
+            value: c.volume ?? 0,
+            color: c.close >= c.open ? chartTheme.volUpColor : chartTheme.volDownColor,
+          }));
+          volumeSeries.setData(volumeData);
+          volumeSeriesRef.current = volumeSeries;
+        } else {
+          // No volume pane — reclaim the bottom margin for the candle series.
+          series.priceScale().applyOptions({
+            scaleMargins: { top: 0.08, bottom: 0.04 },
+          });
+        }
+
+        addOverlayLines(series);
+        break;
+      }
+      case "bar": {
+        if (!hasRenderableData(chartStyle, candleData, lineData).ready) break;
+        const series = chart.addBarSeries({
+          upColor: chartTheme.upColor,
+          downColor: chartTheme.downColor,
+          openVisible: true,
+          thinBars: false,
+          lastValueVisible: false,
+          priceLineVisible: false,
+        });
+        const formatted = candleData.map((c) => ({
+          time: (Math.floor(c.timestamp / 1000)) as import("lightweight-charts").UTCTimestamp,
+          open: c.open,
+          high: c.high,
+          low: c.low,
+          close: c.close,
+        }));
+        series.setData(formatted);
+        seriesRef.current = series;
+        addOverlayLines(series);
+        break;
+      }
+      case "line": {
+        if (!hasRenderableData(chartStyle, candleData, lineData).ready) break;
+        const series = chart.addLineSeries({
+          color: chartTheme.upColor,
           lineWidth: 2,
-          lineStyle: LineStyle.Solid,
-          axisLabelVisible: true,
-          title: "Liq",
+          // Same rationale as candle series — only the mark price should show
+          // as a price-axis label. DEX last-close goes away.
+          lastValueVisible: false,
+          priceLineVisible: false,
         });
+        const formatted = lineData.map((p) => ({
+          time: (Math.floor(p.timestamp / 1000)) as import("lightweight-charts").UTCTimestamp,
+          value: p.price,
+        }));
+        series.setData(formatted);
+        seriesRef.current = series;
+        addOverlayLines(series);
+        break;
       }
-
-      // Entry price on line chart
-      if (entryPriceNum != null && entryPriceNum > 0) {
-        entryLineRef.current = series.createPriceLine({
-          price: entryPriceNum,
-          color: "#22d3ee",
-          lineWidth: 1,
-          lineStyle: LineStyle.Dashed,
-          axisLabelVisible: true,
-          title: "Entry",
+      case "area": {
+        if (!hasRenderableData(chartStyle, candleData, lineData).ready) break;
+        // Brand purple (--accent in globals.css) gives the area mode a distinct
+        // identity vs. the green line series — same data, different feel.
+        const ACCENT = "#9945FF";
+        const series = chart.addAreaSeries({
+          lineColor: ACCENT,
+          topColor: `${ACCENT}66`,    // ~40% alpha at the top
+          bottomColor: `${ACCENT}00`, // fade to transparent at the bottom
+          lineWidth: 2,
+          lastValueVisible: false,
+          priceLineVisible: false,
         });
+        const formatted = lineData.map((p) => ({
+          time: (Math.floor(p.timestamp / 1000)) as import("lightweight-charts").UTCTimestamp,
+          value: p.price,
+        }));
+        series.setData(formatted);
+        seriesRef.current = series;
+        addOverlayLines(series);
+        break;
       }
+      default:
+        return assertNever(chartStyle);
     }
 
     // Crosshair-hover OHLCV readout. Publishes the bar under the cursor to
@@ -563,16 +606,15 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
     chart.subscribeCrosshairMove(crosshairHandler);
 
     // Only fit the content to viewport on the FIRST render for the current
-    // (timeframe, chart kind, data source) combo. Subsequent polls just
+    // (timeframe, data-kind, data source) combo. Subsequent polls just
     // update-in-place so the user's pan/zoom is preserved.
     //
-    // Bucket all candle variants under one key so flipping between
-    // candle-solid / candle-hollow / candle-hollow-up / candle-hollow-down
-    // does not reset pan/zoom — the variants share the same OHLC series
-    // and only differ in fill/border styling.
+    // Bucket by data shape (chartDataKind): candle variants + bar all read
+    // OHLC; line + area both read the single-value lineData stream. Flipping
+    // between styles that share a data source preserves pan/zoom; only
+    // switching kinds (candle ↔ line) refits the viewport.
     const source = hasPythData ? "pyth" : hasExternalData ? "dex" : "oracle";
-    const styleBucket = isCandleStyle(chartStyle) ? "candle" : chartStyle;
-    const fitKey = `${styleBucket}:${timeframe}:${source}`;
+    const fitKey = `${chartDataKind(chartStyle)}:${timeframe}:${source}`;
     if (fitKeyRef.current !== fitKey) {
       chart.timeScale().fitContent();
       fitKeyRef.current = fitKey;

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -20,6 +20,7 @@ import { ChartPnlBadge } from "./ChartPnlBadge";
 import { computeRef24h, computePriceChange } from "@/lib/chart-stats";
 import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab, getMockUserAccount } from "@/lib/mock-trade-data";
+import { getEntryPrice } from "@/lib/entry-price";
 import { useChartStylePref } from "@/hooks/useChartStylePref";
 import { useChartOverlayPrefs } from "@/hooks/useChartOverlayPrefs";
 import {
@@ -380,8 +381,10 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
     const ua = realUserAccount;
     if (!ua) return null;
     const ep = ua.account.entryPrice;
-    if (ep == null || ep === 0n) return null;
-    return Number(ep) / 1e6;
+    const resolvedEntryPrice =
+      ep != null && ep > 0n ? ep : getEntryPrice(slabAddress, ua.idx);
+    if (resolvedEntryPrice <= 0n) return null;
+    return Number(resolvedEntryPrice) / 1e6;
   })();
 
   // Update series when data or chartStyle changes
@@ -618,7 +621,13 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
     // OHLC; line + area both read the single-value lineData stream. Flipping
     // between styles that share a data source preserves pan/zoom; only
     // switching kinds (candle ↔ line) refits the viewport.
-    const source = hasPythData ? "pyth" : hasExternalData ? "dex" : "oracle";
+    const source = hasPercolatorData
+      ? "percolator"
+      : hasPythData
+        ? "pyth"
+        : hasExternalData
+          ? "dex"
+          : "oracle";
     const fitKey = `${chartDataKind(chartStyle)}:${timeframe}:${source}`;
     if (fitKeyRef.current !== fitKey) {
       chart.timeScale().fitContent();
@@ -628,7 +637,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
     return () => {
       chart.unsubscribeCrosshairMove(crosshairHandler);
     };
-  }, [chartStyle, timeframe, candleData, lineData, priceUsd, liqPriceE6, entryPriceNum, chartTheme, hasPythData, hasExternalData, overlayPrefs.entry, overlayPrefs.liq]);
+  }, [chartStyle, timeframe, candleData, lineData, priceUsd, liqPriceE6, entryPriceNum, chartTheme, hasPercolatorData, hasPythData, hasExternalData, overlayPrefs.entry, overlayPrefs.liq]);
 
   // Update mark price line when live price changes
   useEffect(() => {

--- a/app/hooks/useChartOverlayPrefs.ts
+++ b/app/hooks/useChartOverlayPrefs.ts
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  type OverlayKey,
+  type OverlayPrefs,
+  DEFAULT_OVERLAY_PREFS,
+  mergeOverlayPrefs,
+} from "@/lib/chart-overlays";
+
+export type { OverlayKey, OverlayPrefs } from "@/lib/chart-overlays";
+
+const STORAGE_KEY = "perc:chart:overlays";
+
+/** Persisted chart-overlay preferences. SSR-safe: returns DEFAULT_OVERLAY_PREFS
+ *  on the server and during the first client render, then hydrates from
+ *  localStorage in an effect. The setter writes through to localStorage and
+ *  updates state in one hop.
+ *
+ *  Returns [prefs, setPref] where setPref toggles a single key:
+ *
+ *      const [prefs, setPref] = useChartOverlayPrefs();
+ *      setPref("entry", false); // hide entry-price line
+ */
+export function useChartOverlayPrefs(): [
+  OverlayPrefs,
+  (key: OverlayKey, value: boolean) => void,
+] {
+  const [prefs, setPrefs] = useState<OverlayPrefs>(DEFAULT_OVERLAY_PREFS);
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (raw == null) return;
+      const parsed = JSON.parse(raw);
+      // mergeOverlayPrefs tolerates partial / unknown shapes — recovers
+      // gracefully from older deploys that persisted a smaller key set, and
+      // from forward-compat reads where a downgraded build encounters a key
+      // it doesn't know about.
+      setPrefs(mergeOverlayPrefs(parsed));
+    } catch {
+      // localStorage unavailable, JSON parse failed, etc — keep defaults
+    }
+  }, []);
+
+  const setPref = useCallback((key: OverlayKey, value: boolean) => {
+    setPrefs((current) => {
+      const next = { ...current, [key]: value };
+      try {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      } catch {
+        // best-effort write; ignore quota / privacy errors
+      }
+      return next;
+    });
+  }, []);
+
+  return [prefs, setPref];
+}

--- a/app/hooks/useChartStylePref.ts
+++ b/app/hooks/useChartStylePref.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  type ChartStyle,
+  DEFAULT_CHART_STYLE,
+  isChartStyle,
+} from "@/lib/chart-style";
+
+export type { ChartStyle } from "@/lib/chart-style";
+
+const STORAGE_KEY = "perc:chart:style";
+
+/** Persisted chart-style preference. SSR-safe: returns DEFAULT_CHART_STYLE on
+ * the server and during the first client render, then hydrates from
+ * localStorage in an effect. Setter writes through to localStorage.
+ *
+ * Returns [style, setStyle]. */
+export function useChartStylePref(): [ChartStyle, (next: ChartStyle) => void] {
+  const [style, setStyleState] = useState<ChartStyle>(DEFAULT_CHART_STYLE);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (isChartStyle(stored)) setStyleState(stored);
+    } catch {
+      // localStorage may be unavailable (SSR, iframes, privacy mode) — keep default
+    }
+  }, []);
+
+  const setStyle = useCallback((next: ChartStyle) => {
+    setStyleState(next);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      // best-effort write; ignore quota / privacy errors
+    }
+  }, []);
+
+  return [style, setStyle];
+}

--- a/app/lib/chart-overlays.ts
+++ b/app/lib/chart-overlays.ts
@@ -13,18 +13,21 @@
  */
 
 /** Single source of truth for every overlay the chart can toggle. */
-const ALL_OVERLAYS = ["entry", "liq", "pnl"] as const;
+const ALL_OVERLAYS = ["position", "entry", "liq", "pnl"] as const;
 
 /** Discriminator union for chart-overlay preferences. */
 export type OverlayKey = (typeof ALL_OVERLAYS)[number];
 
-/** Display order in the Display menu. Reads top-to-bottom in priority of
- *  what a trader watches when a position is open: entry → liq → pnl. */
+/** Display order in the Display menu. Reads top-to-bottom in the order a
+ *  trader thinks about an open position: do I have one (Position) → where
+ *  did I get in (Entry) → where do I get liquidated (Liq) → what's it doing
+ *  (PnL). */
 export const OVERLAY_DISPLAY_ORDER: readonly OverlayKey[] = ALL_OVERLAYS;
 
 /** Human-readable labels. Adding a new OverlayKey forces this Record to grow
  *  — TypeScript flags any missing entry. */
 export const OVERLAY_LABELS: Record<OverlayKey, string> = {
+  position: "Position Summary",
   entry: "Avg Entry Price",
   liq: "Liquidation Price",
   pnl: "Live PnL",
@@ -38,6 +41,7 @@ export type OverlayPrefs = Record<OverlayKey, boolean>;
  *  opt in. Future overlays added to ALL_OVERLAYS must declare a default
  *  here or this Record fails to type-check. */
 export const DEFAULT_OVERLAY_PREFS: OverlayPrefs = {
+  position: true,
   entry: true,
   liq: true,
   pnl: true,

--- a/app/lib/chart-overlays.ts
+++ b/app/lib/chart-overlays.ts
@@ -70,4 +70,3 @@ export function mergeOverlayPrefs(stored: unknown): OverlayPrefs {
   }
   return merged;
 }
-

--- a/app/lib/chart-overlays.ts
+++ b/app/lib/chart-overlays.ts
@@ -1,0 +1,69 @@
+/**
+ * Single source of truth for the chart-overlay user preferences.
+ *
+ * Each overlay (Avg Entry price line, Liquidation price line, Live PnL label)
+ * has an independent ON/OFF user preference, persisted to localStorage and
+ * surfaced via the toolbar's Display menu. The renderer reads the prefs and
+ * conditionally draws the overlay; this module owns ONLY the union, defaults,
+ * labels, and parse-safety helpers.
+ *
+ * Mirrors the architecture of chart-style.ts — append-once-update-everywhere
+ * via a single `as const` tuple, with assertNever and `Record<OverlayKey,...>`
+ * giving compile-time enforcement that labels and defaults stay in lockstep.
+ */
+
+/** Single source of truth for every overlay the chart can toggle. */
+const ALL_OVERLAYS = ["entry", "liq", "pnl"] as const;
+
+/** Discriminator union for chart-overlay preferences. */
+export type OverlayKey = (typeof ALL_OVERLAYS)[number];
+
+/** Display order in the Display menu. Reads top-to-bottom in priority of
+ *  what a trader watches when a position is open: entry → liq → pnl. */
+export const OVERLAY_DISPLAY_ORDER: readonly OverlayKey[] = ALL_OVERLAYS;
+
+/** Human-readable labels. Adding a new OverlayKey forces this Record to grow
+ *  — TypeScript flags any missing entry. */
+export const OVERLAY_LABELS: Record<OverlayKey, string> = {
+  entry: "Avg Entry Price",
+  liq: "Liquidation Price",
+  pnl: "Live PnL",
+};
+
+/** Persisted preference shape: every overlay key mapped to ON/OFF. */
+export type OverlayPrefs = Record<OverlayKey, boolean>;
+
+/** Defaults are all ON — matches today's behaviour where Liq/Entry render
+ *  whenever a position is open. The Display menu is a way to OPT OUT, not
+ *  opt in. Future overlays added to ALL_OVERLAYS must declare a default
+ *  here or this Record fails to type-check. */
+export const DEFAULT_OVERLAY_PREFS: OverlayPrefs = {
+  entry: true,
+  liq: true,
+  pnl: true,
+};
+
+const VALID_KEYS: ReadonlySet<string> = new Set(ALL_OVERLAYS);
+
+/** Type guard for unknown input (localStorage reads, URL params, etc). */
+export function isOverlayKey(v: unknown): v is OverlayKey {
+  return typeof v === "string" && VALID_KEYS.has(v);
+}
+
+/** Merge a partial / unknown stored value with defaults. Recovers gracefully
+ *  from older deploys that persisted a smaller set of keys, or from forward-
+ *  compat reads where a downgraded build sees a key it doesn't know about
+ *  (the unknown key is dropped, known keys missing from the input fall back
+ *  to DEFAULT_OVERLAY_PREFS). */
+export function mergeOverlayPrefs(stored: unknown): OverlayPrefs {
+  if (typeof stored !== "object" || stored === null || Array.isArray(stored)) {
+    return { ...DEFAULT_OVERLAY_PREFS };
+  }
+  const obj = stored as Record<string, unknown>;
+  const merged = { ...DEFAULT_OVERLAY_PREFS };
+  for (const key of ALL_OVERLAYS) {
+    if (typeof obj[key] === "boolean") merged[key] = obj[key] as boolean;
+  }
+  return merged;
+}
+

--- a/app/lib/chart-pnl-format.ts
+++ b/app/lib/chart-pnl-format.ts
@@ -1,0 +1,42 @@
+/**
+ * Pure presentation helpers for the ChartPnlBadge.
+ *
+ * The math (computeMarkPnl, computePnlPercent) lives in `@percolatorct/sdk`
+ * and is already covered by `__tests__/lib/phantom-position-pnl.test.ts`.
+ * This module owns ONLY the string formatting + sign classification so the
+ * badge can be tested without mocking hooks.
+ */
+
+/** Sign classification for visual styling. `"zero"` exists so callers can
+ *  render "$0.00 (0%)" without forcing a colour choice — green/red on a
+ *  dead-flat position would imply movement that isn't there. */
+export type PnlSign = "positive" | "negative" | "zero";
+
+export interface FormattedPnl {
+  /** "+$120.50 (+8.4%)" / "-$15.00 (-1.2%)" / "$0.00 (0.0%)" */
+  display: string;
+  sign: PnlSign;
+}
+
+/** Format a USD PnL + ROE percentage into a single human-readable string and
+ *  classify the sign. Used by the chart's floating PnL badge.
+ *
+ *  Conventions:
+ *  - Two decimal places for both USD and percent (matches existing
+ *    PositionPanel formatting).
+ *  - Explicit `+` sign on positive values (`+$120.50` reads as profit at a
+ *    glance vs. an unsigned `$120.50` that could be either).
+ *  - Negative values get the standard `-` from `toFixed`; we don't double-sign.
+ *  - Sub-cent values round to "$0.00" but the sign still classifies based on
+ *    the raw input — a near-zero loss should still render red. */
+export function formatPnl(pnlUsd: number, roePercent: number): FormattedPnl {
+  const sign: PnlSign = pnlUsd > 0 ? "positive" : pnlUsd < 0 ? "negative" : "zero";
+
+  const usdAbs = Math.abs(pnlUsd).toFixed(2);
+  const usdStr = sign === "positive" ? `+$${usdAbs}` : sign === "negative" ? `-$${usdAbs}` : `$${usdAbs}`;
+
+  const pctAbs = Math.abs(roePercent).toFixed(2);
+  const pctStr = sign === "positive" ? `+${pctAbs}%` : sign === "negative" ? `-${pctAbs}%` : `${pctAbs}%`;
+
+  return { display: `${usdStr} (${pctStr})`, sign };
+}

--- a/app/lib/chart-style.ts
+++ b/app/lib/chart-style.ts
@@ -47,6 +47,25 @@ export type CandleStyle = (typeof ALL_CANDLE_STYLES)[number];
  *  recovery target when a stored preference fails validation. */
 export const DEFAULT_CHART_STYLE: ChartStyle = "candle-solid";
 
+/** Human-readable labels for the style picker. Kept here (not inline in the
+ *  menu component) so adding a new ChartStyle variant forces the
+ *  `Record<ChartStyle, string>` to grow in lockstep — TypeScript flags any
+ *  new union member that lacks an entry here. */
+export const CHART_STYLE_LABELS: Record<ChartStyle, string> = {
+  "line": "Line",
+  "area": "Area",
+  "candle-solid": "Candle (Solid)",
+  "candle-hollow": "Candle (Hollow)",
+  "candle-hollow-up": "Candle (Hollow Up)",
+  "candle-hollow-down": "Candle (Hollow Down)",
+  "bar": "Bar (OHLC)",
+};
+
+/** Display order for the style picker. Reads top-to-bottom from simplest
+ *  series (line) to richest (bar OHLC). Derived from ALL_STYLES so the menu
+ *  cannot drift from the union — the order is intentional, not alphabetic. */
+export const CHART_STYLE_DISPLAY_ORDER: readonly ChartStyle[] = ALL_STYLES;
+
 const VALID_STYLES: ReadonlySet<ChartStyle> = new Set(ALL_STYLES);
 const CANDLE_STYLES: ReadonlySet<ChartStyle> = new Set(ALL_CANDLE_STYLES);
 

--- a/app/lib/chart-style.ts
+++ b/app/lib/chart-style.ts
@@ -15,10 +15,12 @@ import { assertNever } from "./exhaustive";
  *  from this tuple — append here to add a variant. */
 const ALL_STYLES = [
   "line",
+  "area",
   "candle-solid",
   "candle-hollow",
   "candle-hollow-up",
   "candle-hollow-down",
+  "bar",
 ] as const;
 
 /** Subset of `ALL_STYLES` that renders as a candlestick series. The
@@ -71,6 +73,64 @@ export interface CandleStyleOptions {
   wickUpColor: string;
   wickDownColor: string;
   borderVisible: boolean;
+}
+
+/** lightweight-charts series-API discriminator strings TradingChart can hold a
+ *  ref to. Every render branch in TradingChart's series-creation switch maps
+ *  to exactly one of these. Centralised here so the `seriesRef` declaration
+ *  and the `addOverlayLines` parameter cannot drift apart. */
+export type ChartSeriesKind = "Candlestick" | "Line" | "Area" | "Bar";
+
+/** Which raw data shape a chart style consumes:
+ *
+ *  - `"ohlc"`   — needs `{open, high, low, close}` per bar (candle + bar series)
+ *  - `"single"` — needs `{price}` per point (line + area series)
+ *
+ *  Two distinct call sites in TradingChart need this answer (sparse-data
+ *  overlay, fit-key viewport bucket). Centralising it means adding a new
+ *  ChartStyle to ALL_STYLES forces a build error at the assertNever default
+ *  rather than silently mis-classifying. */
+export function chartDataKind(style: ChartStyle): "ohlc" | "single" {
+  switch (style) {
+    case "candle-solid":
+    case "candle-hollow":
+    case "candle-hollow-up":
+    case "candle-hollow-down":
+    case "bar":
+      return "ohlc";
+    case "line":
+    case "area":
+      return "single";
+    default:
+      return assertNever(style);
+  }
+}
+
+/** Minimal structural shapes the renderable-data check needs. Declared here
+ *  (not imported from TradingChart) to keep this module pure and avoid an
+ *  import cycle. Callers can pass their richer types — only `.length` is read. */
+interface OhlcLike { readonly timestamp: number }
+interface PricePointLike { readonly timestamp: number }
+
+/** Render-readiness of the data source the given style will actually consume.
+ *
+ *  - `ready`  — true when the relevant array has >= 1 point. Used by the
+ *               render-switch to bail before calling `addXSeries(...)`.
+ *  - `sparse` — true when the relevant array has < 2 points. A single point
+ *               cannot draw a usable body/line, so the "Price chart building…"
+ *               overlay paints instead.
+ *
+ *  The two thresholds (`>= 1` vs `< 2`) are intentional and live here so they
+ *  cannot drift across call sites — before this helper, the switch used
+ *  `=== 0` and the overlay used `< 2`, and the overlay only checked candle +
+ *  line so area and bar fell through and never showed the sparse banner. */
+export function hasRenderableData(
+  style: ChartStyle,
+  candleData: readonly OhlcLike[],
+  lineData: readonly PricePointLike[],
+): { ready: boolean; sparse: boolean } {
+  const len = chartDataKind(style) === "ohlc" ? candleData.length : lineData.length;
+  return { ready: len >= 1, sparse: len < 2 };
 }
 
 /** Build the `addCandlestickSeries` option preset for a given candle variant.

--- a/app/lib/chart-style.ts
+++ b/app/lib/chart-style.ts
@@ -8,6 +8,8 @@
  * the union and the runtime sets at compile time.
  */
 
+import { assertNever } from "./exhaustive";
+
 /** Single source of truth for every chart style TradingChart can render.
  *  The `ChartStyle` union and the `VALID_STYLES` set are both derived
  *  from this tuple — append here to add a variant. */
@@ -55,4 +57,61 @@ export function isChartStyle(v: unknown): v is ChartStyle {
  *  downstream code can branch on candle-only chart options for free. */
 export function isCandleStyle(s: ChartStyle): s is CandleStyle {
   return CANDLE_STYLES.has(s);
+}
+
+/** Subset of lightweight-charts `CandlestickSeriesPartialOptions` we set per
+ *  variant. We avoid importing the library type here to keep this module
+ *  pure (Apache-2.0 friendly + tree-shakeable). The shape is enforced
+ *  structurally by `addCandlestickSeries` at the call site. */
+export interface CandleStyleOptions {
+  upColor: string;
+  downColor: string;
+  borderUpColor: string;
+  borderDownColor: string;
+  wickUpColor: string;
+  wickDownColor: string;
+  borderVisible: boolean;
+}
+
+/** Build the `addCandlestickSeries` option preset for a given candle variant.
+ *
+ *  - `candle-solid`: filled bodies in trend color (the default lightweight-charts look)
+ *  - `candle-hollow`: transparent bodies, colored borders — minimal "outlined" look
+ *  - `candle-hollow-up`: hollow on bullish bars, solid on bearish (TradingView's
+ *    classic style — emphasises selling pressure)
+ *  - `candle-hollow-down`: solid bullish, hollow bearish (less common; some traders
+ *    use it to emphasise buying pressure)
+ *
+ *  Wick colors always follow the trend color so direction stays visible even
+ *  when the body is hollow. `borderVisible` is true for any hollow variant
+ *  so the outline draws. */
+export function candleStyleOptions(
+  style: CandleStyle,
+  upColor: string,
+  downColor: string,
+): CandleStyleOptions {
+  const base: CandleStyleOptions = {
+    upColor,
+    downColor,
+    borderUpColor: upColor,
+    borderDownColor: downColor,
+    wickUpColor: upColor,
+    wickDownColor: downColor,
+    borderVisible: false,
+  };
+  switch (style) {
+    case "candle-solid":
+      return base;
+    case "candle-hollow":
+      return { ...base, upColor: "rgba(0,0,0,0)", downColor: "rgba(0,0,0,0)", borderVisible: true };
+    case "candle-hollow-up":
+      return { ...base, upColor: "rgba(0,0,0,0)", borderVisible: true };
+    case "candle-hollow-down":
+      return { ...base, downColor: "rgba(0,0,0,0)", borderVisible: true };
+    default:
+      // If a new CandleStyle is added to ALL_CANDLE_STYLES without a case
+      // here, TypeScript fails at this call site rather than at the function
+      // signature, pointing at the missing branch.
+      return assertNever(style);
+  }
 }

--- a/app/lib/chart-style.ts
+++ b/app/lib/chart-style.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure helpers for the TradingChart series-style preference.
+ *
+ * Extracted from useChartStylePref.ts and TradingChart.tsx so the union,
+ * the "is this a valid persisted value?" guard, and the "is this a candle
+ * variant?" guard all derive from a single source of truth. Adding a new
+ * variant means appending to one tuple — TypeScript catches drift between
+ * the union and the runtime sets at compile time.
+ */
+
+/** Single source of truth for every chart style TradingChart can render.
+ *  The `ChartStyle` union and the `VALID_STYLES` set are both derived
+ *  from this tuple — append here to add a variant. */
+const ALL_STYLES = [
+  "line",
+  "candle-solid",
+  "candle-hollow",
+  "candle-hollow-up",
+  "candle-hollow-down",
+] as const;
+
+/** Subset of `ALL_STYLES` that renders as a candlestick series. The
+ *  `satisfies readonly ChartStyle[]` clause makes a typo or removed
+ *  variant a compile error rather than a silent runtime fall-through. */
+const ALL_CANDLE_STYLES = [
+  "candle-solid",
+  "candle-hollow",
+  "candle-hollow-up",
+  "candle-hollow-down",
+] as const satisfies readonly ChartStyle[];
+
+/** Chart series styles TradingChart can render today. The union is kept
+ *  intentionally narrow — each new variant is added in lockstep with the
+ *  render branch that draws it. Stale values from older deploys (or future
+ *  builds being downgraded) fail isChartStyle() and fall back to
+ *  DEFAULT_CHART_STYLE. */
+export type ChartStyle = (typeof ALL_STYLES)[number];
+
+/** Strict subset narrowed to the candlestick variants. */
+export type CandleStyle = (typeof ALL_CANDLE_STYLES)[number];
+
+/** Default series style used during SSR / first paint and as the
+ *  recovery target when a stored preference fails validation. */
+export const DEFAULT_CHART_STYLE: ChartStyle = "candle-solid";
+
+const VALID_STYLES: ReadonlySet<ChartStyle> = new Set(ALL_STYLES);
+const CANDLE_STYLES: ReadonlySet<ChartStyle> = new Set(ALL_CANDLE_STYLES);
+
+/** Type guard for unknown input (localStorage reads, URL params, etc). */
+export function isChartStyle(v: unknown): v is ChartStyle {
+  return typeof v === "string" && VALID_STYLES.has(v as ChartStyle);
+}
+
+/** True when `s` is one of the candlestick variants. Narrows the type so
+ *  downstream code can branch on candle-only chart options for free. */
+export function isCandleStyle(s: ChartStyle): s is CandleStyle {
+  return CANDLE_STYLES.has(s);
+}

--- a/app/lib/exhaustive.ts
+++ b/app/lib/exhaustive.ts
@@ -1,0 +1,15 @@
+/**
+ * Compile-time exhaustiveness check for switch / discriminated-union dispatch.
+ *
+ * Add `default: return assertNever(value)` (or `default: assertNever(value)`)
+ * to a switch over a union type. If a future contributor extends the union
+ * without adding a matching case, TypeScript fails at the assertNever call
+ * site — pointing at the missing branch instead of at the function signature.
+ *
+ * The runtime throw is a safety net for paths that bypass the type system
+ * (stale enum values from storage, `as any` upstream, JSON deserialisation,
+ * `// @ts-expect-error`). Production code should never reach it.
+ */
+export function assertNever(x: never): never {
+  throw new Error(`Unexpected value: ${JSON.stringify(x)}`);
+}


### PR DESCRIPTION
## Summary

Brings the trade-page chart up to parity with TradingView/MEXC/Binance polish — additional series styles, a Display menu that gates on-chart overlays, and a live PnL badge — without any new data fetches or dependencies.

## What's new

**Series styles** (toolbar dropdown): line, area, candle solid / hollow / hollow-up / hollow-down, bar. Selection persists to localStorage (`perc:chart:style`) with SSR-safe hydration. Single `ChartStyle` union in `app/lib/chart-style.ts` drives the toolbar, the renderer switch, and per-variant color presets — adding a new style is a one-line tuple change with `assertNever` catching any drift at compile time.

**Display menu** (toolbar): independent ON/OFF toggles for each on-chart overlay — Position Summary, Avg Entry price line, Liquidation price line, Live PnL badge. Defaults are all-on so existing behavior is unchanged for users who never open the menu. Prefs persist to `perc:chart:overlays` via a tolerant merge (older deploys missing newer keys fall back to defaults; downgraded builds drop unknown future keys).

**Live PnL badge** (chart corner, stacked under PositionSummary): displays unrealized PnL refreshed on every live-price tick. Math reuses the existing `computeMarkPnl` + `computePnlPercent` from `@percolatorct/sdk` (same path as `PositionPanel`); a small `formatPnl` helper owns just the string formatting + sign classification so the presentation is testable without mocking hooks. Returns null when there's no open position, no entry price, or no valid mark — avoids a misleading ""\$0.00 (0%)"" placeholder during data fetch. Includes the v12.1 entry-price fallback to localStorage for accounts where the on-chain ` + "`entry_price`" + ` field was removed.

## Architecture notes

- **Single source of truth tuples**: `ALL_STYLES` and `ALL_OVERLAYS` are ` + "`as const`" + ` tuples; the union, validators, labels, and display orders all derive from them. Adding a variant forces every dependent ` + "`Record`" + ` and ` + "`switch`" + ` to grow in lockstep at compile time.
- **ARIA chosen by widget semantics**: `ChartStyleMenu` uses ` + "`role=\"listbox\"`" + ` + ` + "`role=\"option\"`" + ` (single-select); ` + "`ChartDisplayMenu`" + ` uses ` + "`<button aria-pressed>`" + ` (independent toggles). Neither claims the WAI-ARIA APG menu keyboard contract since arrow-key focus management isn't implemented — declared semantics match actual behavior.
- **No new dependencies**: still on ` + "`lightweight-charts@4.2.0`" + `. No backend changes.
- **fitKey buckets by data shape**: candle variants + bar share an OHLC bucket; line + area share a single-value bucket. Flipping styles within a bucket preserves user pan/zoom; only switching kinds refits the viewport.

## Test coverage

- 30 lib tests for ChartStyle (validators, candle subset, color presets, exhaustiveness)
- 14 lib tests for OverlayPrefs (validators, merge tolerance, defaults, display order)
- 8 lib tests for formatPnl (sign classification, sub-cent edge cases, no double-signing)
- 10 RTL tests for ChartStyleMenu (toggle, Escape, outside-click, aria-selected, tabIndex)
- 10 RTL tests for ChartDisplayMenu (toggle, Escape, outside-click, aria-pressed, multi-toggle UX, tabIndex)
- Full project test suite passes (1927 tests, 34 pre-existing skips, 0 failures)
- ` + "`tsc --noEmit`" + ` clean (pre-existing ` + "`@percolator/sdk`" + ` import errors are unrelated to this branch)

## Test plan

- [ ] Cycle through every series style with both light and dark themes
- [ ] Confirm localStorage persistence survives a hard refresh (`perc:chart:style` and `perc:chart:overlays`)
- [ ] Open a position; toggle each overlay (Position, Entry, Liq, PnL) off and on; confirm clean draw/teardown
- [ ] Verify Live PnL badge updates on every oracle tick and matches the value shown in the side `PositionPanel`
- [ ] Verify the badge hides when the position closes
- [ ] Verify v12.1 NFT-position users see the badge (entry-price fallback works)
- [ ] Confirm Escape and outside-click close both toolbar dropdowns
- [ ] Mobile (≤ 768px): confirm the toolbar wraps cleanly and the dropdown panels remain visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chart style selector (candles, line, area, bar) and overlay visibility toggles for position, entry, liquidation, and PnL.
  * Floating PnL badge showing unrealized USD and percentage.
  * Preferences for chart style and overlays persisted locally.

* **Refactor**
  * Chart rendering updated to use the new style system and honor overlay preferences.

* **Accessibility / UX**
  * Dropdowns improved for keyboard, Escape, and outside-click behavior.

* **Tests**
  * Extensive test coverage added for charts, overlays, formatting, and prefs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->