### PR TITLE
fix(chart): preserve the default price pane when momentarily empty

### DIFF
--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -412,6 +412,18 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
     });
 
     chartRef.current = chart;
+    // Preserve the default price pane when momentarily empty. The
+    // price-series effect below remove-and-re-adds the price series on
+    // every dep change (priceUsd tick, theme switch, etc.), and v5
+    // auto-destroys empty panes whenever any other panes exist. With
+    // RSI / MACD oscillator panes active, the brief empty window
+    // between removeSeries(price) and addSeries(price) was triggering
+    // v5 to compact pane 0 out of existence — the pane indices then
+    // shifted (the first oscillator pane became pane 0), and the next
+    // addSeries(price) defaulted into the oscillator pane, dumping the
+    // price line on top of the indicator. Setting preserveEmptyPane
+    // keeps pane 0 alive across the empty window.
+    chart.panes()[0]?.setPreserveEmptyPane(true);
     setChartReady(true);
 
     return () => {


### PR DESCRIPTION
## Summary

After #2136 and #2137 merged, the indicator panes worked correctly when toggled manually but **broke on page refresh**: the price line ended up in the same pane as the MACD histogram + lines, with the RSI pane below them as a sliver. Same visual symptom as the bug #2136 set out to fix, different root cause.

## Root cause

Same v5 auto-destroy-empty-pane behaviour, but on **pane 0** (the default price pane) instead of the oscillator pane:

1. Page refresh → indicators hydrated from localStorage → oscillator panes allocated.
2. Live-price tick → price-series effect re-fires → `removeSeries(price)` → pane 0 has no series for one synchronous tick.
3. With Pyth as the data source there is no volume series, so pane 0 is momentarily completely empty.
4. v5 sees pane 0 empty *and* sees other panes (the oscillator panes) exist → compacts pane 0 out.
5. Pane indices shift: the first oscillator pane (was pane 1) becomes pane 0.
6. `addSeries(price)` (no paneIndex argument) defaults to pane 0 — which is now the oscillator pane.
7. Price line lands on top of the oscillator's histogram + lines.

The same logic doesn't trigger on the manual toggle path because at that moment pane 0 is the *only* pane, and v5 doesn't compact a pane that has no siblings. As soon as the user toggles RSI on, the next live-price tick triggers the cascade — but visually the user is already looking at the chart and may not notice the few-second delay before things go wrong. On refresh the cascade fires within the first tick, hence \"immediately broken\".

## Fix

One line: `chart.panes()[0].setPreserveEmptyPane(true)` right after `createChart()`. Pane 0 now survives the brief empty window between `removeSeries` and `addSeries` in the price-series effect; indices stay stable; the price series always lands in its own pane.

## Why the indicator hooks already use this

#2136 added `addPane(true)` for the oscillator panes for the same reason (pane survives the diff loop's empty window). This PR completes the picture by applying the same protection to the default pane that came with `createChart`.

## Test plan

- [x] All 77 indicator-related unit tests still green.
- [ ] Hard-refresh on a market with RSI active → RSI in its own pane below the price chart, price line in pane 0. No merging.
- [ ] Hard-refresh with MACD active → MACD in its own pane below the price chart.
- [ ] Hard-refresh with both → two oscillator panes stacked below the price chart, no merging.
- [ ] Live data flowing — wait 30 s — confirm price stays in its pane and oscillators stay in theirs.
- [ ] Toggle indicators on / off after refresh → behaviour matches manual-toggle case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart display stability and layout consistency. The trading chart no longer unexpectedly reorganizes its visual elements during live price updates or theme switches, ensuring a more stable and predictable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->