### PR TITLE
[codex] fix live price decimal display

### DIFF
--- a/app/__tests__/lib/format.test.ts
+++ b/app/__tests__/lib/format.test.ts
@@ -6,6 +6,8 @@ import {
   formatBps,
   LIQ_PRICE_UNLIQUIDATABLE,
   formatUsd,
+  formatUsdPriceE6,
+  formatUsdFromNumber,
   formatLiqPrice,
   shortenAddress,
   formatSlotAge,
@@ -145,6 +147,37 @@ describe("formatUsd", () => {
     const result = formatUsd(1_000_000_000_000_000n);
     expect(result).not.toBe("$—");
     expect(result).toContain("1,000,000,000");
+  });
+});
+
+describe("formatUsdFromNumber", () => {
+  it("preserves E6 precision for USD floats", () => {
+    expect(formatUsdFromNumber(84.428453)).toBe("$84.428453");
+  });
+
+  it("keeps all six E6 decimal places", () => {
+    expect(formatUsdFromNumber(84.4)).toBe("$84.400000");
+    expect(formatUsdFromNumber(0.03)).toBe("$0.030000");
+    expect(formatUsdFromNumber(1)).toBe("$1.000000");
+  });
+
+  it("returns fallback for missing or invalid prices", () => {
+    expect(formatUsdFromNumber(null)).toBe("—");
+    expect(formatUsdFromNumber(Number.NaN, "N/A")).toBe("N/A");
+    expect(formatUsdFromNumber(0)).toBe("—");
+  });
+});
+
+describe("formatUsdPriceE6", () => {
+  it("renders fixed E6 precision for price values", () => {
+    expect(formatUsdPriceE6(84_400_000n)).toBe("$84.400000");
+    expect(formatUsdPriceE6(30_000n)).toBe("$0.030000");
+    expect(formatUsdPriceE6(1_000_000n)).toBe("$1.000000");
+  });
+
+  it("returns fallback for unavailable E6 price values", () => {
+    expect(formatUsdPriceE6(0n)).toBe("—");
+    expect(formatUsdPriceE6(-1n, "N/A")).toBe("N/A");
   });
 });
 

--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -7,7 +7,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useMarketDiscovery } from "@/hooks/useMarketDiscovery";
 import { computeMarketHealth, computeMarketHealthFromStats, sanitizeOnChainValue, isSentinelValue } from "@/lib/health";
 import { HealthBadge } from "@/components/market/HealthBadge";
-import { formatTokenAmount } from "@/lib/format";
+import { formatTokenAmount, formatUsdFromNumber } from "@/lib/format";
 import { isSaneMarketValue, isZombieMarket } from "@/lib/activeMarketFilter";
 import { BLOCKED_SLAB_ADDRESSES } from "@/lib/blocklist";
 import type { Database } from "@/lib/database.types";
