### PR TITLE
chore(chart): upgrade lightweight-charts from v4.2 to v5.2

### DIFF
--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -1,7 +1,19 @@
 "use client";
 
 import { FC, useState, useRef, useEffect, useCallback } from "react";
-import { createChart, IChartApi, ISeriesApi, LineStyle, ColorType, CrosshairMode } from "lightweight-charts";
+import {
+  createChart,
+  IChartApi,
+  ISeriesApi,
+  LineStyle,
+  ColorType,
+  CrosshairMode,
+  CandlestickSeries,
+  HistogramSeries,
+  BarSeries,
+  LineSeries,
+  AreaSeries,
+} from "lightweight-charts";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { useLivePrice } from "@/hooks/useLivePrice";
 import { useTokenChart } from "@/hooks/useTokenChart";
@@ -462,7 +474,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
       case "candle-hollow-up":
       case "candle-hollow-down": {
         if (!hasRenderableData(chartStyle, candleData, lineData).ready) break;
-        const series = chart.addCandlestickSeries({
+        const series = chart.addSeries(CandlestickSeries, {
           ...candleStyleOptions(chartStyle, chartTheme.upColor, chartTheme.downColor),
           // Suppress lightweight-charts' built-in last-price label + horizontal
           // price line. Those show the DEX pool's last candle close (e.g. 84.20)
@@ -490,7 +502,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
         // fill the full pane. Hide the series entirely in that case and let the
         // candles reclaim the bottom 10% of vertical space instead.
         if (hasVolumeData) {
-          const volumeSeries = chart.addHistogramSeries({
+          const volumeSeries = chart.addSeries(HistogramSeries, {
             priceFormat: { type: "volume" },
             priceScaleId: "volume",
           });
@@ -516,10 +528,13 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
       }
       case "bar": {
         if (!hasRenderableData(chartStyle, candleData, lineData).ready) break;
-        const series = chart.addBarSeries({
+        const series = chart.addSeries(BarSeries, {
           upColor: chartTheme.upColor,
           downColor: chartTheme.downColor,
           openVisible: true,
+          // Keep proportional bar widths (matches v4 behaviour). v5 still
+          // accepts this option but flipped the default to `true`, which
+          // would render visibly thinner bars without this explicit override.
           thinBars: false,
           lastValueVisible: false,
           priceLineVisible: false,
@@ -538,7 +553,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
       }
       case "line": {
         if (!hasRenderableData(chartStyle, candleData, lineData).ready) break;
-        const series = chart.addLineSeries({
+        const series = chart.addSeries(LineSeries, {
           color: chartTheme.upColor,
           lineWidth: 2,
           // Same rationale as candle series — only the mark price should show
@@ -560,7 +575,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
         // Brand purple (--accent in globals.css) gives the area mode a distinct
         // identity vs. the green line series — same data, different feel.
         const ACCENT = "#9945FF";
-        const series = chart.addAreaSeries({
+        const series = chart.addSeries(AreaSeries, {
           lineColor: ACCENT,
           topColor: `${ACCENT}66`,    // ~40% alpha at the top
           bottomColor: `${ACCENT}00`, // fade to transparent at the bottom

--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,7 @@
     "bs58": "^6.0.0",
     "buffer": "^6.0.3",
     "gsap": "^3.14.2",
-    "lightweight-charts": "^4.2.0",
+    "lightweight-charts": "^5.2.0",
     "next": "16.2.3",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,8 +106,8 @@ importers:
         specifier: ^3.14.2
         version: 3.14.2
       lightweight-charts:
-        specifier: ^4.2.0
-        version: 4.2.3
+        specifier: ^5.2.0
+        version: 5.2.0
       next:
         specifier: 16.2.3
         version: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -5371,8 +5371,8 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
-  lightweight-charts@4.2.3:
-    resolution: {integrity: sha512-5kS/2hY3wNYNzhnS8Gb+GAS07DX8GPF2YVDnd2NMC85gJVQ6RLU6YrXNgNJ6eg0AnWPwCnvaGtYmGky3HiLQEw==}
+  lightweight-charts@5.2.0:
+    resolution: {integrity: sha512-ey3Vas8UhV06ni+LT9TA1nEe4y8So4Mi6CL/oarNHFMyTktz/xy8e8+oh04Q//eO3t6etvFXgayz2fClyFQb5w==}
 
   lit-element@4.2.2:
     resolution: {integrity: sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==}
@@ -7350,7 +7350,7 @@ snapshots:
       idb-keyval: 6.2.1
       ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
       preact: 10.24.2
-      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zustand: 5.0.3(@types/react@19.2.13)(immer@11.1.4)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
     transitivePeerDependencies:
       - '@types/react'
@@ -7418,7 +7418,7 @@ snapshots:
       idb-keyval: 6.2.1
       ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
       preact: 10.24.2
-      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zustand: 5.0.3(@types/react@19.2.13)(immer@11.1.4)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
     transitivePeerDependencies:
       - '@types/react'
@@ -8718,7 +8718,7 @@ snapshots:
     dependencies:
       big.js: 6.2.2
       dayjs: 1.11.13
-      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -8753,7 +8753,7 @@ snapshots:
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@walletconnect/universal-provider': 2.21.0(@upstash/redis@1.36.4)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       valtio: 1.13.2(@types/react@19.2.13)(react@18.3.1)
-      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -9051,7 +9051,7 @@ snapshots:
       '@walletconnect/logger': 2.1.2
       '@walletconnect/universal-provider': 2.21.0(@upstash/redis@1.36.4)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       valtio: 1.13.2(@types/react@19.2.13)(react@18.3.1)
-      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -9155,7 +9155,7 @@ snapshots:
       '@walletconnect/universal-provider': 2.21.0(@upstash/redis@1.36.4)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       bs58: 6.0.0
       valtio: 1.13.2(@types/react@19.2.13)(react@18.3.1)
-      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -9393,7 +9393,7 @@ snapshots:
   '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.23.1
-      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -14412,7 +14412,7 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
-  lightweight-charts@4.2.3:
+  lightweight-charts@5.2.0:
     dependencies:
       fancy-canvas: 2.1.0
 


### PR DESCRIPTION
## Summary

Behavior-preserving upgrade of `lightweight-charts` from `4.2.0` to `5.2.0`. Lays the foundation for native multi-pane support (`chart.addPane()`) which the upcoming indicators PR will use for RSI/MACD oscillators — those would otherwise need a second chart instance and manual time-scale sync.

## What changed

**Two commits, three files:**
- `app/package.json` — version bump
- `pnpm-lock.yaml` — regenerated
- `app/components/trade/TradingChart.tsx` — 5 series-creation call sites migrated to v5's unified `chart.addSeries(SeriesType, options)` API + 5 series-type constructors imported

**Specifically:**
- `chart.addCandlestickSeries(opts)` → `chart.addSeries(CandlestickSeries, opts)`
- `chart.addBarSeries(opts)` → `chart.addSeries(BarSeries, opts)` (keeps explicit `thinBars: false` since v5 flipped the default to `true`)
- `chart.addLineSeries(opts)` → `chart.addSeries(LineSeries, opts)`
- `chart.addAreaSeries(opts)` → `chart.addSeries(AreaSeries, opts)`
- `chart.addHistogramSeries(opts)` → `chart.addSeries(HistogramSeries, opts)`

## What stayed the same

The `ISeriesApi<...>` discriminator strings (`Candlestick`, `Line`, `Area`, `Bar`, `Histogram`) are unchanged in v5, so the existing `ChartSeriesKind` type alias and all the refs (`seriesRef`, `volumeSeriesRef`, `priceLineRef`, `liqLineRef`, `entryLineRef`) needed no updates.

`createPriceLine`, `setData`, `applyOptions`, `subscribeCrosshairMove`, `removeSeries`, `subscribeVisibleTimeRangeChange`, `priceScale().applyOptions()`, `timeScale().fitContent()` — all unchanged.

## Why now

The upcoming indicators PR adds RSI/MACD as oscillators. v5's `chart.addPane()` API lets us render those in a native pane on the same chart instance with automatic time-scale and crosshair sync. v4 would have required a second chart instance plus manual sync plumbing — meaningfully more complex and a known source of subtle bugs.

This upgrade is its own focused PR so the v5 dep change can be reviewed and rolled back independently if needed, rather than getting tangled with feature work.

## Tests

- All 72 existing chart tests pass (`__tests__/lib/chart-style.test.ts`, `chart-overlays.test.ts`, `chart-pnl-format.test.ts`, `__tests__/components/trade/ChartStyleMenu.test.tsx`, `ChartDisplayMenu.test.tsx`)
- `npx tsc --noEmit` clean (filtering pre-existing `@percolator/sdk` import errors which are unrelated to this branch)
- No new tests added — this is a behavior-preserving library upgrade

## Manual QA checklist

The test suite verifies logic but not pixel-level rendering. v5 may have changed defaults in ways that mechanical API replacements miss. **Please verify the following before merging:**

**Smoke**
- [ ] Chart loads on the trade page with no console errors

**Style rendering** (regression risk — v5 default changes)
- [ ] All 7 chart styles render: line, area, candle solid, candle hollow, candle hollow-up, candle hollow-down, bar
- [ ] **Bar style**: bar widths look comparable to v4 (the explicit `thinBars: false` override should preserve the v4 fat-bar look)
- [ ] **Candle hollow / hollow-up / hollow-down**: bodies are transparent (grid lines visible through them), wicks are colored, borders visible
- [ ] **Candle solid**: bodies fully filled with up/down color

**Overlays** (regression risk — \`lastValueVisible\` / \`priceLineVisible\` interaction with \`createPriceLine\`)
- [ ] Mark price line (white dashed) renders ONCE — not doubled with a built-in price label
- [ ] Liq price line (red solid) renders at correct position when position is open
- [ ] Entry price line (cyan dashed) renders at correct position when position is open
- [ ] Right price-axis shows mark price label only — no stray "DEX last close" labels reappearing

**Volume pane** (regression risk — \`scaleMargins\` semantics)
- [ ] Volume histogram renders for sources with real volume data (Percolator, GeckoTerminal)
- [ ] Volume pane occupies bottom ~10% of chart (not 90%, not clipped, not invisible)
- [ ] Volume absent for Pyth (which has v=0 bars) — full chart height reclaimed for candles

**Crosshair tooltip** (regression risk — \`MouseEventParams.seriesData\` shape)
- [ ] Hover candles → OHLCV tooltip shows all 5 values, no NaN, no undefined
- [ ] Hover line/area → single value tooltip shows
- [ ] Hover volume bars → volume value shows

**Interactions**
- [ ] Pan/zoom works smoothly
- [ ] Switching timeframes redraws cleanly without flicker
- [ ] Switching styles preserves pan/zoom within data-shape buckets (candle ↔ bar share OHLC; line ↔ area share single-value)
- [ ] Switching slabs loads new market data
- [ ] Position summary + Live PnL badges update live and follow chart on resize

**Theming**
- [ ] Light/dark theme switch repaints chart correctly

**Responsive**
- [ ] Mobile (≤768px): toolbar wraps cleanly, dropdowns position correctly, chart sizes correctly via \`autoSize\`
- [ ] Desktop wide (≥1440px): chart fills container, no clipping

## Notes for reviewer

- The build is intentionally broken between commit 1 (`5398ae4f` dep bump) and commit 2 (`c4a2a600` migration). Reviewing the PR end-state is what matters — both commits together leave the app in a working state.
- v5 dropped CommonJS in favor of ES2020. Our Next.js bundler handles this without changes.
- v5 unlocks `chart.addPane()` for the upcoming indicators work — RSI/MACD oscillators get a native sub-pane with automatic time-scale and crosshair sync, eliminating the second-chart-instance pattern that v4 would have required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the trading chart library to version 5.2.0, enhancing rendering performance and visual stability for all chart types.

* **Refactor**
  * Migrated chart series rendering to an updated API for improved support of candlestick, bar, line, area charts and volume data visualization with better viewport handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->