### PR TITLE
feat(chart): SMA, EMA, Bollinger, RSI, MACD indicators with settings menu

### DIFF
--- a/app/__tests__/components/trade/ChartIndicatorMenu.test.tsx
+++ b/app/__tests__/components/trade/ChartIndicatorMenu.test.tsx
@@ -84,15 +84,13 @@ describe("ChartIndicatorMenu", () => {
     };
     render(<ChartIndicatorMenu {...noopProps} indicators={[sma]} />);
     fireEvent.click(screen.getByRole("button", { name: /Indicators/i }));
-    expect(
-      screen.getByLabelText(/Indicator colour #9945FF/i),
-    ).toBeInTheDocument();
+    const smaSwatch = screen.getByTestId("indicator-swatch-sma");
+    expect(smaSwatch).toBeInTheDocument();
+    expect(smaSwatch).toHaveStyle({ backgroundColor: "#9945FF" });
+    // Swatch is decorative — aria-hidden so screen readers ignore the hex.
+    expect(smaSwatch).toHaveAttribute("aria-hidden", "true");
     // EMA is OFF in this test — no swatch for it.
-    const emaRow = screen.getByText("Exponential Moving Average").parentElement!
-      .parentElement!;
-    expect(
-      emaRow.querySelector('[aria-label*="Indicator colour"]'),
-    ).toBeNull();
+    expect(screen.queryByTestId("indicator-swatch-ema")).toBeNull();
   });
 
   it("Bollinger row shows period AND stdDev inputs when enabled", () => {
@@ -288,5 +286,144 @@ describe("ChartIndicatorMenu", () => {
 
     fireEvent.mouseDown(document.body);
     expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+
+  // Toggle-ON path is structurally identical across all 5 kinds (one map
+  // over ALL_INDICATOR_KINDS). Each label only resolves to its own kind
+  // if the closure captures `kind` correctly inside the .map — a bug that
+  // hardcoded "sma" would slip past the SMA-only test above.
+  it.each([
+    ["Exponential Moving Average", "ema"],
+    ["Bollinger Bands", "bollinger"],
+    ["Relative Strength Index", "rsi"],
+    ["MACD", "macd"],
+  ])("toggling an OFF row for %s adds the matching kind", (label, kind) => {
+    const addIndicator = vi.fn();
+    render(
+      <ChartIndicatorMenu {...noopProps} addIndicator={addIndicator} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Indicators/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: new RegExp(label, "i"), pressed: false }),
+    );
+    expect(addIndicator).toHaveBeenCalledWith(kind);
+  });
+
+  it("Bollinger StdDev input commits with the stdDev key (not period)", () => {
+    const updateIndicator = vi.fn();
+    const bb: IndicatorConfig = {
+      id: "abc",
+      kind: "bollinger",
+      period: 20,
+      stdDev: 2,
+      color: "#22D3EE",
+    };
+    render(
+      <ChartIndicatorMenu
+        {...noopProps}
+        indicators={[bb]}
+        updateIndicator={updateIndicator}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Indicators/i }));
+    const stdDevInput = screen.getByLabelText("StdDev");
+    fireEvent.change(stdDevInput, { target: { value: "2.5" } });
+    fireEvent.blur(stdDevInput);
+    expect(updateIndicator).toHaveBeenCalledWith("abc", { stdDev: 2.5 });
+  });
+
+  it("MACD slow / signal inputs commit with their own keys", () => {
+    const updateIndicator = vi.fn();
+    const m: IndicatorConfig = {
+      id: "abc",
+      kind: "macd",
+      fastPeriod: 12,
+      slowPeriod: 26,
+      signalPeriod: 9,
+      color: "#F59E0B",
+    };
+    render(
+      <ChartIndicatorMenu
+        {...noopProps}
+        indicators={[m]}
+        updateIndicator={updateIndicator}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Indicators/i }));
+
+    const slow = screen.getByLabelText("Slow");
+    fireEvent.change(slow, { target: { value: "30" } });
+    fireEvent.blur(slow);
+    expect(updateIndicator).toHaveBeenCalledWith("abc", { slowPeriod: 30 });
+
+    const signal = screen.getByLabelText("Signal");
+    fireEvent.change(signal, { target: { value: "12" } });
+    fireEvent.blur(signal);
+    expect(updateIndicator).toHaveBeenCalledWith("abc", { signalPeriod: 12 });
+  });
+
+  it("clamps below-min input up to min on commit", () => {
+    const updateIndicator = vi.fn();
+    const sma: IndicatorConfig = {
+      id: "abc",
+      kind: "sma",
+      period: 20,
+      color: "#9945FF",
+    };
+    render(
+      <ChartIndicatorMenu
+        {...noopProps}
+        indicators={[sma]}
+        updateIndicator={updateIndicator}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Indicators/i }));
+    const input = screen.getByLabelText("Period");
+
+    // SMA period min is 2.
+    fireEvent.change(input, { target: { value: "1" } });
+    fireEvent.blur(input);
+    expect(updateIndicator).toHaveBeenCalledWith("abc", { period: 2 });
+    expect(input).toHaveValue(2);
+  });
+
+  it("treats an empty input as no-change (does not call onChange with 0/min)", () => {
+    const updateIndicator = vi.fn();
+    const sma: IndicatorConfig = {
+      id: "abc",
+      kind: "sma",
+      period: 20,
+      color: "#9945FF",
+    };
+    render(
+      <ChartIndicatorMenu
+        {...noopProps}
+        indicators={[sma]}
+        updateIndicator={updateIndicator}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Indicators/i }));
+    const input = screen.getByLabelText("Period");
+
+    // Cleared field — Number("") is 0 which would clamp to min=2 if the
+    // empty-string guard were removed.
+    fireEvent.change(input, { target: { value: "" } });
+    fireEvent.blur(input);
+    expect(updateIndicator).not.toHaveBeenCalled();
+    expect(input).toHaveValue(20);
+  });
+
+  it("Clear all keeps the menu open so the user can immediately re-add", () => {
+    const sma: IndicatorConfig = {
+      id: "abc",
+      kind: "sma",
+      period: 20,
+      color: "#9945FF",
+    };
+    render(<ChartIndicatorMenu {...noopProps} indicators={[sma]} clearAll={() => {}} />);
+    const trigger = screen.getByRole("button", { name: /Indicators/i });
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByRole("button", { name: /Clear all/i }));
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
   });
 });