@@ -1009,9 +1009,7 @@ function MarketsPageInner() {
                       </div>
                       <div className="text-right truncate">
                         <span className="text-sm text-[var(--text)] tabular-nums" style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>
-                          {lastPrice != null
-                            ? `$${lastPrice < 0.01 ? lastPrice.toFixed(6) : lastPrice < 1 ? lastPrice.toFixed(4) : lastPrice.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
-                            : "\u2014"}
+                          {formatUsdFromNumber(lastPrice)}
                         </span>
                       </div>
                       <div className="hidden sm:block text-right text-sm text-[var(--text-secondary)] truncate tabular-nums" style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>{oiDisplay}</div>

--- a/app/app/my-markets/page.tsx
+++ b/app/app/my-markets/page.tsx
@@ -10,6 +10,7 @@ import { useAdminActions } from "@/hooks/useAdminActions";
 import { useToast } from "@/hooks/useToast";
 import { getConfig, explorerAccountUrl } from "@/lib/config";
 import { sanitizeAccountCount } from "@/lib/health";
+import { formatUsdPriceE6 } from "@/lib/format";
 import { deriveInsuranceLpMint } from "@percolatorct/sdk";
 import { isMockMode } from "@/lib/mock-mode";
 import { getMockMyMarkets } from "@/lib/mock-trade-data";
@@ -18,11 +19,6 @@ import { getMockMyMarkets } from "@/lib/mock-trade-data";
 function fmt(v: bigint, decimals = 6): string {
   const n = Number(v) / 10 ** decimals;
   return n.toLocaleString(undefined, { maximumFractionDigits: 2 });
-}
-
-function fmtPrice(v: bigint): string {
-  const n = Number(v) / 1e6;
-  return "$" + n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 6 });
 }
 
 function shortAddr(addr: string): string {
@@ -198,7 +194,7 @@ const MarketCard: FC<{
         {/* Stats Grid */}
         <div className="grid grid-cols-2 sm:grid-cols-4">
           {[
-            { label: "oracle price", value: oraclePrice > 0n ? fmtPrice(oraclePrice) : "—" },
+            { label: "oracle price", value: oraclePrice > 0n ? formatUsdPriceE6(oraclePrice) : "—" },
             { label: "open interest", value: fmt(oi) },
             { label: "vault balance", value: fmt(vault) },
             { label: "insurance", value: fmt(insurance) },

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -15,6 +15,7 @@ import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
 import { OnboardingIcon } from "@/components/icons/OnboardingIcons";
 import { HeroSection } from "@/components/marketing/HeroSection";
 import { ShimmerSkeleton } from "@/components/ui/ShimmerSkeleton";
+import { formatUsdFromNumber } from "@/lib/format";
 
 /**
  * GH#1666: Validate a symbol is a real ticker (1-10 uppercase alpha chars).
@@ -512,9 +513,7 @@ export default function Home() {
                       {isValidSymbol(m.symbol) ? `${m.symbol}/USD` : `${m.slab_address.slice(0, 6)}...`}
                     </div>
                     <div className="text-right text-[12px] text-[var(--text-secondary)]">
-                      {m.last_price != null
-                        ? `$${m.last_price < 0.01 ? m.last_price.toFixed(6) : m.last_price < 1 ? m.last_price.toFixed(4) : m.last_price.toFixed(2)}`
-                        : "\u2014"}
+                      {formatUsdFromNumber(m.last_price)}
                     </div>
                     <div className="text-right text-[12px] text-[var(--text-secondary)]">
                       {m.volume_24h > 0 ? formatCompact(m.volume_24h) : "—"}

--- a/app/app/trade/[slab]/page.tsx
+++ b/app/app/trade/[slab]/page.tsx
@@ -33,6 +33,7 @@ import { MarketLogo } from "@/components/market/MarketLogo";
 import { MarketSelector } from "@/components/trade/MarketSelector";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
 import { computeMarketHealth } from "@/lib/health";
+import { formatUsdFromNumber } from "@/lib/format";
 import { useLivePrice } from "@/hooks/useLivePrice";
 import { useTokenMeta } from "@/hooks/useTokenMeta";
 import { useToast } from "@/hooks/useToast";
@@ -223,7 +224,7 @@ function TradePageInner({ slab }: { slab: string }) {
     // Update meta description
     const metaDesc = document.querySelector('meta[name="description"]');
     if (metaDesc) {
-      const priceText = priceUsd != null ? `Current price: $${priceUsd.toFixed(2)}` : "";
+      const priceText = priceUsd != null ? `Current price: ${formatUsdFromNumber(priceUsd)}` : "";
       metaDesc.setAttribute("content", `Trade ${symbol} perpetual futures on Percolator. ${priceText}`);
     }
 
@@ -233,15 +234,11 @@ function TradePageInner({ slab }: { slab: string }) {
     
     const ogDesc = document.querySelector('meta[property="og:description"]');
     if (ogDesc) {
-      const priceText = priceUsd != null ? `Current price: $${priceUsd.toFixed(2)}` : "";
+      const priceText = priceUsd != null ? `Current price: ${formatUsdFromNumber(priceUsd)}` : "";
       ogDesc.setAttribute("content", `Trade ${symbol} perpetual futures on Percolator. ${priceText}`);
     }
     
   }, [symbol, priceUsd]);
-
-  const priceDisplay = priceUsd != null
-    ? `$${priceUsd < 0.01 ? priceUsd.toFixed(6) : priceUsd < 1 ? priceUsd.toFixed(4) : priceUsd.toFixed(2)}`
-    : null;
 
   // Track whether the fade-in animation has already been applied
   const animatedRef = useRef(false);

--- a/app/components/market/ShareCard.tsx
+++ b/app/components/market/ShareCard.tsx
@@ -3,6 +3,7 @@
 import { FC, useState, useRef, useEffect } from "react";
 import gsap from "gsap";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+import { formatUsd } from "@/lib/format";
 
 interface ShareCardProps {
   slabAddress: string;
@@ -30,8 +31,7 @@ function buildXShareText(marketName: string, fmtPrice: string, changeStr: string
 export const ShareCard: FC<ShareCardProps> = ({ slabAddress, marketName, price, change24h }) => {
   const [copied, setCopied] = useState(false);
 
-  const priceNum = Number(price) / 1e6;
-  const fmtPrice = priceNum < 0.01 ? priceNum.toFixed(6) : priceNum < 1 ? priceNum.toFixed(4) : priceNum.toFixed(2);
+  const fmtPrice = formatUsd(price).slice(1);
   const changeStr = change24h != null ? `${change24h >= 0 ? "+" : ""}${change24h.toFixed(2)}%` : "";
   const tradeUrl = buildTradeUrl(slabAddress);
 

--- a/app/components/oracle/OracleDetailsPanel.tsx
+++ b/app/components/oracle/OracleDetailsPanel.tsx
@@ -5,6 +5,7 @@ import { useOracleFreshness } from "@/hooks/useOracleFreshness";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { useLivePrice } from "@/hooks/useLivePrice";
 import { detectOracleMode } from "@/lib/oraclePrice";
+import { formatUsdFromNumber } from "@/lib/format";
 import { OracleBadge } from "./OracleBadge";
 import { useOraclePublishers, type PublisherInfo } from "@/hooks/useOraclePublishers";
 
@@ -64,9 +65,7 @@ export const OracleDetailsPanel: FC<OracleDetailsPanelProps> = ({ onClose }) => 
     [handleClose]
   );
 
-  const priceText = priceUsd != null
-    ? `$${priceUsd < 0.01 ? priceUsd.toFixed(6) : priceUsd < 1 ? priceUsd.toFixed(4) : priceUsd.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
-    : "—";
+  const priceText = formatUsdFromNumber(priceUsd);
 
   const elapsedText =
     elapsedSecs < 60

--- a/app/components/trade/AccountsCard.tsx
+++ b/app/components/trade/AccountsCard.tsx
@@ -5,7 +5,7 @@ import { useSlabState } from "@/components/providers/SlabProvider";
 import { useEngineState } from "@/hooks/useEngineState";
 import { useTokenMeta } from "@/hooks/useTokenMeta";
 import { useLivePrice } from "@/hooks/useLivePrice";
-import { formatTokenAmount, formatUsd, formatPnl, formatLiqPrice, shortenAddress } from "@/lib/format";
+import { formatTokenAmount, formatUsdPriceE6, formatPnl, formatLiqPrice, shortenAddress } from "@/lib/format";
 import { AccountKind, computeMarkPnl, computeLiqPrice } from "@percolatorct/sdk";
 import { LIQ_PRICE_UNLIQUIDATABLE } from "@/lib/format";
 import { applyInvert, sanitizePriceE6 } from "@/lib/oraclePrice";
@@ -188,7 +188,7 @@ export const AccountsCard: FC = () => {
                         {row.positionSize !== 0n ? formatTokenAmount(absPos, decimals) : "-"}
                       </td>
                     )}
-                    {isOpenLike && <td className="whitespace-nowrap px-2 py-1.5 text-right text-[var(--text)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>{row.entryPrice > 0n ? formatUsd(row.entryPrice) : "-"}</td>}
+                    {isOpenLike && <td className="whitespace-nowrap px-2 py-1.5 text-right text-[var(--text)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>{row.entryPrice > 0n ? formatUsdPriceE6(row.entryPrice) : "-"}</td>}
                     {isOpenLike && (
                       <td className="whitespace-nowrap px-2 py-1.5 text-right">
                         {row.positionSize !== 0n ? (

--- a/app/components/trade/ChartEmptyState.tsx
+++ b/app/components/trade/ChartEmptyState.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { FC } from "react";
+import { formatUsdFromNumber } from "@/lib/format";
 
 interface ChartEmptyStateProps {
   /** Optional current price to display alongside the empty state */
@@ -41,7 +42,7 @@ export const ChartEmptyState: FC<ChartEmptyStateProps> = ({
               className="text-2xl font-bold text-[var(--text)] drop-shadow-sm"
               style={{ fontFamily: "var(--font-mono)" }}
             >
-              ${currentPrice < 0.01 ? currentPrice.toFixed(6) : currentPrice.toFixed(2)}
+              {formatUsdFromNumber(currentPrice)}
             </div>
             <div className="mt-1 text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">
               Price chart building…

--- a/app/components/trade/ClosePositionModal.tsx
+++ b/app/components/trade/ClosePositionModal.tsx
@@ -4,7 +4,7 @@ import { FC, useEffect, useRef, useState, useMemo } from "react";
 import { createPortal } from "react-dom";
 import gsap from "gsap";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
-import { formatTokenAmount, formatUsd } from "@/lib/format";
+import { formatTokenAmount, formatUsdPriceE6 } from "@/lib/format";
 import { computeMarkPnl } from "@/lib/trading";
 
 interface ClosePositionModalProps {
@@ -170,7 +170,7 @@ export const ClosePositionModal: FC<ClosePositionModalProps> = ({
           </p>
           <p className="mt-1 text-[10px] text-[var(--text-secondary)]">
             <span style={{ fontFamily: "var(--font-mono)" }}>{formatTokenAmount(absPosition, decimals)}</span> {symbol} at{" "}
-            <span style={{ fontFamily: "var(--font-mono)" }}>{formatUsd(entryPrice)}</span> entry
+            <span style={{ fontFamily: "var(--font-mono)" }}>{formatUsdPriceE6(entryPrice)}</span> entry
           </p>
         </div>
 

--- a/app/components/trade/MarketBookCard.tsx
+++ b/app/components/trade/MarketBookCard.tsx
@@ -7,7 +7,7 @@ import { useSlabState } from "@/components/providers/SlabProvider";
 import { useTokenMeta } from "@/hooks/useTokenMeta";
 import { useLivePrice } from "@/hooks/useLivePrice";
 import { useOrderBookVisibility } from "@/hooks/useOrderBookVisibility";
-import { formatUsd, formatTokenAmount, shortenAddress } from "@/lib/format";
+import { formatUsdPriceE6, formatTokenAmount, shortenAddress } from "@/lib/format";
 import { resolveMarketPriceE6 } from "@/lib/oraclePrice";
 import { AccountKind } from "@percolatorct/sdk";
 
@@ -94,7 +94,7 @@ export const MarketBookCard: FC = () => {
         {/* Bid */}
         <div className="bg-[var(--bg)] p-2 text-center">
           <p className="text-[8px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Bid</p>
-          <p className="text-[11px] font-medium text-[var(--long)]" style={{ fontFamily: "var(--font-mono)" }}>{formatUsd(bestBidE6)}</p>
+          <p className="text-[11px] font-medium text-[var(--long)]" style={{ fontFamily: "var(--font-mono)" }}>{formatUsdPriceE6(bestBidE6)}</p>
         </div>
         {/* Oracle — subtle accent border + bg */}
         <div className="p-2 text-center border-x border-[var(--accent)]/20 bg-[var(--accent)]/[0.03]">
@@ -103,13 +103,13 @@ export const MarketBookCard: FC = () => {
             className="text-[13px] font-medium text-[var(--text)]"
             style={{ fontFamily: "var(--font-mono)" }}
           >
-            {formatUsd(oraclePrice)}
+            {formatUsdPriceE6(oraclePrice)}
           </p>
         </div>
         {/* Ask */}
         <div className="bg-[var(--bg)] p-2 text-center">
           <p className="text-[8px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Ask</p>
-          <p className="text-[11px] font-medium text-[var(--short)]" style={{ fontFamily: "var(--font-mono)" }}>{formatUsd(bestAskE6)}</p>
+          <p className="text-[11px] font-medium text-[var(--short)]" style={{ fontFamily: "var(--font-mono)" }}>{formatUsdPriceE6(bestAskE6)}</p>
         </div>
       </div>
 

--- a/app/components/trade/MarketInfoBar.tsx
+++ b/app/components/trade/MarketInfoBar.tsx
@@ -6,6 +6,7 @@ import { useMarketInfo } from "@/hooks/useMarketInfo";
 import { useEngineState } from "@/hooks/useEngineState";
 import { useOracleFreshness } from "@/hooks/useOracleFreshness";
 import { MarketLogo } from "@/components/market/MarketLogo";
+import { formatUsdFromNumber } from "@/lib/format";
 
 interface MarketInfoBarProps {
   slabAddress: string;
@@ -68,9 +69,7 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol, log
   const { fundingRate, engine } = useEngineState();
   const { level: oracleLevel } = useOracleFreshness();
 
-  const priceDisplay = priceUsd != null
-    ? `$${priceUsd < 0.01 ? priceUsd.toFixed(6) : priceUsd < 1 ? priceUsd.toFixed(4) : priceUsd.toFixed(2)}`
-    : "—";
+  const priceDisplay = formatUsdFromNumber(priceUsd);
 
   const change24hDisplay = change24h ?? 0;
   const isUp = change24hDisplay >= 0;
@@ -158,9 +157,7 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol, log
         <div className="flex flex-col shrink-0">
           <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">24h High</span>
           <span className="text-xs font-medium text-[var(--long)]" style={{ fontFamily: "var(--font-mono)" }}>
-            {high24h != null
-              ? `$${high24h < 0.01 ? high24h.toFixed(6) : high24h < 1 ? high24h.toFixed(4) : high24h.toFixed(2)}`
-              : "—"}
+            {formatUsdFromNumber(high24h)}
           </span>
         </div>
 
@@ -168,9 +165,7 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol, log
         <div className="flex flex-col shrink-0">
           <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">24h Low</span>
           <span className="text-xs font-medium text-[var(--short)]" style={{ fontFamily: "var(--font-mono)" }}>
-            {low24h != null
-              ? `$${low24h < 0.01 ? low24h.toFixed(6) : low24h < 1 ? low24h.toFixed(4) : low24h.toFixed(2)}`
-              : "—"}
+            {formatUsdFromNumber(low24h)}
           </span>
         </div>
 

--- a/app/components/trade/MarketSelector.tsx
+++ b/app/components/trade/MarketSelector.tsx
@@ -5,19 +5,12 @@ import { useRouter } from "next/navigation";
 import { useAllMarketStats } from "@/hooks/useAllMarketStats";
 import { useLivePrice } from "@/hooks/useLivePrice";
 import { MarketLogo } from "@/components/market/MarketLogo";
+import { formatUsdPriceE6, formatUsdFromNumber } from "@/lib/format";
 
 interface MarketSelectorProps {
   currentSlabAddress: string;
   symbol: string;
   logoUrl: string | null;
-}
-
-function formatPrice(priceE6: number | null): string {
-  if (priceE6 == null) return "—";
-  const p = priceE6 / 1e6;
-  if (p < 0.01) return `$${p.toFixed(6)}`;
-  if (p < 1) return `$${p.toFixed(4)}`;
-  return `$${p.toFixed(2)}`;
 }
 
 function formatVolume(vol: number | null): string {
@@ -114,9 +107,9 @@ export const MarketSelector: FC<MarketSelectorProps> = ({
 
   // Format live price for trigger display
   const livePriceDisplay = livePriceE6 != null && livePriceE6 > 0n
-    ? formatPrice(Number(livePriceE6))
+    ? formatUsdPriceE6(livePriceE6)
     : currentMarket?.last_price != null
-      ? formatPrice(currentMarket.last_price)
+      ? formatUsdFromNumber(currentMarket.last_price)
       : null;
 
   return (
@@ -221,7 +214,7 @@ export const MarketSelector: FC<MarketSelectorProps> = ({
                   className="w-24 text-right text-[10px] text-[var(--text-secondary)]"
                   style={{ fontFamily: "var(--font-mono)" }}
                 >
-                  {livePriceDisplay ?? formatPrice(currentMarket.last_price)}
+                  {livePriceDisplay ?? formatUsdFromNumber(currentMarket.last_price)}
                 </span>
                 <span
                   className={`w-16 text-right text-[10px] ${changeColor(change24hPct)}`}
@@ -326,7 +319,7 @@ export const MarketSelector: FC<MarketSelectorProps> = ({
                         className="w-24 text-right text-[10px] text-[var(--text-secondary)]"
                         style={{ fontFamily: "var(--font-mono)" }}
                       >
-                        {formatPrice(m.last_price)}
+                        {formatUsdFromNumber(m.last_price)}
                       </span>
                     )}
 

--- a/app/components/trade/MarketStatsCard.tsx
+++ b/app/components/trade/MarketStatsCard.tsx
@@ -6,7 +6,7 @@ import { useMarketConfig } from "@/hooks/useMarketConfig";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { useUsdToggle } from "@/components/providers/UsdToggleProvider";
 import { useTokenMeta } from "@/hooks/useTokenMeta";
-import { formatTokenAmount, formatCompactTokenAmount, formatUsd, formatBps } from "@/lib/format";
+import { formatTokenAmount, formatCompactTokenAmount, formatUsd, formatUsdPriceE6, formatBps } from "@/lib/format";
 import { sanitizeOnChainValue, sanitizeAccountCount, sanitizeBps, sanitizeFundingRateBps } from "@/lib/health";
 import { useLivePrice } from "@/hooks/useLivePrice";
 import { resolveMarketPriceE6, sanitizePriceE6, detectOracleMode } from "@/lib/oraclePrice";
@@ -27,14 +27,6 @@ function formatNum(n: number): string {
 // When exceeded, fall back to live WebSocket price (#1131).
 const MAX_SANE_MARK_PRICE_USD = 1_000_000; // $1M
 const MAX_SANE_MARK_E6 = BigInt(MAX_SANE_MARK_PRICE_USD) * 1_000_000n;
-
-/** Format a price in E6 format as a USD string with appropriate precision. */
-function formatPriceE6(priceE6: bigint): string {
-  const price = Number(priceE6) / 1_000_000;
-  if (price >= 1_000) return `$${price.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
-  if (price >= 1) return `$${price.toFixed(4)}`;
-  return `$${price.toFixed(6)}`;
-}
 
 /**
  * Convert fundingRateBpsPerSlotLast (i64) to 8-hour percentage.
@@ -145,8 +137,7 @@ export const MarketStatsCard: FC = () => {
     if (!showSpread || spreadAbs === null || spreadBps === null) return "—";
     const absSpread = spreadAbs < 0n ? -spreadAbs : spreadAbs;
     const sign = spreadAbs >= 0n ? "+" : "−";
-    // formatPriceE6 returns "$X.XX" — replace the $ with sign+$
-    const dollarPart = formatPriceE6(absSpread).replace("$", `${sign}$`);
+    const dollarPart = formatUsd(absSpread).replace("$", `${sign}$`);
     const pctPart = `${sign}${Math.abs(spreadBps / 100).toFixed(2)}%`;
     return `${dollarPart} (${pctPart})`;
   })();
@@ -183,12 +174,12 @@ export const MarketStatsCard: FC = () => {
     // Row 1 — Pricing signals
     {
       label: "Mark",
-      value: markPriceE6 !== null ? formatPriceE6(markPriceE6) : formatUsd(livePriceE6 ?? (mktConfig ? resolveMarketPriceE6(mktConfig) : 0n)),
+      value: markPriceE6 !== null ? formatUsdPriceE6(markPriceE6) : formatUsdPriceE6(livePriceE6 ?? (mktConfig ? resolveMarketPriceE6(mktConfig) : 0n)),
       tooltip: "EMA mark price used for liquidations and PnL",
     },
     {
       label: "Index",
-      value: indexPriceE6 !== null ? formatPriceE6(indexPriceE6) : "—",
+      value: indexPriceE6 !== null ? formatUsdPriceE6(indexPriceE6) : "—",
       tooltip: "On-chain oracle index price",
     },
     {

--- a/app/components/trade/PositionPanel.tsx
+++ b/app/components/trade/PositionPanel.tsx
@@ -10,7 +10,7 @@ import { useSlabState } from "@/components/providers/SlabProvider";
 import { useTokenMeta } from "@/hooks/useTokenMeta";
 import { useMarketInfo } from "@/hooks/useMarketInfo";
 import { AccountKind } from "@percolatorct/sdk";
-import { formatTokenAmount, formatUsd, formatLiqPrice } from "@/lib/format";
+import { formatTokenAmount, formatUsdPriceE6, formatLiqPrice } from "@/lib/format";
 import { useLivePrice } from "@/hooks/useLivePrice";
 import {
   computeMarkPnl,
@@ -499,7 +499,7 @@ export const PositionPanel: FC<{ slabAddress: string }> = ({ slabAddress }) => {
               <div className="flex items-center justify-between py-1.5">
                 <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Entry Price</span>
                 <span className="text-[11px] text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>
-                  {formatUsd(entryPriceE6)}
+                  {formatUsdPriceE6(entryPriceE6)}
                 </span>
               </div>
               {/* 3.4: Funding/8h inline — replaces the entry price row area */}
@@ -519,7 +519,7 @@ export const PositionPanel: FC<{ slabAddress: string }> = ({ slabAddress }) => {
               <div className="flex items-center justify-between py-1.5">
                 <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Market Price</span>
                 <span className={`text-[11px] ${hasValidMark ? "text-[var(--text)]" : "text-[var(--text-dim)]"}`} style={{ fontFamily: "var(--font-mono)" }}>
-                  {hasValidMark ? formatUsd(currentPriceE6) : "--"}
+                  {hasValidMark ? formatUsdPriceE6(currentPriceE6) : "--"}
                 </span>
               </div>
               <div className="flex items-center justify-between py-1.5">

--- a/app/components/trade/PositionsTable.tsx
+++ b/app/components/trade/PositionsTable.tsx
@@ -11,7 +11,7 @@ import { useMarketInfo } from "@/hooks/useMarketInfo";
 import { AccountKind } from "@percolatorct/sdk";
 import {
   formatTokenAmount,
-  formatUsd,
+  formatUsdPriceE6,
   formatLiqPrice,
   formatPnl,
   formatPercent,
@@ -227,12 +227,12 @@ export const PositionsTable: FC<{ slabAddress: string }> = ({ slabAddress }) => 
 
               {/* Entry */}
               <td className="whitespace-nowrap px-3 py-2.5 text-right text-[var(--text)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
-                {formatUsd(entryPriceE6)}
+                {formatUsdPriceE6(entryPriceE6)}
               </td>
 
               {/* Mark */}
               <td className="whitespace-nowrap px-3 py-2.5 text-right text-[var(--text)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
-                {hasValidMark ? formatUsd(currentPriceE6) : <span className="text-[var(--text-dim)]">--</span>}
+                {hasValidMark ? formatUsdPriceE6(currentPriceE6) : <span className="text-[var(--text-dim)]">--</span>}
               </td>
 
               {/* Liq. Price */}

--- a/app/components/trade/PreTradeSummary.tsx
+++ b/app/components/trade/PreTradeSummary.tsx
@@ -6,7 +6,7 @@ import {
   computeTradingFee,
   computePreTradeLiqPrice,
 } from "@/lib/trading";
-import { formatUsd, formatTokenAmount } from "@/lib/format";
+import { formatUsdPriceE6, formatTokenAmount } from "@/lib/format";
 import { useUsdToggle } from "@/components/providers/UsdToggleProvider";
 import { useLivePrice } from "@/hooks/useLivePrice";
 import {
@@ -154,7 +154,7 @@ export const PreTradeSummary: FC<PreTradeSummaryProps> = ({
             valueClass="text-[var(--text-secondary)]"
           />
         )}
-        <SummaryRow label="Est. Entry Price" value={formatUsd(estEntry)} />
+        <SummaryRow label="Est. Entry Price" value={formatUsdPriceE6(estEntry)} />
         <SummaryRow
           label="Notional Value"
           value={notionalDisplay}
@@ -183,7 +183,7 @@ export const PreTradeSummary: FC<PreTradeSummaryProps> = ({
         )}
         <SummaryRow
           label="Est. Liq Price"
-          value={`${liqWarning ? "⚠️ " : ""}${formatUsd(liqPrice)}`}
+          value={`${liqWarning ? "⚠️ " : ""}${formatUsdPriceE6(liqPrice)}`}
           valueClass={liqWarning ? "text-orange-400" : isLong ? "text-[var(--short)]" : "text-[var(--long)]"}
         />
       </div>

--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -24,7 +24,7 @@ import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab, getMockUserAccountIdle } from "@/lib/mock-trade-data";
 import { sanitizeSymbol } from "@/lib/symbol-utils";
 import { useMarketInfo } from "@/hooks/useMarketInfo";
-import { formatTokenAmount, formatUsd } from "@/lib/format";
+import { formatTokenAmount, formatUsdPriceE6 } from "@/lib/format";
 import { useClosePosition } from "@/hooks/useClosePosition";
 import { saveEntryPrice, getEntryPrice, getEntryLeverage, clearEntryPrice } from "@/lib/entry-price";
 import { isSentinelValue } from "@/lib/health";
@@ -561,7 +561,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
             <div>
               <span className="text-[var(--text-dim)] uppercase tracking-[0.08em]">Entry</span>
               <span className="ml-2 font-mono font-medium text-[var(--text)]">
-                {openEntryPriceE6 > 0n ? formatUsd(openEntryPriceE6) : "—"}
+                {openEntryPriceE6 > 0n ? formatUsdPriceE6(openEntryPriceE6) : "—"}
               </span>
             </div>
             <div>
@@ -569,7 +569,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
                 Liq {openLiqDanger ? "⚠" : ""}
               </span>
               <span className={`ml-2 font-mono font-medium ${openLiqDanger ? "text-orange-400" : "text-[var(--text)]"}`}>
-                {openLiqPriceE6 > 0n ? formatUsd(openLiqPriceE6) : "—"}
+                {openLiqPriceE6 > 0n ? formatUsdPriceE6(openLiqPriceE6) : "—"}
               </span>
             </div>
             <div>

--- a/app/components/trade/TradeHistoryTable.tsx
+++ b/app/components/trade/TradeHistoryTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTradeHistory } from "@/hooks/useTradeHistory";
-import { formatTokenAmount } from "@/lib/format";
+import { formatTokenAmount, formatUsdFromNumber } from "@/lib/format";
 import { useMultiTokenMeta } from "@/hooks/useMultiTokenMeta";
 import { useEffect, useState } from "react";
 import { ShimmerSkeleton } from "@/components/ui/ShimmerSkeleton";
@@ -15,9 +15,7 @@ interface TradeHistoryTableProps {
 
 function formatPrice(priceNum: number): string {
   if (!priceNum) return "—";
-  if (priceNum >= 1000) return `$${priceNum.toLocaleString("en-US", { maximumFractionDigits: 2 })}`;
-  if (priceNum >= 1) return `$${priceNum.toFixed(4)}`;
-  return `$${priceNum.toPrecision(4)}`;
+  return formatUsdFromNumber(priceNum);
 }
 
 function formatFee(feeNum: number, decimals = 6): string {

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -48,6 +48,7 @@ import {
   type ChartSeriesKind,
 } from "@/lib/chart-style";
 import { assertNever } from "@/lib/exhaustive";
+import { formatUsdFromNumber } from "@/lib/format";
 
 // Phase 2: added 15m timeframe
 type Timeframe = "1m" | "5m" | "15m" | "1h" | "4h" | "1d" | "7d" | "30d";
@@ -838,7 +839,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
                   className="text-2xl font-bold text-[var(--text)] drop-shadow-sm"
                   style={{ fontFamily: "var(--font-mono)" }}
                 >
-                  ${priceUsd < 0.01 ? priceUsd.toFixed(6) : priceUsd.toFixed(2)}
+                  {formatUsdFromNumber(priceUsd)}
                 </div>
                 <div className="mt-1 text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">
                   Price chart building…
@@ -905,13 +906,13 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
             <div className="flex items-center gap-3 whitespace-nowrap">
               {hoverBar.isCandle ? (
                 <>
-                  <span className="text-[var(--text-dim)]">O <span className="text-[var(--text)]">{hoverBar.open.toFixed(hoverBar.open < 1 ? 6 : 2)}</span></span>
-                  <span className="text-[var(--text-dim)]">H <span className="text-[var(--text)]">{hoverBar.high.toFixed(hoverBar.high < 1 ? 6 : 2)}</span></span>
-                  <span className="text-[var(--text-dim)]">L <span className="text-[var(--text)]">{hoverBar.low.toFixed(hoverBar.low < 1 ? 6 : 2)}</span></span>
-                  <span className="text-[var(--text-dim)]">C <span className="text-[var(--text)]" style={{ color: hoverBar.close >= hoverBar.open ? "var(--long)" : "var(--short)" }}>{hoverBar.close.toFixed(hoverBar.close < 1 ? 6 : 2)}</span></span>
+                  <span className="text-[var(--text-dim)]">O <span className="text-[var(--text)]">{formatUsdFromNumber(hoverBar.open).slice(1)}</span></span>
+                  <span className="text-[var(--text-dim)]">H <span className="text-[var(--text)]">{formatUsdFromNumber(hoverBar.high).slice(1)}</span></span>
+                  <span className="text-[var(--text-dim)]">L <span className="text-[var(--text)]">{formatUsdFromNumber(hoverBar.low).slice(1)}</span></span>
+                  <span className="text-[var(--text-dim)]">C <span className="text-[var(--text)]" style={{ color: hoverBar.close >= hoverBar.open ? "var(--long)" : "var(--short)" }}>{formatUsdFromNumber(hoverBar.close).slice(1)}</span></span>
                 </>
               ) : (
-                <span className="text-[var(--text-dim)]">Price <span className="text-[var(--text)]">{hoverBar.close.toFixed(hoverBar.close < 1 ? 6 : 2)}</span></span>
+                <span className="text-[var(--text-dim)]">Price <span className="text-[var(--text)]">{formatUsdFromNumber(hoverBar.close).slice(1)}</span></span>
               )}
               {hoverBar.volume > 0 && (
                 <span className="text-[var(--text-dim)]">V <span className="text-[var(--text)]">{hoverBar.volume.toLocaleString(undefined, { maximumFractionDigits: 0 })}</span></span>

--- a/app/hooks/useLivePrice.ts
+++ b/app/hooks/useLivePrice.ts
@@ -68,6 +68,7 @@ async function livePriceJsonFetcher<T>(url: string): Promise<T> {
 
 const SWR_REST_OPTS = {
   dedupingInterval: 10_000,
+  refreshInterval: 10_000,
   revalidateOnFocus: false,
   shouldRetryOnError: false,
 } as const;

--- a/app/lib/format.ts
+++ b/app/lib/format.ts
@@ -101,6 +101,22 @@ export function formatUsd(priceE6: bigint | null | undefined): string {
   return `$${val.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 6 })}`;
 }
 
+export function formatUsdPriceE6(priceE6: bigint | null | undefined, fallback = "—"): string {
+  if (priceE6 == null || priceE6 <= 0n || priceE6 > 1_000_000_000_000_000n) return fallback;
+  const val = Number(priceE6) / 1_000_000;
+  return `$${val.toLocaleString(undefined, { minimumFractionDigits: 6, maximumFractionDigits: 6 })}`;
+}
+
+/**
+ * Format a USD float while preserving Percolator's E6 price precision.
+ * Use this for API/WebSocket prices that are already in USD units.
+ */
+export function formatUsdFromNumber(priceUsd: number | null | undefined, fallback = "—"): string {
+  if (priceUsd == null || !Number.isFinite(priceUsd)) return fallback;
+  const priceE6 = BigInt(Math.round(priceUsd * 1_000_000));
+  return formatUsdPriceE6(priceE6, fallback);
+}
+
 /**
  * Format a liquidation price in e6 format.
  * Returns "∞" when the position is unliquidatable (liqPrice === max u64),


### PR DESCRIPTION
## What changed

- Added fixed-E6 USD price formatters so market prices render with six decimal places instead of trimming trailing zeroes.
- Moved live price surfaces onto the shared formatter: homepage featured markets, markets table, trade header, market selector, chart labels/tooltips, oracle details, order-book bid/oracle/ask, mark/index stats, position entry/mark, and trade/close summaries.
- Added formatter coverage for number and bigint E6 price inputs.

## Why

Production was still rendering several prices through compact formatting paths, so values like `84.4`, `1`, or `0.03` could show as `$84.40`, `$1.00`, or `$0.03` instead of the full Percolator E6 precision.

## Validation

- `pnpm --filter @percolator/app exec vitest run __tests__/lib/format.test.ts`
- `pnpm --filter @percolator/app exec tsc --noEmit`
- `NEXT_PUBLIC_API_URL=https://mainnet.percolatorlaunch.com pnpm --filter @percolator/app build`
- `pnpm --filter @percolator/app exec vitest run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for USD price formatting helpers.

* **Refactor**
  * Standardized USD price formatting across all market, trading, and chart components for consistent display throughout the app.

* **Chores**
  * Added periodic price refresh interval to live market data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->