### PR TITLE
Fix remaining price decimal displays

### DIFF
--- a/app/app/portfolio/page.tsx
+++ b/app/app/portfolio/page.tsx
@@ -6,7 +6,7 @@ import { useWalletCompat } from "@/hooks/useWalletCompat";
 import { usePortfolio, getLiquidationSeverity, type PortfolioPosition } from "@/hooks/usePortfolio";
 import { useLpPositions } from "@/hooks/useLpPositions";
 import { LpPositionsPanel } from "@/components/portfolio/LpPositionsPanel";
-import { formatTokenAmount, formatPriceE6 } from "@/lib/format";
+import { formatTokenAmount, formatUsdPriceE6 } from "@/lib/format";
 import dynamic from "next/dynamic";
 import { ScrollReveal } from "@/components/ui/ScrollReveal";
 import { GlowButton } from "@/components/ui/GlowButton";
@@ -345,13 +345,13 @@ export default function PortfolioPage() {
                         <div>
                           <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">Entry</p>
                           <p className="text-[12px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>
-                            {formatPriceE6(posEntry)}
+                            {formatUsdPriceE6(posEntry)}
                           </p>
                         </div>
                         <div>
                           <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">Mark Price</p>
                           <p className="text-[12px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>
-                            {oraclePriceE6 > 0n ? formatPriceE6(oraclePriceE6) : "—"}
+                            {oraclePriceE6 > 0n ? formatUsdPriceE6(oraclePriceE6) : "—"}
                           </p>
                         </div>
                         <div>
@@ -394,7 +394,7 @@ export default function PortfolioPage() {
                               style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}
                             >
                               {hasPosition && liquidationPriceE6 > 0n
-                                ? formatPriceE6(liquidationPriceE6)
+                                ? formatUsdPriceE6(liquidationPriceE6)
                                 : "—"}
                             </p>
                           </div>

--- a/app/components/dashboard/PositionSummary.tsx
+++ b/app/components/dashboard/PositionSummary.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePortfolio, getLiquidationSeverity, type PortfolioPosition } from "@/hooks/usePortfolio";
-import { formatTokenAmount, formatPriceE6 } from "@/lib/format";
+import { formatTokenAmount, formatUsdPriceE6 } from "@/lib/format";
 import { useMultiTokenMeta } from "@/hooks/useMultiTokenMeta";
 
 import { GlowButton } from "@/components/ui/GlowButton";
@@ -111,13 +111,13 @@ function PositionCard({ pos, symbol, decimals = 6 }: { pos: PortfolioPosition; s
           <div>
             <span className="text-[var(--text-dim)]">Entry: </span>
             <span className="text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
-              {pos.account?.entryPrice != null ? formatPriceE6(pos.account.entryPrice) : "—"}
+              {pos.account?.entryPrice != null ? formatUsdPriceE6(pos.account.entryPrice) : "—"}
             </span>
           </div>
           <div>
             <span className="text-[var(--text-dim)]">Mark: </span>
             <span className="text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
-              {pos.oraclePriceE6 > 0n ? formatPriceE6(pos.oraclePriceE6) : "—"}
+              {pos.oraclePriceE6 > 0n ? formatUsdPriceE6(pos.oraclePriceE6) : "—"}
             </span>
           </div>
           <div>
@@ -128,7 +128,7 @@ function PositionCard({ pos, symbol, decimals = 6 }: { pos: PortfolioPosition; s
               }`}
               style={{ fontFamily: "var(--font-jetbrains-mono)" }}
             >
-              {hasPosition && pos.liquidationPriceE6 > 0n ? formatPriceE6(pos.liquidationPriceE6) : "—"}
+              {hasPosition && pos.liquidationPriceE6 > 0n ? formatUsdPriceE6(pos.liquidationPriceE6) : "—"}
             </span>
           </div>
         </div>

--- a/app/components/dashboard/TradeHistory.tsx
+++ b/app/components/dashboard/TradeHistory.tsx
@@ -12,6 +12,7 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useWalletCompat } from "@/hooks/useWalletCompat";
 import { explorerTxUrl } from "@/lib/config";
+import { formatUsdFromNumber } from "@/lib/format";
 import type { TraderTradeEntry } from "@/app/api/trader/[wallet]/trades/route";
 
 type TradeType = "all" | "long" | "short";
@@ -233,7 +234,7 @@ export function TradeHistory() {
                     className="px-3 py-2.5 text-right text-[var(--text-secondary)]"
                     style={{ fontFamily: "var(--font-jetbrains-mono)" }}
                   >
-                    {formatUsd(trade.price)}
+                    {formatUsdFromNumber(trade.price)}
                   </td>
                   <td
                     className="px-3 py-2.5 text-right text-[var(--text-muted)]"

--- a/app/components/market/ShareCard.tsx
+++ b/app/components/market/ShareCard.tsx
@@ -3,7 +3,7 @@
 import { FC, useState, useRef, useEffect } from "react";
 import gsap from "gsap";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
-import { formatUsd } from "@/lib/format";
+import { formatUsdPriceE6 } from "@/lib/format";
 
 interface ShareCardProps {
   slabAddress: string;
@@ -31,7 +31,7 @@ function buildXShareText(marketName: string, fmtPrice: string, changeStr: string
 export const ShareCard: FC<ShareCardProps> = ({ slabAddress, marketName, price, change24h }) => {
   const [copied, setCopied] = useState(false);
 
-  const fmtPrice = formatUsd(price).slice(1);
+  const fmtPrice = formatUsdPriceE6(price).slice(1);
   const changeStr = change24h != null ? `${change24h >= 0 ? "+" : ""}${change24h.toFixed(2)}%` : "";
   const tradeUrl = buildTradeUrl(slabAddress);
 

--- a/app/components/trade/TradeHistory.tsx
+++ b/app/components/trade/TradeHistory.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { FC, useEffect, useState, useCallback } from "react";
-import { formatTokenAmount, formatPriceE6 } from "@/lib/format";
+import { formatTokenAmount, formatUsdFromNumber } from "@/lib/format";
 import { explorerTxUrl } from "@/lib/config";
 import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab, getMockTrades } from "@/lib/mock-trade-data";
@@ -128,7 +128,7 @@ export const TradeHistory: FC<{ slabAddress: string }> = ({ slabAddress }) => {
                   {trade.size != null ? formatTokenAmount(toBigInt(Math.abs(typeof trade.size === "number" ? trade.size : parseFloat(trade.size))), decimals) : "—"}
                 </div>
                 <div className="text-right text-[var(--text-muted)]" style={{ fontFamily: "var(--font-mono)" }}>
-                  {trade.price != null ? formatPriceE6(BigInt(Math.round(Number(trade.price) * 1e6))) : "—"}
+                  {trade.price != null ? formatUsdFromNumber(Number(trade.price)) : "—"}
                 </div>
               </a>
             ))}


### PR DESCRIPTION
## Summary
- switch portfolio and dashboard entry/mark/liquidation price displays to fixed-six USD formatting
- switch compact trade-history/share-card price displays to fixed-six formatting
- leave non-price USD totals/fees/balances unchanged

## Tests
- pnpm install --frozen-lockfile
- pnpm --filter @percolator/app exec tsc --noEmit
- pnpm --filter @percolator/app exec vitest run __tests__/lib/format.test.ts __tests__/lib/format-extended.test.ts
- NEXT_PUBLIC_API_URL=https://mainnet.percolatorlaunch.com pnpm --filter @percolator/app build
- pnpm --filter @percolator/app exec vitest run
- git diff --check