--- a/app/__tests__/components/trade/ChartIndicatorMenu.test.tsx
+++ b/app/__tests__/components/trade/ChartIndicatorMenu.test.tsx
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi } from "vitest";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ChartIndicatorMenu } from "@/components/trade/ChartIndicatorMenu";
+import type { IndicatorConfig } from "@/lib/indicator-registry";
+
+const noopProps = {
+  indicators: [] as IndicatorConfig[],
+  addIndicator: () => {},
+  removeIndicator: () => {},
+  updateIndicator: () => {},
+  clearAll: () => {},
+};
+
+describe("ChartIndicatorMenu", () => {
+  it("renders the f(x) trigger with aria-haspopup", () => {
+    render(<ChartIndicatorMenu {...noopProps} />);
+    const trigger = screen.getByRole("button", { name: /Indicators/i });
+    expect(trigger).toHaveTextContent("f(x)");
+    expect(trigger).toHaveAttribute("aria-haspopup", "true");
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("toggles open / closed when the trigger is clicked", () => {
+    render(<ChartIndicatorMenu {...noopProps} />);
+    const trigger = screen.getByRole("button", { name: /Indicators/i });
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("renders one row per indicator kind when open", () => {
+    render(<ChartIndicatorMenu {...noopProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /Indicators/i }));
+    expect(screen.getByText("Simple Moving Average")).toBeInTheDocument();
+    expect(screen.getByText("Exponential Moving Average")).toBeInTheDocument();
+    expect(screen.getByText("Bollinger Bands")).toBeInTheDocument();
+    expect(screen.getByText("Relative Strength Index")).toBeInTheDocument();
+    expect(screen.getByText("MACD")).toBeInTheDocument();
+  });
+
+  it("toggling an OFF row calls addIndicator with the kind", () => {
+    const addIndicator = vi.fn();
+    render(
+      <ChartIndicatorMenu {...noopProps} addIndicator={addIndicator} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Indicators/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /Simple Moving Average/i, pressed: false }),
+    );
+    expect(addIndicator).toHaveBeenCalledWith("sma");
+    expect(addIndicator).toHaveBeenCalledTimes(1);
+  });
+
+  it("toggling an ON row calls removeIndicator with the matching id", () => {
+    const removeIndicator = vi.fn();
+    const sma: IndicatorConfig = {
+      id: "abc",
+      kind: "sma",
+      period: 20,
+      color: "#9945FF",
+    };
+    render(
+      <ChartIndicatorMenu
+        {...noopProps}
+        indicators={[sma]}
+        removeIndicator={removeIndicator}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Indicators/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /Simple Moving Average/i, pressed: true }),
+    );
+    expect(removeIndicator).toHaveBeenCalledWith("abc");
+  });
+
+  it("shows a colour swatch only for enabled indicators", () => {
+    const sma: IndicatorConfig = {
+      id: "abc",
+      kind: "sma",
+      period: 20,
+      color: "#9945FF",
+    };
+    render(<ChartIndicatorMenu {...noopProps} indicators={[sma]} />);
+    fireEvent.click(screen.getByRole("button", { name: /Indicators/i }));
+    expect(
+      screen.getByLabelText(/Indicator colour #9945FF/i),
+    ).toBeInTheDocument();
+    // EMA is OFF in this test — no swatch for it.
+    const emaRow = screen.getByText("Exponential Moving Average").parentElement!
+      .parentElement!;
+    expect(
+      emaRow.querySelector('[aria-label*="Indicator colour"]'),
+    ).toBeNull();
+  });
+
+  it("Bollinger row shows period AND stdDev inputs when enabled", () => {
+    const bb: IndicatorConfig = {
+      id: "abc",
+      kind: "bollinger",
+      period: 20,
+      stdDev: 2,
+      color: "#22D3EE",
+    };
+    render(<ChartIndicatorMenu {...noopProps} indicators={[bb]} />);
+    fireEvent.click(screen.getByRole("button", { name: /Indicators/i }));
+    expect(screen.getByLabelText("Period")).toHaveValue(20);
+    expect(screen.getByLabelText("StdDev")).toHaveValue(2);
+  });
+
+  it("MACD row shows fast / slow / signal inputs when enabled", () => {
+    const m: IndicatorConfig = {
+      id: "abc",
+      kind: "macd",
+      fastPeriod: 12,
+      slowPeriod: 26,
+      signalPeriod: 9,
+      color: "#F59E0B",
+    };
+    render(<ChartIndicatorMenu {...noopProps} indicators={[m]} />);
+    fireEvent.click(screen.getByRole("button", { name: /Indicators/i }));
+    expect(screen.getByLabelText("Fast")).toHaveValue(12);
+    expect(screen.getByLabelText("Slow")).toHaveValue(26);
+    expect(screen.getByLabelText("Signal")).toHaveValue(9);
+  });
+
+  it("commits a number-input change on blur (not on every keystroke)", () => {
+    const updateIndicator = vi.fn();
+    const sma: IndicatorConfig = {
+      id: "abc",
+      kind: "sma",
+      period: 20,
+      color: "#9945FF",
+    };
+    render(
+      <ChartIndicatorMenu
+        {...noopProps}
+        indicators={[sma]}
+        updateIndicator={updateIndicator}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Indicators/i }));
+    const input = screen.getByLabelText("Period");
+
+    // Typing should NOT call updateIndicator yet.
+    fireEvent.change(input, { target: { value: "5" } });
+    fireEvent.change(input, { target: { value: "50" } });
+    expect(updateIndicator).not.toHaveBeenCalled();
+
+    // Blur commits.
+    fireEvent.blur(input);
+    expect(updateIndicator).toHaveBeenCalledWith("abc", { period: 50 });
+  });
+
+  it("Enter key commits a number-input change", () => {
+    const updateIndicator = vi.fn();
+    const sma: IndicatorConfig = {
+      id: "abc",
+      kind: "sma",
+      period: 20,
+      color: "#9945FF",
+    };
+    render(
+      <ChartIndicatorMenu
+        {...noopProps}
+        indicators={[sma]}
+        updateIndicator={updateIndicator}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Indicators/i }));
+    const input = screen.getByLabelText("Period");
+
+    fireEvent.change(input, { target: { value: "100" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(updateIndicator).toHaveBeenCalledWith("abc", { period: 100 });
+  });
+
+  it("clamps out-of-range input to [min, max] on commit", () => {
+    const updateIndicator = vi.fn();
+    const sma: IndicatorConfig = {
+      id: "abc",
+      kind: "sma",
+      period: 20,
+      color: "#9945FF",
+    };
+    render(
+      <ChartIndicatorMenu
+        {...noopProps}
+        indicators={[sma]}
+        updateIndicator={updateIndicator}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Indicators/i }));
+    const input = screen.getByLabelText("Period");
+
+    // SMA period range is [2, 500]
+    fireEvent.change(input, { target: { value: "9999" } });
+    fireEvent.blur(input);
+    expect(updateIndicator).toHaveBeenCalledWith("abc", { period: 500 });
+    expect(input).toHaveValue(500);
+  });
+
+  it("reverts to last valid value when given non-numeric garbage", () => {
+    const updateIndicator = vi.fn();
+    const sma: IndicatorConfig = {
+      id: "abc",
+      kind: "sma",
+      period: 20,
+      color: "#9945FF",
+    };
+    render(
+      <ChartIndicatorMenu
+        {...noopProps}
+        indicators={[sma]}
+        updateIndicator={updateIndicator}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Indicators/i }));
+    const input = screen.getByLabelText("Period");
+
+    fireEvent.change(input, { target: { value: "abc" } });
+    fireEvent.blur(input);
+    expect(updateIndicator).not.toHaveBeenCalled();
+    expect(input).toHaveValue(20); // reverted
+  });
+
+  it("Clear all is disabled when no indicators are active", () => {
+    render(<ChartIndicatorMenu {...noopProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /Indicators/i }));
+    const clearAll = screen.getByRole("button", { name: /Clear all/i });
+    expect(clearAll).toBeDisabled();
+  });
+
+  it("Clear all calls clearAll() when active", () => {
+    const clearAll = vi.fn();
+    const sma: IndicatorConfig = {
+      id: "abc",
+      kind: "sma",
+      period: 20,
+      color: "#9945FF",
+    };
+    render(
+      <ChartIndicatorMenu
+        {...noopProps}
+        indicators={[sma]}
+        clearAll={clearAll}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Indicators/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Clear all/i }));
+    expect(clearAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes when Escape is pressed (and focus is NOT in an input)", () => {
+    render(<ChartIndicatorMenu {...noopProps} />);
+    const trigger = screen.getByRole("button", { name: /Indicators/i });
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("does NOT close when Escape is pressed while focus is in a number input", () => {
+    const sma: IndicatorConfig = {
+      id: "abc",
+      kind: "sma",
+      period: 20,
+      color: "#9945FF",
+    };
+    render(<ChartIndicatorMenu {...noopProps} indicators={[sma]} />);
+    const trigger = screen.getByRole("button", { name: /Indicators/i });
+    fireEvent.click(trigger);
+    const input = screen.getByLabelText("Period");
+    input.focus();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    // Menu should stay open; user might be editing.
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("closes when a mousedown occurs outside the menu", () => {
+    render(<ChartIndicatorMenu {...noopProps} />);
+    const trigger = screen.getByRole("button", { name: /Indicators/i });
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.mouseDown(document.body);
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+});

--- a/app/__tests__/lib/indicator-palette.test.ts
+++ b/app/__tests__/lib/indicator-palette.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { INDICATOR_COLORS, getNextColor } from "@/lib/indicator-palette";
+
+describe("INDICATOR_COLORS", () => {
+  it("provides at least 8 distinct colors (one per typical user pick)", () => {
+    expect(INDICATOR_COLORS.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it("every entry is a valid 7-character hex string starting with #", () => {
+    const hexRegex = /^#[0-9A-Fa-f]{6}$/;
+    for (const color of INDICATOR_COLORS) {
+      expect(color).toMatch(hexRegex);
+    }
+  });
+
+  it("no duplicate colors in the palette", () => {
+    const set = new Set(INDICATOR_COLORS);
+    expect(set.size).toBe(INDICATOR_COLORS.length);
+  });
+
+  it("does NOT use the brand green/red (avoids confusion with candle bodies)", () => {
+    // We don't have direct access to chartTheme here, but the established
+    // candle colors in this codebase are tailwind green-500/red-500-ish:
+    // #22c55e (green) and #ef4444 (red). The palette must not collide.
+    expect(INDICATOR_COLORS).not.toContain("#22c55e");
+    expect(INDICATOR_COLORS).not.toContain("#ef4444");
+  });
+});
+
+describe("getNextColor", () => {
+  it("returns the first palette color when no colors are in use", () => {
+    expect(getNextColor([])).toBe(INDICATOR_COLORS[0]);
+  });
+
+  it("skips colors already used and returns the next available one", () => {
+    expect(getNextColor([INDICATOR_COLORS[0]])).toBe(INDICATOR_COLORS[1]);
+    expect(getNextColor([INDICATOR_COLORS[0], INDICATOR_COLORS[1]])).toBe(INDICATOR_COLORS[2]);
+  });
+
+  it("always picks the LOWEST-index unused color (deterministic order)", () => {
+    // If palette is [A, B, C, D, E, F, G, H] and used = [B, C, D],
+    // next should be A (lowest unused), not E (next after the used block).
+    const used = [INDICATOR_COLORS[1], INDICATOR_COLORS[2], INDICATOR_COLORS[3]];
+    expect(getNextColor(used)).toBe(INDICATOR_COLORS[0]);
+  });
+
+  it("cycles back to the first color when every palette color is used", () => {
+    const allUsed = [...INDICATOR_COLORS];
+    expect(getNextColor(allUsed)).toBe(INDICATOR_COLORS[0]);
+  });
+
+  it("ignores colors not in the palette (e.g., a user-chosen #FFFFFF)", () => {
+    // Treats unknown colors as "not blocking" — the palette only cares
+    // about its own entries.
+    expect(getNextColor(["#FFFFFF", "#000000"])).toBe(INDICATOR_COLORS[0]);
+  });
+
+  it("handles repeated entries in usedColors without breaking", () => {
+    // Pathological input: same color listed many times. Should still skip it.
+    const used = [
+      INDICATOR_COLORS[0],
+      INDICATOR_COLORS[0],
+      INDICATOR_COLORS[0],
+      INDICATOR_COLORS[1],
+    ];
+    expect(getNextColor(used)).toBe(INDICATOR_COLORS[2]);
+  });
+});

--- a/app/__tests__/lib/indicator-registry.test.ts
+++ b/app/__tests__/lib/indicator-registry.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from "vitest";
+import {
+  ALL_INDICATOR_KINDS,
+  INDICATOR_LABELS,
+  INDICATOR_DEFAULTS,
+  INDICATOR_DISPLAY_ORDER,
+  INDICATORS_STORAGE_VERSION,
+  MAX_INDICATORS_PER_SLAB,
+  isOverlayKind,
+  isPaneKind,
+  isIndicatorKind,
+  isIndicatorConfig,
+  mergeIndicators,
+  type IndicatorKind,
+} from "@/lib/indicator-registry";
+
+describe("ALL_INDICATOR_KINDS", () => {
+  it("lists every kind we ship in v1: sma, ema, bollinger, rsi, macd", () => {
+    const expected: IndicatorKind[] = ["sma", "ema", "bollinger", "rsi", "macd"];
+    expect([...ALL_INDICATOR_KINDS]).toEqual(expected);
+  });
+});
+
+describe("INDICATOR_LABELS", () => {
+  it("provides a non-empty label for every indicator kind", () => {
+    for (const kind of ALL_INDICATOR_KINDS) {
+      expect(INDICATOR_LABELS[kind]).toBeTruthy();
+      expect(INDICATOR_LABELS[kind].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("labels are unique — no two kinds collide in the menu", () => {
+    const seen = new Set<string>();
+    for (const kind of ALL_INDICATOR_KINDS) {
+      expect(seen.has(INDICATOR_LABELS[kind])).toBe(false);
+      seen.add(INDICATOR_LABELS[kind]);
+    }
+  });
+});
+
+describe("INDICATOR_DEFAULTS", () => {
+  it("has TradingView's universal defaults pinned", () => {
+    expect(INDICATOR_DEFAULTS.sma).toEqual({ kind: "sma", period: 20 });
+    expect(INDICATOR_DEFAULTS.ema).toEqual({ kind: "ema", period: 21 });
+    expect(INDICATOR_DEFAULTS.bollinger).toEqual({ kind: "bollinger", period: 20, stdDev: 2 });
+    expect(INDICATOR_DEFAULTS.rsi).toEqual({ kind: "rsi", period: 14 });
+    expect(INDICATOR_DEFAULTS.macd).toEqual({
+      kind: "macd",
+      fastPeriod: 12,
+      slowPeriod: 26,
+      signalPeriod: 9,
+    });
+  });
+
+  it("provides defaults for every indicator kind", () => {
+    for (const kind of ALL_INDICATOR_KINDS) {
+      expect(INDICATOR_DEFAULTS[kind]).toBeDefined();
+      expect((INDICATOR_DEFAULTS[kind] as { kind: IndicatorKind }).kind).toBe(kind);
+    }
+  });
+});
+
+describe("isOverlayKind / isPaneKind", () => {
+  it("classifies sma, ema, bollinger as overlay (drawn on price scale)", () => {
+    expect(isOverlayKind("sma")).toBe(true);
+    expect(isOverlayKind("ema")).toBe(true);
+    expect(isOverlayKind("bollinger")).toBe(true);
+  });
+
+  it("classifies rsi, macd as pane (drawn in their own pane)", () => {
+    expect(isPaneKind("rsi")).toBe(true);
+    expect(isPaneKind("macd")).toBe(true);
+  });
+
+  it("every kind is either overlay or pane (not both, not neither)", () => {
+    for (const kind of ALL_INDICATOR_KINDS) {
+      const overlay = isOverlayKind(kind);
+      const pane = isPaneKind(kind);
+      expect(overlay !== pane).toBe(true); // XOR — exactly one is true
+    }
+  });
+});
+
+describe("isIndicatorKind", () => {
+  it("accepts every member of the union", () => {
+    for (const kind of ALL_INDICATOR_KINDS) {
+      expect(isIndicatorKind(kind)).toBe(true);
+    }
+  });
+
+  it("rejects unknown strings, including case-mismatches", () => {
+    for (const v of ["", "SMA", "Sma", "vwap", "stochastic", "ichimoku"]) {
+      expect(isIndicatorKind(v)).toBe(false);
+    }
+  });
+
+  it("rejects non-string inputs", () => {
+    for (const v of [null, undefined, 0, 1, {}, [], true, false]) {
+      expect(isIndicatorKind(v)).toBe(false);
+    }
+  });
+});
+
+describe("isIndicatorConfig", () => {
+  it("accepts a fully-formed SMA config", () => {
+    expect(isIndicatorConfig({ id: "abc", kind: "sma", period: 20, color: "#9945FF" })).toBe(true);
+  });
+
+  it("accepts a fully-formed Bollinger config", () => {
+    expect(
+      isIndicatorConfig({ id: "abc", kind: "bollinger", period: 20, stdDev: 2, color: "#9945FF" }),
+    ).toBe(true);
+  });
+
+  it("accepts a fully-formed MACD config", () => {
+    expect(
+      isIndicatorConfig({
+        id: "abc",
+        kind: "macd",
+        fastPeriod: 12,
+        slowPeriod: 26,
+        signalPeriod: 9,
+        color: "#9945FF",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects missing id or empty id", () => {
+    expect(isIndicatorConfig({ kind: "sma", period: 20, color: "#9945FF" })).toBe(false);
+    expect(isIndicatorConfig({ id: "", kind: "sma", period: 20, color: "#9945FF" })).toBe(false);
+  });
+
+  it("rejects missing or empty color", () => {
+    expect(isIndicatorConfig({ id: "abc", kind: "sma", period: 20 })).toBe(false);
+    expect(isIndicatorConfig({ id: "abc", kind: "sma", period: 20, color: "" })).toBe(false);
+  });
+
+  it("rejects unknown kind", () => {
+    expect(isIndicatorConfig({ id: "abc", kind: "vwap", period: 20, color: "#9945FF" })).toBe(false);
+  });
+
+  it("rejects non-numeric or non-finite period", () => {
+    expect(isIndicatorConfig({ id: "abc", kind: "sma", period: "20", color: "#9945FF" })).toBe(false);
+    expect(isIndicatorConfig({ id: "abc", kind: "sma", period: NaN, color: "#9945FF" })).toBe(false);
+    expect(isIndicatorConfig({ id: "abc", kind: "sma", period: Infinity, color: "#9945FF" })).toBe(
+      false,
+    );
+    expect(isIndicatorConfig({ id: "abc", kind: "sma", period: 0, color: "#9945FF" })).toBe(false);
+  });
+
+  it("rejects MACD with missing or invalid period fields", () => {
+    expect(
+      isIndicatorConfig({ id: "abc", kind: "macd", fastPeriod: 12, slowPeriod: 26, color: "#9945FF" }),
+    ).toBe(false); // missing signalPeriod
+    expect(
+      isIndicatorConfig({
+        id: "abc",
+        kind: "macd",
+        fastPeriod: 12,
+        slowPeriod: 26,
+        signalPeriod: -1,
+        color: "#9945FF",
+      }),
+    ).toBe(false); // negative signal
+  });
+
+  it("rejects null, arrays, primitives", () => {
+    for (const v of [null, undefined, [], "x", 0, true]) {
+      expect(isIndicatorConfig(v)).toBe(false);
+    }
+  });
+});
+
+describe("mergeIndicators", () => {
+  const validSma = { id: "abc", kind: "sma" as const, period: 20, color: "#9945FF" };
+  const validRsi = { id: "def", kind: "rsi" as const, period: 14, color: "#22D3EE" };
+
+  it("returns [] for null / non-object input", () => {
+    for (const v of [null, undefined, 42, "x", []]) {
+      expect(mergeIndicators(v)).toEqual([]);
+    }
+  });
+
+  it("returns [] when version is missing or wrong", () => {
+    expect(mergeIndicators({ indicators: [validSma] })).toEqual([]);
+    expect(mergeIndicators({ version: 2, indicators: [validSma] })).toEqual([]);
+    expect(mergeIndicators({ version: "1", indicators: [validSma] })).toEqual([]);
+  });
+
+  it("returns [] when indicators field is missing or wrong type", () => {
+    expect(mergeIndicators({ version: 1 })).toEqual([]);
+    expect(mergeIndicators({ version: 1, indicators: "not-an-array" })).toEqual([]);
+  });
+
+  it("preserves valid entries from a properly-shaped envelope", () => {
+    const result = mergeIndicators({ version: 1, indicators: [validSma, validRsi] });
+    expect(result).toEqual([validSma, validRsi]);
+  });
+
+  it("drops malformed entries silently and keeps the valid ones", () => {
+    const result = mergeIndicators({
+      version: 1,
+      indicators: [validSma, { kind: "garbage" }, validRsi, null, "string"],
+    });
+    expect(result).toEqual([validSma, validRsi]);
+  });
+
+  it("drops duplicate IDs (keeps the first occurrence)", () => {
+    const dup = { id: "abc", kind: "ema" as const, period: 50, color: "#F59E0B" };
+    const result = mergeIndicators({ version: 1, indicators: [validSma, dup] });
+    expect(result).toEqual([validSma]); // dup dropped because id "abc" already seen
+  });
+
+  it("caps at MAX_INDICATORS_PER_SLAB even if storage has more", () => {
+    const lots = Array.from({ length: MAX_INDICATORS_PER_SLAB + 5 }, (_, i) => ({
+      id: `id-${i}`,
+      kind: "sma" as const,
+      period: 20,
+      color: "#9945FF",
+    }));
+    const result = mergeIndicators({ version: 1, indicators: lots });
+    expect(result).toHaveLength(MAX_INDICATORS_PER_SLAB);
+  });
+});
+
+describe("INDICATORS_STORAGE_VERSION + MAX_INDICATORS_PER_SLAB", () => {
+  it("storage version is 1 (initial release)", () => {
+    expect(INDICATORS_STORAGE_VERSION).toBe(1);
+  });
+
+  it("max indicators per slab is finite and positive", () => {
+    expect(MAX_INDICATORS_PER_SLAB).toBeGreaterThan(0);
+    expect(Number.isFinite(MAX_INDICATORS_PER_SLAB)).toBe(true);
+  });
+});
+
+describe("INDICATOR_DISPLAY_ORDER", () => {
+  it("contains every indicator kind exactly once", () => {
+    expect(INDICATOR_DISPLAY_ORDER.length).toBe(ALL_INDICATOR_KINDS.length);
+    for (const kind of ALL_INDICATOR_KINDS) {
+      expect(INDICATOR_DISPLAY_ORDER).toContain(kind);
+    }
+  });
+});

--- a/app/__tests__/lib/indicators/bollinger.test.ts
+++ b/app/__tests__/lib/indicators/bollinger.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { bollingerBands } from "@/lib/indicators/bollinger";
+import { candlesFromCloses } from "./helpers";
+
+describe("bollingerBands", () => {
+  it("collapses all three bands to the mean when prices are constant (σ = 0)", () => {
+    // Constant prices → variance = 0 → σ = 0 → upper = middle = lower.
+    const result = bollingerBands(candlesFromCloses([100, 100, 100, 100, 100]), 3, 2);
+    expect(result).toHaveLength(3);
+    for (const point of result) {
+      expect(point.middle).toBeCloseTo(100, 9);
+      expect(point.upper).toBeCloseTo(100, 9);
+      expect(point.lower).toBeCloseTo(100, 9);
+    }
+  });
+
+  it("computes population σ (not sample) for the canonical reference vector", () => {
+    // closes [2, 4, 4, 4, 5, 5, 7, 9], period 8, stdDev 2
+    // mean = (2+4+4+4+5+5+7+9)/8 = 40/8 = 5
+    // squared diffs = [9, 1, 1, 1, 0, 0, 4, 16] sum = 32
+    // POPULATION σ = sqrt(32/8) = sqrt(4) = 2
+    // (Sample σ would be sqrt(32/7) ≈ 2.138 — wrong for TradingView parity)
+    // upper = 5 + 2*2 = 9; lower = 5 - 2*2 = 1
+    const result = bollingerBands(
+      candlesFromCloses([2, 4, 4, 4, 5, 5, 7, 9]),
+      8,
+      2,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].middle).toBeCloseTo(5, 9);
+    expect(result[0].upper).toBeCloseTo(9, 9);
+    expect(result[0].lower).toBeCloseTo(1, 9);
+  });
+
+  it("invariant: lower ≤ middle ≤ upper for every output point", () => {
+    // Random-ish but deterministic input
+    const closes = [10, 12, 11, 14, 13, 15, 17, 16, 18, 20, 19, 21, 23, 22, 25];
+    const result = bollingerBands(candlesFromCloses(closes), 5, 2);
+    for (const point of result) {
+      expect(point.lower).toBeLessThanOrEqual(point.middle);
+      expect(point.middle).toBeLessThanOrEqual(point.upper);
+    }
+  });
+
+  it("invariant: bands are symmetric around the middle (upper - middle === middle - lower)", () => {
+    const closes = [10, 12, 11, 14, 13, 15, 17, 16, 18, 20];
+    const result = bollingerBands(candlesFromCloses(closes), 5, 2);
+    for (const point of result) {
+      expect(point.upper - point.middle).toBeCloseTo(point.middle - point.lower, 9);
+    }
+  });
+
+  it("stdDev = 0 collapses both bands to the middle line", () => {
+    // Even with varying prices, stdDev=0 means upper = middle = lower.
+    const result = bollingerBands(candlesFromCloses([10, 20, 30, 40, 50]), 3, 0);
+    expect(result).toHaveLength(3);
+    for (const point of result) {
+      expect(point.upper).toBeCloseTo(point.middle, 9);
+      expect(point.lower).toBeCloseTo(point.middle, 9);
+    }
+  });
+
+  it("returns [] for empty input", () => {
+    expect(bollingerBands([], 20, 2)).toEqual([]);
+  });
+
+  it("returns [] when candles.length < period (window can't fill)", () => {
+    expect(bollingerBands(candlesFromCloses([1, 2, 3]), 5, 2)).toEqual([]);
+  });
+
+  it("returns [] for non-positive period (defensive)", () => {
+    expect(bollingerBands(candlesFromCloses([1, 2, 3, 4]), 0, 2)).toEqual([]);
+    expect(bollingerBands(candlesFromCloses([1, 2, 3, 4]), -1, 2)).toEqual([]);
+  });
+
+  it("output length is exactly candles.length - period + 1 (matches SMA)", () => {
+    for (const len of [10, 50, 100, 500]) {
+      for (const period of [5, 10, 20, 50]) {
+        if (len < period) continue;
+        const closes = Array.from({ length: len }, (_, i) => i + 1);
+        const result = bollingerBands(candlesFromCloses(closes), period, 2);
+        expect(result).toHaveLength(len - period + 1);
+      }
+    }
+  });
+
+  it("output time aligns with the candle's timestamp at the window's right edge", () => {
+    const candles = candlesFromCloses([10, 20, 30, 40, 50]);
+    const result = bollingerBands(candles, 3, 2);
+    expect(result[0].time).toBe(candles[2].timestamp);
+    expect(result[result.length - 1].time).toBe(candles[candles.length - 1].timestamp);
+  });
+
+  it("widening stdDev pushes upper higher and lower lower (linear in stdDev)", () => {
+    // For the same data + period, doubling stdDev should double the band gap.
+    const closes = [10, 12, 11, 14, 13, 15, 17, 16, 18, 20];
+    const r1 = bollingerBands(candlesFromCloses(closes), 5, 1);
+    const r2 = bollingerBands(candlesFromCloses(closes), 5, 2);
+    // Same middle; bands at exactly 2x the distance.
+    for (let i = 0; i < r1.length; i++) {
+      expect(r2[i].middle).toBeCloseTo(r1[i].middle, 9);
+      expect(r2[i].upper - r2[i].middle).toBeCloseTo(2 * (r1[i].upper - r1[i].middle), 9);
+      expect(r1[i].middle - r2[i].lower).toBeCloseTo(2 * (r1[i].middle - r1[i].lower), 9);
+    }
+  });
+});

--- a/app/__tests__/lib/indicators/ema.test.ts
+++ b/app/__tests__/lib/indicators/ema.test.ts
@@ -1,16 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { exponentialMovingAverage } from "@/lib/indicators/ema";
-import type { Candle } from "@/lib/indicators/types";
-
-function candlesFromCloses(closes: readonly number[]): Candle[] {
-  return closes.map((close, i) => ({
-    timestamp: i * 60_000,
-    open: close,
-    high: close,
-    low: close,
-    close,
-  }));
-}
+import { candlesFromCloses } from "./helpers";
 
 describe("exponentialMovingAverage", () => {
   it("seeds with SMA of first `period` closes (TradingView convention)", () => {

--- a/app/__tests__/lib/indicators/ema.test.ts
+++ b/app/__tests__/lib/indicators/ema.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { exponentialMovingAverage } from "@/lib/indicators/ema";
+import type { Candle } from "@/lib/indicators/types";
+
+function candlesFromCloses(closes: readonly number[]): Candle[] {
+  return closes.map((close, i) => ({
+    timestamp: i * 60_000,
+    open: close,
+    high: close,
+    low: close,
+    close,
+  }));
+}
+
+describe("exponentialMovingAverage", () => {
+  it("seeds with SMA of first `period` closes (TradingView convention)", () => {
+    // For closes [1, 2, 3, 4, 5] with period 3:
+    // Seed = SMA([1,2,3]) = 2 → first output point is { value: 2 } at index 2
+    const result = exponentialMovingAverage(candlesFromCloses([1, 2, 3, 4, 5]), 3);
+    expect(result).toHaveLength(3);
+    expect(result[0].value).toBeCloseTo(2, 9);
+  });
+
+  it("applies the standard k = 2/(period+1) recurrence after seeding", () => {
+    // closes [1, 2, 3, 4, 5], period 3, k = 2/4 = 0.5
+    // Seed (i=2) = (1+2+3)/3 = 2
+    // i=3: 4*0.5 + 2*0.5 = 3
+    // i=4: 5*0.5 + 3*0.5 = 4
+    const result = exponentialMovingAverage(candlesFromCloses([1, 2, 3, 4, 5]), 3);
+    expect(result[0].value).toBeCloseTo(2, 9);
+    expect(result[1].value).toBeCloseTo(3, 9);
+    expect(result[2].value).toBeCloseTo(4, 9);
+  });
+
+  it("constant prices → all EMA values equal that constant", () => {
+    const result = exponentialMovingAverage(candlesFromCloses([100, 100, 100, 100, 100]), 3);
+    expect(result).toHaveLength(3);
+    for (const point of result) {
+      expect(point.value).toBeCloseTo(100, 9);
+    }
+  });
+
+  it("returns identity when period === 1 (k = 1, each EMA = its close)", () => {
+    // k = 2/(1+1) = 1, so EMA[i] = close[i] * 1 + prev * 0 = close[i]
+    // Seed = SMA([10]) = 10, then each subsequent point equals its close.
+    const result = exponentialMovingAverage(candlesFromCloses([10, 20, 30]), 1);
+    expect(result.map((p) => p.value)).toEqual([10, 20, 30]);
+  });
+
+  it("returns [] for empty input", () => {
+    expect(exponentialMovingAverage([], 14)).toEqual([]);
+  });
+
+  it("returns [] when candles.length < period (can't compute the seed)", () => {
+    expect(exponentialMovingAverage(candlesFromCloses([1, 2, 3]), 5)).toEqual([]);
+  });
+
+  it("returns [] for non-positive period (defensive)", () => {
+    expect(exponentialMovingAverage(candlesFromCloses([1, 2, 3, 4]), 0)).toEqual([]);
+    expect(exponentialMovingAverage(candlesFromCloses([1, 2, 3, 4]), -1)).toEqual([]);
+  });
+
+  it("output length is exactly candles.length - period + 1 (matches SMA)", () => {
+    for (const len of [10, 50, 100, 500]) {
+      for (const period of [5, 10, 20, 50]) {
+        if (len < period) continue;
+        const closes = Array.from({ length: len }, (_, i) => i + 1);
+        const result = exponentialMovingAverage(candlesFromCloses(closes), period);
+        expect(result).toHaveLength(len - period + 1);
+      }
+    }
+  });
+
+  it("output time aligns with the candle's timestamp at each step", () => {
+    const candles = candlesFromCloses([10, 20, 30, 40, 50]);
+    const result = exponentialMovingAverage(candles, 3);
+    // First EMA at candle index 2; subsequent at indices 3, 4
+    expect(result[0].time).toBe(candles[2].timestamp);
+    expect(result[1].time).toBe(candles[3].timestamp);
+    expect(result[2].time).toBe(candles[4].timestamp);
+  });
+
+  it("EMA reacts faster than SMA to the latest close (regression spot-check)", () => {
+    // After a sudden jump, EMA should be closer to the new value than SMA.
+    // closes [1, 1, 1, 1, 100], period 3
+    // SMA(3) at i=4: (1 + 1 + 100) / 3 ≈ 34.0
+    // EMA(3) seed at i=2: 1; i=3: 1*0.5 + 1*0.5 = 1; i=4: 100*0.5 + 1*0.5 = 50.5
+    // EMA (50.5) > SMA (34.0) — EMA weighs the recent jump more heavily.
+    const closes = [1, 1, 1, 1, 100];
+    const ema = exponentialMovingAverage(candlesFromCloses(closes), 3);
+    const lastEma = ema[ema.length - 1].value;
+    const sma = (closes[2] + closes[3] + closes[4]) / 3;
+    expect(lastEma).toBeGreaterThan(sma);
+    expect(lastEma).toBeCloseTo(50.5, 9);
+  });
+});

--- a/app/__tests__/lib/indicators/helpers.ts
+++ b/app/__tests__/lib/indicators/helpers.ts
@@ -1,0 +1,15 @@
+import type { Candle } from "@/lib/indicators/types";
+
+/** Build a Candle array from close prices for tests. open=high=low=close
+ *  (the indicator math only reads close + timestamp; the OHLC shape stays
+ *  realistic so tests look like real market data). Timestamps are 60s apart
+ *  starting at epoch 0 for deterministic output. */
+export function candlesFromCloses(closes: readonly number[]): Candle[] {
+  return closes.map((close, i) => ({
+    timestamp: i * 60_000,
+    open: close,
+    high: close,
+    low: close,
+    close,
+  }));
+}

--- a/app/__tests__/lib/indicators/macd.test.ts
+++ b/app/__tests__/lib/indicators/macd.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { macd } from "@/lib/indicators/macd";
+import { candlesFromCloses } from "./helpers";
+
+describe("macd", () => {
+  it("computes the canonical reference vector with hand-verifiable arithmetic", () => {
+    // closes [10,12,14,13,15,17,16], fast=2, slow=4, signal=2
+    //
+    // Fast EMA(2), k = 2/3:
+    //   seed at i=1: SMA([10,12]) = 11
+    //   i=2: 14*(2/3) + 11*(1/3) = 13
+    //   i=3: 13*(2/3) + 13*(1/3) = 13
+    //   i=4: 15*(2/3) + 13*(1/3) = 43/3 ≈ 14.3333
+    //   i=5: 17*(2/3) + (43/3)*(1/3) = 145/9 ≈ 16.1111
+    //   i=6: 16*(2/3) + (145/9)*(1/3) = 433/27 ≈ 16.0370
+    //
+    // Slow EMA(4), k = 2/5:
+    //   seed at i=3: SMA([10,12,14,13]) = 12.25
+    //   i=4: 15*(0.4) + 12.25*(0.6) = 13.35
+    //   i=5: 17*(0.4) + 13.35*(0.6) = 14.81
+    //   i=6: 16*(0.4) + 14.81*(0.6) = 15.286
+    //
+    // MACD line (offset = fastEma.length - slowEma.length = 6 - 4 = 2):
+    //   at i=3: fastEma[2] - slowEma[0] = 13 - 12.25 = 0.75
+    //   at i=4: fastEma[3] - slowEma[1] = 14.3333 - 13.35 = 0.9833
+    //   at i=5: fastEma[4] - slowEma[2] = 16.1111 - 14.81 = 1.3011
+    //   at i=6: fastEma[5] - slowEma[3] = 16.0370 - 15.286 = 0.7510
+    //
+    // Signal EMA(macdLine, 2), k = 2/3:
+    //   seed at macdIndex=1 (candle i=4): SMA([0.75, 0.9833]) = 0.8667
+    //   macdIndex=2 (i=5): 1.3011*(2/3) + 0.8667*(1/3) = 1.1563
+    //   macdIndex=3 (i=6): 0.7510*(2/3) + 1.1563*(1/3) = 0.8861
+    //
+    // Final output (signalOffset = macdLine.length − signalLine.length = 4 − 3 = 1):
+    //   at i=4: macd = macdLine[1] = 0.9833, signal = 0.8667, histogram = +0.1166
+    //   at i=5: macd = macdLine[2] = 1.3011, signal = 1.1563, histogram = +0.1448
+    //   at i=6: macd = macdLine[3] = 0.7510, signal = 0.8861, histogram = −0.1351
+    const result = macd(
+      candlesFromCloses([10, 12, 14, 13, 15, 17, 16]),
+      2, // fast
+      4, // slow
+      2, // signal
+    );
+    expect(result).toHaveLength(3);
+    expect(result[0].macd).toBeCloseTo(0.9833, 3);
+    expect(result[0].signal).toBeCloseTo(0.8667, 3);
+    expect(result[0].histogram).toBeCloseTo(0.1166, 3);
+    expect(result[1].macd).toBeCloseTo(1.3011, 3);
+    expect(result[1].signal).toBeCloseTo(1.1563, 3);
+    expect(result[1].histogram).toBeCloseTo(0.1448, 3);
+    expect(result[2].macd).toBeCloseTo(0.751, 3);
+    expect(result[2].signal).toBeCloseTo(0.8861, 3);
+    expect(result[2].histogram).toBeCloseTo(-0.1351, 3);
+  });
+
+  it("invariant: histogram === macd − signal at every point", () => {
+    // The histogram value is purely derived; this invariant must hold by
+    // construction, not by chance. If the formula ever flips to
+    // (signal − macd), every chart's histogram colors invert.
+    const closes = Array.from({ length: 50 }, (_, i) => 100 + Math.sin(i / 5) * 10);
+    const result = macd(candlesFromCloses(closes), 12, 26, 9);
+    for (const point of result) {
+      expect(point.histogram).toBeCloseTo(point.macd - point.signal, 9);
+    }
+  });
+
+  it("constant prices → MACD = 0 and signal = 0 at every point", () => {
+    // If price never moves, both EMAs equal the constant. macd = 0, then
+    // EMA(zeros) = 0, so signal = 0. histogram = 0.
+    const result = macd(candlesFromCloses(Array(40).fill(100)), 12, 26, 9);
+    expect(result.length).toBeGreaterThan(0);
+    for (const point of result) {
+      expect(point.macd).toBeCloseTo(0, 9);
+      expect(point.signal).toBeCloseTo(0, 9);
+      expect(point.histogram).toBeCloseTo(0, 9);
+    }
+  });
+
+  it("output length is exactly N − slowPeriod − signalPeriod + 2", () => {
+    // For defaults (12, 26, 9) and N = 50: output = 50 − 26 − 9 + 2 = 17.
+    // Verify the formula across multiple input sizes.
+    for (const N of [40, 50, 100, 500]) {
+      const closes = Array.from({ length: N }, (_, i) => i + 1);
+      const result = macd(candlesFromCloses(closes), 12, 26, 9);
+      expect(result).toHaveLength(N - 26 - 9 + 2);
+    }
+  });
+
+  it("returns [] when slowPeriod < fastPeriod (misconfigured)", () => {
+    // slow is supposed to be the slower-moving line. swapping them is a
+    // user error, not a valid input.
+    const closes = Array.from({ length: 50 }, (_, i) => i + 1);
+    expect(macd(candlesFromCloses(closes), 26, 12, 9)).toEqual([]);
+  });
+
+  it("returns [] when any period is non-positive", () => {
+    const closes = Array.from({ length: 50 }, (_, i) => i + 1);
+    expect(macd(candlesFromCloses(closes), 0, 26, 9)).toEqual([]);
+    expect(macd(candlesFromCloses(closes), 12, 0, 9)).toEqual([]);
+    expect(macd(candlesFromCloses(closes), 12, 26, 0)).toEqual([]);
+    expect(macd(candlesFromCloses(closes), -1, 26, 9)).toEqual([]);
+  });
+
+  it("returns [] for empty input", () => {
+    expect(macd([], 12, 26, 9)).toEqual([]);
+  });
+
+  it("returns [] when input is too short to seed the slow EMA", () => {
+    // slowEma needs slowPeriod candles minimum. 25 < 26.
+    const closes = Array.from({ length: 25 }, (_, i) => i + 1);
+    expect(macd(candlesFromCloses(closes), 12, 26, 9)).toEqual([]);
+  });
+
+  it("returns [] when input has slow EMA but not enough for signal seed", () => {
+    // slowPeriod + signalPeriod − 1 = 34 minimum. 33 candles → empty.
+    const closes = Array.from({ length: 33 }, (_, i) => i + 1);
+    expect(macd(candlesFromCloses(closes), 12, 26, 9)).toEqual([]);
+  });
+
+  it("output time aligns to the candle's timestamp at the right edge of the window", () => {
+    const candles = candlesFromCloses([10, 12, 14, 13, 15, 17, 16]);
+    const result = macd(candles, 2, 4, 2);
+    // First output is at candle index 4 (the 5th candle) per the alignment math
+    // computed in the canonical reference test above.
+    expect(result[0].time).toBe(candles[4].timestamp);
+    expect(result[result.length - 1].time).toBe(candles[candles.length - 1].timestamp);
+  });
+
+  it("MACD line crosses above signal → histogram flips positive (regression spot-check)", () => {
+    // After a sustained rise, the fast EMA leads the slow EMA, so MACD > 0.
+    // The signal line lags the MACD line, so during the upswing histogram
+    // should be positive somewhere.
+    const closes = [
+      ...Array(30).fill(100),       // flat
+      ...Array(30).fill(0).map((_, i) => 100 + i * 2), // rising
+    ];
+    const result = macd(candlesFromCloses(closes), 12, 26, 9);
+    const hasPositiveHist = result.some((p) => p.histogram > 0.5);
+    expect(hasPositiveHist).toBe(true);
+  });
+});

--- a/app/__tests__/lib/indicators/rsi.test.ts
+++ b/app/__tests__/lib/indicators/rsi.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import { relativeStrengthIndex } from "@/lib/indicators/rsi";
+import { candlesFromCloses } from "./helpers";
+
+describe("relativeStrengthIndex", () => {
+  it("computes the canonical reference vector with hand-verifiable arithmetic", () => {
+    // closes [1,2,3,2,1,2,3,4], period 3
+    // Changes: [+1, +1, -1, -1, +1, +1, +1]
+    //
+    // Seed (first 3 changes):
+    //   avgGain = (1+1+0)/3 = 2/3
+    //   avgLoss = (0+0+1)/3 = 1/3
+    //   RS = 2 → RSI at i=3 = 100 − 100/3 = 66.6667
+    //
+    // Wilder's at i=4 (change −1):
+    //   avgGain = (2/3 × 2 + 0)/3 = 4/9
+    //   avgLoss = (1/3 × 2 + 1)/3 = 5/9
+    //   RS = 4/5 = 0.8 → RSI = 100 − 100/1.8 = 44.4444
+    //
+    // Wilder's at i=5 (change +1):
+    //   avgGain = (4/9 × 2 + 1)/3 = 17/27
+    //   avgLoss = (5/9 × 2 + 0)/3 = 10/27
+    //   RS = 17/10 = 1.7 → RSI = 100 − 100/2.7 = 62.9630
+    //
+    // Wilder's at i=6 (change +1):
+    //   avgGain = (17/27 × 2 + 1)/3 = 61/81
+    //   avgLoss = (10/27 × 2 + 0)/3 = 20/81
+    //   RS = 61/20 = 3.05 → RSI = 100 − 100/4.05 = 75.3086
+    //
+    // Wilder's at i=7 (change +1):
+    //   avgGain = (61/81 × 2 + 1)/3 = 203/243
+    //   avgLoss = (20/81 × 2 + 0)/3 = 40/243
+    //   RS = 203/40 = 5.075 → RSI = 100 − 100/6.075 = 83.5391
+    const result = relativeStrengthIndex(
+      candlesFromCloses([1, 2, 3, 2, 1, 2, 3, 4]),
+      3,
+    );
+    expect(result).toHaveLength(5);
+    expect(result[0].value).toBeCloseTo(66.6667, 3);
+    expect(result[1].value).toBeCloseTo(44.4444, 3);
+    expect(result[2].value).toBeCloseTo(62.9630, 3);
+    expect(result[3].value).toBeCloseTo(75.3086, 3);
+    expect(result[4].value).toBeCloseTo(83.5391, 3);
+  });
+
+  it("monotonically increasing closes → RSI approaches 100", () => {
+    // No losses ever → avgLoss === 0 → RSI = 100 every point.
+    const closes = Array.from({ length: 50 }, (_, i) => 100 + i);
+    const result = relativeStrengthIndex(candlesFromCloses(closes), 14);
+    for (const point of result) {
+      expect(point.value).toBeCloseTo(100, 9);
+    }
+  });
+
+  it("monotonically decreasing closes → RSI approaches 0", () => {
+    // No gains ever → avgGain === 0 → RS = 0 → RSI = 100 − 100/1 = 0.
+    const closes = Array.from({ length: 50 }, (_, i) => 100 - i);
+    const result = relativeStrengthIndex(candlesFromCloses(closes), 14);
+    for (const point of result) {
+      expect(point.value).toBeCloseTo(0, 9);
+    }
+  });
+
+  it("constant prices → RSI = 100 (avgLoss === 0 guard fires for the flat case)", () => {
+    // Every change is 0 → avgGain = avgLoss = 0 → guard returns 100.
+    // TradingView convention; some references return 50 for the flat case.
+    const result = relativeStrengthIndex(candlesFromCloses([100, 100, 100, 100, 100]), 3);
+    expect(result).toHaveLength(2);
+    for (const point of result) {
+      expect(point.value).toBe(100);
+    }
+  });
+
+  it("invariant: every output value is in [0, 100]", () => {
+    // Random-ish but deterministic. Mix of gains and losses.
+    const closes = [10, 12, 11, 14, 13, 15, 17, 16, 18, 20, 19, 21, 23, 22, 25, 24, 26, 28, 27, 30];
+    const result = relativeStrengthIndex(candlesFromCloses(closes), 14);
+    for (const point of result) {
+      expect(point.value).toBeGreaterThanOrEqual(0);
+      expect(point.value).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("returns [] for empty input", () => {
+    expect(relativeStrengthIndex([], 14)).toEqual([]);
+  });
+
+  it("returns [] when candles.length < period + 1 (insufficient changes for the seed)", () => {
+    // Need period+1 candles to produce period price changes.
+    expect(relativeStrengthIndex(candlesFromCloses([1, 2, 3]), 3)).toEqual([]);
+    expect(relativeStrengthIndex(candlesFromCloses([1, 2, 3, 4]), 14)).toEqual([]);
+  });
+
+  it("returns [] for non-positive period (defensive)", () => {
+    expect(relativeStrengthIndex(candlesFromCloses([1, 2, 3, 4, 5]), 0)).toEqual([]);
+    expect(relativeStrengthIndex(candlesFromCloses([1, 2, 3, 4, 5]), -1)).toEqual([]);
+  });
+
+  it("output length is exactly candles.length − period (NOT − period + 1 like SMA/EMA/Bollinger)", () => {
+    // RSI consumes price CHANGES, which need period+1 candles → one less output.
+    for (const len of [10, 50, 100, 500]) {
+      for (const period of [3, 14, 20, 50]) {
+        if (len < period + 1) continue;
+        const closes = Array.from({ length: len }, (_, i) => i + 1);
+        const result = relativeStrengthIndex(candlesFromCloses(closes), period);
+        expect(result).toHaveLength(len - period);
+      }
+    }
+  });
+
+  it("first output time aligns to candles[period].timestamp (NOT candles[period − 1])", () => {
+    // RSI lives one index later than SMA/EMA/Bollinger because of the
+    // change-of-prices semantics. Pinning this prevents an off-by-one
+    // regression that would mis-align the line on the chart.
+    const candles = candlesFromCloses([1, 2, 3, 4, 5, 6]);
+    const result = relativeStrengthIndex(candles, 3);
+    expect(result[0].time).toBe(candles[3].timestamp);
+    expect(result[result.length - 1].time).toBe(candles[candles.length - 1].timestamp);
+  });
+
+  it("post-jump value is meaningfully different from constant baseline (regression spot-check)", () => {
+    // closes [10, 10, 10, 10, 50] period 3
+    // Seed at i=3 over changes [0, 0, 0]: avgGain = avgLoss = 0 → RSI = 100
+    // At i=4 (change +40): avgGain = (0×2 + 40)/3 = 40/3, avgLoss = 0 → still 100
+    // Confirms: a single huge gain after flat prices doesn't drag RSI down.
+    const result = relativeStrengthIndex(candlesFromCloses([10, 10, 10, 10, 50]), 3);
+    expect(result).toHaveLength(2);
+    expect(result[0].value).toBe(100);
+    expect(result[1].value).toBe(100);
+  });
+});

--- a/app/__tests__/lib/indicators/sma.test.ts
+++ b/app/__tests__/lib/indicators/sma.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { simpleMovingAverage } from "@/lib/indicators/sma";
+import type { Candle } from "@/lib/indicators/types";
+
+/** Build a minimal Candle array from an array of close prices. The other
+ *  OHLC fields are unused by SMA but required by the type — fill with the
+ *  close so the structure is realistic (open=high=low=close). Timestamps
+ *  are 60s apart starting at epoch 0 for deterministic output. */
+function candlesFromCloses(closes: readonly number[]): Candle[] {
+  return closes.map((close, i) => ({
+    timestamp: i * 60_000,
+    open: close,
+    high: close,
+    low: close,
+    close,
+  }));
+}
+
+describe("simpleMovingAverage", () => {
+  it("computes the canonical reference vector: [1,2,3,4,5] period 3 → [2,3,4]", () => {
+    // SMA(3) at index 2: (1+2+3)/3 = 2
+    // SMA(3) at index 3: (2+3+4)/3 = 3
+    // SMA(3) at index 4: (3+4+5)/3 = 4
+    const result = simpleMovingAverage(candlesFromCloses([1, 2, 3, 4, 5]), 3);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ time: 2 * 60_000, value: 2 });
+    expect(result[1]).toEqual({ time: 3 * 60_000, value: 3 });
+    expect(result[2]).toEqual({ time: 4 * 60_000, value: 4 });
+  });
+
+  it("returns identity when period === 1 (each output equals its close)", () => {
+    const result = simpleMovingAverage(candlesFromCloses([10, 20, 30]), 1);
+    expect(result).toHaveLength(3);
+    expect(result.map((p) => p.value)).toEqual([10, 20, 30]);
+  });
+
+  it("returns a single point when period === candles.length", () => {
+    const result = simpleMovingAverage(candlesFromCloses([100, 200, 300]), 3);
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toBeCloseTo(200, 9); // mean of [100,200,300]
+  });
+
+  it("returns [] for empty input", () => {
+    expect(simpleMovingAverage([], 14)).toEqual([]);
+  });
+
+  it("returns [] when candles.length < period (window can't fill)", () => {
+    expect(simpleMovingAverage(candlesFromCloses([1, 2, 3]), 5)).toEqual([]);
+  });
+
+  it("returns [] for non-positive period (defensive)", () => {
+    expect(simpleMovingAverage(candlesFromCloses([1, 2, 3, 4]), 0)).toEqual([]);
+    expect(simpleMovingAverage(candlesFromCloses([1, 2, 3, 4]), -1)).toEqual([]);
+  });
+
+  it("output length is exactly candles.length - period + 1 (invariant)", () => {
+    for (const len of [10, 50, 100, 500]) {
+      for (const period of [5, 10, 20, 50]) {
+        if (len < period) continue;
+        const closes = Array.from({ length: len }, (_, i) => i + 1);
+        const result = simpleMovingAverage(candlesFromCloses(closes), period);
+        expect(result).toHaveLength(len - period + 1);
+      }
+    }
+  });
+
+  it("output time aligns with the candle's timestamp at each window's right edge", () => {
+    const candles = candlesFromCloses([10, 20, 30, 40, 50]);
+    const result = simpleMovingAverage(candles, 3);
+    // First SMA point is at candle index 2 (the third candle), so its time
+    // must equal candles[2].timestamp, not candles[0].timestamp.
+    expect(result[0].time).toBe(candles[2].timestamp);
+    expect(result[result.length - 1].time).toBe(candles[candles.length - 1].timestamp);
+  });
+});

--- a/app/__tests__/lib/indicators/sma.test.ts
+++ b/app/__tests__/lib/indicators/sma.test.ts
@@ -1,20 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { simpleMovingAverage } from "@/lib/indicators/sma";
-import type { Candle } from "@/lib/indicators/types";
-
-/** Build a minimal Candle array from an array of close prices. The other
- *  OHLC fields are unused by SMA but required by the type — fill with the
- *  close so the structure is realistic (open=high=low=close). Timestamps
- *  are 60s apart starting at epoch 0 for deterministic output. */
-function candlesFromCloses(closes: readonly number[]): Candle[] {
-  return closes.map((close, i) => ({
-    timestamp: i * 60_000,
-    open: close,
-    high: close,
-    low: close,
-    close,
-  }));
-}
+import { candlesFromCloses } from "./helpers";
 
 describe("simpleMovingAverage", () => {
   it("computes the canonical reference vector: [1,2,3,4,5] period 3 → [2,3,4]", () => {

--- a/app/components/trade/ChartIndicatorMenu.tsx
+++ b/app/components/trade/ChartIndicatorMenu.tsx
@@ -133,14 +133,18 @@ export const ChartIndicatorMenu: FC<ChartIndicatorMenuProps> = ({
         // @ts-expect-error - inert is a valid HTML attribute, React types lag
         inert={!open ? "" : undefined}
         className={[
-          "absolute left-0 top-full z-20 mt-1 min-w-[280px] rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] py-1 shadow-[0_8px_32px_rgba(0,0,0,0.48)] transition-opacity duration-[120ms] ease-out",
+          // z-[60] so the mobile bottom-sheet variant sits ABOVE the global
+          // MobileBottomNav (z-50) — at z-20 the nav was painting over the
+          // sheet's "Clear all" footer, leaving it unreachable on phones.
+          "absolute left-0 top-full z-[60] mt-1 min-w-[280px] rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] py-1 shadow-[0_8px_32px_rgba(0,0,0,0.48)] transition-opacity duration-[120ms] ease-out",
           open
             ? "opacity-100 pointer-events-auto"
             : "opacity-0 pointer-events-none",
           // Mobile: bottom sheet. max-h + overflow keeps "Clear all" reachable
-          // when all five rows are expanded with their per-kind inputs (the
-          // unconstrained sheet would clip the footer below the viewport).
-          "max-md:fixed max-md:bottom-0 max-md:left-0 max-md:right-0 max-md:top-auto max-md:max-h-[80vh] max-md:overflow-y-auto max-md:rounded-t-lg max-md:border-t",
+          // when all five rows are expanded with their per-kind inputs.
+          // pb-[env(safe-area-inset-bottom)] adds iOS home-indicator clearance
+          // so the footer button isn't covered by the home bar.
+          "max-md:fixed max-md:bottom-0 max-md:left-0 max-md:right-0 max-md:top-auto max-md:max-h-[80vh] max-md:overflow-y-auto max-md:rounded-t-lg max-md:border-t max-md:pb-[env(safe-area-inset-bottom)]",
         ].join(" ")}
       >
         <div className="px-3 py-2 text-[10px] font-bold uppercase tracking-[0.12em] text-[var(--text-dim)] border-b border-[var(--border)]">

--- a/app/components/trade/ChartIndicatorMenu.tsx
+++ b/app/components/trade/ChartIndicatorMenu.tsx
@@ -7,13 +7,14 @@ import {
   type IndicatorConfig,
   type IndicatorKind,
 } from "@/lib/indicator-registry";
+import type { IndicatorPatch } from "@/hooks/useChartIndicatorPrefs";
 import { assertNever } from "@/lib/exhaustive";
 
 interface ChartIndicatorMenuProps {
   indicators: IndicatorConfig[];
   addIndicator: (kind: IndicatorKind) => void;
   removeIndicator: (id: string) => void;
-  updateIndicator: (id: string, patch: Partial<IndicatorConfig>) => void;
+  updateIndicator: (id: string, patch: IndicatorPatch) => void;
   clearAll: () => void;
 }
 
@@ -178,7 +179,7 @@ interface ChartIndicatorRowProps {
   config: IndicatorConfig | null;
   onAdd: () => void;
   onRemove: () => void;
-  onUpdate: (patch: Partial<IndicatorConfig>) => void;
+  onUpdate: (patch: IndicatorPatch) => void;
 }
 
 const ChartIndicatorRow: FC<ChartIndicatorRowProps> = ({
@@ -232,7 +233,7 @@ const ChartIndicatorRow: FC<ChartIndicatorRowProps> = ({
 
 interface ConfigInputsProps {
   config: IndicatorConfig;
-  onUpdate: (patch: Partial<IndicatorConfig>) => void;
+  onUpdate: (patch: IndicatorPatch) => void;
 }
 
 const ConfigInputs: FC<ConfigInputsProps> = ({ config, onUpdate }) => {

--- a/app/components/trade/ChartIndicatorMenu.tsx
+++ b/app/components/trade/ChartIndicatorMenu.tsx
@@ -7,6 +7,7 @@ import {
   type IndicatorConfig,
   type IndicatorKind,
 } from "@/lib/indicator-registry";
+import { assertNever } from "@/lib/exhaustive";
 
 interface ChartIndicatorMenuProps {
   indicators: IndicatorConfig[];
@@ -92,6 +93,7 @@ export const ChartIndicatorMenu: FC<ChartIndicatorMenuProps> = ({
         aria-expanded={open}
         aria-haspopup="true"
         aria-label="Indicators"
+        title="Indicators"
         className={[
           "flex items-center gap-1 rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] px-2 py-1 text-xs transition-colors",
           open
@@ -123,13 +125,21 @@ export const ChartIndicatorMenu: FC<ChartIndicatorMenuProps> = ({
 
       <div
         aria-hidden={!open || undefined}
+        // `inert` removes the panel from sequential focus and click target
+        // when closed. Without this, Tab walks through every toggle and
+        // input even though the panel is invisible (opacity:0 alone keeps
+        // children in the focus tree).
+        // @ts-expect-error - inert is a valid HTML attribute, React types lag
+        inert={!open ? "" : undefined}
         className={[
           "absolute left-0 top-full z-20 mt-1 min-w-[280px] rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] py-1 shadow-[0_8px_32px_rgba(0,0,0,0.48)] transition-opacity duration-[120ms] ease-out",
           open
             ? "opacity-100 pointer-events-auto"
             : "opacity-0 pointer-events-none",
-          // Mobile: bottom sheet
-          "max-md:fixed max-md:bottom-0 max-md:left-0 max-md:right-0 max-md:top-auto max-md:rounded-t-lg max-md:border-t",
+          // Mobile: bottom sheet. max-h + overflow keeps "Clear all" reachable
+          // when all five rows are expanded with their per-kind inputs (the
+          // unconstrained sheet would clip the footer below the viewport).
+          "max-md:fixed max-md:bottom-0 max-md:left-0 max-md:right-0 max-md:top-auto max-md:max-h-[80vh] max-md:overflow-y-auto max-md:rounded-t-lg max-md:border-t",
         ].join(" ")}
       >
         <div className="px-3 py-2 text-[10px] font-bold uppercase tracking-[0.12em] text-[var(--text-dim)] border-b border-[var(--border)]">
@@ -198,10 +208,14 @@ const ChartIndicatorRow: FC<ChartIndicatorRowProps> = ({
           </span>
         </button>
         {config && (
+          // The swatch is decorative — the colour itself isn't actionable
+          // from this menu, and a hex code is noise to a screen reader.
+          // The toggle's aria-pressed already conveys enabled state.
           <span
+            data-testid={`indicator-swatch-${kind}`}
             className="inline-block h-3 w-3 rounded-sm border border-[var(--border)]"
             style={{ backgroundColor: config.color }}
-            aria-label={`Indicator colour ${config.color}`}
+            aria-hidden="true"
           />
         )}
       </div>
@@ -282,9 +296,9 @@ const ConfigInputs: FC<ConfigInputsProps> = ({ config, onUpdate }) => {
         </>
       );
     default:
-      // Exhaustive for the IndicatorConfig union; if a future kind is
-      // added without a case the type checker will flag this branch.
-      return null;
+      // Exhaustive for the IndicatorConfig union — assertNever fails
+      // compilation if a future kind is added without a case here.
+      return assertNever(config);
   }
 };
 

--- a/app/components/trade/ChartIndicatorMenu.tsx
+++ b/app/components/trade/ChartIndicatorMenu.tsx
@@ -1,0 +1,392 @@
+"use client";
+
+import { FC, useState, useRef, useEffect, useCallback } from "react";
+import {
+  ALL_INDICATOR_KINDS,
+  INDICATOR_LABELS,
+  type IndicatorConfig,
+  type IndicatorKind,
+} from "@/lib/indicator-registry";
+
+interface ChartIndicatorMenuProps {
+  indicators: IndicatorConfig[];
+  addIndicator: (kind: IndicatorKind) => void;
+  removeIndicator: (id: string) => void;
+  updateIndicator: (id: string, patch: Partial<IndicatorConfig>) => void;
+  clearAll: () => void;
+}
+
+/** Toolbar dropdown that surfaces every supported indicator as a toggle row.
+ *  Click the row's toggle to add the indicator with its TradingView default
+ *  parameters; click again to remove it. While enabled, the row exposes
+ *  per-kind period inputs (and stdDev for Bollinger; fast/slow/signal for
+ *  MACD) plus a colour swatch showing the auto-assigned palette colour.
+ *
+ *  This v1 menu is single-instance-per-kind: clicking the SMA toggle adds
+ *  ONE SMA, clicking again removes the first matching one. The hook
+ *  itself supports multi-instance (multiple SMAs at different periods),
+ *  but the UI for managing multiples lives in a future polish commit.
+ *
+ *  Mobile: panel switches to a bottom sheet anchored to the viewport
+ *  bottom on viewports below the md breakpoint, so the dropdown doesn't
+ *  overflow off the right edge of narrow phones.
+ *
+ *  ARIA: trigger is `aria-haspopup="true"` + `aria-expanded`; toggles use
+ *  `aria-pressed` rather than `role="menuitemcheckbox"` because the
+ *  toggle-button pattern doesn't promise the WAI-ARIA APG menu keyboard
+ *  contract (arrow-key focus management, type-ahead) which we don't
+ *  implement. Tab + Enter on each row is the full keyboard contract. */
+export const ChartIndicatorMenu: FC<ChartIndicatorMenuProps> = ({
+  indicators,
+  addIndicator,
+  removeIndicator,
+  updateIndicator,
+  clearAll,
+}) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  // Escape closes the menu, but only when focus is OUTSIDE a number input.
+  // Otherwise pressing Escape while editing a period would eat the
+  // keystroke instead of letting the input do whatever it normally does.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      const active = document.activeElement;
+      if (
+        active != null &&
+        (active.tagName === "INPUT" || active.tagName === "TEXTAREA")
+      ) {
+        return;
+      }
+      setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  // Outside-click closes.
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, [open]);
+
+  const handleClearAll = useCallback(() => {
+    if (indicators.length === 0) return;
+    clearAll();
+    // keep menu open so the user can immediately re-add what they want
+  }, [indicators.length, clearAll]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        aria-haspopup="true"
+        aria-label="Indicators"
+        className={[
+          "flex items-center gap-1 rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] px-2 py-1 text-xs transition-colors",
+          open
+            ? "text-[var(--accent)]"
+            : "text-[var(--text-secondary)] hover:text-[var(--text)]",
+        ].join(" ")}
+      >
+        <span className="font-mono italic">f(x)</span>
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 10 10"
+          fill="none"
+          aria-hidden="true"
+          className={[
+            "transition-transform duration-150",
+            open ? "rotate-180" : "",
+          ].join(" ")}
+        >
+          <path
+            d="M2.5 3.75L5 6.25L7.5 3.75"
+            stroke="currentColor"
+            strokeWidth="1.25"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+
+      <div
+        aria-hidden={!open || undefined}
+        className={[
+          "absolute left-0 top-full z-20 mt-1 min-w-[280px] rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] py-1 shadow-[0_8px_32px_rgba(0,0,0,0.48)] transition-opacity duration-[120ms] ease-out",
+          open
+            ? "opacity-100 pointer-events-auto"
+            : "opacity-0 pointer-events-none",
+          // Mobile: bottom sheet
+          "max-md:fixed max-md:bottom-0 max-md:left-0 max-md:right-0 max-md:top-auto max-md:rounded-t-lg max-md:border-t",
+        ].join(" ")}
+      >
+        <div className="px-3 py-2 text-[10px] font-bold uppercase tracking-[0.12em] text-[var(--text-dim)] border-b border-[var(--border)]">
+          Indicators
+        </div>
+        {ALL_INDICATOR_KINDS.map((kind) => {
+          const config = indicators.find((i) => i.kind === kind) ?? null;
+          return (
+            <ChartIndicatorRow
+              key={kind}
+              kind={kind}
+              config={config}
+              onAdd={() => addIndicator(kind)}
+              onRemove={() => config && removeIndicator(config.id)}
+              onUpdate={(patch) => config && updateIndicator(config.id, patch)}
+            />
+          );
+        })}
+        <button
+          type="button"
+          onClick={handleClearAll}
+          disabled={indicators.length === 0}
+          className="w-full px-3 py-2 text-xs text-[var(--text-dim)] hover:text-[var(--text)] hover:bg-[var(--bg-surface)] border-t border-[var(--border)] disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Clear all
+        </button>
+      </div>
+    </div>
+  );
+};
+
+// =====================================================================
+
+interface ChartIndicatorRowProps {
+  kind: IndicatorKind;
+  config: IndicatorConfig | null;
+  onAdd: () => void;
+  onRemove: () => void;
+  onUpdate: (patch: Partial<IndicatorConfig>) => void;
+}
+
+const ChartIndicatorRow: FC<ChartIndicatorRowProps> = ({
+  kind,
+  config,
+  onAdd,
+  onRemove,
+  onUpdate,
+}) => {
+  const enabled = config !== null;
+  return (
+    <div className="px-3 py-2 border-b border-[var(--border)]/50 last:border-b-0">
+      <div className="flex items-center justify-between gap-2">
+        <button
+          type="button"
+          aria-pressed={enabled}
+          onClick={() => (enabled ? onRemove() : onAdd())}
+          className="flex flex-1 items-center gap-2 text-xs"
+        >
+          <ToggleSwitch on={enabled} />
+          <span
+            className={
+              enabled ? "text-[var(--text)]" : "text-[var(--text-dim)]"
+            }
+          >
+            {INDICATOR_LABELS[kind]}
+          </span>
+        </button>
+        {config && (
+          <span
+            className="inline-block h-3 w-3 rounded-sm border border-[var(--border)]"
+            style={{ backgroundColor: config.color }}
+            aria-label={`Indicator colour ${config.color}`}
+          />
+        )}
+      </div>
+      {config && (
+        <div className="mt-2 ml-7 flex flex-wrap items-center gap-2 text-xs">
+          <ConfigInputs config={config} onUpdate={onUpdate} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+// =====================================================================
+
+interface ConfigInputsProps {
+  config: IndicatorConfig;
+  onUpdate: (patch: Partial<IndicatorConfig>) => void;
+}
+
+const ConfigInputs: FC<ConfigInputsProps> = ({ config, onUpdate }) => {
+  switch (config.kind) {
+    case "sma":
+    case "ema":
+    case "rsi":
+      return (
+        <NumberInput
+          label="Period"
+          value={config.period}
+          min={2}
+          max={500}
+          onChange={(period) => onUpdate({ period })}
+        />
+      );
+    case "bollinger":
+      return (
+        <>
+          <NumberInput
+            label="Period"
+            value={config.period}
+            min={2}
+            max={500}
+            onChange={(period) => onUpdate({ period })}
+          />
+          <NumberInput
+            label="StdDev"
+            value={config.stdDev}
+            min={0.1}
+            max={10}
+            step={0.1}
+            onChange={(stdDev) => onUpdate({ stdDev })}
+          />
+        </>
+      );
+    case "macd":
+      return (
+        <>
+          <NumberInput
+            label="Fast"
+            value={config.fastPeriod}
+            min={2}
+            max={100}
+            onChange={(fastPeriod) => onUpdate({ fastPeriod })}
+          />
+          <NumberInput
+            label="Slow"
+            value={config.slowPeriod}
+            min={2}
+            max={500}
+            onChange={(slowPeriod) => onUpdate({ slowPeriod })}
+          />
+          <NumberInput
+            label="Signal"
+            value={config.signalPeriod}
+            min={2}
+            max={100}
+            onChange={(signalPeriod) => onUpdate({ signalPeriod })}
+          />
+        </>
+      );
+    default:
+      // Exhaustive for the IndicatorConfig union; if a future kind is
+      // added without a case the type checker will flag this branch.
+      return null;
+  }
+};
+
+// =====================================================================
+
+interface NumberInputProps {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  onChange: (value: number) => void;
+}
+
+/** Number input that commits on blur (or Enter) rather than every
+ *  keystroke. Per-keystroke commits would re-render the chart at every
+ *  digit ("type 1 → EMA(1), type 0 → EMA(10), type 0 → EMA(100)") which
+ *  is jarring. The committed value is also clamped to [min, max] so a
+ *  user typing 9999 ends up with a sane 500 instead of an EMA call that
+ *  returns []. */
+const NumberInput: FC<NumberInputProps> = ({
+  label,
+  value,
+  min,
+  max,
+  step = 1,
+  onChange,
+}) => {
+  const [draft, setDraft] = useState(String(value));
+
+  // Re-sync draft when the externally-controlled value changes (e.g.,
+  // after a "Clear all" or after the indicator is re-added with defaults).
+  useEffect(() => {
+    setDraft(String(value));
+  }, [value]);
+
+  const commit = useCallback(() => {
+    // Empty input means the user typed garbage that the native number
+    // input rejected to "" (or cleared the field). Either way, treat it
+    // as "no change" rather than parsing as 0 and clamping to min.
+    const trimmed = draft.trim();
+    if (trimmed === "") {
+      setDraft(String(value));
+      return;
+    }
+    const parsed = Number(trimmed);
+    if (!Number.isFinite(parsed)) {
+      // Garbage input — revert to last valid value.
+      setDraft(String(value));
+      return;
+    }
+    const clamped = Math.max(min, Math.min(max, parsed));
+    if (clamped !== value) onChange(clamped);
+    // Always re-sync draft to the clamped value so the input doesn't
+    // visually retain an out-of-range number (e.g., 9999 → 500).
+    setDraft(String(clamped));
+  }, [draft, value, min, max, onChange]);
+
+  return (
+    <label className="flex items-center gap-1 text-[var(--text-dim)]">
+      <span>{label}</span>
+      <input
+        type="number"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            commit();
+            (e.target as HTMLInputElement).blur();
+          }
+        }}
+        min={min}
+        max={max}
+        step={step}
+        className="w-14 rounded-none border border-[var(--border)] bg-[var(--bg)] px-1 py-0.5 text-xs text-[var(--text)]"
+      />
+    </label>
+  );
+};
+
+// =====================================================================
+
+interface ToggleSwitchProps {
+  on: boolean;
+}
+
+const ToggleSwitch: FC<ToggleSwitchProps> = ({ on }) => (
+  <span
+    aria-hidden="true"
+    className={[
+      "inline-flex h-3.5 w-6 items-center rounded-full border transition-colors",
+      on
+        ? "bg-[var(--accent)] border-[var(--accent)]"
+        : "bg-transparent border-[var(--border)]",
+    ].join(" ")}
+  >
+    <span
+      className={[
+        "h-2.5 w-2.5 rounded-full bg-[var(--bg)] transition-transform",
+        on ? "translate-x-[10px]" : "translate-x-[2px]",
+      ].join(" ")}
+    />
+  </span>
+);

--- a/app/components/trade/ChartIndicatorMenu.tsx
+++ b/app/components/trade/ChartIndicatorMenu.tsx
@@ -96,7 +96,7 @@ export const ChartIndicatorMenu: FC<ChartIndicatorMenuProps> = ({
         aria-label="Indicators"
         title="Indicators"
         className={[
-          "flex items-center gap-1 rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] px-2 py-1 text-xs transition-colors",
+          "flex items-center gap-1 rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] px-1.5 sm:px-2 py-1 text-xs transition-colors",
           open
             ? "text-[var(--accent)]"
             : "text-[var(--text-secondary)] hover:text-[var(--text)]",

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -36,8 +36,9 @@ import { getEntryPrice } from "@/lib/entry-price";
 import { useChartStylePref } from "@/hooks/useChartStylePref";
 import { useChartOverlayPrefs } from "@/hooks/useChartOverlayPrefs";
 import { useChartIndicatorPrefs } from "@/hooks/useChartIndicatorPrefs";
-import { isOverlayKind } from "@/lib/indicator-registry";
+import { isOverlayKind, isPaneKind } from "@/lib/indicator-registry";
 import { useIndicatorOverlays } from "./useIndicatorOverlays";
+import { useIndicatorOscillatorPane } from "./useIndicatorOscillatorPane";
 import {
   isCandleStyle,
   candleStyleOptions,
@@ -325,6 +326,15 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
     [indicators],
   );
   useIndicatorOverlays(chartRef, chartReady, candleData, overlayIndicatorConfigs);
+
+  // Oscillator-pane indicators (RSI / MACD). Same memo discipline. The pane
+  // is allocated lazily inside the hook — empty pane configs collapses the
+  // pane and the chart fills the reclaimed vertical space.
+  const paneIndicatorConfigs = useMemo(
+    () => indicators.filter((i) => isPaneKind(i.kind)),
+    [indicators],
+  );
+  useIndicatorOscillatorPane(chartRef, chartReady, candleData, paneIndicatorConfigs, chartTheme);
 
   // Create/destroy chart
   useEffect(() => {

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -300,19 +300,25 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
   // Data source priority: Percolator internal trades (tier-0, when >=10 bars) →
   // Pyth Benchmarks (canonical spot) → GeckoTerminal (DEX-pool history for
   // long-tail tokens) → oracle-aggregated fallback (keeper observations).
-  const candleData = (() => {
+  //
+  // Memoed so the reference is stable between renders that don't change the
+  // underlying source arrays. Without this, every parent render (e.g. on
+  // unrelated state like timeframe-pill hover) creates a new array, which
+  // re-fires the indicator hooks' effects and tears down + reallocates the
+  // oscillator pane on every WebSocket tick.
+  const candleData = useMemo(() => {
     if (hasPercolatorData) return percolatorCandles;
     if (hasPythData) return pythCandles as { timestamp: number; open: number; high: number; low: number; close: number; volume: number }[];
     if (hasExternalData) return externalCandles as { timestamp: number; open: number; high: number; low: number; close: number; volume: number }[];
     return aggregateCandles(oracleFiltered, CANDLE_INTERVAL_MS);
-  })();
+  }, [hasPercolatorData, hasPythData, hasExternalData, percolatorCandles, pythCandles, externalCandles, oracleFiltered]);
 
-  const lineData = (() => {
+  const lineData = useMemo(() => {
     if (hasPercolatorData) return percolatorCandles.map((c) => ({ timestamp: c.timestamp, price: c.close }));
     if (hasPythData) return pythCandles.map((c) => ({ timestamp: c.timestamp, price: c.close }));
     if (hasExternalData) return externalCandles.map((c) => ({ timestamp: c.timestamp, price: c.close }));
     return oracleFiltered;
-  })();
+  }, [hasPercolatorData, hasPythData, hasExternalData, percolatorCandles, pythCandles, externalCandles, oracleFiltered]);
 
   const totalDataPoints = candleData.length + lineData.length;
 

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -230,14 +230,21 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
   } = usePercolatorCandles(slabAddress ?? null, timeframe);
 
   // Convert from {time: unix-seconds} to {timestamp: ms} shape used by the chart.
-  const percolatorCandles = percolatorCandlesRaw.map((c) => ({
-    timestamp: c.time * 1000,
-    open: c.open,
-    high: c.high,
-    low: c.low,
-    close: c.close,
-    volume: c.volume,
-  }));
+  // Memoed so identity is stable between renders that don't change the source
+  // array — without this, every parent render (live-price tick, crosshair
+  // hover, etc.) produces a fresh array, which cascades into candleData →
+  // indicator hooks → full series remove+recreate at WS cadence.
+  const percolatorCandles = useMemo(
+    () => percolatorCandlesRaw.map((c) => ({
+      timestamp: c.time * 1000,
+      open: c.open,
+      high: c.high,
+      low: c.low,
+      close: c.close,
+      volume: c.volume,
+    })),
+    [percolatorCandlesRaw],
+  );
 
   // Prefer Percolator as the chart source only when it has enough coverage to
   // form a readable chart. With 1–2 candles against a 24 h window, the tier-0
@@ -291,11 +298,17 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
     });
   }, [config, priceUsd]);
 
-  // Derive data
-  const oracleFiltered = (() => {
-    const cutoff = Date.now() - TIMEFRAME_MS[timeframe];
-    return oraclePrices.filter((p) => p.timestamp >= cutoff);
-  })();
+  // Derive data. Memoed because oraclePrices only changes on the 5s-gated
+  // live-price effect (line ~287), so the filtered slice is reference-stable
+  // between most renders. Same WS-tick churn argument as percolatorCandles
+  // above — without this, candleData's memo invalidates on every tick.
+  const oracleFiltered = useMemo(
+    () => {
+      const cutoff = Date.now() - TIMEFRAME_MS[timeframe];
+      return oraclePrices.filter((p) => p.timestamp >= cutoff);
+    },
+    [oraclePrices, timeframe],
+  );
 
   // Data source priority: Percolator internal trades (tier-0, when >=10 bars) →
   // Pyth Benchmarks (canonical spot) → GeckoTerminal (DEX-pool history for

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -800,7 +800,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
               <button
                 key={tf}
                 onClick={() => setTimeframe(tf)}
-                className={`rounded-none px-2 py-1 text-xs transition-colors ${
+                className={`rounded-none px-1.5 sm:px-2 py-1 text-xs transition-colors ${
                   timeframe === tf
                     ? "bg-[var(--accent)]/10 text-[var(--accent)]"
                     : "text-[var(--text-dim)] hover:text-[var(--text-secondary)]"

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -39,6 +39,7 @@ import { useChartIndicatorPrefs } from "@/hooks/useChartIndicatorPrefs";
 import { isOverlayKind, isPaneKind } from "@/lib/indicator-registry";
 import { useIndicatorOverlays } from "./useIndicatorOverlays";
 import { useIndicatorOscillatorPane } from "./useIndicatorOscillatorPane";
+import { ChartIndicatorMenu } from "./ChartIndicatorMenu";
 import {
   isCandleStyle,
   candleStyleOptions,
@@ -150,7 +151,13 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
   const chartTheme = useChartTheme();
   const [chartStyle, setChartStyle] = useChartStylePref();
   const [overlayPrefs, setOverlayPref] = useChartOverlayPrefs();
-  const { indicators } = useChartIndicatorPrefs(slabAddress);
+  const {
+    indicators,
+    addIndicator,
+    removeIndicator,
+    updateIndicator,
+    clearAll: clearAllIndicators,
+  } = useChartIndicatorPrefs(slabAddress);
   const [timeframe, setTimeframe] = useState<Timeframe>("1d");
   const [oraclePrices, setOraclePrices] = useState<PricePoint[]>([]);
 
@@ -760,6 +767,13 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
         <div className="flex flex-wrap items-center gap-2">
           <ChartStyleMenu value={chartStyle} onChange={setChartStyle} />
           <ChartDisplayMenu prefs={overlayPrefs} onToggle={setOverlayPref} />
+          <ChartIndicatorMenu
+            indicators={indicators}
+            addIndicator={addIndicator}
+            removeIndicator={removeIndicator}
+            updateIndicator={updateIndicator}
+            clearAll={clearAllIndicators}
+          />
 
           {/* PERC-8090: 1m/5m/15m/1h/4h/1d only — 7d/30d collapsed */}
           <div className="flex gap-1 rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] p-0.5">

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FC, useState, useRef, useEffect, useCallback } from "react";
+import { FC, useState, useRef, useEffect, useCallback, useMemo } from "react";
 import {
   createChart,
   IChartApi,
@@ -35,6 +35,9 @@ import { isMockSlab, getMockUserAccount } from "@/lib/mock-trade-data";
 import { getEntryPrice } from "@/lib/entry-price";
 import { useChartStylePref } from "@/hooks/useChartStylePref";
 import { useChartOverlayPrefs } from "@/hooks/useChartOverlayPrefs";
+import { useChartIndicatorPrefs } from "@/hooks/useChartIndicatorPrefs";
+import { isOverlayKind } from "@/lib/indicator-registry";
+import { useIndicatorOverlays } from "./useIndicatorOverlays";
 import {
   isCandleStyle,
   candleStyleOptions,
@@ -146,6 +149,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
   const chartTheme = useChartTheme();
   const [chartStyle, setChartStyle] = useChartStylePref();
   const [overlayPrefs, setOverlayPref] = useChartOverlayPrefs();
+  const { indicators } = useChartIndicatorPrefs(slabAddress);
   const [timeframe, setTimeframe] = useState<Timeframe>("1d");
   const [oraclePrices, setOraclePrices] = useState<PricePoint[]>([]);
 
@@ -163,6 +167,11 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
 
   const containerRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<IChartApi | null>(null);
+  // Flips true once the chart-init effect has populated chartRef.current,
+  // back to false on unmount. Provides a reactive trigger for downstream
+  // hooks (useIndicatorOverlays) that need to attach series to the chart
+  // — refs alone can't drive an effect since they don't trigger re-runs.
+  const [chartReady, setChartReady] = useState(false);
   const seriesRef = useRef<ISeriesApi<ChartSeriesKind> | null>(null);
   const volumeSeriesRef = useRef<ISeriesApi<"Histogram"> | null>(null);
   const priceLineRef = useRef<ReturnType<ISeriesApi<"Candlestick">["createPriceLine"]> | null>(null);
@@ -307,6 +316,16 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
   // Phase 2: volume has data (used to show empty state in volume pane)
   const hasVolumeData = candleData.some((c) => (c.volume ?? 0) > 0);
 
+  // Indicator overlays (SMA / EMA / Bollinger). Memo the filtered subset so
+  // the overlay hook's effect only re-runs when the user actually adds /
+  // removes / edits an indicator — not on every WebSocket price tick (which
+  // would churn series remove+recreate at 250ms cadence).
+  const overlayIndicatorConfigs = useMemo(
+    () => indicators.filter((i) => isOverlayKind(i.kind)),
+    [indicators],
+  );
+  useIndicatorOverlays(chartRef, chartReady, candleData, overlayIndicatorConfigs);
+
   // Create/destroy chart
   useEffect(() => {
     if (!containerRef.current) return;
@@ -357,8 +376,10 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
     });
 
     chartRef.current = chart;
+    setChartReady(true);
 
     return () => {
+      setChartReady(false);
       chart.remove();
       chartRef.current = null;
       seriesRef.current = null;

--- a/app/components/trade/useIndicatorOscillatorPane.ts
+++ b/app/components/trade/useIndicatorOscillatorPane.ts
@@ -1,0 +1,307 @@
+"use client";
+
+import { useEffect, useRef, type RefObject } from "react";
+import {
+  HistogramSeries,
+  LineSeries,
+  LineStyle,
+  type IChartApi,
+  type ISeriesApi,
+  type UTCTimestamp,
+} from "lightweight-charts";
+import type { IndicatorConfig } from "@/lib/indicator-registry";
+import type { Candle } from "@/lib/indicators/types";
+import { relativeStrengthIndex } from "@/lib/indicators/rsi";
+import { macd } from "@/lib/indicators/macd";
+import type { ChartTheme } from "@/hooks/useChartTheme";
+import { assertNever } from "@/lib/exhaustive";
+
+/** Series spawned by an oscillator-kind indicator: a single line series for
+ *  RSI; a histogram + two lines for MACD. */
+type OscillatorSeries = ISeriesApi<"Line" | "Histogram">;
+type OscillatorPriceLine = ReturnType<ISeriesApi<"Line">["createPriceLine"]>;
+
+/**
+ * Wires oscillator-kind indicator configs (RSI, MACD) into a native pane
+ * below the main price pane via lightweight-charts v5's `chart.addPane()`.
+ * Overlay-kind configs (SMA, EMA, Bollinger) are filtered out by the
+ * caller and rendered separately by useIndicatorOverlays.
+ *
+ * The v5 native pane API gives us, for free, what the v4 plan would have
+ * required ~120 lines of manual plumbing for: shared time scale across
+ * panes, shared crosshair, theme propagation, and viewport sync. The
+ * pane lives inside the same chart instance — no second `<canvas>`, no
+ * `subscribeVisibleTimeRangeChange` mirror, no separate teardown path.
+ *
+ * The pane is allocated lazily — only when at least one oscillator config
+ * is active. Removing the last oscillator tears the pane down (collapsing
+ * the chart back to its original height). Adding the next oscillator
+ * reallocates a fresh pane.
+ *
+ * Multiple oscillators in one pane share the canvas. Their value scales
+ * differ (RSI is 0–100; MACD is unbounded around zero) but lightweight-
+ * charts auto-scales each series independently when they have distinct
+ * `priceScaleId` values. We assign each indicator instance a unique
+ * priceScaleId derived from its id so the scales don't fight each other.
+ *
+ * RSI gets a horizontal reference line at 70 (overbought) and 30
+ * (oversold) via `series.createPriceLine`. MACD's histogram bars are
+ * coloured per-bar (green for positive, red for negative) by setting
+ * `color` on each data point — TradingView's universal convention. The
+ * MACD line uses the indicator's chosen palette colour; the signal line
+ * uses the theme's text colour for contrast.
+ */
+export function useIndicatorOscillatorPane(
+  chartRef: RefObject<IChartApi | null>,
+  chartReady: boolean,
+  candleData: readonly Candle[],
+  configs: readonly IndicatorConfig[],
+  theme: ChartTheme,
+): void {
+  const paneIndexRef = useRef<number | null>(null);
+  const seriesMapRef = useRef<Map<string, OscillatorSeries[]>>(new Map());
+  const priceLineMapRef = useRef<Map<string, OscillatorPriceLine[]>>(new Map());
+
+  useEffect(() => {
+    const chart = chartRef.current;
+    if (!chart || !chartReady) return;
+
+    const seriesMap = seriesMapRef.current;
+    const priceLineMap = priceLineMapRef.current;
+
+    // No oscillators active — tear down the pane if it exists. The pane
+    // collapses; the main chart fills the reclaimed vertical space.
+    if (configs.length === 0) {
+      tearDownPane(chart);
+      return;
+    }
+
+    // Lazily allocate the oscillator pane on first use. v5 returns an
+    // IPaneApi from addPane(); we keep just the index so subsequent
+    // addSeries calls can target it via the third argument.
+    if (paneIndexRef.current === null) {
+      const newPane = chart.addPane();
+      newPane.setHeight(120);
+      paneIndexRef.current = newPane.paneIndex();
+    }
+    const paneIndex = paneIndexRef.current;
+
+    const activeIds = new Set(configs.map((c) => c.id));
+
+    // Remove series for configs no longer present. Price lines attached
+    // to a removed series go with it automatically — we just clear our
+    // tracking Map entry.
+    for (const [id, seriesList] of seriesMap) {
+      if (!activeIds.has(id)) {
+        for (const s of seriesList) {
+          try {
+            chart.removeSeries(s);
+          } catch {
+            /* chart was destroyed in a parallel cleanup */
+          }
+        }
+        seriesMap.delete(id);
+        priceLineMap.delete(id);
+      }
+    }
+
+    // Add or update each active config. Same remove-and-recreate strategy
+    // as the overlay hook: simpler than per-property diff, trivial cost
+    // at our data sizes.
+    for (const config of configs) {
+      const existing = seriesMap.get(config.id);
+      if (existing) {
+        for (const s of existing) {
+          try {
+            chart.removeSeries(s);
+          } catch {
+            /* destroyed in parallel */
+          }
+        }
+      }
+      const { series, priceLines } = renderOscillatorConfig(
+        chart,
+        candleData,
+        config,
+        theme,
+        paneIndex,
+      );
+      if (series.length > 0) {
+        seriesMap.set(config.id, series);
+        priceLineMap.set(config.id, priceLines);
+      } else {
+        seriesMap.delete(config.id);
+        priceLineMap.delete(config.id);
+      }
+    }
+
+    return () => {
+      const c = chartRef.current;
+      if (c) tearDownPane(c);
+    };
+  }, [chartRef, chartReady, candleData, configs, theme]);
+
+  function tearDownPane(chart: IChartApi) {
+    const seriesMap = seriesMapRef.current;
+    // Remove tracked series. removePane below would also drop them, but
+    // explicitly removing first means our refs and the chart's internal
+    // state stay in sync even if removePane fails for any reason.
+    for (const seriesList of seriesMap.values()) {
+      for (const s of seriesList) {
+        try {
+          chart.removeSeries(s);
+        } catch {
+          /* destroyed in parallel */
+        }
+      }
+    }
+    seriesMap.clear();
+    priceLineMapRef.current.clear();
+
+    if (paneIndexRef.current !== null) {
+      try {
+        chart.removePane(paneIndexRef.current);
+      } catch {
+        /* destroyed in parallel */
+      }
+      paneIndexRef.current = null;
+    }
+  }
+}
+
+/** Build the series + reference lines for a single oscillator config. */
+function renderOscillatorConfig(
+  chart: IChartApi,
+  candles: readonly Candle[],
+  config: IndicatorConfig,
+  theme: ChartTheme,
+  paneIndex: number,
+): { series: OscillatorSeries[]; priceLines: OscillatorPriceLine[] } {
+  switch (config.kind) {
+    case "rsi": {
+      const data = relativeStrengthIndex(candles, config.period);
+      const series = chart.addSeries(
+        LineSeries,
+        {
+          color: config.color,
+          lineWidth: 1,
+          priceLineVisible: false,
+          lastValueVisible: false,
+          // Per-instance scale so multiple oscillators in the same pane
+          // don't fight over a shared right-side scale.
+          priceScaleId: config.id,
+          // Pin the visible range to [0, 100] so the 30 / 70 reference
+          // lines below render at fixed positions regardless of where
+          // the RSI line is currently sitting. autoscaleInfoProvider is
+          // v5's explicit way to declare a logical range — `autoScale:
+          // false` alone would freeze the scale to whatever was first
+          // auto-fit, leaving the reference lines clipped if RSI hadn't
+          // touched 0 or 100 yet.
+          autoscaleInfoProvider: () => ({
+            priceRange: { minValue: 0, maxValue: 100 },
+          }),
+        },
+        paneIndex,
+      );
+      series.setData(
+        data.map((p) => ({ time: msToUtc(p.time), value: p.value })),
+      );
+      // Overbought (70) and oversold (30) reference lines — universal
+      // RSI convention. Dashed, in the theme's grid colour for subtlety.
+      const overbought = series.createPriceLine({
+        price: 70,
+        color: theme.gridColor,
+        lineStyle: LineStyle.Dashed,
+        lineWidth: 1,
+        axisLabelVisible: true,
+        title: "70",
+      });
+      const oversold = series.createPriceLine({
+        price: 30,
+        color: theme.gridColor,
+        lineStyle: LineStyle.Dashed,
+        lineWidth: 1,
+        axisLabelVisible: true,
+        title: "30",
+      });
+      return { series: [series], priceLines: [overbought, oversold] };
+    }
+    case "macd": {
+      const data = macd(
+        candles,
+        config.fastPeriod,
+        config.slowPeriod,
+        config.signalPeriod,
+      );
+      // Histogram first so the lines render on top of the bars.
+      const histogram = chart.addSeries(
+        HistogramSeries,
+        {
+          priceLineVisible: false,
+          lastValueVisible: false,
+          priceScaleId: config.id,
+        },
+        paneIndex,
+      );
+      histogram.setData(
+        data.map((p) => ({
+          time: msToUtc(p.time),
+          value: p.histogram,
+          // Per-bar colour by sign — TradingView convention. Positive
+          // bars in up-colour (bullish, MACD above signal); negative in
+          // down-colour (bearish, MACD below signal).
+          color: p.histogram >= 0 ? theme.upColor : theme.downColor,
+        })),
+      );
+      // MACD line in the indicator's chosen palette colour.
+      const macdLine = chart.addSeries(
+        LineSeries,
+        {
+          color: config.color,
+          lineWidth: 1,
+          priceLineVisible: false,
+          lastValueVisible: false,
+          priceScaleId: config.id,
+        },
+        paneIndex,
+      );
+      macdLine.setData(
+        data.map((p) => ({ time: msToUtc(p.time), value: p.macd })),
+      );
+      // Signal line in the theme text colour for contrast against the
+      // palette-coloured MACD line. Both share the same scale so a
+      // crossover at the same y-coordinate IS a true crossover.
+      const signalLine = chart.addSeries(
+        LineSeries,
+        {
+          color: theme.textColor,
+          lineWidth: 1,
+          priceLineVisible: false,
+          lastValueVisible: false,
+          priceScaleId: config.id,
+        },
+        paneIndex,
+      );
+      signalLine.setData(
+        data.map((p) => ({ time: msToUtc(p.time), value: p.signal })),
+      );
+      return { series: [histogram, macdLine, signalLine], priceLines: [] };
+    }
+    case "sma":
+    case "ema":
+    case "bollinger":
+      // Overlay-kind, handled by useIndicatorOverlays. Return empty so
+      // the caller treats this config as a no-op for the pane.
+      return { series: [], priceLines: [] };
+    default:
+      return assertNever(config);
+  }
+}
+
+/** Convert internal millisecond timestamps to lightweight-charts'
+ *  UTCTimestamp (Unix seconds) at the API boundary. The math layer keeps
+ *  everything in ms (matches Date.now() and Candle.timestamp); only this
+ *  conversion site knows about lightweight-charts' seconds convention. */
+function msToUtc(timeMs: number): UTCTimestamp {
+  return Math.floor(timeMs / 1000) as UTCTimestamp;
+}

--- a/app/components/trade/useIndicatorOscillatorPane.ts
+++ b/app/components/trade/useIndicatorOscillatorPane.ts
@@ -227,10 +227,14 @@ function renderOscillatorConfig(
         data.map((p) => ({ time: msToUtc(p.time), value: p.value })),
       );
       // Overbought (70) and oversold (30) reference lines — universal
-      // RSI convention. Dashed, in the theme's grid colour for subtlety.
+      // RSI convention. Dashed, derived from the theme's text colour at
+      // ~25% alpha so they read as secondary structure rather than noise.
+      // theme.gridColor (~4-5% alpha) was effectively invisible on real
+      // charts.
+      const referenceColor = withAlpha(theme.textColor, 0.25);
       const overbought = series.createPriceLine({
         price: 70,
-        color: theme.gridColor,
+        color: referenceColor,
         lineStyle: LineStyle.Dashed,
         lineWidth: 1,
         axisLabelVisible: true,
@@ -238,7 +242,7 @@ function renderOscillatorConfig(
       });
       const oversold = series.createPriceLine({
         price: 30,
-        color: theme.gridColor,
+        color: referenceColor,
         lineStyle: LineStyle.Dashed,
         lineWidth: 1,
         axisLabelVisible: true,
@@ -291,13 +295,15 @@ function renderOscillatorConfig(
       macdLine.setData(
         data.map((p) => ({ time: msToUtc(p.time), value: p.macd })),
       );
-      // Signal line in the theme text colour for contrast against the
-      // palette-coloured MACD line. Both share the same scale so a
-      // crossover at the same y-coordinate IS a true crossover.
+      // Signal line in the theme text colour, ramped to ~75% alpha so it
+      // reads as a peer line to the palette-coloured MACD line rather
+      // than as background noise (the default theme.textColor is ~45%
+      // alpha — too faint at 1px line width). Both share the same scale
+      // so a crossover at the same y-coordinate IS a true crossover.
       const signalLine = chart.addSeries(
         LineSeries,
         {
-          color: theme.textColor,
+          color: withAlpha(theme.textColor, 0.75),
           lineWidth: 1,
           priceLineVisible: false,
           lastValueVisible: false,
@@ -327,4 +333,18 @@ function renderOscillatorConfig(
  *  conversion site knows about lightweight-charts' seconds convention. */
 function msToUtc(timeMs: number): UTCTimestamp {
   return Math.floor(timeMs / 1000) as UTCTimestamp;
+}
+
+/** Override the alpha channel of an `rgba(...)` string. The chart theme
+ *  exposes `textColor` as `rgba(R,G,B,A)` for both dark and light themes;
+ *  this helper lets us derive higher-contrast variants for the RSI
+ *  reference lines (~25%) and MACD signal line (~75%) without hardcoding
+ *  light/dark colors at the use site. */
+function withAlpha(rgbaColor: string, alpha: number): string {
+  const match = rgbaColor.match(/^rgba?\(([^)]+)\)$/);
+  if (!match) return rgbaColor;
+  const parts = match[1].split(",").map((p) => p.trim());
+  if (parts.length < 3) return rgbaColor;
+  const [r, g, b] = parts;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }

--- a/app/components/trade/useIndicatorOscillatorPane.ts
+++ b/app/components/trade/useIndicatorOscillatorPane.ts
@@ -62,6 +62,18 @@ export function useIndicatorOscillatorPane(
   const seriesMapRef = useRef<Map<string, OscillatorSeries[]>>(new Map());
   const priceLineMapRef = useRef<Map<string, OscillatorPriceLine[]>>(new Map());
 
+  // When the chart is destroyed (unmount, Strict Mode double-mount, hot-
+  // reload), chartReady flips false. Our refs still point at the dead
+  // chart's pane index and series — clear them so the next mount allocates
+  // fresh state against the new chart instance.
+  useEffect(() => {
+    if (!chartReady) {
+      paneIndexRef.current = null;
+      seriesMapRef.current.clear();
+      priceLineMapRef.current.clear();
+    }
+  }, [chartReady]);
+
   useEffect(() => {
     const chart = chartRef.current;
     if (!chart || !chartReady) return;
@@ -135,10 +147,13 @@ export function useIndicatorOscillatorPane(
       }
     }
 
-    return () => {
-      const c = chartRef.current;
-      if (c) tearDownPane(c);
-    };
+    // No cleanup. Teardown is driven by:
+    //   - `configs.length === 0` branch above (user disabled all oscillators)
+    //   - the chartReady-reset effect above (chart instance destroyed)
+    //   - the chart-init effect's `chart.remove()` (full unmount cascade)
+    // A cleanup here would fire on every dep change (data tick, theme
+    // toggle), tearing down + reallocating the pane on every WS tick —
+    // exactly what the body's diff is trying to avoid.
   }, [chartRef, chartReady, candleData, configs, theme]);
 
   function tearDownPane(chart: IChartApi) {
@@ -203,6 +218,11 @@ function renderOscillatorConfig(
         },
         paneIndex,
       );
+      // Force the per-instance scale visible — overlay scales (created by
+      // assigning a non-default priceScaleId) hide their axis by default
+      // in v5, which would suppress both the 0-100 axis labels AND the
+      // 30 / 70 reference-line labels below.
+      chart.priceScale(config.id, paneIndex).applyOptions({ visible: true });
       series.setData(
         data.map((p) => ({ time: msToUtc(p.time), value: p.value })),
       );
@@ -243,6 +263,9 @@ function renderOscillatorConfig(
         },
         paneIndex,
       );
+      // Make the per-instance MACD scale visible (same reasoning as RSI
+      // above — overlay scales suppress axis labels by default in v5).
+      chart.priceScale(config.id, paneIndex).applyOptions({ visible: true });
       histogram.setData(
         data.map((p) => ({
           time: msToUtc(p.time),

--- a/app/components/trade/useIndicatorOverlays.ts
+++ b/app/components/trade/useIndicatorOverlays.ts
@@ -1,0 +1,203 @@
+"use client";
+
+import { useEffect, useRef, type RefObject } from "react";
+import {
+  LineSeries,
+  LineStyle,
+  type IChartApi,
+  type ISeriesApi,
+  type UTCTimestamp,
+} from "lightweight-charts";
+import type { IndicatorConfig } from "@/lib/indicator-registry";
+import type { Candle } from "@/lib/indicators/types";
+import { simpleMovingAverage } from "@/lib/indicators/sma";
+import { exponentialMovingAverage } from "@/lib/indicators/ema";
+import { bollingerBands } from "@/lib/indicators/bollinger";
+import { assertNever } from "@/lib/exhaustive";
+
+/** Series spawned by an overlay-kind indicator: one for SMA/EMA, three
+ *  for Bollinger (upper / middle / lower lines). All are line series. */
+type IndicatorSeries = ISeriesApi<"Line">;
+
+/**
+ * Wires overlay-kind indicator configs (SMA, EMA, Bollinger) to line series
+ * on the main chart. Pane-kind configs (RSI, MACD) are filtered out and
+ * handled separately by the oscillator-pane hook.
+ *
+ * Critical design point: this hook attaches series to the EXISTING chart
+ * instance. It must NOT trigger the chart-init effect to re-run when
+ * indicators change — that would destroy and recreate the entire chart on
+ * every period tweak the user makes in the settings menu. The chart-init
+ * effect's deps array stays clean of indicator state; this hook diffs the
+ * config list against an internal Map and adds/removes series in place.
+ *
+ * The chart instance is stable for the component's lifetime in this
+ * codebase (the chart-init effect uses []-deps and lives once per mount).
+ * `chartReady` flips true after createChart() and false on unmount; the
+ * hook re-runs on each flip, attaching/detaching series at the right time.
+ *
+ * Bollinger fill caveat: lightweight-charts cannot natively fill between
+ * two series. The semi-transparent band fill (TradingView's default look)
+ * would require a custom canvas primitive or a stacked area-series trick
+ * with masking. For v1, ship the three lines only — the indicator is still
+ * fully readable. The fill can ship as a polish commit later.
+ */
+export function useIndicatorOverlays(
+  chartRef: RefObject<IChartApi | null>,
+  chartReady: boolean,
+  candleData: readonly Candle[],
+  configs: readonly IndicatorConfig[],
+): void {
+  const seriesMapRef = useRef<Map<string, IndicatorSeries[]>>(new Map());
+
+  useEffect(() => {
+    const chart = chartRef.current;
+    if (!chart || !chartReady) return;
+
+    const seriesMap = seriesMapRef.current;
+    const activeIds = new Set(configs.map((c) => c.id));
+
+    // Remove series for configs no longer present.
+    for (const [id, seriesList] of seriesMap) {
+      if (!activeIds.has(id)) {
+        for (const s of seriesList) {
+          try {
+            chart.removeSeries(s);
+          } catch {
+            /* chart was already destroyed in a parallel cleanup */
+          }
+        }
+        seriesMap.delete(id);
+      }
+    }
+
+    // Add or update series for every active config. We always remove-and-
+    // recreate on update (period change, color change) — simpler than a
+    // per-property diff and the cost is trivial at our data sizes
+    // (200–500 candles, sub-millisecond render per series).
+    for (const config of configs) {
+      const existing = seriesMap.get(config.id);
+      if (existing) {
+        for (const s of existing) {
+          try {
+            chart.removeSeries(s);
+          } catch {
+            /* destroyed in parallel */
+          }
+        }
+      }
+      const seriesList = renderConfig(chart, candleData, config);
+      if (seriesList.length > 0) {
+        seriesMap.set(config.id, seriesList);
+      } else {
+        seriesMap.delete(config.id);
+      }
+    }
+
+    return () => {
+      // Remove every attached series before the chart is destroyed (or
+      // before this effect re-runs to attach to a new chart instance).
+      const c = chartRef.current;
+      const map = seriesMapRef.current;
+      for (const seriesList of map.values()) {
+        for (const s of seriesList) {
+          try {
+            if (c) c.removeSeries(s);
+          } catch {
+            /* chart already destroyed; refs are already dangling */
+          }
+        }
+      }
+      map.clear();
+    };
+  }, [chartRef, chartReady, candleData, configs]);
+}
+
+/** Build the series list for a single indicator config. Returns an empty
+ *  array for pane-kind indicators (RSI, MACD) — those render in a separate
+ *  pane via the sibling oscillator hook. The exhaustive switch + assertNever
+ *  catches any future kind that isn't classified as overlay-or-pane. */
+function renderConfig(
+  chart: IChartApi,
+  candles: readonly Candle[],
+  config: IndicatorConfig,
+): IndicatorSeries[] {
+  switch (config.kind) {
+    case "sma": {
+      const data = simpleMovingAverage(candles, config.period);
+      const series = chart.addSeries(LineSeries, {
+        color: config.color,
+        lineWidth: 1,
+        priceLineVisible: false,
+        lastValueVisible: false,
+      });
+      series.setData(
+        data.map((p) => ({ time: msToUtc(p.time), value: p.value })),
+      );
+      return [series];
+    }
+    case "ema": {
+      const data = exponentialMovingAverage(candles, config.period);
+      const series = chart.addSeries(LineSeries, {
+        color: config.color,
+        lineWidth: 1,
+        priceLineVisible: false,
+        lastValueVisible: false,
+      });
+      series.setData(
+        data.map((p) => ({ time: msToUtc(p.time), value: p.value })),
+      );
+      return [series];
+    }
+    case "bollinger": {
+      const data = bollingerBands(candles, config.period, config.stdDev);
+      // Three line series: middle (solid), upper (dashed), lower (dashed).
+      // Same color so they read as a group; dashed-vs-solid distinguishes
+      // the bands from the SMA midline at a glance.
+      const middle = chart.addSeries(LineSeries, {
+        color: config.color,
+        lineWidth: 1,
+        priceLineVisible: false,
+        lastValueVisible: false,
+      });
+      middle.setData(
+        data.map((p) => ({ time: msToUtc(p.time), value: p.middle })),
+      );
+      const upper = chart.addSeries(LineSeries, {
+        color: config.color,
+        lineWidth: 1,
+        lineStyle: LineStyle.Dashed,
+        priceLineVisible: false,
+        lastValueVisible: false,
+      });
+      upper.setData(
+        data.map((p) => ({ time: msToUtc(p.time), value: p.upper })),
+      );
+      const lower = chart.addSeries(LineSeries, {
+        color: config.color,
+        lineWidth: 1,
+        lineStyle: LineStyle.Dashed,
+        priceLineVisible: false,
+        lastValueVisible: false,
+      });
+      lower.setData(
+        data.map((p) => ({ time: msToUtc(p.time), value: p.lower })),
+      );
+      return [middle, upper, lower];
+    }
+    case "rsi":
+    case "macd":
+      // Oscillator-pane kinds — handled by useIndicatorOscillatorPane.
+      return [];
+    default:
+      return assertNever(config);
+  }
+}
+
+/** Convert internal millisecond timestamps to lightweight-charts' UTCTimestamp
+ *  (Unix seconds) at the API boundary. The math layer keeps everything in
+ *  ms (matches Date.now() and Candle.timestamp); only this conversion site
+ *  knows about the seconds convention lightweight-charts requires. */
+function msToUtc(timeMs: number): UTCTimestamp {
+  return Math.floor(timeMs / 1000) as UTCTimestamp;
+}

--- a/app/components/trade/useIndicatorOverlays.ts
+++ b/app/components/trade/useIndicatorOverlays.ts
@@ -50,6 +50,16 @@ export function useIndicatorOverlays(
 ): void {
   const seriesMapRef = useRef<Map<string, IndicatorSeries[]>>(new Map());
 
+  // When the chart is destroyed (unmount, Strict Mode double-mount, hot-
+  // reload), chartReady flips false. Our refs still point at series on
+  // the dead chart — clear them so the next mount diffs against an empty
+  // map and attaches fresh series to the new chart instance.
+  useEffect(() => {
+    if (!chartReady) {
+      seriesMapRef.current.clear();
+    }
+  }, [chartReady]);
+
   useEffect(() => {
     const chart = chartRef.current;
     if (!chart || !chartReady) return;
@@ -94,22 +104,13 @@ export function useIndicatorOverlays(
       }
     }
 
-    return () => {
-      // Remove every attached series before the chart is destroyed (or
-      // before this effect re-runs to attach to a new chart instance).
-      const c = chartRef.current;
-      const map = seriesMapRef.current;
-      for (const seriesList of map.values()) {
-        for (const s of seriesList) {
-          try {
-            if (c) c.removeSeries(s);
-          } catch {
-            /* chart already destroyed; refs are already dangling */
-          }
-        }
-      }
-      map.clear();
-    };
+    // No cleanup. Teardown is driven by:
+    //   - the activeIds diff above (user removed a specific indicator)
+    //   - the chartReady-reset effect above (chart instance destroyed)
+    //   - the chart-init effect's `chart.remove()` (full unmount cascade)
+    // A cleanup here would fire on every dep change (data tick, config
+    // edit), removing every series only to re-add them in the next run —
+    // exactly the WS-tick churn we want to avoid.
   }, [chartRef, chartReady, candleData, configs]);
 }
 

--- a/app/hooks/useChartIndicatorPrefs.ts
+++ b/app/hooks/useChartIndicatorPrefs.ts
@@ -36,6 +36,17 @@ export type IndicatorPatch = Partial<
 
 const STORAGE_KEY_PREFIX = "perc:chart:indicators:";
 
+/** Solana base58 pubkey: 32–44 chars from the base58 alphabet (no 0OIl).
+ *  Validating before forming the storage key prevents an empty / crafted
+ *  slab address from poisoning a shared bucket (e.g. `slabAddress = ""`
+ *  would otherwise write to `perc:chart:indicators:` — a single key
+ *  visible to every page that mounts the hook with a falsy slab). */
+const SOLANA_PUBKEY_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+
+function isValidSlabAddress(slabAddress: string): boolean {
+  return SOLANA_PUBKEY_RE.test(slabAddress);
+}
+
 function storageKey(slabAddress: string): string {
   return STORAGE_KEY_PREFIX + slabAddress;
 }
@@ -88,6 +99,14 @@ export function useChartIndicatorPrefs(slabAddress: string): UseChartIndicatorPr
   useEffect(() => {
     slabRef.current = slabAddress;
     if (typeof window === "undefined") return;
+    // Treat an invalid/empty slab as "no persistence" — start with an
+    // empty list and don't read from localStorage. Without this guard,
+    // hooks mounted before the route param resolves would read from the
+    // shared `perc:chart:indicators:` bucket.
+    if (!isValidSlabAddress(slabAddress)) {
+      setIndicators([]);
+      return;
+    }
     try {
       const raw = window.localStorage.getItem(storageKey(slabAddress));
       if (raw == null) {
@@ -104,9 +123,11 @@ export function useChartIndicatorPrefs(slabAddress: string): UseChartIndicatorPr
 
   /** Persist the current list to localStorage. Best-effort — quota errors,
    *  privacy mode, etc. are swallowed. Wraps the list in the versioned
-   *  envelope. */
+   *  envelope. Skips the write entirely for invalid slab addresses to
+   *  avoid poisoning a shared bucket. */
   const persist = useCallback((slab: string, list: IndicatorConfig[]) => {
     if (typeof window === "undefined") return;
+    if (!isValidSlabAddress(slab)) return;
     try {
       const envelope: IndicatorsStorage = {
         version: INDICATORS_STORAGE_VERSION,

--- a/app/hooks/useChartIndicatorPrefs.ts
+++ b/app/hooks/useChartIndicatorPrefs.ts
@@ -14,6 +14,26 @@ import { getNextColor } from "@/lib/indicator-palette";
 
 export type { IndicatorConfig, IndicatorKind } from "@/lib/indicator-registry";
 
+/** Distribute Omit over a discriminated union — built-in Omit collapses
+ *  to common keys via `keyof`, dropping per-variant fields like `period`
+ *  and `stdDev`. The conditional-type trick (`T extends unknown ? ... :
+ *  never`) forces distribution, preserving each variant's full key set
+ *  before the omit is applied. */
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
+  ? Omit<T, K>
+  : never;
+
+/** Patch shape accepted by `updateIndicator`. Excludes `id` (immutable
+ *  identity) and `kind` (the discriminator — changing it without supplying
+ *  the new variant's required fields would corrupt the config). Each
+ *  variant retains its per-kind fields (period for SMA/EMA/RSI;
+ *  period+stdDev for Bollinger; fast/slow/signal for MACD) so a Bollinger
+ *  row can patch `stdDev` and a MACD row can patch `signalPeriod` — but
+ *  no caller can switch a config's kind. */
+export type IndicatorPatch = Partial<
+  DistributiveOmit<IndicatorConfig, "id" | "kind">
+>;
+
 const STORAGE_KEY_PREFIX = "perc:chart:indicators:";
 
 function storageKey(slabAddress: string): string {
@@ -35,7 +55,7 @@ export interface UseChartIndicatorPrefsReturn {
   indicators: IndicatorConfig[];
   addIndicator: (kind: IndicatorKind) => void;
   removeIndicator: (id: string) => void;
-  updateIndicator: (id: string, patch: Partial<IndicatorConfig>) => void;
+  updateIndicator: (id: string, patch: IndicatorPatch) => void;
   clearAll: () => void;
 }
 
@@ -129,8 +149,13 @@ export function useChartIndicatorPrefs(slabAddress: string): UseChartIndicatorPr
   );
 
   const updateIndicator = useCallback(
-    (id: string, patch: Partial<IndicatorConfig>) => {
+    (id: string, patch: IndicatorPatch) => {
       setIndicators((current) => {
+        // Spread is sound now that IndicatorPatch excludes `kind`: i.kind
+        // wins, so the discriminator can't be flipped to a variant whose
+        // required fields are missing. Per-kind fields not native to this
+        // variant (e.g. stdDev landing on an SMA) are extra-property noise
+        // — read sites switch on kind and ignore them.
         const list = current.map((i) =>
           i.id === id ? ({ ...i, ...patch } as IndicatorConfig) : i,
         );

--- a/app/hooks/useChartIndicatorPrefs.ts
+++ b/app/hooks/useChartIndicatorPrefs.ts
@@ -1,0 +1,152 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  type IndicatorConfig,
+  type IndicatorKind,
+  type IndicatorsStorage,
+  INDICATORS_STORAGE_VERSION,
+  INDICATOR_DEFAULTS,
+  MAX_INDICATORS_PER_SLAB,
+  mergeIndicators,
+} from "@/lib/indicator-registry";
+import { getNextColor } from "@/lib/indicator-palette";
+
+export type { IndicatorConfig, IndicatorKind } from "@/lib/indicator-registry";
+
+const STORAGE_KEY_PREFIX = "perc:chart:indicators:";
+
+function storageKey(slabAddress: string): string {
+  return STORAGE_KEY_PREFIX + slabAddress;
+}
+
+function generateId(): string {
+  // crypto.randomUUID is supported in every modern browser. SSR-safe via
+  // the `typeof window` guard at the call site.
+  return crypto.randomUUID();
+}
+
+/** Return shape of `useChartIndicatorPrefs`. Object form (not tuple) so
+ *  consumers can destructure only what they need (commit 6's overlay
+ *  renderer only reads `indicators`; commit 8's settings menu uses all
+ *  five). Named fields also catch typos and reordering — five items is
+ *  too many to safely position-destructure. */
+export interface UseChartIndicatorPrefsReturn {
+  indicators: IndicatorConfig[];
+  addIndicator: (kind: IndicatorKind) => void;
+  removeIndicator: (id: string) => void;
+  updateIndicator: (id: string, patch: Partial<IndicatorConfig>) => void;
+  clearAll: () => void;
+}
+
+/** Persisted chart-indicator preferences, scoped per slab address. SSR-safe:
+ *  returns [] on the server and during the first client render, then
+ *  hydrates from localStorage in an effect. The setters write through to
+ *  localStorage synchronously inside the React state updater.
+ *
+ *  Usage:
+ *
+ *      const { indicators, addIndicator, removeIndicator, updateIndicator, clearAll }
+ *        = useChartIndicatorPrefs(slabAddress);
+ *
+ *      addIndicator("sma");                             // appends with defaults
+ *      removeIndicator(indicators[0].id);                // delete by id
+ *      updateIndicator(indicators[0].id, { period: 50 }); // patch one field
+ *      clearAll();                                      // remove every indicator
+ *
+ *  Slab address change: the hook re-hydrates from the new key, replacing
+ *  the in-memory list with whatever the new market had stored.
+ */
+export function useChartIndicatorPrefs(slabAddress: string): UseChartIndicatorPrefsReturn {
+  const [indicators, setIndicators] = useState<IndicatorConfig[]>([]);
+  // Track which slab address the in-memory state corresponds to. Used to
+  // skip the hydration write-through on the very first render after a
+  // slab change (we don't want to persist [] to the new key before
+  // hydration finishes).
+  const slabRef = useRef<string>(slabAddress);
+
+  useEffect(() => {
+    slabRef.current = slabAddress;
+    if (typeof window === "undefined") return;
+    try {
+      const raw = window.localStorage.getItem(storageKey(slabAddress));
+      if (raw == null) {
+        setIndicators([]);
+        return;
+      }
+      const parsed = JSON.parse(raw);
+      setIndicators(mergeIndicators(parsed));
+    } catch {
+      // localStorage unavailable, JSON parse failed, etc — start empty
+      setIndicators([]);
+    }
+  }, [slabAddress]);
+
+  /** Persist the current list to localStorage. Best-effort — quota errors,
+   *  privacy mode, etc. are swallowed. Wraps the list in the versioned
+   *  envelope. */
+  const persist = useCallback((slab: string, list: IndicatorConfig[]) => {
+    if (typeof window === "undefined") return;
+    try {
+      const envelope: IndicatorsStorage = {
+        version: INDICATORS_STORAGE_VERSION,
+        indicators: list,
+      };
+      window.localStorage.setItem(storageKey(slab), JSON.stringify(envelope));
+    } catch {
+      // best-effort; ignore quota / privacy errors
+    }
+  }, []);
+
+  const addIndicator = useCallback(
+    (kind: IndicatorKind) => {
+      setIndicators((current) => {
+        const usedColors = current.map((i) => i.color);
+        const color = getNextColor(usedColors);
+        const id = generateId();
+        const defaults = INDICATOR_DEFAULTS[kind];
+        const next: IndicatorConfig = { ...defaults, id, color } as IndicatorConfig;
+        // Cap at MAX_INDICATORS_PER_SLAB — drop oldest on insertion past cap.
+        const list = current.length >= MAX_INDICATORS_PER_SLAB
+          ? [...current.slice(1), next]
+          : [...current, next];
+        persist(slabRef.current, list);
+        return list;
+      });
+    },
+    [persist],
+  );
+
+  const removeIndicator = useCallback(
+    (id: string) => {
+      setIndicators((current) => {
+        const list = current.filter((i) => i.id !== id);
+        persist(slabRef.current, list);
+        return list;
+      });
+    },
+    [persist],
+  );
+
+  const updateIndicator = useCallback(
+    (id: string, patch: Partial<IndicatorConfig>) => {
+      setIndicators((current) => {
+        const list = current.map((i) =>
+          i.id === id ? ({ ...i, ...patch } as IndicatorConfig) : i,
+        );
+        persist(slabRef.current, list);
+        return list;
+      });
+    },
+    [persist],
+  );
+
+  const clearAll = useCallback(() => {
+    setIndicators(() => {
+      persist(slabRef.current, []);
+      return [];
+    });
+  }, [persist]);
+
+  return { indicators, addIndicator, removeIndicator, updateIndicator, clearAll };
+}

--- a/app/lib/indicator-palette.ts
+++ b/app/lib/indicator-palette.ts
@@ -1,0 +1,38 @@
+/**
+ * Brand-aware color palette for indicator line colors.
+ *
+ * Avoids the green/red used by candle bodies (chartTheme.upColor /
+ * downColor) so a moving-average line never visually merges with a
+ * candle's fill. Ordered to cycle through visually distinct hues so that
+ * adding multiple indicators in quick succession produces lines that are
+ * easy to tell apart at a glance.
+ *
+ * The palette is hex strings (no alpha) — alpha is applied per-renderer
+ * if needed (e.g., the Bollinger band fill uses ~10% alpha on the
+ * indicator's chosen color).
+ */
+
+/** Eight distinct, brand-aware indicator colors. Cycles when exhausted. */
+export const INDICATOR_COLORS = [
+  "#9945FF", // brand purple
+  "#22D3EE", // cyan
+  "#F59E0B", // amber
+  "#3B82F6", // blue
+  "#EC4899", // pink
+  "#A855F7", // violet
+  "#14B8A6", // teal
+  "#F97316", // orange
+] as const;
+
+/** Pick the next color for a new indicator. Prefers colors not already in
+ *  `usedColors`; if all 8 are taken, cycles from the start (returns the
+ *  first palette color). The user can have at most 20 indicators per slab
+ *  — the duplicate cycling at >8 is a deliberate trade-off (color picker
+ *  for fine-grained control is deferred to a follow-up commit). */
+export function getNextColor(usedColors: readonly string[]): string {
+  for (const color of INDICATOR_COLORS) {
+    if (!usedColors.includes(color)) return color;
+  }
+  // All palette colors used — cycle from the first.
+  return INDICATOR_COLORS[0];
+}

--- a/app/lib/indicator-registry.ts
+++ b/app/lib/indicator-registry.ts
@@ -1,0 +1,177 @@
+/**
+ * Single source of truth for the indicator system.
+ *
+ * Owns the `IndicatorKind` union, the `IndicatorConfig` discriminated union
+ * over per-kind parameter shapes, the default config per kind, the human-
+ * readable labels, and the overlay-vs-pane classification used by the
+ * renderer to decide where each indicator draws.
+ *
+ * Mirrors the architecture of chart-overlays.ts and chart-style.ts —
+ * append-once-update-everywhere via a single `as const` tuple. Adding a new
+ * indicator means appending to ALL_INDICATOR_KINDS, adding entries to the
+ * Record maps, picking overlay-or-pane, and adding a case to the math
+ * dispatch in the renderer hooks. TypeScript flags every missing entry at
+ * compile time.
+ */
+
+import { assertNever } from "./exhaustive";
+
+/** Single source of truth for every indicator the chart can render. */
+export const ALL_INDICATOR_KINDS = ["sma", "ema", "bollinger", "rsi", "macd"] as const;
+
+/** Discriminator for indicator dispatch. */
+export type IndicatorKind = (typeof ALL_INDICATOR_KINDS)[number];
+
+/** Display order in the f(x) settings menu. Reads top-to-bottom from the
+ *  indicators traders use most heavily down to less common ones — matches
+ *  the convention on TradingView and MEXC. Derived from ALL_INDICATOR_KINDS
+ *  so the menu cannot drift from the union. */
+export const INDICATOR_DISPLAY_ORDER: readonly IndicatorKind[] = ALL_INDICATOR_KINDS;
+
+/** Human-readable labels used by the settings UI. Adding a new
+ *  IndicatorKind forces this Record to grow — TypeScript flags any missing
+ *  entry. */
+export const INDICATOR_LABELS: Record<IndicatorKind, string> = {
+  sma: "Simple Moving Average",
+  ema: "Exponential Moving Average",
+  bollinger: "Bollinger Bands",
+  rsi: "Relative Strength Index",
+  macd: "MACD",
+};
+
+/** Per-instance indicator configuration. Each entry in the user's
+ *  indicator list is one of these — multiple SMAs at different periods,
+ *  one RSI, etc. The `id` distinguishes instances; the `kind` discriminates
+ *  the per-kind parameter shape. */
+export type IndicatorConfig =
+  | { id: string; kind: "sma"; period: number; color: string }
+  | { id: string; kind: "ema"; period: number; color: string }
+  | { id: string; kind: "bollinger"; period: number; stdDev: number; color: string }
+  | { id: string; kind: "rsi"; period: number; color: string }
+  | {
+      id: string;
+      kind: "macd";
+      fastPeriod: number;
+      slowPeriod: number;
+      signalPeriod: number;
+      color: string;
+    };
+
+/** Per-kind default parameter shape. The `Extract<…>` pattern narrows the
+ *  union to the variant matching `K`, then `Omit` strips the per-instance
+ *  fields (id, color) leaving just the kind discriminator + params. */
+type IndicatorDefaultsFor<K extends IndicatorKind> = Omit<
+  Extract<IndicatorConfig, { kind: K }>,
+  "id" | "color"
+>;
+
+/** Default parameter values per kind (NO id, NO color — those are filled in
+ *  at "add indicator" time). Defaults match TradingView's universal
+ *  conventions: SMA 20, EMA 21, Bollinger 20/2σ, RSI 14, MACD 12/26/9. */
+export const INDICATOR_DEFAULTS: { [K in IndicatorKind]: IndicatorDefaultsFor<K> } = {
+  sma: { kind: "sma", period: 20 },
+  ema: { kind: "ema", period: 21 },
+  bollinger: { kind: "bollinger", period: 20, stdDev: 2 },
+  rsi: { kind: "rsi", period: 14 },
+  macd: { kind: "macd", fastPeriod: 12, slowPeriod: 26, signalPeriod: 9 },
+};
+
+/** Kinds that render as line series ON the main price chart. */
+const OVERLAY_KINDS: ReadonlySet<IndicatorKind> = new Set(["sma", "ema", "bollinger"]);
+
+/** Kinds that render in a separate pane below the main chart (oscillators). */
+const PANE_KINDS: ReadonlySet<IndicatorKind> = new Set(["rsi", "macd"]);
+
+/** True when the indicator overlays on the main price scale (SMA, EMA,
+ *  Bollinger). These render as line series on the existing chart. */
+export function isOverlayKind(kind: IndicatorKind): boolean {
+  return OVERLAY_KINDS.has(kind);
+}
+
+/** True when the indicator renders in a separate pane below the main chart
+ *  (RSI, MACD — oscillators with their own value scale). */
+export function isPaneKind(kind: IndicatorKind): boolean {
+  return PANE_KINDS.has(kind);
+}
+
+const VALID_KINDS: ReadonlySet<string> = new Set(ALL_INDICATOR_KINDS);
+
+/** Type guard for unknown input (localStorage reads, URL params, etc). */
+export function isIndicatorKind(v: unknown): v is IndicatorKind {
+  return typeof v === "string" && VALID_KINDS.has(v);
+}
+
+/** Validates the shape of a stored indicator config. Returns true only when
+ *  every required field for the kind is present and correctly typed. Used
+ *  by mergeIndicators() to filter junk out of localStorage on load. */
+export function isIndicatorConfig(v: unknown): v is IndicatorConfig {
+  if (typeof v !== "object" || v === null || Array.isArray(v)) return false;
+  const obj = v as Record<string, unknown>;
+  if (typeof obj.id !== "string" || obj.id.length === 0) return false;
+  if (typeof obj.color !== "string" || obj.color.length === 0) return false;
+  if (!isIndicatorKind(obj.kind)) return false;
+  switch (obj.kind) {
+    case "sma":
+    case "ema":
+    case "rsi":
+      return typeof obj.period === "number" && Number.isFinite(obj.period) && obj.period >= 1;
+    case "bollinger":
+      return (
+        typeof obj.period === "number" &&
+        Number.isFinite(obj.period) &&
+        obj.period >= 1 &&
+        typeof obj.stdDev === "number" &&
+        Number.isFinite(obj.stdDev) &&
+        obj.stdDev >= 0
+      );
+    case "macd":
+      return (
+        typeof obj.fastPeriod === "number" &&
+        Number.isFinite(obj.fastPeriod) &&
+        obj.fastPeriod >= 1 &&
+        typeof obj.slowPeriod === "number" &&
+        Number.isFinite(obj.slowPeriod) &&
+        obj.slowPeriod >= 1 &&
+        typeof obj.signalPeriod === "number" &&
+        Number.isFinite(obj.signalPeriod) &&
+        obj.signalPeriod >= 1
+      );
+    default:
+      return assertNever(obj.kind);
+  }
+}
+
+/** Versioned storage envelope. Bumping the version triggers a graceful
+ *  fallback to defaults rather than crash-parsing a future format. */
+export interface IndicatorsStorage {
+  version: number;
+  indicators: IndicatorConfig[];
+}
+
+export const INDICATORS_STORAGE_VERSION = 1;
+
+/** Maximum indicators per slab. Past this cap the user has too much chart
+ *  clutter to read anyway, and the localStorage write grows unbounded.
+ *  When inserting past the cap, drop the OLDEST (front of the array). */
+export const MAX_INDICATORS_PER_SLAB = 20;
+
+/** Tolerant deserializer for the stored indicator list. Drops malformed
+ *  entries silently, falls back to [] for unparseable input, ignores
+ *  unknown future-format envelopes. Mirrors the merge-not-reject pattern
+ *  used by mergeOverlayPrefs. */
+export function mergeIndicators(stored: unknown): IndicatorConfig[] {
+  if (typeof stored !== "object" || stored === null || Array.isArray(stored)) return [];
+  const obj = stored as Record<string, unknown>;
+  if (typeof obj.version !== "number" || obj.version !== INDICATORS_STORAGE_VERSION) return [];
+  if (!Array.isArray(obj.indicators)) return [];
+  const result: IndicatorConfig[] = [];
+  const seenIds = new Set<string>();
+  for (const entry of obj.indicators) {
+    if (!isIndicatorConfig(entry)) continue;
+    if (seenIds.has(entry.id)) continue; // drop duplicates
+    seenIds.add(entry.id);
+    result.push(entry);
+    if (result.length >= MAX_INDICATORS_PER_SLAB) break;
+  }
+  return result;
+}

--- a/app/lib/indicators/bollinger.ts
+++ b/app/lib/indicators/bollinger.ts
@@ -1,0 +1,60 @@
+import type { Candle } from "./types";
+
+/** A single Bollinger Bands point: middle line (SMA) plus the upper and
+ *  lower bands at `stdDev` standard deviations from the middle. */
+export interface BollingerPoint {
+  time: number;
+  upper: number;
+  middle: number;
+  lower: number;
+}
+
+/**
+ * Bollinger Bands over a candle's close prices.
+ *
+ * For each window of `period` closes:
+ *  - middle = arithmetic mean (SMA)
+ *  - σ      = population standard deviation (NOT sample) — divide by `period`
+ *  - upper  = middle + stdDev × σ
+ *  - lower  = middle − stdDev × σ
+ *
+ * The output point at index `i` (for i ≥ period - 1) carries the
+ * candle's timestamp at the right edge of the window. Output length is
+ * exactly `candles.length - period + 1`.
+ *
+ * **Convention pinned**: population standard deviation is the TradingView
+ * convention. Many references and `numpy.std` (default) use sample σ
+ * (divide by `period - 1`), which produces values 5–10% wider on small
+ * windows. Future contributors who "fix" this to sample σ will silently
+ * diverge from every other charting tool — keep population.
+ *
+ * Returns `[]` when input is empty, when `period < 1`, or when there
+ * aren't enough candles to fill one window.
+ */
+export function bollingerBands(
+  candles: readonly Candle[],
+  period: number,
+  stdDev: number,
+): BollingerPoint[] {
+  if (period < 1 || candles.length < period) return [];
+  const result: BollingerPoint[] = [];
+  for (let i = period - 1; i < candles.length; i++) {
+    let sum = 0;
+    for (let j = 0; j < period; j++) sum += candles[i - j].close;
+    const mean = sum / period;
+    let variance = 0;
+    for (let j = 0; j < period; j++) {
+      const diff = candles[i - j].close - mean;
+      variance += diff * diff;
+    }
+    // Population σ: divide by `period`, not `period - 1` (TradingView convention).
+    const sigma = Math.sqrt(variance / period);
+    result.push({
+      time: candles[i].timestamp,
+      middle: mean,
+      upper: mean + stdDev * sigma,
+      lower: mean - stdDev * sigma,
+    });
+  }
+  return result;
+}

--- a/app/lib/indicators/ema.ts
+++ b/app/lib/indicators/ema.ts
@@ -1,0 +1,41 @@
+import type { Candle, IndicatorPoint } from "./types";
+
+/**
+ * Exponential Moving Average over a candle's close prices.
+ *
+ * Uses the standard multiplier `k = 2 / (period + 1)` and seeds the EMA
+ * with the SMA of the first `period` closes (TradingView convention,
+ * matches TA-Lib's `EMA` when called with a period >= 1). After the seed,
+ * each subsequent EMA value is `close * k + prevEma * (1 - k)`.
+ *
+ * The first output point is at index `period - 1` (the seed). Output
+ * length is `candles.length - period + 1`.
+ *
+ * Conventions worth pinning down because future contributors may "fix"
+ * one of them and silently break TradingView parity:
+ *  - Multiplier is `2 / (period + 1)` (not `1 / period` and not Wilder's).
+ *  - Seed is the SMA of the first `period` closes, NOT just the first close.
+ *  - Output `time` matches the candle's `timestamp` exactly so the line
+ *    aligns with the price axis on every renderer.
+ *
+ * Returns `[]` when the input is empty, when `period < 1`, or when there
+ * aren't enough candles to compute the seed.
+ */
+export function exponentialMovingAverage(
+  candles: readonly Candle[],
+  period: number,
+): IndicatorPoint[] {
+  if (period < 1 || candles.length < period) return [];
+  const result: IndicatorPoint[] = [];
+  const k = 2 / (period + 1);
+  // Seed with SMA of first `period` closes
+  let ema = 0;
+  for (let i = 0; i < period; i++) ema += candles[i].close;
+  ema /= period;
+  result.push({ time: candles[period - 1].timestamp, value: ema });
+  for (let i = period; i < candles.length; i++) {
+    ema = candles[i].close * k + ema * (1 - k);
+    result.push({ time: candles[i].timestamp, value: ema });
+  }
+  return result;
+}

--- a/app/lib/indicators/macd.ts
+++ b/app/lib/indicators/macd.ts
@@ -1,0 +1,100 @@
+import type { Candle, IndicatorPoint } from "./types";
+import { exponentialMovingAverage } from "./ema";
+
+/** A single MACD point: the MACD line value, the signal line value (EMA
+ *  of the MACD line), and the histogram (macd − signal). */
+export interface MacdPoint {
+  time: number;
+  macd: number;
+  signal: number;
+  histogram: number;
+}
+
+/**
+ * Moving Average Convergence Divergence.
+ *
+ *  - macdLine  = EMA(close, fastPeriod) − EMA(close, slowPeriod)
+ *  - signalLine = EMA(macdLine, signalPeriod)
+ *  - histogram = macdLine − signalLine
+ *
+ * TradingView defaults: fast 12, slow 26, signal 9.
+ *
+ * **The tricky part is alignment.** Each EMA produces an array of a
+ * different length:
+ *  - fastEma.length = N − fastPeriod + 1
+ *  - slowEma.length = N − slowPeriod + 1   (shorter; longer warm-up)
+ *
+ * To compute the MACD line we need them aligned at the SAME timestamps,
+ * so we trim the head of fastEma by `slowPeriod − fastPeriod` points.
+ * Then signal is an EMA of the (already-aligned) MACD line, which warms
+ * up for another `signalPeriod − 1` points. Final output length is
+ * exactly `N − slowPeriod − signalPeriod + 2`.
+ *
+ * **Sign convention pinned**: histogram = macd − signal, NOT signal − macd.
+ * Positive histogram means the MACD line is above the signal line —
+ * the bullish-crossover region. TradingView and TA-Lib both use this
+ * convention; flipping it would invert every histogram bar's color in
+ * the chart.
+ *
+ * **Synthetic-candle approach for the signal line**: the EMA function
+ * takes `Candle[]` (it reads `close` and `timestamp`), so we feed it
+ * pseudo-candles where every OHLC field equals the MACD line value.
+ * This is mathematically equivalent to running EMA on a single-value
+ * series and avoids duplicating the EMA recurrence in this file.
+ *
+ * Returns `[]` when:
+ *  - any period is < 1
+ *  - slowPeriod < fastPeriod (misconfigured — slow is supposed to be slower)
+ *  - input has fewer than `slowPeriod + signalPeriod − 1` candles
+ *    (not enough data to seed both the slow EMA and the signal EMA)
+ */
+export function macd(
+  candles: readonly Candle[],
+  fastPeriod: number,
+  slowPeriod: number,
+  signalPeriod: number,
+): MacdPoint[] {
+  if (fastPeriod < 1 || slowPeriod < 1 || signalPeriod < 1) return [];
+  if (slowPeriod < fastPeriod) return [];
+
+  const fastEma = exponentialMovingAverage(candles, fastPeriod);
+  const slowEma = exponentialMovingAverage(candles, slowPeriod);
+
+  if (slowEma.length === 0) return [];
+
+  // Trim fastEma head to align with slowEma. Both functions return values
+  // keyed to the right edge of their window; slowEma starts later (longer
+  // warm-up), so fastEma has a longer prefix that doesn't have a matching
+  // slow value yet.
+  const offset = fastEma.length - slowEma.length;
+  const macdLine: IndicatorPoint[] = slowEma.map((slowPoint, i) => ({
+    time: slowPoint.time,
+    value: fastEma[i + offset].value - slowPoint.value,
+  }));
+
+  if (macdLine.length < signalPeriod) return [];
+
+  // Signal line is EMA of the MACD line. Feed it as synthetic candles —
+  // EMA only reads `close` and `timestamp`, so OHLC fields all equal the
+  // MACD value. This avoids duplicating the EMA recurrence here.
+  const syntheticCandles: Candle[] = macdLine.map((p) => ({
+    timestamp: p.time,
+    open: p.value,
+    high: p.value,
+    low: p.value,
+    close: p.value,
+  }));
+  const signalLine = exponentialMovingAverage(syntheticCandles, signalPeriod);
+
+  // Trim macdLine head to align with signalLine for the final output.
+  const signalOffset = macdLine.length - signalLine.length;
+  return signalLine.map((sigPoint, i) => {
+    const macdValue = macdLine[i + signalOffset].value;
+    return {
+      time: sigPoint.time,
+      macd: macdValue,
+      signal: sigPoint.value,
+      histogram: macdValue - sigPoint.value,
+    };
+  });
+}

--- a/app/lib/indicators/rsi.ts
+++ b/app/lib/indicators/rsi.ts
@@ -1,0 +1,80 @@
+import type { Candle, IndicatorPoint } from "./types";
+
+/**
+ * Relative Strength Index using Wilder's smoothing.
+ *
+ * RSI = 100 − 100 / (1 + RS), where RS = avgGain / avgLoss.
+ *
+ * Three conventions are pinned here. ALL three must hold for the output to
+ * match TradingView's RSI(14) on the same dataset. Future contributors may
+ * "fix" any one of them and silently diverge — the JSDoc on each is the
+ * load-bearing documentation, NOT the test reference values.
+ *
+ *  1. **Wilder's smoothing**, NOT a simple-EMA-based RSI:
+ *       avgGain[t] = (avgGain[t−1] × (period − 1) + currentGain) / period
+ *     Mathematically equivalent to an EMA with k = 1/period. This is LOWER
+ *     than a standard EMA's k = 2/(period + 1), which is why Wilder-RSI is
+ *     smoother (slower to react) than the EMA-RSI variant some references
+ *     describe. Wilder's is the original 1978 definition and what every
+ *     major charting tool uses.
+ *
+ *  2. **SMA seeding for the first `period` price changes** (NOT Wilder's
+ *     from the start). The first avgGain and avgLoss are simple averages
+ *     over the first `period` changes; only AFTER that does Wilder's
+ *     smoothing kick in. TA-Lib does this; some textbook implementations
+ *     skip the seed and start Wilder's immediately, which produces values
+ *     that drift from TradingView for ~2× the period before converging.
+ *
+ *  3. **Divide-by-zero rule**: when `avgLoss === 0`, RSI = 100. This covers
+ *     both the all-gains case AND the perfectly-flat market case (where
+ *     avgGain = avgLoss = 0; the avgLoss === 0 guard fires first and
+ *     returns 100 by convention). Some implementations return 50 or
+ *     undefined for the flat case; TradingView returns 100.
+ *
+ * Output length is exactly `candles.length − period` — note this is one
+ * less than SMA/EMA/Bollinger because RSI consumes price *changes* (which
+ * need `period + 1` price points to produce `period` changes). The first
+ * output point is at index `period` of the input, not `period − 1`.
+ *
+ * Returns `[]` when input is empty, when `period < 1`, or when there
+ * aren't enough candles to compute the seed (need `period + 1` candles).
+ */
+export function relativeStrengthIndex(
+  candles: readonly Candle[],
+  period: number,
+): IndicatorPoint[] {
+  if (period < 1 || candles.length < period + 1) return [];
+  const result: IndicatorPoint[] = [];
+
+  // Seed: simple average of first `period` price changes
+  let avgGain = 0;
+  let avgLoss = 0;
+  for (let i = 1; i <= period; i++) {
+    const change = candles[i].close - candles[i - 1].close;
+    if (change > 0) avgGain += change;
+    else avgLoss += -change;
+  }
+  avgGain /= period;
+  avgLoss /= period;
+
+  // First RSI value is at input index `period` (after consuming `period` changes)
+  result.push({
+    time: candles[period].timestamp,
+    value: avgLoss === 0 ? 100 : 100 - 100 / (1 + avgGain / avgLoss),
+  });
+
+  // Subsequent: Wilder's smoothing
+  for (let i = period + 1; i < candles.length; i++) {
+    const change = candles[i].close - candles[i - 1].close;
+    const gain = change > 0 ? change : 0;
+    const loss = change < 0 ? -change : 0;
+    avgGain = (avgGain * (period - 1) + gain) / period;
+    avgLoss = (avgLoss * (period - 1) + loss) / period;
+    result.push({
+      time: candles[i].timestamp,
+      value: avgLoss === 0 ? 100 : 100 - 100 / (1 + avgGain / avgLoss),
+    });
+  }
+
+  return result;
+}

--- a/app/lib/indicators/sma.ts
+++ b/app/lib/indicators/sma.ts
@@ -1,0 +1,29 @@
+import type { Candle, IndicatorPoint } from "./types";
+
+/**
+ * Simple Moving Average over a candle's close prices.
+ *
+ * For each index `i` from `period - 1` to `candles.length - 1`, returns
+ * the arithmetic mean of the `period` most recent closes (inclusive of
+ * `candles[i]`). The first `period - 1` candles produce no output (the
+ * window isn't full yet) — output length is `candles.length - period + 1`.
+ *
+ * This matches TradingView's SMA convention and any standard reference
+ * (Investopedia, TA-Lib's `SMA`).
+ *
+ * Returns `[]` when the input is empty, when `period < 1`, or when there
+ * aren't enough candles to fill one window.
+ */
+export function simpleMovingAverage(
+  candles: readonly Candle[],
+  period: number,
+): IndicatorPoint[] {
+  if (period < 1 || candles.length < period) return [];
+  const result: IndicatorPoint[] = [];
+  for (let i = period - 1; i < candles.length; i++) {
+    let sum = 0;
+    for (let j = 0; j < period; j++) sum += candles[i - j].close;
+    result.push({ time: candles[i].timestamp, value: sum / period });
+  }
+  return result;
+}

--- a/app/lib/indicators/types.ts
+++ b/app/lib/indicators/types.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared types for the indicator math layer.
+ *
+ * All indicator functions are pure: they take `Candle[]` + parameters and
+ * return arrays of points keyed by timestamp. Rendering happens elsewhere
+ * (the renderer hooks in app/components/trade/) — this layer has no React
+ * or lightweight-charts dependency.
+ *
+ * `Candle` mirrors the inline shape used throughout TradingChart.tsx and
+ * the data-source hooks (usePythChart, useTokenChart, usePercolatorCandles).
+ * Defined here so a future contributor can grep `Candle` and find a single
+ * authoritative declaration. The math functions only read `close` and
+ * `timestamp` — the other OHLC fields are unused by these indicators but
+ * kept so the type is reusable across callers.
+ */
+
+export interface Candle {
+  timestamp: number; // milliseconds since epoch (matches Date.now() and existing chart code)
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume?: number;
+}
+
+/** A single-value indicator point (SMA, EMA, RSI). */
+export interface IndicatorPoint {
+  time: number; // milliseconds, matches Candle.timestamp
+  value: number;
+}


### PR DESCRIPTION
## Summary

Adds five technical indicators rendered natively on lightweight-charts v5: SMA, EMA, Bollinger Bands (overlay on price pane), and RSI + MACD (in a separate oscillator pane via `chart.addPane()`). User-facing entry point is a new `f(x)` toolbar dropdown next to the existing Style and Display menus — toggle indicators on/off, tune their periods, and clear all in one click. Per-slab persistence in localStorage with a versioned, validated envelope.

## Highlights

- **Math layer.** Custom implementations of SMA, EMA, Bollinger, RSI (Wilder's smoothing — `k = 1/period`, not the EMA `k`), and MACD. Each has hand-verified canonical reference vectors as test cases. Population σ for Bollinger; SMA seed for the EMA / RSI first window; MACD signal computed via fast/slow EMA alignment then EMA-of-MACD-line. Total 51 unit tests in the math layer alone.
- **Rendering hooks.** `useIndicatorOverlays` attaches SMA/EMA/Bollinger as line series on the price pane. `useIndicatorOscillatorPane` allocates a v5 native pane on first oscillator activation, tears it down when the last oscillator is removed. Per-instance `priceScaleId` so multiple oscillators don't fight over a shared right-side scale; explicit `priceScale().applyOptions({visible: true})` so RSI's 0-100 axis labels and the 30/70 reference markers actually render (overlay scales hide their axis by default in v5).
- **Persistence hook.** `useChartIndicatorPrefs(slabAddress)` returns `{indicators, addIndicator, removeIndicator, updateIndicator, clearAll}` and writes through to a per-slab localStorage key (`perc:chart:indicators:{base58Addr}`). Tolerant deserializer rejects malformed entries; 20-per-slab cap; `crypto.randomUUID()` for instance ids. Slab address is validated against the Solana base58 pubkey shape before forming the key — invalid slabs no-op the read and write rather than poisoning a shared bucket.
- **Settings menu.** `f(x)` dropdown with one row per kind, ARIA toggle pattern, per-kind parameter inputs that commit on blur or Enter (clamped to per-field bounds, with revert-on-garbage and no-change-on-empty handling). Mobile bottom-sheet variant lifted to `z-[60]` so it sits above the global `MobileBottomNav`, with `pb-[env(safe-area-inset-bottom)]` for iOS home-indicator clearance. The closed panel uses `inert` so Tab doesn't walk through invisible toggles.
- **Type safety.** Discriminated `IndicatorConfig` union with `assertNever` exhaustiveness in every `kind`-switch. The `updateIndicator` patch type uses a distributive `Omit` to preserve per-variant fields while excluding the `kind` discriminator — the spread merge is sound under that contract (no caller can flip an SMA into a MACD via `updateIndicator`).
- **Performance.** Indicator effects only fire when their inputs actually change. The first round of integration shipped a `candleData` memo, but a deeper audit caught that the upstream `percolatorCandles` and `oracleFiltered` were rebuilt by IIFEs on every render, defeating the memo cascade — both are now wrapped in `useMemo` themselves. Both indicator hooks dropped their unconditional cleanup-on-every-rerun in favor of a chartReady=false reset effect, so dep changes (data ticks, theme toggles) no longer tear down + reallocate the oscillator pane.

## Test plan

Unit + RTL coverage in this PR (127 tests total across the touched suites, all green):

- [x] `__tests__/lib/indicators/{sma,ema,bollinger,rsi,macd}.test.ts` — math correctness against canonical reference vectors, edge cases (period > data, all-equal closes, two-candle data, EMA seed, MACD alignment, Wilder's smoothing).
- [x] `__tests__/lib/indicator-registry.test.ts` — defaults table per-kind shape, `mergeIndicators` tolerant deserialization (malformed entries dropped, version mismatch wipes, 20-per-slab cap on read).
- [x] `__tests__/components/trade/ChartIndicatorMenu.test.tsx` — 26 tests covering ARIA contract, per-kind add path, Bollinger stdDev / MACD slow / signal commit keys, blur-commit, Enter-commit, lower-bound and upper-bound clamps, revert on garbage, no-change on empty, Clear all enabled/disabled state, Escape (with input-focus guard), outside-click close, swatch a11y, "Clear all keeps menu open."

Manual QA (recommended before merge):

- [ ] Open a market, click `f(x)`, toggle SMA → line appears; toggle Bollinger → three lines (middle solid, upper/lower dashed) in one palette colour.
- [ ] Toggle RSI → pane opens below price chart with axis labels at 0/30/70/100 and dashed reference lines.
- [ ] Toggle MACD → same pane (or new one if RSI off). Histogram bars green/red by sign; MACD line in palette colour; signal line in higher-contrast text colour.
- [ ] Type `9999` in SMA period, tab away → snaps to 500. Type `1`, tab → snaps to 2. Type `abc`, tab → reverts. Clear and tab → reverts.
- [ ] Hard-refresh on a market with active indicators → indicators restored. Switch to another market → independent state. Switch back → original restored.
- [ ] Disable RSI but keep MACD → only RSI series gone; pane stays. Disable both → pane collapses, price chart fills the space.
- [ ] Toggle theme (light ↔ dark) while RSI + MACD are active → reference lines, histogram bars, signal line all recolour correctly.
- [ ] Resize to narrow viewport (≤md) → menu opens as bottom sheet, "Clear all" reachable, doesn't hide behind `MobileBottomNav`.
- [ ] Live market with 250ms tick cadence — RSI line should extend smoothly per candle. The pane should NOT flicker every tick.
- [ ] Tab through toolbar → focus does NOT enter the closed dropdown's toggles or inputs.

## Known polish deferred

These were flagged in the audit pass but don't block merge — they are parity items with the existing peer dropdowns or improvements that benefit from a design pass:

- Focus return to the `f(x)` trigger on Escape / outside-click (sibling `ChartStyleMenu` / `ChartDisplayMenu` don't do this either).
- `aria-live` announcement when a value is clamped, an indicator is added/removed, or all are cleared.
- `<fieldset><legend>` grouping for MACD's three sibling inputs.
- Visible "Indicators" text on the trigger (currently `f(x)` glyph + `title` tooltip + `aria-label`).
- Bollinger band fill (semi-transparent area between upper/lower) — would require a custom canvas primitive in lightweight-charts v5.

## Files

- New: `app/lib/indicators/{types,sma,ema,bollinger,rsi,macd}.ts` + tests
- New: `app/lib/indicator-registry.ts`, `app/lib/indicator-palette.ts`
- New: `app/hooks/useChartIndicatorPrefs.ts`
- New: `app/components/trade/{useIndicatorOverlays,useIndicatorOscillatorPane}.ts`
- New: `app/components/trade/ChartIndicatorMenu.tsx` + tests
- Modified: `app/components/trade/TradingChart.tsx` (toolbar + indicator wiring + memo upstream sources)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added indicator management menu to trading charts supporting SMA, EMA, Bollinger Bands, RSI, and MACD indicators.
  * Indicators can be toggled on/off, configured with custom parameters, and color-coded for easy identification.

* **Tests**
  * Added comprehensive test coverage for indicator calculations and UI interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->