### PR TITLE
fix(chart): preserve oscillator pane when momentarily empty

### DIFF
--- a/app/components/trade/useIndicatorOscillatorPane.ts
+++ b/app/components/trade/useIndicatorOscillatorPane.ts
@@ -91,10 +91,23 @@ export function useIndicatorOscillatorPane(
     // Lazily allocate the oscillator pane on first use. v5 returns an
     // IPaneApi from addPane(); we keep just the index so subsequent
     // addSeries calls can target it via the third argument.
+    //
+    // `preserveEmptyPane: true` is critical: the diff loop below removes
+    // each existing series before re-adding it. Without preservation, v5
+    // auto-destroys the pane the instant its last series is removed —
+    // and the very next addSeries(..., paneIndex=1) call falls back to
+    // pane 0 because pane 1 no longer exists. The visual symptom is
+    // every oscillator series migrating into the price pane after the
+    // first re-render. With preservation the pane survives the brief
+    // empty window between remove and re-add.
     if (paneIndexRef.current === null) {
-      const newPane = chart.addPane();
+      const newPane = chart.addPane(true);
       newPane.setHeight(120);
       paneIndexRef.current = newPane.paneIndex();
+    } else {
+      // Defensive: re-assert preservation in case anything else cleared it.
+      const existingPane = chart.panes()[paneIndexRef.current];
+      if (existingPane) existingPane.setPreserveEmptyPane(true);
     }
     const paneIndex = paneIndexRef.current;
 


### PR DESCRIPTION
## Summary

The RSI and MACD panes were visually merging back into the main price pane after a few seconds of being toggled on. Root cause: lightweight-charts v5's `chart.addPane()` defaults `preserveEmptyPane` to `false`, so the moment our diff loop removed a series from the oscillator pane (briefly leaving it empty), v5 destroyed the pane. The next `addSeries(..., paneIndex=1)` then targeted a non-existent pane and silently fell back to pane 0, dropping every RSI / MACD series into the price pane alongside the candles.

The fix is one argument: pass `true` to `addPane()` so the pane survives the brief empty window between remove and re-add. Added a defensive `setPreserveEmptyPane(true)` on the existing-pane branch in case anything else clears the flag.

## What was visible to users

- Toggle RSI → looks correct (separate pane below price chart with 30/70 reference lines).
- A few seconds later → RSI line migrates into the price pane, both scales render side-by-side on the right axis.
- Toggle MACD (any time after the first oscillator was added) → histogram + lines all render in the price pane on top of the candles.

## Why it took until now to surface

The local-dev test setup didn't trigger pane re-renders frequently enough — the bug only manifests when an effect dep actually changes (theme toggle, real new candles, etc.) and the diff loop runs again. PR #2135's automated test suite couldn't catch it because lightweight-charts pane behaviour can't be unit-tested without a real DOM and chart instance.

## Test plan

- [x] Unit tests still green (77 tests across the indicator math + menu suites).
- [ ] Toggle RSI on → wait 30 s with live data flowing → confirm RSI stays in its own pane below the price chart.
- [ ] Toggle MACD on (with or without RSI active) → confirm it lands in the same dedicated oscillator pane, not the price pane.
- [ ] Toggle both RSI and MACD → both render in the single oscillator pane sharing the same time scale.
- [ ] Toggle them off → pane collapses; price chart fills the reclaimed vertical space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where oscillator indicator panes could incorrectly collapse or reset during chart updates, ensuring proper pane persistence and layout stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->