### PR TITLE
Chart drawing tools: trend, horizontal, rectangle + per-slab persistence

### DIFF
--- a/app/__tests__/components/trade/ChartDrawingOverlay.test.tsx
+++ b/app/__tests__/components/trade/ChartDrawingOverlay.test.tsx
@@ -544,6 +544,12 @@ describe("ChartDrawingOverlay", () => {
           setTool={setTool}
         />,
       );
+      // Mount fires the slab/chart-init effect once which seeds tool
+      // back to "pointer" — clear the mock so the assertion reflects
+      // post-mount behaviour only. (The mount call is a separate
+      // contract verified elsewhere; here we test that committing a
+      // horizontal does NOT change tools.)
+      setTool.mockClear();
       fireClick(ch, 50, 150);
       // Tool should NOT have been reset — user keeps drawing
       // horizontals until they explicitly switch tools.
@@ -611,6 +617,9 @@ describe("ChartDrawingOverlay", () => {
           setTool={setTool}
         />,
       );
+      // Clear the mount-time setTool("pointer") seed; we're testing
+      // post-mount behaviour.
+      setTool.mockClear();
       fireClick(ch, 10, 100); // p1 of trend 1
       fireClick(ch, 20, 200); // p2 of trend 1 → commit
       expect(setTool).not.toHaveBeenCalled();
@@ -640,6 +649,7 @@ describe("ChartDrawingOverlay", () => {
           setTool={setTool}
         />,
       );
+      setTool.mockClear(); // drop the mount-time seed call
       fireClick(ch, 10, 100); // p1 set
       fireEvent.keyDown(document, { key: "Escape" });
       // Tool stays in trend (Escape cancelled the pending anchor,
@@ -1059,6 +1069,7 @@ describe("ChartDrawingOverlay", () => {
           setTool={setTool}
         />,
       );
+      setTool.mockClear(); // drop mount-time seed call
       fireEvent.mouseDown(ch.chartElement, {
         clientX: 10,
         clientY: 100,
@@ -1142,6 +1153,7 @@ describe("ChartDrawingOverlay", () => {
           setTool={setTool}
         />,
       );
+      setTool.mockClear(); // drop mount-time seed
       fireEvent.mouseDown(ch.chartElement, {
         clientX: 10,
         clientY: 100,
@@ -1568,6 +1580,7 @@ describe("ChartDrawingOverlay", () => {
           tool="pointer"
         />,
       );
+      setTool.mockClear(); // drop mount-time seed
       // Select first.
       selectVia(ch, 50, 100);
       // Escape should clear selection (verify tool was NOT changed).
@@ -1605,6 +1618,7 @@ describe("ChartDrawingOverlay", () => {
           deleteDrawing={deleteDrawing}
         />,
       );
+      setTool.mockClear(); // drop mount-time seed
       fireEvent.keyDown(document, { key: "Escape" });
       expect(setTool).not.toHaveBeenCalled();
       expect(deleteDrawing).not.toHaveBeenCalled();
@@ -1627,6 +1641,7 @@ describe("ChartDrawingOverlay", () => {
       );
       const input = screen.getByTestId("form-input") as HTMLInputElement;
       input.focus();
+      setTool.mockClear(); // drop mount-time seed
       fireEvent.keyDown(document, { key: "Escape" });
       expect(setTool).not.toHaveBeenCalled();
     });
@@ -1645,6 +1660,7 @@ describe("ChartDrawingOverlay", () => {
           deleteDrawing={deleteDrawing}
         />,
       );
+      setTool.mockClear(); // drop mount-time seed
       fireEvent.keyDown(document, { key: "Enter" });
       fireEvent.keyDown(document, { key: " " });
       fireEvent.keyDown(document, { key: "p" });
@@ -1664,6 +1680,9 @@ describe("ChartDrawingOverlay", () => {
           setTool={setTool}
         />,
       );
+      // Mount fired the slab/chart-init seed; clear so the post-
+      // unmount Escape assertion only tests listener removal.
+      setTool.mockClear();
       unmount();
       fireEvent.keyDown(document, { key: "Escape" });
       expect(setTool).not.toHaveBeenCalled();
@@ -1698,8 +1717,11 @@ describe("ChartDrawingOverlay", () => {
           slabAddress={SLAB_B}
         />,
       );
-      // Now Escape should be a no-op (selection was cleared by slab change),
-      // and setTool stays untouched because tool is already pointer.
+      // Slab change re-fires the reset effect → setTool("pointer")
+      // gets called again as part of the seed contract. Clear those
+      // expected calls before asserting that the subsequent Escape
+      // is a no-op for setTool.
+      setTool.mockClear();
       fireEvent.keyDown(document, { key: "Escape" });
       expect(setTool).not.toHaveBeenCalled();
     });

--- a/app/__tests__/components/trade/ChartDrawingOverlay.test.tsx
+++ b/app/__tests__/components/trade/ChartDrawingOverlay.test.tsx
@@ -22,6 +22,25 @@ function fakeChart() {
   const subscribeCrosshair = vi.fn();
   const unsubscribeCrosshair = vi.fn();
   const applyOptions = vi.fn();
+  // Granular object-form scroll/scale to match what TradingChart's
+  // chart-init configures. The pan-suppression effect's snapshot/
+  // restore reads these via chart.options(); a coarse boolean here
+  // would let a buggy restore (booleans-only) silently pass tests.
+  const initialScroll = {
+    mouseWheel: true,
+    pressedMouseMove: true,
+    horzTouchDrag: true,
+    vertTouchDrag: true,
+  };
+  const initialScale = {
+    axisPressedMouseMove: true,
+    mouseWheel: true,
+    pinch: true,
+  };
+  const options = vi.fn(() => ({
+    handleScroll: initialScroll,
+    handleScale: initialScale,
+  }));
   // Identity-ish time scale: time-in-seconds maps to x-pixel directly.
   const timeScale = () => ({
     subscribeVisibleLogicalRangeChange: subscribeRange,
@@ -57,11 +76,15 @@ function fakeChart() {
     unsubscribeCrosshairMove: unsubscribeCrosshair,
     chartElement: () => chartElement,
     applyOptions,
+    options,
   } as unknown as IChartApi;
   return {
     chart,
     chartElement,
     applyOptions,
+    options,
+    initialScroll,
+    initialScale,
     subscribeRange,
     unsubscribeRange,
     subscribeSize,
@@ -1050,41 +1073,43 @@ describe("ChartDrawingOverlay", () => {
       expect(addDrawing).not.toHaveBeenCalled();
     });
 
-    it("suppresses chart pan/zoom during drag and restores on commit", () => {
+    it("suppresses chart pan/zoom during drag and restores the SNAPSHOT on commit", () => {
+      // Restore must use the snapshot (object form from chart.options())
+      // — NOT coarse boolean true. The fake chart's options() returns
+      // granular objects (handleScroll: { mouseWheel, ... }); the
+      // restore should write those exact objects back so any sub-flag
+      // a parent disabled isn't silently re-enabled.
       stubCanvasContext();
       const ch = fakeChart();
       render(
         <Harness chart={ch.chart} ready={true} tool="rectangle" />,
       );
-      // Before any drag, applyOptions has not been called from the
-      // overlay (the pan-suppress effect requires pendingP1).
       const beforeMouseDown = ch.applyOptions.mock.calls.length;
       fireEvent.mouseDown(ch.chartElement, {
         clientX: 10,
         clientY: 100,
         button: 0,
       });
-      // After mouseDown, the suppress effect ran and disabled pan/zoom.
+      // Disable: writes coarse false (drag suppress is all-off).
       expect(ch.applyOptions.mock.calls.length).toBeGreaterThan(
         beforeMouseDown,
       );
-      // The most recent applyOptions call should disable both.
-      const lastCall = ch.applyOptions.mock.calls.at(-1);
-      expect(lastCall?.[0]).toMatchObject({
+      const disableCall = ch.applyOptions.mock.calls.at(-1);
+      expect(disableCall?.[0]).toMatchObject({
         handleScroll: false,
         handleScale: false,
       });
-      // Commit the drag.
+      // Commit triggers cleanup → restore.
       fireEvent.mouseUp(document, { clientX: 50, clientY: 200 });
-      // After commit, applyOptions called again to RESTORE pan/zoom.
       const restoreCall = ch.applyOptions.mock.calls.at(-1);
-      expect(restoreCall?.[0]).toMatchObject({
-        handleScroll: true,
-        handleScale: true,
+      // Restore writes the OBJECT-FORM snapshot, not boolean true.
+      expect(restoreCall?.[0]).toEqual({
+        handleScroll: ch.initialScroll,
+        handleScale: ch.initialScale,
       });
     });
 
-    it("suppresses chart pan/zoom during drag and restores on Escape cancel", () => {
+    it("restores the SNAPSHOT on Escape cancel (preserves granular config)", () => {
       stubCanvasContext();
       const ch = fakeChart();
       render(
@@ -1096,11 +1121,10 @@ describe("ChartDrawingOverlay", () => {
         button: 0,
       });
       fireEvent.keyDown(document, { key: "Escape" });
-      // Cleanup ran — last applyOptions should be the RESTORE call.
-      const lastCall = ch.applyOptions.mock.calls.at(-1);
-      expect(lastCall?.[0]).toMatchObject({
-        handleScroll: true,
-        handleScale: true,
+      const restoreCall = ch.applyOptions.mock.calls.at(-1);
+      expect(restoreCall?.[0]).toEqual({
+        handleScroll: ch.initialScroll,
+        handleScale: ch.initialScale,
       });
     });
 
@@ -1163,6 +1187,168 @@ describe("ChartDrawingOverlay", () => {
       } finally {
         window.matchMedia = originalMatchMedia;
       }
+    });
+
+    it("mousemove during drag triggers a redraw (preview path is wired)", () => {
+      // The drag's mousemove handler updates previewP2Ref AND calls
+      // redrawRef.current() imperatively. Without this assertion, a
+      // refactor that dropped the redraw call would leave the user
+      // with no live preview during drag, but commit would still
+      // work — current tests would all pass.
+      const { clearRect } = stubCanvasContext();
+      const ch = fakeChart();
+      render(
+        <Harness chart={ch.chart} ready={true} tool="rectangle" />,
+      );
+      fireEvent.mouseDown(ch.chartElement, {
+        clientX: 10,
+        clientY: 100,
+        button: 0,
+      });
+      const afterDown = clearRect.mock.calls.length;
+      fireEvent.mouseMove(document, { clientX: 50, clientY: 200 });
+      expect(clearRect.mock.calls.length).toBeGreaterThan(afterDown);
+    });
+
+    it("mouseup that projects null (off-scale) cancels rather than committing", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      // Series whose projections start working but flip to null
+      // for the mouseup. We toggle the flip via a closure flag.
+      let projectsNull = false;
+      const series: PriceConverter = {
+        priceToCoordinate: (p) => (projectsNull ? null : p),
+        coordinateToPrice: (c) => (projectsNull ? null : c),
+      };
+      const { rerender } = render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="rectangle"
+          addDrawing={addDrawing}
+          series={series}
+        />,
+      );
+      fireEvent.mouseDown(ch.chartElement, {
+        clientX: 10,
+        clientY: 100,
+        button: 0,
+      });
+      // Flip projection to null AND re-render so seriesRef refreshes.
+      projectsNull = true;
+      rerender(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="rectangle"
+          addDrawing={addDrawing}
+          series={series}
+        />,
+      );
+      fireEvent.mouseUp(document, { clientX: 50, clientY: 200 });
+      expect(addDrawing).not.toHaveBeenCalled();
+    });
+
+    it("mouseup with a null seriesRef cancels rather than committing", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      const { rerender } = render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="rectangle"
+          addDrawing={addDrawing}
+        />,
+      );
+      fireEvent.mouseDown(ch.chartElement, {
+        clientX: 10,
+        clientY: 100,
+        button: 0,
+      });
+      // Drop the series mid-drag (chart re-init / slab swap could
+      // produce this).
+      rerender(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="rectangle"
+          addDrawing={addDrawing}
+          series={null}
+        />,
+      );
+      expect(() =>
+        fireEvent.mouseUp(document, { clientX: 50, clientY: 200 }),
+      ).not.toThrow();
+      expect(addDrawing).not.toHaveBeenCalled();
+    });
+
+    it("tool change mid-drag cancels the pending anchor without committing", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      const { rerender } = render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="rectangle"
+          addDrawing={addDrawing}
+        />,
+      );
+      fireEvent.mouseDown(ch.chartElement, {
+        clientX: 10,
+        clientY: 100,
+        button: 0,
+      });
+      // User switches to pointer mid-drag (toolbar click somewhere).
+      rerender(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="pointer"
+          addDrawing={addDrawing}
+        />,
+      );
+      fireEvent.mouseUp(document, { clientX: 50, clientY: 200 });
+      expect(addDrawing).not.toHaveBeenCalled();
+      // And pan was restored (cleanup ran).
+      const lastCall = ch.applyOptions.mock.calls.at(-1);
+      expect(lastCall?.[0]).toEqual({
+        handleScroll: ch.initialScroll,
+        handleScale: ch.initialScale,
+      });
+    });
+
+    it("slab change mid-drag cancels the pending anchor without committing", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      const { rerender } = render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="rectangle"
+          addDrawing={addDrawing}
+          slabAddress={SLAB_A}
+        />,
+      );
+      fireEvent.mouseDown(ch.chartElement, {
+        clientX: 10,
+        clientY: 100,
+        button: 0,
+      });
+      rerender(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="rectangle"
+          addDrawing={addDrawing}
+          slabAddress={SLAB_B}
+        />,
+      );
+      fireEvent.mouseUp(document, { clientX: 50, clientY: 200 });
+      expect(addDrawing).not.toHaveBeenCalled();
     });
 
     it("does NOT attach mousedown listener when tool is not rectangle", () => {

--- a/app/__tests__/components/trade/ChartDrawingOverlay.test.tsx
+++ b/app/__tests__/components/trade/ChartDrawingOverlay.test.tsx
@@ -690,6 +690,199 @@ describe("ChartDrawingOverlay", () => {
     });
   });
 
+  describe("trend tool — Escape, off-scale, and missing-point preserve pendingP1", () => {
+    it("a click with no point info during pendingP1 does not commit and keeps pendingP1", () => {
+      // The shared `if (!param.point) return` early-return at the top
+      // of the click handler is critical: an axis-gutter click (which
+      // lightweight-charts emits with point=undefined) must not
+      // commit the trend AND must not clear pendingP1 — the user's
+      // first anchor is preserved so they can complete with another
+      // valid click. A refactor that moved the early-return inside
+      // the pointer case would break this for trend.
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="trend"
+          addDrawing={addDrawing}
+        />,
+      );
+      fireClick(ch, 10, 100); // p1 set
+      // Fire a click with no point (axis gutter / off-canvas).
+      const onClick = ch.subscribeClick.mock.calls[0][0] as (
+        p: MouseEventParams<Time>,
+      ) => void;
+      act(() => {
+        onClick({} as unknown as MouseEventParams<Time>);
+      });
+      // Must not have committed a trend.
+      expect(addDrawing).not.toHaveBeenCalled();
+      // pendingP1 still set: a follow-up valid click commits the trend
+      // with p1 == the original first click, NOT a fresh p1.
+      fireClick(ch, 20, 200);
+      expect(addDrawing).toHaveBeenCalledWith({
+        kind: "trend",
+        p1: { time: 10000, price: 100 },
+        p2: { time: 20000, price: 200 },
+      });
+    });
+
+    it("an off-scale click 2 (null projection) does not commit and keeps pendingP1", () => {
+      // Symmetrical to the horizontal off-scale test. If the user's
+      // second click projects null, we must not commit garbage AND
+      // we must not clear pendingP1 — the user can pan the chart
+      // back into a valid range and complete the trend.
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      // First click goes through normally with the identity series.
+      // Then we swap the series to one whose coordinateToPrice
+      // returns null (off-scale) BEFORE click 2.
+      let projectsNull = false;
+      const series: PriceConverter = {
+        priceToCoordinate: (p) => p,
+        coordinateToPrice: (c) => (projectsNull ? null : c),
+      };
+      const { rerender } = render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="trend"
+          addDrawing={addDrawing}
+          series={series}
+        />,
+      );
+      fireClick(ch, 10, 100); // p1 set (series projects fine)
+      // Now make subsequent projections fail.
+      projectsNull = true;
+      // Force a re-render so the seriesRef.current refresh is observed
+      // (in production, the parent would do this on chart pan/zoom).
+      rerender(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="trend"
+          addDrawing={addDrawing}
+          series={series}
+        />,
+      );
+      fireClick(ch, 20, 200); // off-scale — should NOT commit
+      expect(addDrawing).not.toHaveBeenCalled();
+      // Restore projection and complete with a valid click.
+      projectsNull = false;
+      rerender(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="trend"
+          addDrawing={addDrawing}
+          series={series}
+        />,
+      );
+      fireClick(ch, 30, 300);
+      expect(addDrawing).toHaveBeenCalledWith({
+        kind: "trend",
+        p1: { time: 10000, price: 100 },
+        p2: { time: 30000, price: 300 },
+      });
+    });
+
+    it("a zero-length trend (click 2 at exact same coords as click 1) is rejected", () => {
+      // A double-click at the same pixel would produce p1 === p2,
+      // which renders as a degenerate dot (hit-tested via the
+      // distance-to-point fallback) and pollutes persisted drawings.
+      // The handler rejects the commit; pendingP1 stays set so the
+      // user can move the cursor and click somewhere else.
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="trend"
+          addDrawing={addDrawing}
+        />,
+      );
+      fireClick(ch, 10, 100); // p1
+      fireClick(ch, 10, 100); // same coords — must NOT commit
+      expect(addDrawing).not.toHaveBeenCalled();
+      // pendingP1 still set — a follow-up at different coords commits
+      // with the original p1, proving rejection didn't clear state.
+      fireClick(ch, 20, 200);
+      expect(addDrawing).toHaveBeenCalledWith({
+        kind: "trend",
+        p1: { time: 10000, price: 100 },
+        p2: { time: 20000, price: 200 },
+      });
+    });
+  });
+
+  describe("crosshair handler — preview path", () => {
+    function fireCrosshair(
+      ch: ReturnType<typeof fakeChart>,
+      pointOrUndefined: { x: number; y: number } | undefined,
+    ): void {
+      const handler = ch.subscribeCrosshair.mock.calls[0][0] as (
+        p: MouseEventParams<Time>,
+      ) => void;
+      act(() => {
+        handler({
+          point: pointOrUndefined,
+        } as unknown as MouseEventParams<Time>);
+      });
+    }
+
+    it("does NOT redraw when tool is not trend", () => {
+      const { clearRect } = stubCanvasContext();
+      const ch = fakeChart();
+      render(<Harness chart={ch.chart} ready={true} tool="pointer" />);
+      const initial = clearRect.mock.calls.length;
+      fireCrosshair(ch, { x: 50, y: 50 });
+      // Pointer mode → handler short-circuits, no redraw fires.
+      expect(clearRect.mock.calls.length).toBe(initial);
+    });
+
+    it("does NOT redraw in trend mode when pendingP1 is null (no preview to update)", () => {
+      const { clearRect } = stubCanvasContext();
+      const ch = fakeChart();
+      render(<Harness chart={ch.chart} ready={true} tool="trend" />);
+      const initial = clearRect.mock.calls.length;
+      fireCrosshair(ch, { x: 50, y: 50 });
+      expect(clearRect.mock.calls.length).toBe(initial);
+    });
+
+    it("redraws on crosshair move when tool=trend AND pendingP1 is set (live preview)", () => {
+      const { clearRect } = stubCanvasContext();
+      const ch = fakeChart();
+      render(<Harness chart={ch.chart} ready={true} tool="trend" />);
+      // Click 1 sets pendingP1 + triggers a redraw via the data-change
+      // effect. Capture clearRect count AFTER the click settles.
+      fireClick(ch, 10, 100);
+      const afterClick = clearRect.mock.calls.length;
+      // Now simulate a cursor move — should trigger another redraw
+      // (the imperative redrawRef.current() call).
+      fireCrosshair(ch, { x: 30, y: 200 });
+      expect(clearRect.mock.calls.length).toBeGreaterThan(afterClick);
+    });
+
+    it("clears the preview ref and redraws when the cursor leaves the chart", () => {
+      const { clearRect } = stubCanvasContext();
+      const ch = fakeChart();
+      render(<Harness chart={ch.chart} ready={true} tool="trend" />);
+      fireClick(ch, 10, 100);
+      // Move into the chart — preview is set.
+      fireCrosshair(ch, { x: 30, y: 200 });
+      const beforeLeave = clearRect.mock.calls.length;
+      // Cursor leaves — handler clears previewP2Ref AND calls redraw.
+      fireCrosshair(ch, undefined);
+      expect(clearRect.mock.calls.length).toBeGreaterThan(beforeLeave);
+    });
+  });
+
   describe("rectangle tool — click is intentionally NOT the trigger", () => {
     it("a single click in rectangle mode does NOT add a drawing (drag-driven creation lands separately)", () => {
       stubCanvasContext();

--- a/app/__tests__/components/trade/ChartDrawingOverlay.test.tsx
+++ b/app/__tests__/components/trade/ChartDrawingOverlay.test.tsx
@@ -373,6 +373,57 @@ describe("ChartDrawingOverlay", () => {
       );
       expect(() => fireClick(ch, 50, 100)).not.toThrow();
     });
+
+    it("clicking empty space DESELECTS a previously-selected drawing", () => {
+      // Pin the deselect contract: setSelectedId(hitId) is called
+      // even when hitId is null. A refactor like
+      // `if (hitId) setSelectedId(hitId)` would skip the null-set
+      // and leave the previous selection stuck — Backspace would
+      // then keep deleting whatever was selected long after the
+      // user clicked away.
+      stubCanvasContext();
+      const ch = fakeChart();
+      const deleteDrawing = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          drawings={[horiz("h1", 100)]}
+          deleteDrawing={deleteDrawing}
+          tool="pointer"
+        />,
+      );
+      // Select via click on the line.
+      selectVia(ch, 50, 100);
+      // Click well off the line (empty space).
+      selectVia(ch, 50, 500);
+      // Backspace must NOT delete — selection was cleared.
+      fireEvent.keyDown(document, { key: "Backspace" });
+      expect(deleteDrawing).not.toHaveBeenCalled();
+    });
+
+    it("clicking a different drawing SWITCHES the selection", () => {
+      // Two horizontals at different prices. Click first → select.
+      // Click second → should switch selection to the second.
+      // Backspace should remove the SECOND, proving switch.
+      stubCanvasContext();
+      const ch = fakeChart();
+      const deleteDrawing = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          drawings={[horiz("h1", 100), horiz("h2", 200)]}
+          deleteDrawing={deleteDrawing}
+          tool="pointer"
+        />,
+      );
+      selectVia(ch, 50, 100); // hits h1
+      selectVia(ch, 50, 200); // hits h2 — switch
+      fireEvent.keyDown(document, { key: "Delete" });
+      expect(deleteDrawing).toHaveBeenCalledWith("h2");
+      expect(deleteDrawing).not.toHaveBeenCalledWith("h1");
+    });
   });
 
   describe("keyboard handler", () => {
@@ -428,6 +479,33 @@ describe("ChartDrawingOverlay", () => {
         />,
       );
       fireEvent.keyDown(document, { key: "Delete" });
+      expect(deleteDrawing).not.toHaveBeenCalled();
+    });
+
+    it("Backspace is suppressed when focus is in a TEXTAREA", () => {
+      // Mirrors the INPUT guard test below. The order form / notes UI
+      // commonly uses textareas for memos; a refactor that dropped
+      // TEXTAREA from the predicate would silently delete drawings
+      // while users edit text. Pin the contract.
+      stubCanvasContext();
+      const ch = fakeChart();
+      const deleteDrawing = vi.fn();
+      render(
+        <>
+          <textarea data-testid="form-textarea" />
+          <Harness
+            chart={ch.chart}
+            ready={true}
+            drawings={[horiz("h1", 100)]}
+            deleteDrawing={deleteDrawing}
+            tool="pointer"
+          />
+        </>,
+      );
+      selectVia(ch, 50, 100);
+      const ta = screen.getByTestId("form-textarea") as HTMLTextAreaElement;
+      ta.focus();
+      fireEvent.keyDown(document, { key: "Backspace" });
       expect(deleteDrawing).not.toHaveBeenCalled();
     });
 

--- a/app/__tests__/components/trade/ChartDrawingOverlay.test.tsx
+++ b/app/__tests__/components/trade/ChartDrawingOverlay.test.tsx
@@ -19,6 +19,8 @@ function fakeChart() {
   const unsubscribeSize = vi.fn();
   const subscribeClick = vi.fn();
   const unsubscribeClick = vi.fn();
+  const subscribeCrosshair = vi.fn();
+  const unsubscribeCrosshair = vi.fn();
   // Identity-ish time scale: time-in-seconds maps to x-pixel directly.
   const timeScale = () => ({
     subscribeVisibleLogicalRangeChange: subscribeRange,
@@ -32,6 +34,8 @@ function fakeChart() {
     timeScale,
     subscribeClick,
     unsubscribeClick,
+    subscribeCrosshairMove: subscribeCrosshair,
+    unsubscribeCrosshairMove: unsubscribeCrosshair,
   } as unknown as IChartApi;
   return {
     chart,
@@ -41,6 +45,8 @@ function fakeChart() {
     unsubscribeSize,
     subscribeClick,
     unsubscribeClick,
+    subscribeCrosshair,
+    unsubscribeCrosshair,
   };
 }
 
@@ -79,6 +85,9 @@ function stubCanvasContext() {
   const fillRect = vi.fn();
   const strokeRect = vi.fn();
   const arc = vi.fn();
+  const save = vi.fn();
+  const restore = vi.fn();
+  const setLineDash = vi.fn();
   const ctxStub = {
     setTransform,
     clearRect,
@@ -90,14 +99,18 @@ function stubCanvasContext() {
     fillRect,
     strokeRect,
     arc,
+    save,
+    restore,
+    setLineDash,
     set strokeStyle(_v: string) {},
     set fillStyle(_v: string) {},
     set lineWidth(_v: number) {},
+    set globalAlpha(_v: number) {},
   } as unknown as CanvasRenderingContext2D;
   HTMLCanvasElement.prototype.getContext = vi
     .fn()
     .mockReturnValue(ctxStub) as unknown as typeof HTMLCanvasElement.prototype.getContext;
-  return { setTransform, clearRect, beginPath, moveTo, lineTo, stroke, fillRect, strokeRect, arc };
+  return { setTransform, clearRect, beginPath, moveTo, lineTo, stroke, fillRect, strokeRect, arc, save, restore };
 }
 
 function stubNullCanvasContext() {
@@ -120,6 +133,7 @@ interface HarnessProps {
   chart: IChartApi | null;
   ready: boolean;
   drawings?: readonly Drawing[];
+  addDrawing?: (input: import("@/lib/chart-drawings").DrawingInput) => void;
   deleteDrawing?: (id: string) => void;
   tool?: DrawingTool;
   setTool?: (next: DrawingTool) => void;
@@ -131,6 +145,7 @@ const Harness: FC<HarnessProps> = ({
   chart,
   ready,
   drawings = [],
+  addDrawing = () => {},
   deleteDrawing = () => {},
   tool = "pointer",
   setTool = () => {},
@@ -150,6 +165,7 @@ const Harness: FC<HarnessProps> = ({
         containerRef={containerRef}
         chartReady={ready}
         drawings={drawings}
+        addDrawing={addDrawing}
         deleteDrawing={deleteDrawing}
         tool={tool}
         setTool={setTool}
@@ -166,11 +182,15 @@ const horiz = (id: string, price: number): Drawing => ({
 });
 
 /** Helper: dispatch a click through the captured chart.subscribeClick
- *  handler, wrapped in act() so React flushes the setSelectedId state
- *  update before the next assertion / keyDown. The handler is invoked
- *  outside React's synthetic-event system (via the lightweight-charts
- *  subscription), so manual act() is required. */
-function selectVia(
+ *  handler, wrapped in act() so React flushes the setSelectedId /
+ *  setPendingP1 state update before the next assertion / keyDown.
+ *  The handler is invoked outside React's synthetic-event system (via
+ *  the lightweight-charts subscription), so manual act() is required.
+ *
+ *  Two name aliases for readability: selectVia reads cleaner for
+ *  pointer-mode selection tests; fireClick reads cleaner for
+ *  creation-flow tests. Same implementation. */
+function fireClick(
   ch: ReturnType<typeof fakeChart>,
   x: number,
   y: number,
@@ -182,6 +202,7 @@ function selectVia(
     onClick({ point: { x, y } } as unknown as MouseEventParams<Time>);
   });
 }
+const selectVia = fireClick;
 
 describe("ChartDrawingOverlay", () => {
   describe("rendering", () => {
@@ -209,24 +230,26 @@ describe("ChartDrawingOverlay", () => {
   describe("subscription lifecycle", () => {
     it("does NOT subscribe when chartReady is false", () => {
       stubCanvasContext();
-      const { chart, subscribeRange, subscribeSize, subscribeClick } = fakeChart();
-      render(<Harness chart={chart} ready={false} />);
-      expect(subscribeRange).not.toHaveBeenCalled();
-      expect(subscribeSize).not.toHaveBeenCalled();
-      expect(subscribeClick).not.toHaveBeenCalled();
+      const ch = fakeChart();
+      render(<Harness chart={ch.chart} ready={false} />);
+      expect(ch.subscribeRange).not.toHaveBeenCalled();
+      expect(ch.subscribeSize).not.toHaveBeenCalled();
+      expect(ch.subscribeClick).not.toHaveBeenCalled();
+      expect(ch.subscribeCrosshair).not.toHaveBeenCalled();
     });
 
-    it("subscribes to range, size, and click when chartReady flips true", () => {
+    it("subscribes to range, size, click, and crosshair when chartReady flips true", () => {
       stubCanvasContext();
-      const { chart, subscribeRange, subscribeSize, subscribeClick } = fakeChart();
-      const { rerender } = render(<Harness chart={chart} ready={false} />);
-      rerender(<Harness chart={chart} ready={true} />);
-      expect(subscribeRange).toHaveBeenCalledTimes(1);
-      expect(subscribeSize).toHaveBeenCalledTimes(1);
-      expect(subscribeClick).toHaveBeenCalledTimes(1);
+      const ch = fakeChart();
+      const { rerender } = render(<Harness chart={ch.chart} ready={false} />);
+      rerender(<Harness chart={ch.chart} ready={true} />);
+      expect(ch.subscribeRange).toHaveBeenCalledTimes(1);
+      expect(ch.subscribeSize).toHaveBeenCalledTimes(1);
+      expect(ch.subscribeClick).toHaveBeenCalledTimes(1);
+      expect(ch.subscribeCrosshair).toHaveBeenCalledTimes(1);
     });
 
-    it("unsubscribes all three channels on unmount with matching handlers", () => {
+    it("unsubscribes all four channels on unmount with matching handlers", () => {
       stubCanvasContext();
       const ch = fakeChart();
       const { unmount } = render(<Harness chart={ch.chart} ready={true} />);
@@ -234,11 +257,15 @@ describe("ChartDrawingOverlay", () => {
       expect(ch.unsubscribeRange).toHaveBeenCalledTimes(1);
       expect(ch.unsubscribeSize).toHaveBeenCalledTimes(1);
       expect(ch.unsubscribeClick).toHaveBeenCalledTimes(1);
+      expect(ch.unsubscribeCrosshair).toHaveBeenCalledTimes(1);
       expect(ch.unsubscribeRange).toHaveBeenCalledWith(
         ch.subscribeRange.mock.calls[0][0],
       );
       expect(ch.unsubscribeClick).toHaveBeenCalledWith(
         ch.subscribeClick.mock.calls[0][0],
+      );
+      expect(ch.unsubscribeCrosshair).toHaveBeenCalledWith(
+        ch.subscribeCrosshair.mock.calls[0][0],
       );
     });
 
@@ -293,22 +320,8 @@ describe("ChartDrawingOverlay", () => {
   });
 
   describe("click dispatch — pointer mode hit-testing", () => {
-    function fireClick(
-      ch: ReturnType<typeof fakeChart>,
-      x: number,
-      y: number,
-    ): void {
-      const onClick = ch.subscribeClick.mock.calls[0][0] as (
-        p: MouseEventParams<Time>,
-      ) => void;
-      // act() so React flushes the setSelectedId state update before
-      // the next keyDown / assertion. The handler is invoked directly
-      // (not through React's synthetic event system), so we need to
-      // tell React to commit pending updates manually.
-      act(() => {
-        onClick({ point: { x, y } } as unknown as MouseEventParams<Time>);
-      });
-    }
+    // fireClick is hoisted to top level so the trend / horizontal
+    // describe blocks below can use it too.
 
     it("ignores clicks when chartReady=false (no subscription registered)", () => {
       stubCanvasContext();
@@ -317,26 +330,28 @@ describe("ChartDrawingOverlay", () => {
       expect(ch.subscribeClick).not.toHaveBeenCalled();
     });
 
-    it("ignores clicks when tool !== pointer (no creation flow yet)", () => {
-      // With a non-pointer tool, the click handler runs but immediately
-      // returns. Selection state does NOT change.
+    it("non-pointer tool clicks do NOT change selection (clicks dispatch to creation flow)", () => {
+      // With a creation tool active, clicking does NOT hit-test —
+      // the click is consumed by the creation dispatch. A drawing
+      // already in the list shouldn't be selectable until the user
+      // switches back to pointer.
       stubCanvasContext();
       const ch = fakeChart();
-      const drawings: Drawing[] = [horiz("h1", 100)];
+      const deleteDrawing = vi.fn();
       render(
         <Harness
           chart={ch.chart}
           ready={true}
-          drawings={drawings}
+          drawings={[horiz("h1", 100)]}
+          deleteDrawing={deleteDrawing}
           tool="trend"
         />,
       );
-      // Click directly on the horizontal line (price=100, y=100).
+      // Click directly on the line in trend mode — should NOT select.
       fireClick(ch, 50, 100);
-      // No way to externally observe selectedId changing — we'd see it
-      // via a re-render that re-clears the canvas. Verify by not throwing
-      // and not crashing the harness; selection effects don't fire.
-      expect(true).toBe(true); // smoke-only — main assertion in pointer-mode tests
+      // Backspace must NOT delete since nothing was selected.
+      fireEvent.keyDown(document, { key: "Backspace" });
+      expect(deleteDrawing).not.toHaveBeenCalled();
     });
 
     it("ignores clicks with no point info (off-canvas)", () => {
@@ -423,6 +438,274 @@ describe("ChartDrawingOverlay", () => {
       fireEvent.keyDown(document, { key: "Delete" });
       expect(deleteDrawing).toHaveBeenCalledWith("h2");
       expect(deleteDrawing).not.toHaveBeenCalledWith("h1");
+    });
+  });
+
+  describe("horizontal tool — single-click creation", () => {
+    it("commits a horizontal-line drawing at the clicked price", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="horizontal"
+          addDrawing={addDrawing}
+        />,
+      );
+      // Click at y=150 — with the identity converter, price=150.
+      fireClick(ch, 50, 150);
+      expect(addDrawing).toHaveBeenCalledTimes(1);
+      expect(addDrawing).toHaveBeenCalledWith({
+        kind: "horizontal",
+        price: 150,
+      });
+    });
+
+    it("ignores a click when coordinateToPrice returns null (off-scale)", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      const nullSeries: PriceConverter = {
+        priceToCoordinate: () => null,
+        coordinateToPrice: () => null,
+      };
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="horizontal"
+          addDrawing={addDrawing}
+          series={nullSeries}
+        />,
+      );
+      fireClick(ch, 50, 150);
+      expect(addDrawing).not.toHaveBeenCalled();
+    });
+
+    it("stays in horizontal mode after committing (TradingView convention)", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      const setTool = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="horizontal"
+          addDrawing={addDrawing}
+          setTool={setTool}
+        />,
+      );
+      fireClick(ch, 50, 150);
+      // Tool should NOT have been reset — user keeps drawing
+      // horizontals until they explicitly switch tools.
+      expect(setTool).not.toHaveBeenCalled();
+      // A second click commits another horizontal.
+      fireClick(ch, 50, 200);
+      expect(addDrawing).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("trend tool — two-click creation", () => {
+    it("first click locks in p1 without committing yet", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="trend"
+          addDrawing={addDrawing}
+        />,
+      );
+      fireClick(ch, 50, 100);
+      // Click 1 alone must NOT commit a drawing.
+      expect(addDrawing).not.toHaveBeenCalled();
+    });
+
+    it("second click commits a trend with p1 from click 1 and p2 from click 2", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="trend"
+          addDrawing={addDrawing}
+        />,
+      );
+      // Click 1 at (10s, price=100). Identity time-scale: x=10 → time=10s.
+      // pixelToPricePoint converts: time=10 sec → 10000 ms; price=100.
+      fireClick(ch, 10, 100);
+      // Click 2 at (20s, price=200).
+      fireClick(ch, 20, 200);
+      expect(addDrawing).toHaveBeenCalledTimes(1);
+      expect(addDrawing).toHaveBeenCalledWith({
+        kind: "trend",
+        p1: { time: 10000, price: 100 },
+        p2: { time: 20000, price: 200 },
+      });
+    });
+
+    it("stays in trend mode after committing — third click starts a new trend", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      const setTool = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="trend"
+          addDrawing={addDrawing}
+          setTool={setTool}
+        />,
+      );
+      fireClick(ch, 10, 100); // p1 of trend 1
+      fireClick(ch, 20, 200); // p2 of trend 1 → commit
+      expect(setTool).not.toHaveBeenCalled();
+      fireClick(ch, 30, 300); // p1 of trend 2 (NOT a third anchor of trend 1)
+      // Still only one commit — trend 2 isn't done yet.
+      expect(addDrawing).toHaveBeenCalledTimes(1);
+      fireClick(ch, 40, 400); // p2 of trend 2
+      expect(addDrawing).toHaveBeenCalledTimes(2);
+      expect(addDrawing).toHaveBeenLastCalledWith({
+        kind: "trend",
+        p1: { time: 30000, price: 300 },
+        p2: { time: 40000, price: 400 },
+      });
+    });
+
+    it("Escape cancels a pending trend (p1 set, no p2 yet) without changing tool", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      const setTool = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="trend"
+          addDrawing={addDrawing}
+          setTool={setTool}
+        />,
+      );
+      fireClick(ch, 10, 100); // p1 set
+      fireEvent.keyDown(document, { key: "Escape" });
+      // Tool stays in trend (Escape cancelled the pending anchor,
+      // not the tool selection).
+      expect(setTool).not.toHaveBeenCalled();
+      // A subsequent click is treated as p1 of a NEW trend, not p2
+      // of the cancelled one.
+      fireClick(ch, 20, 200);
+      expect(addDrawing).not.toHaveBeenCalled();
+      fireClick(ch, 30, 300);
+      expect(addDrawing).toHaveBeenCalledTimes(1);
+      expect(addDrawing).toHaveBeenCalledWith({
+        kind: "trend",
+        p1: { time: 20000, price: 200 },
+        p2: { time: 30000, price: 300 },
+      });
+    });
+
+    it("Escape with no pending trend AND no selection resets tool to pointer", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const setTool = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="trend"
+          setTool={setTool}
+        />,
+      );
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(setTool).toHaveBeenCalledWith("pointer");
+    });
+
+    it("changing tool mid-trend cancels the pending anchor", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      const { rerender } = render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="trend"
+          addDrawing={addDrawing}
+        />,
+      );
+      fireClick(ch, 10, 100); // p1 set
+      // User switches to horizontal mid-trend.
+      rerender(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="horizontal"
+          addDrawing={addDrawing}
+        />,
+      );
+      // Click in horizontal mode — should commit a HORIZONTAL, not
+      // close out the cancelled trend.
+      fireClick(ch, 20, 200);
+      expect(addDrawing).toHaveBeenCalledTimes(1);
+      expect(addDrawing).toHaveBeenCalledWith({
+        kind: "horizontal",
+        price: 200,
+      });
+    });
+
+    it("changing slab mid-trend cancels the pending anchor", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      const { rerender } = render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="trend"
+          addDrawing={addDrawing}
+          slabAddress={SLAB_A}
+        />,
+      );
+      fireClick(ch, 10, 100); // p1 set on slab A
+      rerender(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="trend"
+          addDrawing={addDrawing}
+          slabAddress={SLAB_B}
+        />,
+      );
+      // First click on slab B is a fresh p1, not p2 of the cancelled
+      // slab-A trend. So it shouldn't commit.
+      fireClick(ch, 20, 200);
+      expect(addDrawing).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("rectangle tool — click is intentionally NOT the trigger", () => {
+    it("a single click in rectangle mode does NOT add a drawing (drag-driven creation lands separately)", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="rectangle"
+          addDrawing={addDrawing}
+        />,
+      );
+      fireClick(ch, 10, 100);
+      fireClick(ch, 20, 200);
+      expect(addDrawing).not.toHaveBeenCalled();
     });
   });
 

--- a/app/__tests__/components/trade/ChartDrawingOverlay.test.tsx
+++ b/app/__tests__/components/trade/ChartDrawingOverlay.test.tsx
@@ -4,32 +4,52 @@ import { useRef, type FC } from "react";
 import type { IChartApi } from "lightweight-charts";
 import { ChartDrawingOverlay } from "@/components/trade/ChartDrawingOverlay";
 
-/** Minimal IChartApi stand-in: only the surface the overlay uses
- *  (timeScale().subscribeVisibleTimeRangeChange + unsubscribe). */
+/** Minimal IChartApi stand-in. Captures both subscription channels the
+ *  overlay uses (visibleLogicalRangeChange + sizeChange) plus their
+ *  unsubscribe pairs, so tests can assert balanced lifecycle. */
 function fakeChart() {
-  const subscribe = vi.fn();
-  const unsubscribe = vi.fn();
+  const subscribeRange = vi.fn();
+  const unsubscribeRange = vi.fn();
+  const subscribeSize = vi.fn();
+  const unsubscribeSize = vi.fn();
   const timeScale = () => ({
-    subscribeVisibleTimeRangeChange: subscribe,
-    unsubscribeVisibleTimeRangeChange: unsubscribe,
+    subscribeVisibleLogicalRangeChange: subscribeRange,
+    unsubscribeVisibleLogicalRangeChange: unsubscribeRange,
+    subscribeSizeChange: subscribeSize,
+    unsubscribeSizeChange: unsubscribeSize,
   });
   return {
     chart: { timeScale } as unknown as IChartApi,
-    subscribe,
-    unsubscribe,
+    subscribeRange,
+    unsubscribeRange,
+    subscribeSize,
+    unsubscribeSize,
   };
 }
 
 /** ResizeObserver isn't implemented by jsdom. Stub it just enough to
- *  let the component construct one and call observe / disconnect. */
+ *  let the component construct one and call observe / disconnect, AND
+ *  capture the callback so tests can fire a synthetic size change. */
+let lastResizeObserver: FakeResizeObserver | null = null;
 class FakeResizeObserver {
+  callback: ResizeObserverCallback;
   observe = vi.fn();
   disconnect = vi.fn();
   unobserve = vi.fn();
+  constructor(cb: ResizeObserverCallback) {
+    this.callback = cb;
+    lastResizeObserver = this;
+  }
+  /** Test-only: invoke the callback as if the browser observed a size
+   *  change. Real RO callbacks receive entries; we don't use them. */
+  fire(): void {
+    this.callback([] as unknown as ResizeObserverEntry[], this as unknown as ResizeObserver);
+  }
 }
 
 /** Stub the 2D canvas context. jsdom's real canvas returns null from
- *  getContext("2d") without node-canvas. */
+ *  getContext("2d") without node-canvas. Returns the captured stub
+ *  functions so tests can assert calls. */
 function stubCanvasContext() {
   const setTransform = vi.fn();
   const clearRect = vi.fn();
@@ -40,7 +60,15 @@ function stubCanvasContext() {
   return { setTransform, clearRect };
 }
 
+/** Stub getContext to return null — the overlay's bail path. */
+function stubNullCanvasContext() {
+  HTMLCanvasElement.prototype.getContext = vi
+    .fn()
+    .mockReturnValue(null) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+}
+
 beforeEach(() => {
+  lastResizeObserver = null;
   // @ts-expect-error: stubbing the global for tests.
   globalThis.ResizeObserver = FakeResizeObserver;
 });
@@ -89,39 +117,132 @@ describe("ChartDrawingOverlay", () => {
 
   it("does NOT subscribe when chartReady is false (chart not yet created)", () => {
     stubCanvasContext();
-    const { chart, subscribe } = fakeChart();
+    const { chart, subscribeRange, subscribeSize } = fakeChart();
     render(<Harness chart={chart} ready={false} />);
-    expect(subscribe).not.toHaveBeenCalled();
+    expect(subscribeRange).not.toHaveBeenCalled();
+    expect(subscribeSize).not.toHaveBeenCalled();
   });
 
-  it("subscribes to visibleTimeRangeChange when chartReady flips true", () => {
+  it("subscribes to logical-range AND size changes when chartReady flips true", () => {
     stubCanvasContext();
-    const { chart, subscribe } = fakeChart();
+    const { chart, subscribeRange, subscribeSize } = fakeChart();
     const { rerender } = render(<Harness chart={chart} ready={false} />);
-    expect(subscribe).not.toHaveBeenCalled();
+    expect(subscribeRange).not.toHaveBeenCalled();
     rerender(<Harness chart={chart} ready={true} />);
-    expect(subscribe).toHaveBeenCalledTimes(1);
+    expect(subscribeRange).toHaveBeenCalledTimes(1);
+    expect(subscribeSize).toHaveBeenCalledTimes(1);
   });
 
-  it("unsubscribes when the component unmounts", () => {
+  it("unsubscribes both channels when the component unmounts", () => {
     stubCanvasContext();
-    const { chart, subscribe, unsubscribe } = fakeChart();
+    const {
+      chart,
+      subscribeRange,
+      unsubscribeRange,
+      subscribeSize,
+      unsubscribeSize,
+    } = fakeChart();
     const { unmount } = render(<Harness chart={chart} ready={true} />);
-    expect(subscribe).toHaveBeenCalledTimes(1);
+    expect(subscribeRange).toHaveBeenCalledTimes(1);
+    expect(subscribeSize).toHaveBeenCalledTimes(1);
     unmount();
-    expect(unsubscribe).toHaveBeenCalledTimes(1);
-    // Same handler reference passed to both subscribe and unsubscribe.
-    expect(unsubscribe).toHaveBeenCalledWith(subscribe.mock.calls[0][0]);
+    expect(unsubscribeRange).toHaveBeenCalledTimes(1);
+    expect(unsubscribeSize).toHaveBeenCalledTimes(1);
+    // Same handler reference passed to subscribe and unsubscribe on
+    // both channels — required so lightweight-charts can find and
+    // remove the registered handler.
+    expect(unsubscribeRange).toHaveBeenCalledWith(subscribeRange.mock.calls[0][0]);
+    expect(unsubscribeSize).toHaveBeenCalledWith(subscribeSize.mock.calls[0][0]);
+  });
+
+  it("balances subscribe / unsubscribe across a chartReady toggle cycle", () => {
+    // false → true → false → true must produce exactly 2 subscribes and
+    // 2 unsubscribes per channel, with each unsubscribe pairing the
+    // matching subscribe (Strict Mode + hot-reload come through this
+    // exact path).
+    stubCanvasContext();
+    const {
+      chart,
+      subscribeRange,
+      unsubscribeRange,
+      subscribeSize,
+      unsubscribeSize,
+    } = fakeChart();
+    const { rerender } = render(<Harness chart={chart} ready={false} />);
+    rerender(<Harness chart={chart} ready={true} />); // sub #1
+    rerender(<Harness chart={chart} ready={false} />); // unsub #1
+    rerender(<Harness chart={chart} ready={true} />); // sub #2
+
+    expect(subscribeRange).toHaveBeenCalledTimes(2);
+    expect(unsubscribeRange).toHaveBeenCalledTimes(1);
+    expect(subscribeSize).toHaveBeenCalledTimes(2);
+    expect(unsubscribeSize).toHaveBeenCalledTimes(1);
+
+    // The handler from sub#1 is the same as the handler unsub#1 received.
+    expect(unsubscribeRange.mock.calls[0][0]).toBe(
+      subscribeRange.mock.calls[0][0],
+    );
+    expect(unsubscribeSize.mock.calls[0][0]).toBe(
+      subscribeSize.mock.calls[0][0],
+    );
   });
 
   it("swallows errors from unsubscribe (chart already destroyed)", () => {
     stubCanvasContext();
-    const { chart, unsubscribe } = fakeChart();
-    unsubscribe.mockImplementation(() => {
+    const { chart, unsubscribeRange } = fakeChart();
+    unsubscribeRange.mockImplementation(() => {
       throw new Error("chart destroyed in parallel");
     });
     const { unmount } = render(<Harness chart={chart} ready={true} />);
     // Should not throw — the cleanup catches & swallows.
     expect(() => unmount()).not.toThrow();
+  });
+
+  it("observes the container element via ResizeObserver", () => {
+    stubCanvasContext();
+    const { chart } = fakeChart();
+    const { container } = render(<Harness chart={chart} ready={true} />);
+    expect(lastResizeObserver).not.toBeNull();
+    expect(lastResizeObserver!.observe).toHaveBeenCalledTimes(1);
+    // The argument passed to observe must be the container div, NOT
+    // the canvas — the canvas's size is derived from the container's.
+    const observedTarget = lastResizeObserver!.observe.mock.calls[0][0];
+    const containerDiv = container.querySelector("div");
+    expect(observedTarget).toBe(containerDiv);
+  });
+
+  it("clears the canvas on each redraw trigger (resize observer + range change)", () => {
+    // Pin the redraw seam BEFORE per-kind render branches drop in.
+    // Without this assertion, a future refactor could subscribe to a
+    // no-op closure and ship green.
+    const { clearRect } = stubCanvasContext();
+    const { chart, subscribeRange } = fakeChart();
+    render(<Harness chart={chart} ready={true} />);
+    // Initial mount calls resize() once -> redraw -> clearRect.
+    const initialCalls = clearRect.mock.calls.length;
+    expect(initialCalls).toBeGreaterThan(0);
+
+    // Fire ResizeObserver: should call resize -> redraw -> clearRect.
+    lastResizeObserver!.fire();
+    expect(clearRect.mock.calls.length).toBe(initialCalls + 1);
+
+    // Fire the range-change handler the overlay registered: should
+    // call redraw -> clearRect.
+    const rangeHandler = subscribeRange.mock.calls[0][0];
+    rangeHandler(null);
+    expect(clearRect.mock.calls.length).toBe(initialCalls + 2);
+  });
+
+  it("bails cleanly when getContext('2d') returns null (no throw, no subscribe)", () => {
+    // A canvas where another consumer requested a non-2D context first
+    // returns null on subsequent getContext("2d") calls. The overlay
+    // must not throw and must not subscribe in that state.
+    stubNullCanvasContext();
+    const { chart, subscribeRange, subscribeSize } = fakeChart();
+    expect(() =>
+      render(<Harness chart={chart} ready={true} />),
+    ).not.toThrow();
+    expect(subscribeRange).not.toHaveBeenCalled();
+    expect(subscribeSize).not.toHaveBeenCalled();
   });
 });

--- a/app/__tests__/components/trade/ChartDrawingOverlay.test.tsx
+++ b/app/__tests__/components/trade/ChartDrawingOverlay.test.tsx
@@ -21,6 +21,7 @@ function fakeChart() {
   const unsubscribeClick = vi.fn();
   const subscribeCrosshair = vi.fn();
   const unsubscribeCrosshair = vi.fn();
+  const applyOptions = vi.fn();
   // Identity-ish time scale: time-in-seconds maps to x-pixel directly.
   const timeScale = () => ({
     subscribeVisibleLogicalRangeChange: subscribeRange,
@@ -30,15 +31,37 @@ function fakeChart() {
     timeToCoordinate: (t: number) => t,
     coordinateToTime: (c: number) => c as Time,
   });
+  // Real DOM element so the rectangle drag's mousedown listener can
+  // attach via chart.chartElement(). 800×600 bounding rect anchors
+  // the click → chart-canvas-coord conversion in the drag handlers.
+  const chartElement = document.createElement("div");
+  chartElement.getBoundingClientRect = () =>
+    ({
+      left: 0,
+      top: 0,
+      right: 800,
+      bottom: 600,
+      width: 800,
+      height: 600,
+      x: 0,
+      y: 0,
+      toJSON() {
+        return this;
+      },
+    }) as DOMRect;
   const chart = {
     timeScale,
     subscribeClick,
     unsubscribeClick,
     subscribeCrosshairMove: subscribeCrosshair,
     unsubscribeCrosshairMove: unsubscribeCrosshair,
+    chartElement: () => chartElement,
+    applyOptions,
   } as unknown as IChartApi;
   return {
     chart,
+    chartElement,
+    applyOptions,
     subscribeRange,
     unsubscribeRange,
     subscribeSize,
@@ -883,8 +906,8 @@ describe("ChartDrawingOverlay", () => {
     });
   });
 
-  describe("rectangle tool — click is intentionally NOT the trigger", () => {
-    it("a single click in rectangle mode does NOT add a drawing (drag-driven creation lands separately)", () => {
+  describe("rectangle tool — drag-driven creation", () => {
+    it("a chart.subscribeClick click does NOT add a drawing (rectangle uses raw mouse events)", () => {
       stubCanvasContext();
       const ch = fakeChart();
       const addDrawing = vi.fn();
@@ -898,6 +921,270 @@ describe("ChartDrawingOverlay", () => {
       );
       fireClick(ch, 10, 100);
       fireClick(ch, 20, 200);
+      expect(addDrawing).not.toHaveBeenCalled();
+    });
+
+    it("a drag (mousedown → mousemove → mouseup with size ≥ 10×10) commits a rectangle", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="rectangle"
+          addDrawing={addDrawing}
+        />,
+      );
+      // Mouse-down at (10, 100) — locks pendingP1.
+      fireEvent.mouseDown(ch.chartElement, {
+        clientX: 10,
+        clientY: 100,
+        button: 0,
+      });
+      // Mouse-move during drag (just to update preview, not strictly
+      // required for commit).
+      fireEvent.mouseMove(document, { clientX: 50, clientY: 200 });
+      // Mouse-up at (50, 200) — drag is 40×100 px, well over the
+      // 10×10 minimum.
+      fireEvent.mouseUp(document, { clientX: 50, clientY: 200 });
+      expect(addDrawing).toHaveBeenCalledTimes(1);
+      expect(addDrawing).toHaveBeenCalledWith({
+        kind: "rectangle",
+        p1: { time: 10000, price: 100 },
+        p2: { time: 50000, price: 200 },
+      });
+    });
+
+    it("a tiny drag (< 10×10 in BOTH dimensions) is rejected as click jitter", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="rectangle"
+          addDrawing={addDrawing}
+        />,
+      );
+      fireEvent.mouseDown(ch.chartElement, {
+        clientX: 10,
+        clientY: 100,
+        button: 0,
+      });
+      // Drag of 5px × 5px — under both thresholds. Reject.
+      fireEvent.mouseUp(document, { clientX: 15, clientY: 105 });
+      expect(addDrawing).not.toHaveBeenCalled();
+    });
+
+    it("a drag that's wide but very short (only x dim ≥ 10) commits", () => {
+      // Plan threshold: dx < 10 AND dy < 10 → reject. EITHER ≥ 10 → commit.
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="rectangle"
+          addDrawing={addDrawing}
+        />,
+      );
+      fireEvent.mouseDown(ch.chartElement, {
+        clientX: 10,
+        clientY: 100,
+        button: 0,
+      });
+      // 50px wide, 2px tall — wider than the threshold so commits.
+      fireEvent.mouseUp(document, { clientX: 60, clientY: 102 });
+      expect(addDrawing).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores right-click (button !== 0)", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="rectangle"
+          addDrawing={addDrawing}
+        />,
+      );
+      fireEvent.mouseDown(ch.chartElement, {
+        clientX: 10,
+        clientY: 100,
+        button: 2, // right-click
+      });
+      fireEvent.mouseUp(document, { clientX: 50, clientY: 200 });
+      expect(addDrawing).not.toHaveBeenCalled();
+    });
+
+    it("Escape mid-drag cancels the pending anchor without committing", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      const setTool = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="rectangle"
+          addDrawing={addDrawing}
+          setTool={setTool}
+        />,
+      );
+      fireEvent.mouseDown(ch.chartElement, {
+        clientX: 10,
+        clientY: 100,
+        button: 0,
+      });
+      // Escape — priority chain: pendingP1 is set, so cancel it.
+      // Tool stays in rectangle mode (not reset to pointer).
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(setTool).not.toHaveBeenCalled();
+      // Subsequent mouseup must NOT commit (pendingP1 was cleared).
+      fireEvent.mouseUp(document, { clientX: 50, clientY: 200 });
+      expect(addDrawing).not.toHaveBeenCalled();
+    });
+
+    it("suppresses chart pan/zoom during drag and restores on commit", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      render(
+        <Harness chart={ch.chart} ready={true} tool="rectangle" />,
+      );
+      // Before any drag, applyOptions has not been called from the
+      // overlay (the pan-suppress effect requires pendingP1).
+      const beforeMouseDown = ch.applyOptions.mock.calls.length;
+      fireEvent.mouseDown(ch.chartElement, {
+        clientX: 10,
+        clientY: 100,
+        button: 0,
+      });
+      // After mouseDown, the suppress effect ran and disabled pan/zoom.
+      expect(ch.applyOptions.mock.calls.length).toBeGreaterThan(
+        beforeMouseDown,
+      );
+      // The most recent applyOptions call should disable both.
+      const lastCall = ch.applyOptions.mock.calls.at(-1);
+      expect(lastCall?.[0]).toMatchObject({
+        handleScroll: false,
+        handleScale: false,
+      });
+      // Commit the drag.
+      fireEvent.mouseUp(document, { clientX: 50, clientY: 200 });
+      // After commit, applyOptions called again to RESTORE pan/zoom.
+      const restoreCall = ch.applyOptions.mock.calls.at(-1);
+      expect(restoreCall?.[0]).toMatchObject({
+        handleScroll: true,
+        handleScale: true,
+      });
+    });
+
+    it("suppresses chart pan/zoom during drag and restores on Escape cancel", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      render(
+        <Harness chart={ch.chart} ready={true} tool="rectangle" />,
+      );
+      fireEvent.mouseDown(ch.chartElement, {
+        clientX: 10,
+        clientY: 100,
+        button: 0,
+      });
+      fireEvent.keyDown(document, { key: "Escape" });
+      // Cleanup ran — last applyOptions should be the RESTORE call.
+      const lastCall = ch.applyOptions.mock.calls.at(-1);
+      expect(lastCall?.[0]).toMatchObject({
+        handleScroll: true,
+        handleScale: true,
+      });
+    });
+
+    it("stays in rectangle mode after committing — second drag works the same", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      const setTool = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="rectangle"
+          addDrawing={addDrawing}
+          setTool={setTool}
+        />,
+      );
+      fireEvent.mouseDown(ch.chartElement, {
+        clientX: 10,
+        clientY: 100,
+        button: 0,
+      });
+      fireEvent.mouseUp(document, { clientX: 50, clientY: 200 });
+      fireEvent.mouseDown(ch.chartElement, {
+        clientX: 100,
+        clientY: 300,
+        button: 0,
+      });
+      fireEvent.mouseUp(document, { clientX: 200, clientY: 400 });
+      expect(addDrawing).toHaveBeenCalledTimes(2);
+      expect(setTool).not.toHaveBeenCalled();
+    });
+
+    it("mousedown is suppressed on mobile viewport (matchMedia)", () => {
+      const originalMatchMedia = window.matchMedia;
+      window.matchMedia = vi.fn().mockReturnValue({
+        matches: true,
+      } as MediaQueryList);
+      try {
+        stubCanvasContext();
+        const ch = fakeChart();
+        const addDrawing = vi.fn();
+        render(
+          <Harness
+            chart={ch.chart}
+            ready={true}
+            tool="rectangle"
+            addDrawing={addDrawing}
+          />,
+        );
+        fireEvent.mouseDown(ch.chartElement, {
+          clientX: 10,
+          clientY: 100,
+          button: 0,
+        });
+        fireEvent.mouseUp(document, { clientX: 50, clientY: 200 });
+        // Mobile guard short-circuited before pendingP1 was set;
+        // mouseUp had no pending state to commit.
+        expect(addDrawing).not.toHaveBeenCalled();
+      } finally {
+        window.matchMedia = originalMatchMedia;
+      }
+    });
+
+    it("does NOT attach mousedown listener when tool is not rectangle", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="pointer"
+          addDrawing={addDrawing}
+        />,
+      );
+      // Mousedown on the chart element when pointer mode is active —
+      // no drag handler should fire, no pendingP1 set.
+      fireEvent.mouseDown(ch.chartElement, {
+        clientX: 10,
+        clientY: 100,
+        button: 0,
+      });
+      fireEvent.mouseUp(document, { clientX: 50, clientY: 200 });
       expect(addDrawing).not.toHaveBeenCalled();
     });
   });

--- a/app/__tests__/components/trade/ChartDrawingOverlay.test.tsx
+++ b/app/__tests__/components/trade/ChartDrawingOverlay.test.tsx
@@ -1,35 +1,56 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render } from "@testing-library/react";
+import { render, fireEvent, screen, act } from "@testing-library/react";
 import { useRef, type FC } from "react";
-import type { IChartApi } from "lightweight-charts";
+import type { IChartApi, MouseEventParams, Time } from "lightweight-charts";
 import { ChartDrawingOverlay } from "@/components/trade/ChartDrawingOverlay";
+import type { Drawing, DrawingTool } from "@/lib/chart-drawings";
+import type { PriceConverter } from "@/lib/chart-coords";
 
-/** Minimal IChartApi stand-in. Captures both subscription channels the
- *  overlay uses (visibleLogicalRangeChange + sizeChange) plus their
- *  unsubscribe pairs, so tests can assert balanced lifecycle. */
+const SLAB_A = "So11111111111111111111111111111111111111112";
+const SLAB_B = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+/** Minimal IChartApi stand-in. Captures all subscription channels the
+ *  overlay uses (visibleLogicalRangeChange + sizeChange + click) plus
+ *  their unsubscribe pairs, so tests can assert balanced lifecycle. */
 function fakeChart() {
   const subscribeRange = vi.fn();
   const unsubscribeRange = vi.fn();
   const subscribeSize = vi.fn();
   const unsubscribeSize = vi.fn();
+  const subscribeClick = vi.fn();
+  const unsubscribeClick = vi.fn();
+  // Identity-ish time scale: time-in-seconds maps to x-pixel directly.
   const timeScale = () => ({
     subscribeVisibleLogicalRangeChange: subscribeRange,
     unsubscribeVisibleLogicalRangeChange: unsubscribeRange,
     subscribeSizeChange: subscribeSize,
     unsubscribeSizeChange: unsubscribeSize,
+    timeToCoordinate: (t: number) => t,
+    coordinateToTime: (c: number) => c as Time,
   });
+  const chart = {
+    timeScale,
+    subscribeClick,
+    unsubscribeClick,
+  } as unknown as IChartApi;
   return {
-    chart: { timeScale } as unknown as IChartApi,
+    chart,
     subscribeRange,
     unsubscribeRange,
     subscribeSize,
     unsubscribeSize,
+    subscribeClick,
+    unsubscribeClick,
   };
 }
 
-/** ResizeObserver isn't implemented by jsdom. Stub it just enough to
- *  let the component construct one and call observe / disconnect, AND
- *  capture the callback so tests can fire a synthetic size change. */
+/** Identity-ish series: price maps to y-pixel directly. */
+const idSeries: PriceConverter = {
+  priceToCoordinate: (price) => price,
+  coordinateToPrice: (coord) => coord,
+};
+
+/** ResizeObserver stub. */
 let lastResizeObserver: FakeResizeObserver | null = null;
 class FakeResizeObserver {
   callback: ResizeObserverCallback;
@@ -40,27 +61,45 @@ class FakeResizeObserver {
     this.callback = cb;
     lastResizeObserver = this;
   }
-  /** Test-only: invoke the callback as if the browser observed a size
-   *  change. Real RO callbacks receive entries; we don't use them. */
   fire(): void {
     this.callback([] as unknown as ResizeObserverEntry[], this as unknown as ResizeObserver);
   }
 }
 
 /** Stub the 2D canvas context. jsdom's real canvas returns null from
- *  getContext("2d") without node-canvas. Returns the captured stub
- *  functions so tests can assert calls. */
+ *  getContext("2d") without node-canvas. */
 function stubCanvasContext() {
   const setTransform = vi.fn();
   const clearRect = vi.fn();
-  const ctxStub = { setTransform, clearRect } as unknown as CanvasRenderingContext2D;
+  const beginPath = vi.fn();
+  const moveTo = vi.fn();
+  const lineTo = vi.fn();
+  const stroke = vi.fn();
+  const fill = vi.fn();
+  const fillRect = vi.fn();
+  const strokeRect = vi.fn();
+  const arc = vi.fn();
+  const ctxStub = {
+    setTransform,
+    clearRect,
+    beginPath,
+    moveTo,
+    lineTo,
+    stroke,
+    fill,
+    fillRect,
+    strokeRect,
+    arc,
+    set strokeStyle(_v: string) {},
+    set fillStyle(_v: string) {},
+    set lineWidth(_v: number) {},
+  } as unknown as CanvasRenderingContext2D;
   HTMLCanvasElement.prototype.getContext = vi
     .fn()
     .mockReturnValue(ctxStub) as unknown as typeof HTMLCanvasElement.prototype.getContext;
-  return { setTransform, clearRect };
+  return { setTransform, clearRect, beginPath, moveTo, lineTo, stroke, fillRect, strokeRect, arc };
 }
 
-/** Stub getContext to return null — the overlay's bail path. */
 function stubNullCanvasContext() {
   HTMLCanvasElement.prototype.getContext = vi
     .fn()
@@ -77,172 +116,556 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-/** Tiny harness that wires the overlay up the way TradingChart does:
- *  parent owns chartRef + containerRef + chartReady. The chartRef is
- *  assigned synchronously during render — the real TradingChart sets
- *  it inside its chart-init effect just before flipping chartReady,
- *  and child effects run after parent state commits. Mirroring that
- *  ordering with a render-time assignment is the simplest faithful
- *  test surface (a useEffect-based assignment fires AFTER the child's
- *  effect, leaving chartRef.current null when the overlay subscribes). */
-const Harness: FC<{ chart: IChartApi | null; ready: boolean }> = ({
+interface HarnessProps {
+  chart: IChartApi | null;
+  ready: boolean;
+  drawings?: readonly Drawing[];
+  deleteDrawing?: (id: string) => void;
+  tool?: DrawingTool;
+  setTool?: (next: DrawingTool) => void;
+  slabAddress?: string;
+  series?: PriceConverter | null;
+}
+
+const Harness: FC<HarnessProps> = ({
   chart,
   ready,
+  drawings = [],
+  deleteDrawing = () => {},
+  tool = "pointer",
+  setTool = () => {},
+  slabAddress = SLAB_A,
+  series = idSeries,
 }) => {
   const chartRef = useRef<IChartApi | null>(null);
   chartRef.current = chart;
+  const seriesRef = useRef<PriceConverter | null>(null);
+  seriesRef.current = series;
   const containerRef = useRef<HTMLDivElement | null>(null);
   return (
     <div ref={containerRef} style={{ width: 800, height: 600 }}>
       <ChartDrawingOverlay
         chartRef={chartRef}
+        seriesRef={seriesRef}
         containerRef={containerRef}
         chartReady={ready}
+        drawings={drawings}
+        deleteDrawing={deleteDrawing}
+        tool={tool}
+        setTool={setTool}
+        slabAddress={slabAddress}
       />
     </div>
   );
 };
 
+const horiz = (id: string, price: number): Drawing => ({
+  id,
+  kind: "horizontal",
+  price,
+});
+
+/** Helper: dispatch a click through the captured chart.subscribeClick
+ *  handler, wrapped in act() so React flushes the setSelectedId state
+ *  update before the next assertion / keyDown. The handler is invoked
+ *  outside React's synthetic-event system (via the lightweight-charts
+ *  subscription), so manual act() is required. */
+function selectVia(
+  ch: ReturnType<typeof fakeChart>,
+  x: number,
+  y: number,
+): void {
+  const onClick = ch.subscribeClick.mock.calls[0][0] as (
+    p: MouseEventParams<Time>,
+  ) => void;
+  act(() => {
+    onClick({ point: { x, y } } as unknown as MouseEventParams<Time>);
+  });
+}
+
 describe("ChartDrawingOverlay", () => {
-  it("renders an aria-hidden, pointer-events-none canvas", () => {
-    stubCanvasContext();
-    const { chart } = fakeChart();
-    const { container } = render(<Harness chart={chart} ready={false} />);
-    const canvas = container.querySelector("canvas");
-    expect(canvas).not.toBeNull();
-    expect(canvas?.getAttribute("aria-hidden")).toBe("true");
-    expect(canvas?.className).toContain("pointer-events-none");
-    expect(canvas?.className).toContain("absolute");
-  });
-
-  it("does NOT subscribe when chartReady is false (chart not yet created)", () => {
-    stubCanvasContext();
-    const { chart, subscribeRange, subscribeSize } = fakeChart();
-    render(<Harness chart={chart} ready={false} />);
-    expect(subscribeRange).not.toHaveBeenCalled();
-    expect(subscribeSize).not.toHaveBeenCalled();
-  });
-
-  it("subscribes to logical-range AND size changes when chartReady flips true", () => {
-    stubCanvasContext();
-    const { chart, subscribeRange, subscribeSize } = fakeChart();
-    const { rerender } = render(<Harness chart={chart} ready={false} />);
-    expect(subscribeRange).not.toHaveBeenCalled();
-    rerender(<Harness chart={chart} ready={true} />);
-    expect(subscribeRange).toHaveBeenCalledTimes(1);
-    expect(subscribeSize).toHaveBeenCalledTimes(1);
-  });
-
-  it("unsubscribes both channels when the component unmounts", () => {
-    stubCanvasContext();
-    const {
-      chart,
-      subscribeRange,
-      unsubscribeRange,
-      subscribeSize,
-      unsubscribeSize,
-    } = fakeChart();
-    const { unmount } = render(<Harness chart={chart} ready={true} />);
-    expect(subscribeRange).toHaveBeenCalledTimes(1);
-    expect(subscribeSize).toHaveBeenCalledTimes(1);
-    unmount();
-    expect(unsubscribeRange).toHaveBeenCalledTimes(1);
-    expect(unsubscribeSize).toHaveBeenCalledTimes(1);
-    // Same handler reference passed to subscribe and unsubscribe on
-    // both channels — required so lightweight-charts can find and
-    // remove the registered handler.
-    expect(unsubscribeRange).toHaveBeenCalledWith(subscribeRange.mock.calls[0][0]);
-    expect(unsubscribeSize).toHaveBeenCalledWith(subscribeSize.mock.calls[0][0]);
-  });
-
-  it("balances subscribe / unsubscribe across a chartReady toggle cycle", () => {
-    // false → true → false → true must produce exactly 2 subscribes and
-    // 2 unsubscribes per channel, with each unsubscribe pairing the
-    // matching subscribe (Strict Mode + hot-reload come through this
-    // exact path).
-    stubCanvasContext();
-    const {
-      chart,
-      subscribeRange,
-      unsubscribeRange,
-      subscribeSize,
-      unsubscribeSize,
-    } = fakeChart();
-    const { rerender } = render(<Harness chart={chart} ready={false} />);
-    rerender(<Harness chart={chart} ready={true} />); // sub #1
-    rerender(<Harness chart={chart} ready={false} />); // unsub #1
-    rerender(<Harness chart={chart} ready={true} />); // sub #2
-
-    expect(subscribeRange).toHaveBeenCalledTimes(2);
-    expect(unsubscribeRange).toHaveBeenCalledTimes(1);
-    expect(subscribeSize).toHaveBeenCalledTimes(2);
-    expect(unsubscribeSize).toHaveBeenCalledTimes(1);
-
-    // The handler from sub#1 is the same as the handler unsub#1 received.
-    expect(unsubscribeRange.mock.calls[0][0]).toBe(
-      subscribeRange.mock.calls[0][0],
-    );
-    expect(unsubscribeSize.mock.calls[0][0]).toBe(
-      subscribeSize.mock.calls[0][0],
-    );
-  });
-
-  it("swallows errors from unsubscribe (chart already destroyed)", () => {
-    stubCanvasContext();
-    const { chart, unsubscribeRange } = fakeChart();
-    unsubscribeRange.mockImplementation(() => {
-      throw new Error("chart destroyed in parallel");
+  describe("rendering", () => {
+    it("renders an aria-hidden, pointer-events-none canvas", () => {
+      stubCanvasContext();
+      const { chart } = fakeChart();
+      const { container } = render(<Harness chart={chart} ready={false} />);
+      const canvas = container.querySelector("canvas");
+      expect(canvas).not.toBeNull();
+      expect(canvas?.getAttribute("aria-hidden")).toBe("true");
+      expect(canvas?.className).toContain("pointer-events-none");
+      expect(canvas?.className).toContain("absolute");
     });
-    const { unmount } = render(<Harness chart={chart} ready={true} />);
-    // Should not throw — the cleanup catches & swallows.
-    expect(() => unmount()).not.toThrow();
+
+    it("bails cleanly when getContext('2d') returns null", () => {
+      stubNullCanvasContext();
+      const { chart, subscribeRange } = fakeChart();
+      expect(() =>
+        render(<Harness chart={chart} ready={true} />),
+      ).not.toThrow();
+      expect(subscribeRange).not.toHaveBeenCalled();
+    });
   });
 
-  it("observes the container element via ResizeObserver", () => {
-    stubCanvasContext();
-    const { chart } = fakeChart();
-    const { container } = render(<Harness chart={chart} ready={true} />);
-    expect(lastResizeObserver).not.toBeNull();
-    expect(lastResizeObserver!.observe).toHaveBeenCalledTimes(1);
-    // The argument passed to observe must be the container div, NOT
-    // the canvas — the canvas's size is derived from the container's.
-    const observedTarget = lastResizeObserver!.observe.mock.calls[0][0];
-    const containerDiv = container.querySelector("div");
-    expect(observedTarget).toBe(containerDiv);
+  describe("subscription lifecycle", () => {
+    it("does NOT subscribe when chartReady is false", () => {
+      stubCanvasContext();
+      const { chart, subscribeRange, subscribeSize, subscribeClick } = fakeChart();
+      render(<Harness chart={chart} ready={false} />);
+      expect(subscribeRange).not.toHaveBeenCalled();
+      expect(subscribeSize).not.toHaveBeenCalled();
+      expect(subscribeClick).not.toHaveBeenCalled();
+    });
+
+    it("subscribes to range, size, and click when chartReady flips true", () => {
+      stubCanvasContext();
+      const { chart, subscribeRange, subscribeSize, subscribeClick } = fakeChart();
+      const { rerender } = render(<Harness chart={chart} ready={false} />);
+      rerender(<Harness chart={chart} ready={true} />);
+      expect(subscribeRange).toHaveBeenCalledTimes(1);
+      expect(subscribeSize).toHaveBeenCalledTimes(1);
+      expect(subscribeClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("unsubscribes all three channels on unmount with matching handlers", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const { unmount } = render(<Harness chart={ch.chart} ready={true} />);
+      unmount();
+      expect(ch.unsubscribeRange).toHaveBeenCalledTimes(1);
+      expect(ch.unsubscribeSize).toHaveBeenCalledTimes(1);
+      expect(ch.unsubscribeClick).toHaveBeenCalledTimes(1);
+      expect(ch.unsubscribeRange).toHaveBeenCalledWith(
+        ch.subscribeRange.mock.calls[0][0],
+      );
+      expect(ch.unsubscribeClick).toHaveBeenCalledWith(
+        ch.subscribeClick.mock.calls[0][0],
+      );
+    });
+
+    it("balances subscribe / unsubscribe across a chartReady toggle cycle", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const { rerender } = render(<Harness chart={ch.chart} ready={false} />);
+      rerender(<Harness chart={ch.chart} ready={true} />);
+      rerender(<Harness chart={ch.chart} ready={false} />);
+      rerender(<Harness chart={ch.chart} ready={true} />);
+      expect(ch.subscribeRange).toHaveBeenCalledTimes(2);
+      expect(ch.unsubscribeRange).toHaveBeenCalledTimes(1);
+      expect(ch.subscribeClick).toHaveBeenCalledTimes(2);
+      expect(ch.unsubscribeClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("swallows errors from unsubscribe (chart already destroyed)", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      ch.unsubscribeRange.mockImplementation(() => {
+        throw new Error("chart destroyed in parallel");
+      });
+      const { unmount } = render(<Harness chart={ch.chart} ready={true} />);
+      expect(() => unmount()).not.toThrow();
+    });
+
+    it("observes the container element via ResizeObserver", () => {
+      stubCanvasContext();
+      const { chart } = fakeChart();
+      const { container } = render(<Harness chart={chart} ready={true} />);
+      expect(lastResizeObserver).not.toBeNull();
+      expect(lastResizeObserver!.observe).toHaveBeenCalledTimes(1);
+      const observed = lastResizeObserver!.observe.mock.calls[0][0];
+      expect(observed).toBe(container.querySelector("div"));
+    });
+
+    it("clears the canvas on each redraw trigger (resize, range change, size change)", () => {
+      const { clearRect } = stubCanvasContext();
+      const ch = fakeChart();
+      render(<Harness chart={ch.chart} ready={true} />);
+      const initial = clearRect.mock.calls.length;
+      expect(initial).toBeGreaterThan(0);
+      lastResizeObserver!.fire();
+      expect(clearRect.mock.calls.length).toBe(initial + 1);
+      const rangeHandler = ch.subscribeRange.mock.calls[0][0];
+      rangeHandler(null);
+      expect(clearRect.mock.calls.length).toBe(initial + 2);
+      const sizeHandler = ch.subscribeSize.mock.calls[0][0];
+      sizeHandler();
+      expect(clearRect.mock.calls.length).toBe(initial + 3);
+    });
   });
 
-  it("clears the canvas on each redraw trigger (resize observer + range change)", () => {
-    // Pin the redraw seam BEFORE per-kind render branches drop in.
-    // Without this assertion, a future refactor could subscribe to a
-    // no-op closure and ship green.
-    const { clearRect } = stubCanvasContext();
-    const { chart, subscribeRange } = fakeChart();
-    render(<Harness chart={chart} ready={true} />);
-    // Initial mount calls resize() once -> redraw -> clearRect.
-    const initialCalls = clearRect.mock.calls.length;
-    expect(initialCalls).toBeGreaterThan(0);
+  describe("click dispatch — pointer mode hit-testing", () => {
+    function fireClick(
+      ch: ReturnType<typeof fakeChart>,
+      x: number,
+      y: number,
+    ): void {
+      const onClick = ch.subscribeClick.mock.calls[0][0] as (
+        p: MouseEventParams<Time>,
+      ) => void;
+      // act() so React flushes the setSelectedId state update before
+      // the next keyDown / assertion. The handler is invoked directly
+      // (not through React's synthetic event system), so we need to
+      // tell React to commit pending updates manually.
+      act(() => {
+        onClick({ point: { x, y } } as unknown as MouseEventParams<Time>);
+      });
+    }
 
-    // Fire ResizeObserver: should call resize -> redraw -> clearRect.
-    lastResizeObserver!.fire();
-    expect(clearRect.mock.calls.length).toBe(initialCalls + 1);
+    it("ignores clicks when chartReady=false (no subscription registered)", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      render(<Harness chart={ch.chart} ready={false} />);
+      expect(ch.subscribeClick).not.toHaveBeenCalled();
+    });
 
-    // Fire the range-change handler the overlay registered: should
-    // call redraw -> clearRect.
-    const rangeHandler = subscribeRange.mock.calls[0][0];
-    rangeHandler(null);
-    expect(clearRect.mock.calls.length).toBe(initialCalls + 2);
+    it("ignores clicks when tool !== pointer (no creation flow yet)", () => {
+      // With a non-pointer tool, the click handler runs but immediately
+      // returns. Selection state does NOT change.
+      stubCanvasContext();
+      const ch = fakeChart();
+      const drawings: Drawing[] = [horiz("h1", 100)];
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          drawings={drawings}
+          tool="trend"
+        />,
+      );
+      // Click directly on the horizontal line (price=100, y=100).
+      fireClick(ch, 50, 100);
+      // No way to externally observe selectedId changing — we'd see it
+      // via a re-render that re-clears the canvas. Verify by not throwing
+      // and not crashing the harness; selection effects don't fire.
+      expect(true).toBe(true); // smoke-only — main assertion in pointer-mode tests
+    });
+
+    it("ignores clicks with no point info (off-canvas)", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          drawings={[horiz("h1", 100)]}
+          tool="pointer"
+        />,
+      );
+      const onClick = ch.subscribeClick.mock.calls[0][0] as (
+        p: MouseEventParams<Time>,
+      ) => void;
+      // No `point` in MouseEventParams — handler must early-return.
+      expect(() =>
+        onClick({} as unknown as MouseEventParams<Time>),
+      ).not.toThrow();
+    });
+
+    it("ignores clicks when seriesRef is null (chart not ready for hit-test)", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          drawings={[horiz("h1", 100)]}
+          tool="pointer"
+          series={null}
+        />,
+      );
+      expect(() => fireClick(ch, 50, 100)).not.toThrow();
+    });
   });
 
-  it("bails cleanly when getContext('2d') returns null (no throw, no subscribe)", () => {
-    // A canvas where another consumer requested a non-2D context first
-    // returns null on subsequent getContext("2d") calls. The overlay
-    // must not throw and must not subscribe in that state.
-    stubNullCanvasContext();
-    const { chart, subscribeRange, subscribeSize } = fakeChart();
-    expect(() =>
-      render(<Harness chart={chart} ready={true} />),
-    ).not.toThrow();
-    expect(subscribeRange).not.toHaveBeenCalled();
-    expect(subscribeSize).not.toHaveBeenCalled();
+  describe("keyboard handler", () => {
+    it("Delete key removes the selected drawing", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const deleteDrawing = vi.fn();
+      const drawings: Drawing[] = [horiz("h1", 100)];
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          drawings={drawings}
+          deleteDrawing={deleteDrawing}
+          tool="pointer"
+        />,
+      );
+      // First, select via click on the horizontal line at price=100.
+      selectVia(ch, 50, 100);
+      // Now press Delete.
+      fireEvent.keyDown(document, { key: "Delete" });
+      expect(deleteDrawing).toHaveBeenCalledWith("h1");
+    });
+
+    it("Backspace key removes the selected drawing", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const deleteDrawing = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          drawings={[horiz("h1", 100)]}
+          deleteDrawing={deleteDrawing}
+          tool="pointer"
+        />,
+      );
+      selectVia(ch, 50, 100);
+      fireEvent.keyDown(document, { key: "Backspace" });
+      expect(deleteDrawing).toHaveBeenCalledWith("h1");
+    });
+
+    it("Delete is a no-op when no drawing is selected", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const deleteDrawing = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          drawings={[horiz("h1", 100)]}
+          deleteDrawing={deleteDrawing}
+        />,
+      );
+      fireEvent.keyDown(document, { key: "Delete" });
+      expect(deleteDrawing).not.toHaveBeenCalled();
+    });
+
+    it("Delete is suppressed when focus is in an INPUT", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const deleteDrawing = vi.fn();
+      render(
+        <>
+          <input data-testid="form-input" />
+          <Harness
+            chart={ch.chart}
+            ready={true}
+            drawings={[horiz("h1", 100)]}
+            deleteDrawing={deleteDrawing}
+            tool="pointer"
+          />
+        </>,
+      );
+      // Select first.
+      selectVia(ch, 50, 100);
+      // Focus the input, then press Backspace — should NOT delete the drawing.
+      const input = screen.getByTestId("form-input") as HTMLInputElement;
+      input.focus();
+      fireEvent.keyDown(document, { key: "Backspace" });
+      expect(deleteDrawing).not.toHaveBeenCalled();
+    });
+
+    it("Escape with a selection clears the selection (does not change tool)", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const setTool = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          drawings={[horiz("h1", 100)]}
+          setTool={setTool}
+          tool="pointer"
+        />,
+      );
+      // Select first.
+      selectVia(ch, 50, 100);
+      // Escape should clear selection (verify tool was NOT changed).
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(setTool).not.toHaveBeenCalled();
+    });
+
+    it("Escape with no selection and a non-pointer tool resets to pointer", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const setTool = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="trend"
+          setTool={setTool}
+        />,
+      );
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(setTool).toHaveBeenCalledWith("pointer");
+    });
+
+    it("Escape is a no-op when nothing is selected and tool is pointer", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const setTool = vi.fn();
+      const deleteDrawing = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="pointer"
+          setTool={setTool}
+          deleteDrawing={deleteDrawing}
+        />,
+      );
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(setTool).not.toHaveBeenCalled();
+      expect(deleteDrawing).not.toHaveBeenCalled();
+    });
+
+    it("Escape is suppressed when focus is in an INPUT", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const setTool = vi.fn();
+      render(
+        <>
+          <input data-testid="form-input" />
+          <Harness
+            chart={ch.chart}
+            ready={true}
+            tool="trend"
+            setTool={setTool}
+          />
+        </>,
+      );
+      const input = screen.getByTestId("form-input") as HTMLInputElement;
+      input.focus();
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(setTool).not.toHaveBeenCalled();
+    });
+
+    it("non-Escape / non-Delete keys are ignored", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const setTool = vi.fn();
+      const deleteDrawing = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="trend"
+          setTool={setTool}
+          deleteDrawing={deleteDrawing}
+        />,
+      );
+      fireEvent.keyDown(document, { key: "Enter" });
+      fireEvent.keyDown(document, { key: " " });
+      fireEvent.keyDown(document, { key: "p" });
+      expect(setTool).not.toHaveBeenCalled();
+      expect(deleteDrawing).not.toHaveBeenCalled();
+    });
+
+    it("removes the keydown listener on unmount", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const setTool = vi.fn();
+      const { unmount } = render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="trend"
+          setTool={setTool}
+        />,
+      );
+      unmount();
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(setTool).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("selection lifecycle", () => {
+    it("clears selection when slabAddress changes", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const setTool = vi.fn();
+      const { rerender } = render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          drawings={[horiz("h1", 100)]}
+          tool="pointer"
+          setTool={setTool}
+          slabAddress={SLAB_A}
+        />,
+      );
+      // Select via click.
+      selectVia(ch, 50, 100);
+      // Switch slab.
+      rerender(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          drawings={[horiz("h1", 100)]}
+          tool="pointer"
+          setTool={setTool}
+          slabAddress={SLAB_B}
+        />,
+      );
+      // Now Escape should be a no-op (selection was cleared by slab change),
+      // and setTool stays untouched because tool is already pointer.
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(setTool).not.toHaveBeenCalled();
+    });
+
+    it("clears selection when tool changes", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const setTool = vi.fn();
+      const deleteDrawing = vi.fn();
+      const { rerender } = render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          drawings={[horiz("h1", 100)]}
+          tool="pointer"
+          setTool={setTool}
+          deleteDrawing={deleteDrawing}
+        />,
+      );
+      // Select.
+      selectVia(ch, 50, 100);
+      // Switch tool away from pointer.
+      rerender(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          drawings={[horiz("h1", 100)]}
+          tool="trend"
+          setTool={setTool}
+          deleteDrawing={deleteDrawing}
+        />,
+      );
+      // Backspace should NOT delete (selection was cleared).
+      fireEvent.keyDown(document, { key: "Backspace" });
+      expect(deleteDrawing).not.toHaveBeenCalled();
+    });
+
+    it("clears selection when the selected drawing is removed from the list", () => {
+      stubCanvasContext();
+      const ch = fakeChart();
+      const deleteDrawing = vi.fn();
+      const { rerender } = render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          drawings={[horiz("h1", 100)]}
+          tool="pointer"
+          deleteDrawing={deleteDrawing}
+        />,
+      );
+      // Select.
+      selectVia(ch, 50, 100);
+      // Remove the drawing externally (e.g. clearAll).
+      rerender(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          drawings={[]}
+          tool="pointer"
+          deleteDrawing={deleteDrawing}
+        />,
+      );
+      // Backspace must NOT delete — selection cleared.
+      fireEvent.keyDown(document, { key: "Backspace" });
+      expect(deleteDrawing).not.toHaveBeenCalled();
+    });
   });
 });

--- a/app/__tests__/components/trade/ChartDrawingOverlay.test.tsx
+++ b/app/__tests__/components/trade/ChartDrawingOverlay.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "@testing-library/react";
+import { useRef, type FC } from "react";
+import type { IChartApi } from "lightweight-charts";
+import { ChartDrawingOverlay } from "@/components/trade/ChartDrawingOverlay";
+
+/** Minimal IChartApi stand-in: only the surface the overlay uses
+ *  (timeScale().subscribeVisibleTimeRangeChange + unsubscribe). */
+function fakeChart() {
+  const subscribe = vi.fn();
+  const unsubscribe = vi.fn();
+  const timeScale = () => ({
+    subscribeVisibleTimeRangeChange: subscribe,
+    unsubscribeVisibleTimeRangeChange: unsubscribe,
+  });
+  return {
+    chart: { timeScale } as unknown as IChartApi,
+    subscribe,
+    unsubscribe,
+  };
+}
+
+/** ResizeObserver isn't implemented by jsdom. Stub it just enough to
+ *  let the component construct one and call observe / disconnect. */
+class FakeResizeObserver {
+  observe = vi.fn();
+  disconnect = vi.fn();
+  unobserve = vi.fn();
+}
+
+/** Stub the 2D canvas context. jsdom's real canvas returns null from
+ *  getContext("2d") without node-canvas. */
+function stubCanvasContext() {
+  const setTransform = vi.fn();
+  const clearRect = vi.fn();
+  const ctxStub = { setTransform, clearRect } as unknown as CanvasRenderingContext2D;
+  HTMLCanvasElement.prototype.getContext = vi
+    .fn()
+    .mockReturnValue(ctxStub) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+  return { setTransform, clearRect };
+}
+
+beforeEach(() => {
+  // @ts-expect-error: stubbing the global for tests.
+  globalThis.ResizeObserver = FakeResizeObserver;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** Tiny harness that wires the overlay up the way TradingChart does:
+ *  parent owns chartRef + containerRef + chartReady. The chartRef is
+ *  assigned synchronously during render — the real TradingChart sets
+ *  it inside its chart-init effect just before flipping chartReady,
+ *  and child effects run after parent state commits. Mirroring that
+ *  ordering with a render-time assignment is the simplest faithful
+ *  test surface (a useEffect-based assignment fires AFTER the child's
+ *  effect, leaving chartRef.current null when the overlay subscribes). */
+const Harness: FC<{ chart: IChartApi | null; ready: boolean }> = ({
+  chart,
+  ready,
+}) => {
+  const chartRef = useRef<IChartApi | null>(null);
+  chartRef.current = chart;
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  return (
+    <div ref={containerRef} style={{ width: 800, height: 600 }}>
+      <ChartDrawingOverlay
+        chartRef={chartRef}
+        containerRef={containerRef}
+        chartReady={ready}
+      />
+    </div>
+  );
+};
+
+describe("ChartDrawingOverlay", () => {
+  it("renders an aria-hidden, pointer-events-none canvas", () => {
+    stubCanvasContext();
+    const { chart } = fakeChart();
+    const { container } = render(<Harness chart={chart} ready={false} />);
+    const canvas = container.querySelector("canvas");
+    expect(canvas).not.toBeNull();
+    expect(canvas?.getAttribute("aria-hidden")).toBe("true");
+    expect(canvas?.className).toContain("pointer-events-none");
+    expect(canvas?.className).toContain("absolute");
+  });
+
+  it("does NOT subscribe when chartReady is false (chart not yet created)", () => {
+    stubCanvasContext();
+    const { chart, subscribe } = fakeChart();
+    render(<Harness chart={chart} ready={false} />);
+    expect(subscribe).not.toHaveBeenCalled();
+  });
+
+  it("subscribes to visibleTimeRangeChange when chartReady flips true", () => {
+    stubCanvasContext();
+    const { chart, subscribe } = fakeChart();
+    const { rerender } = render(<Harness chart={chart} ready={false} />);
+    expect(subscribe).not.toHaveBeenCalled();
+    rerender(<Harness chart={chart} ready={true} />);
+    expect(subscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("unsubscribes when the component unmounts", () => {
+    stubCanvasContext();
+    const { chart, subscribe, unsubscribe } = fakeChart();
+    const { unmount } = render(<Harness chart={chart} ready={true} />);
+    expect(subscribe).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    // Same handler reference passed to both subscribe and unsubscribe.
+    expect(unsubscribe).toHaveBeenCalledWith(subscribe.mock.calls[0][0]);
+  });
+
+  it("swallows errors from unsubscribe (chart already destroyed)", () => {
+    stubCanvasContext();
+    const { chart, unsubscribe } = fakeChart();
+    unsubscribe.mockImplementation(() => {
+      throw new Error("chart destroyed in parallel");
+    });
+    const { unmount } = render(<Harness chart={chart} ready={true} />);
+    // Should not throw — the cleanup catches & swallows.
+    expect(() => unmount()).not.toThrow();
+  });
+});

--- a/app/__tests__/components/trade/ChartDrawingOverlay.test.tsx
+++ b/app/__tests__/components/trade/ChartDrawingOverlay.test.tsx
@@ -1351,6 +1351,78 @@ describe("ChartDrawingOverlay", () => {
       expect(addDrawing).not.toHaveBeenCalled();
     });
 
+    it("right-click (contextmenu) during drag cancels the pending anchor", () => {
+      // Right-click opens the OS context menu; Firefox skips the
+      // mouseup that would normally end the drag. Without an
+      // explicit contextmenu cancel, pendingP1 sticks and the
+      // chart's pan stays suppressed indefinitely.
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="rectangle"
+          addDrawing={addDrawing}
+        />,
+      );
+      fireEvent.mouseDown(ch.chartElement, {
+        clientX: 10,
+        clientY: 100,
+        button: 0,
+      });
+      // contextmenu fires before mouseup in real browsers when the
+      // user right-clicks during a drag.
+      fireEvent.contextMenu(document);
+      // Pan should be RESTORED (cleanup ran).
+      const lastCall = ch.applyOptions.mock.calls.at(-1);
+      expect(lastCall?.[0]).toEqual({
+        handleScroll: ch.initialScroll,
+        handleScale: ch.initialScale,
+      });
+      // A subsequent mouseup must NOT commit — pendingP1 was cleared.
+      fireEvent.mouseUp(document, { clientX: 50, clientY: 200 });
+      expect(addDrawing).not.toHaveBeenCalled();
+    });
+
+    it("window blur during drag cancels the pending anchor", () => {
+      // alt-tab / OS focus theft / drag into another window all
+      // produce a window blur. The mouseup never reaches our
+      // document listener; we'd be left with stuck state.
+      stubCanvasContext();
+      const ch = fakeChart();
+      const addDrawing = vi.fn();
+      render(
+        <Harness
+          chart={ch.chart}
+          ready={true}
+          tool="rectangle"
+          addDrawing={addDrawing}
+        />,
+      );
+      fireEvent.mouseDown(ch.chartElement, {
+        clientX: 10,
+        clientY: 100,
+        button: 0,
+      });
+      // jsdom dispatches blur on window directly. Wrap in act() so
+      // the setPendingP1(null) state update flushes before we assert
+      // (window events aren't auto-wrapped by RTL's fireEvent).
+      act(() => {
+        window.dispatchEvent(new Event("blur"));
+      });
+      // Pan restored.
+      const lastCall = ch.applyOptions.mock.calls.at(-1);
+      expect(lastCall?.[0]).toEqual({
+        handleScroll: ch.initialScroll,
+        handleScale: ch.initialScale,
+      });
+      // Subsequent mouseup must not commit.
+      fireEvent.mouseUp(document, { clientX: 50, clientY: 200 });
+      expect(addDrawing).not.toHaveBeenCalled();
+    });
+
     it("does NOT attach mousedown listener when tool is not rectangle", () => {
       stubCanvasContext();
       const ch = fakeChart();

--- a/app/__tests__/components/trade/ChartDrawingOverlay.test.tsx
+++ b/app/__tests__/components/trade/ChartDrawingOverlay.test.tsx
@@ -169,10 +169,20 @@ beforeEach(() => {
   lastResizeObserver = null;
   // @ts-expect-error: stubbing the global for tests.
   globalThis.ResizeObserver = FakeResizeObserver;
+  // Synchronous rAF for tests so the rAF-coalesced crosshair preview
+  // and rectangle drag mousemove redraws fire inline. Production runs
+  // the real rAF (one redraw per vsync); tests assert against the
+  // post-coalesce frame state, not against the schedule mechanism.
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    cb(performance.now());
+    return 1;
+  });
+  vi.stubGlobal("cancelAnimationFrame", () => {});
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 interface HarnessProps {

--- a/app/__tests__/components/trade/ChartDrawingToolbar.test.tsx
+++ b/app/__tests__/components/trade/ChartDrawingToolbar.test.tsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi } from "vitest";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ChartDrawingToolbar } from "@/components/trade/ChartDrawingToolbar";
+import type { DrawingTool } from "@/lib/chart-drawings";
+
+const noopProps = {
+  tool: "pointer" as DrawingTool,
+  setTool: () => {},
+};
+
+describe("ChartDrawingToolbar", () => {
+  it("renders a toolbar with role + vertical orientation", () => {
+    render(<ChartDrawingToolbar {...noopProps} />);
+    const tb = screen.getByRole("toolbar", { name: /Drawing tools/i });
+    expect(tb).toHaveAttribute("aria-orientation", "vertical");
+  });
+
+  it("renders one button per drawing tool (pointer + 3 creation tools)", () => {
+    render(<ChartDrawingToolbar {...noopProps} />);
+    expect(screen.getByRole("button", { name: /Pointer/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Trend line/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Horizontal line/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Rectangle/i })).toBeInTheDocument();
+  });
+
+  it("marks the active tool with aria-pressed=true and others false", () => {
+    render(<ChartDrawingToolbar {...noopProps} tool="trend" />);
+    expect(
+      screen.getByRole("button", { name: /Trend line/i }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(
+      screen.getByRole("button", { name: /Pointer/i }),
+    ).toHaveAttribute("aria-pressed", "false");
+    expect(
+      screen.getByRole("button", { name: /Horizontal line/i }),
+    ).toHaveAttribute("aria-pressed", "false");
+    expect(
+      screen.getByRole("button", { name: /Rectangle/i }),
+    ).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("clicking an inactive tool calls setTool with that kind", () => {
+    const setTool = vi.fn();
+    render(<ChartDrawingToolbar tool="pointer" setTool={setTool} />);
+    fireEvent.click(screen.getByRole("button", { name: /Trend line/i }));
+    expect(setTool).toHaveBeenCalledWith("trend");
+  });
+
+  it("clicking the active non-pointer tool returns to pointer", () => {
+    const setTool = vi.fn();
+    render(<ChartDrawingToolbar tool="rectangle" setTool={setTool} />);
+    fireEvent.click(screen.getByRole("button", { name: /Rectangle/i }));
+    expect(setTool).toHaveBeenCalledWith("pointer");
+  });
+
+  it("clicking the active pointer tool sets pointer (no-op equivalent)", () => {
+    const setTool = vi.fn();
+    render(<ChartDrawingToolbar tool="pointer" setTool={setTool} />);
+    fireEvent.click(screen.getByRole("button", { name: /Pointer/i }));
+    expect(setTool).toHaveBeenCalledWith("pointer");
+  });
+
+  it.each(["trend", "horizontal", "rectangle"] as const)(
+    "Escape returns to pointer from %s",
+    (active) => {
+      const setTool = vi.fn();
+      render(<ChartDrawingToolbar tool={active} setTool={setTool} />);
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(setTool).toHaveBeenCalledWith("pointer");
+    },
+  );
+
+  it("Escape is a no-op when the tool is already pointer", () => {
+    const setTool = vi.fn();
+    render(<ChartDrawingToolbar tool="pointer" setTool={setTool} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(setTool).not.toHaveBeenCalled();
+  });
+
+  it("Escape with focus inside an INPUT is suppressed (input-focus guard)", () => {
+    const setTool = vi.fn();
+    render(
+      <>
+        <input data-testid="form-input" />
+        <ChartDrawingToolbar tool="trend" setTool={setTool} />
+      </>,
+    );
+    const input = screen.getByTestId("form-input") as HTMLInputElement;
+    input.focus();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(setTool).not.toHaveBeenCalled();
+  });
+
+  it("Escape with focus inside a TEXTAREA is suppressed", () => {
+    const setTool = vi.fn();
+    render(
+      <>
+        <textarea data-testid="form-textarea" />
+        <ChartDrawingToolbar tool="trend" setTool={setTool} />
+      </>,
+    );
+    const ta = screen.getByTestId("form-textarea") as HTMLTextAreaElement;
+    ta.focus();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(setTool).not.toHaveBeenCalled();
+  });
+
+  it("Escape with focus inside a contenteditable is suppressed", () => {
+    const setTool = vi.fn();
+    render(
+      <>
+        {/* tabIndex=0 makes the contenteditable focusable in jsdom.
+            jsdom doesn't compute isContentEditable from the
+            attribute, so we patch the property on the element after
+            it mounts so the input-focus guard's runtime check runs
+            against a representative DOM shape. */}
+        <div
+          data-testid="ce"
+          contentEditable
+          tabIndex={0}
+          suppressContentEditableWarning
+        />
+        <ChartDrawingToolbar tool="trend" setTool={setTool} />
+      </>,
+    );
+    const ce = screen.getByTestId("ce") as HTMLDivElement;
+    Object.defineProperty(ce, "isContentEditable", {
+      value: true,
+      configurable: true,
+    });
+    ce.focus();
+    expect(document.activeElement).toBe(ce);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(setTool).not.toHaveBeenCalled();
+  });
+
+  it("non-Escape keys do not call setTool", () => {
+    const setTool = vi.fn();
+    render(<ChartDrawingToolbar tool="trend" setTool={setTool} />);
+    fireEvent.keyDown(document, { key: "Enter" });
+    fireEvent.keyDown(document, { key: " " });
+    fireEvent.keyDown(document, { key: "p" });
+    expect(setTool).not.toHaveBeenCalled();
+  });
+
+  it("removes the keydown listener on unmount", () => {
+    const setTool = vi.fn();
+    const { unmount } = render(
+      <ChartDrawingToolbar tool="trend" setTool={setTool} />,
+    );
+    unmount();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(setTool).not.toHaveBeenCalled();
+  });
+
+  it("hides the toolbar below the md breakpoint via responsive classes", () => {
+    // Visual gate: the toolbar uses Tailwind's `hidden md:flex` so it
+    // only appears on tablets+. Pinned via class assertion since
+    // jsdom doesn't run media queries.
+    render(<ChartDrawingToolbar {...noopProps} />);
+    const tb = screen.getByRole("toolbar", { name: /Drawing tools/i });
+    expect(tb.className).toContain("hidden");
+    expect(tb.className).toContain("md:flex");
+  });
+});

--- a/app/__tests__/components/trade/ChartDrawingToolbar.test.tsx
+++ b/app/__tests__/components/trade/ChartDrawingToolbar.test.tsx
@@ -66,95 +66,13 @@ describe("ChartDrawingToolbar", () => {
     expect(setTool).toHaveBeenCalledWith("pointer");
   });
 
-  it.each(["trend", "horizontal", "rectangle"] as const)(
-    "Escape returns to pointer from %s",
-    (active) => {
-      const setTool = vi.fn();
-      render(<ChartDrawingToolbar tool={active} setTool={setTool} />);
-      fireEvent.keyDown(document, { key: "Escape" });
-      expect(setTool).toHaveBeenCalledWith("pointer");
-    },
-  );
-
-  it("Escape is a no-op when the tool is already pointer", () => {
-    const setTool = vi.fn();
-    render(<ChartDrawingToolbar tool="pointer" setTool={setTool} />);
-    fireEvent.keyDown(document, { key: "Escape" });
-    expect(setTool).not.toHaveBeenCalled();
-  });
-
-  it("Escape with focus inside an INPUT is suppressed (input-focus guard)", () => {
-    const setTool = vi.fn();
-    render(
-      <>
-        <input data-testid="form-input" />
-        <ChartDrawingToolbar tool="trend" setTool={setTool} />
-      </>,
-    );
-    const input = screen.getByTestId("form-input") as HTMLInputElement;
-    input.focus();
-    fireEvent.keyDown(document, { key: "Escape" });
-    expect(setTool).not.toHaveBeenCalled();
-  });
-
-  it("Escape with focus inside a TEXTAREA is suppressed", () => {
-    const setTool = vi.fn();
-    render(
-      <>
-        <textarea data-testid="form-textarea" />
-        <ChartDrawingToolbar tool="trend" setTool={setTool} />
-      </>,
-    );
-    const ta = screen.getByTestId("form-textarea") as HTMLTextAreaElement;
-    ta.focus();
-    fireEvent.keyDown(document, { key: "Escape" });
-    expect(setTool).not.toHaveBeenCalled();
-  });
-
-  it("Escape with focus inside a contenteditable is suppressed", () => {
-    const setTool = vi.fn();
-    render(
-      <>
-        {/* tabIndex=0 makes the contenteditable focusable in jsdom.
-            jsdom doesn't compute isContentEditable from the
-            attribute, so we patch the property on the element after
-            it mounts so the input-focus guard's runtime check runs
-            against a representative DOM shape. */}
-        <div
-          data-testid="ce"
-          contentEditable
-          tabIndex={0}
-          suppressContentEditableWarning
-        />
-        <ChartDrawingToolbar tool="trend" setTool={setTool} />
-      </>,
-    );
-    const ce = screen.getByTestId("ce") as HTMLDivElement;
-    Object.defineProperty(ce, "isContentEditable", {
-      value: true,
-      configurable: true,
-    });
-    ce.focus();
-    expect(document.activeElement).toBe(ce);
-    fireEvent.keyDown(document, { key: "Escape" });
-    expect(setTool).not.toHaveBeenCalled();
-  });
-
-  it("non-Escape keys do not call setTool", () => {
+  it("does NOT register a keydown listener (Escape is owned by the overlay)", () => {
+    // The Escape priority chain (cancel-pending → deselect → reset-tool)
+    // lives in ChartDrawingOverlay so a single handler can sequence
+    // those states. The toolbar must not race a second handler for
+    // the same key.
     const setTool = vi.fn();
     render(<ChartDrawingToolbar tool="trend" setTool={setTool} />);
-    fireEvent.keyDown(document, { key: "Enter" });
-    fireEvent.keyDown(document, { key: " " });
-    fireEvent.keyDown(document, { key: "p" });
-    expect(setTool).not.toHaveBeenCalled();
-  });
-
-  it("removes the keydown listener on unmount", () => {
-    const setTool = vi.fn();
-    const { unmount } = render(
-      <ChartDrawingToolbar tool="trend" setTool={setTool} />,
-    );
-    unmount();
     fireEvent.keyDown(document, { key: "Escape" });
     expect(setTool).not.toHaveBeenCalled();
   });

--- a/app/__tests__/components/trade/ChartDrawingToolbar.test.tsx
+++ b/app/__tests__/components/trade/ChartDrawingToolbar.test.tsx
@@ -7,6 +7,8 @@ import type { DrawingTool } from "@/lib/chart-drawings";
 const noopProps = {
   tool: "pointer" as DrawingTool,
   setTool: () => {},
+  drawingCount: 0,
+  clearAll: () => {},
 };
 
 describe("ChartDrawingToolbar", () => {
@@ -118,5 +120,141 @@ describe("ChartDrawingToolbar", () => {
     // And the inactive button does NOT carry the active classes.
     const pointer = screen.getByRole("button", { name: /Pointer/i });
     expect(pointer.className).not.toContain("bg-[var(--accent)]/10");
+  });
+
+  describe("clear-all button", () => {
+    it("renders below a separator", () => {
+      render(<ChartDrawingToolbar {...noopProps} drawingCount={3} />);
+      expect(
+        screen.getByRole("separator", { hidden: true }) ??
+          screen.getByRole("separator"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /Clear all drawings/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("is disabled when drawingCount is 0", () => {
+      render(<ChartDrawingToolbar {...noopProps} drawingCount={0} />);
+      const btn = screen.getByRole("button", { name: /Clear all drawings/i });
+      expect(btn).toBeDisabled();
+    });
+
+    it("is enabled when drawingCount > 0", () => {
+      render(<ChartDrawingToolbar {...noopProps} drawingCount={1} />);
+      const btn = screen.getByRole("button", { name: /Clear all drawings/i });
+      expect(btn).toBeEnabled();
+    });
+
+    it("does NOT prompt when count is 0 (defensive: button is disabled but clicks routed via onClick still no-op)", () => {
+      const confirmSpy = vi.spyOn(window, "confirm");
+      const clearAll = vi.fn();
+      const setTool = vi.fn();
+      render(
+        <ChartDrawingToolbar
+          {...noopProps}
+          drawingCount={0}
+          clearAll={clearAll}
+          setTool={setTool}
+        />,
+      );
+      const btn = screen.getByRole("button", { name: /Clear all drawings/i });
+      // Browser blocks click on disabled, but force a click via fireEvent
+      // to verify the JS-side guard (some test harnesses bypass disabled).
+      fireEvent.click(btn);
+      expect(confirmSpy).not.toHaveBeenCalled();
+      expect(clearAll).not.toHaveBeenCalled();
+      expect(setTool).not.toHaveBeenCalled();
+      confirmSpy.mockRestore();
+    });
+
+    it("prompts via window.confirm with the drawing count when clicked", () => {
+      const confirmSpy = vi
+        .spyOn(window, "confirm")
+        .mockReturnValue(true);
+      const clearAll = vi.fn();
+      render(
+        <ChartDrawingToolbar
+          {...noopProps}
+          drawingCount={5}
+          clearAll={clearAll}
+        />,
+      );
+      fireEvent.click(
+        screen.getByRole("button", { name: /Clear all drawings/i }),
+      );
+      expect(confirmSpy).toHaveBeenCalledTimes(1);
+      const message = confirmSpy.mock.calls[0][0] as string;
+      expect(message).toContain("5");
+      expect(message).toContain("drawings");
+      expect(clearAll).toHaveBeenCalledTimes(1);
+      confirmSpy.mockRestore();
+    });
+
+    it("uses singular wording when drawingCount === 1", () => {
+      const confirmSpy = vi
+        .spyOn(window, "confirm")
+        .mockReturnValue(true);
+      render(
+        <ChartDrawingToolbar
+          {...noopProps}
+          drawingCount={1}
+          clearAll={() => {}}
+        />,
+      );
+      fireEvent.click(
+        screen.getByRole("button", { name: /Clear all drawings/i }),
+      );
+      const message = confirmSpy.mock.calls[0][0] as string;
+      expect(message).toContain("1 drawing");
+      expect(message).not.toContain("drawings");
+      confirmSpy.mockRestore();
+    });
+
+    it("does NOT call clearAll when the user cancels the prompt", () => {
+      const confirmSpy = vi
+        .spyOn(window, "confirm")
+        .mockReturnValue(false);
+      const clearAll = vi.fn();
+      const setTool = vi.fn();
+      render(
+        <ChartDrawingToolbar
+          {...noopProps}
+          drawingCount={3}
+          clearAll={clearAll}
+          setTool={setTool}
+        />,
+      );
+      fireEvent.click(
+        screen.getByRole("button", { name: /Clear all drawings/i }),
+      );
+      expect(confirmSpy).toHaveBeenCalledTimes(1);
+      expect(clearAll).not.toHaveBeenCalled();
+      expect(setTool).not.toHaveBeenCalled();
+      confirmSpy.mockRestore();
+    });
+
+    it("resets the active tool to pointer after a confirmed clear", () => {
+      const confirmSpy = vi
+        .spyOn(window, "confirm")
+        .mockReturnValue(true);
+      const clearAll = vi.fn();
+      const setTool = vi.fn();
+      render(
+        <ChartDrawingToolbar
+          {...noopProps}
+          tool="trend"
+          drawingCount={3}
+          clearAll={clearAll}
+          setTool={setTool}
+        />,
+      );
+      fireEvent.click(
+        screen.getByRole("button", { name: /Clear all drawings/i }),
+      );
+      expect(clearAll).toHaveBeenCalledTimes(1);
+      expect(setTool).toHaveBeenCalledWith("pointer");
+      confirmSpy.mockRestore();
+    });
   });
 });

--- a/app/__tests__/components/trade/ChartDrawingToolbar.test.tsx
+++ b/app/__tests__/components/trade/ChartDrawingToolbar.test.tsx
@@ -10,10 +10,15 @@ const noopProps = {
 };
 
 describe("ChartDrawingToolbar", () => {
-  it("renders a toolbar with role + vertical orientation", () => {
+  it("renders a labelled container without overstating ARIA contract", () => {
+    // Deliberately not role="toolbar" — the APG toolbar pattern
+    // requires roving tabindex + arrow-key focus management which we
+    // don't implement. A plain labelled div is honest semantics.
     render(<ChartDrawingToolbar {...noopProps} />);
-    const tb = screen.getByRole("toolbar", { name: /Drawing tools/i });
-    expect(tb).toHaveAttribute("aria-orientation", "vertical");
+    const tb = screen.getByLabelText(/Drawing tools/i);
+    expect(tb).toBeInTheDocument();
+    expect(tb).not.toHaveAttribute("role", "toolbar");
+    expect(tb).not.toHaveAttribute("aria-orientation");
   });
 
   it("renders one button per drawing tool (pointer + 3 creation tools)", () => {
@@ -159,8 +164,41 @@ describe("ChartDrawingToolbar", () => {
     // only appears on tablets+. Pinned via class assertion since
     // jsdom doesn't run media queries.
     render(<ChartDrawingToolbar {...noopProps} />);
-    const tb = screen.getByRole("toolbar", { name: /Drawing tools/i });
+    const tb = screen.getByLabelText(/Drawing tools/i);
     expect(tb.className).toContain("hidden");
     expect(tb.className).toContain("md:flex");
+  });
+
+  it("each tool button exposes a hover-tooltip via title attribute", () => {
+    // title gives sighted mouse users the tool name on hover
+    // (icons alone are abstract). Pinned so a refactor that drops
+    // title doesn't silently break discoverability — aria-pressed +
+    // aria-label tests would still pass.
+    render(<ChartDrawingToolbar {...noopProps} />);
+    expect(
+      screen.getByRole("button", { name: /Pointer/i }),
+    ).toHaveAttribute("title", "Pointer (select)");
+    expect(
+      screen.getByRole("button", { name: /Trend line/i }),
+    ).toHaveAttribute("title", "Trend line");
+    expect(
+      screen.getByRole("button", { name: /Horizontal line/i }),
+    ).toHaveAttribute("title", "Horizontal line");
+    expect(
+      screen.getByRole("button", { name: /Rectangle/i }),
+    ).toHaveAttribute("title", "Rectangle");
+  });
+
+  it("active tool carries the accent-tint background class (visual feedback)", () => {
+    // aria-pressed alone doesn't render a visible difference. Pin the
+    // accent-tint background class so a refactor that drops the
+    // active branch of the className ternary still fails a test.
+    render(<ChartDrawingToolbar {...noopProps} tool="trend" />);
+    const trend = screen.getByRole("button", { name: /Trend line/i });
+    expect(trend.className).toContain("bg-[var(--accent)]/10");
+    expect(trend.className).toContain("text-[var(--accent)]");
+    // And the inactive button does NOT carry the active classes.
+    const pointer = screen.getByRole("button", { name: /Pointer/i });
+    expect(pointer.className).not.toContain("bg-[var(--accent)]/10");
   });
 });

--- a/app/__tests__/hooks/useChartDrawingTool.test.ts
+++ b/app/__tests__/hooks/useChartDrawingTool.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { act, renderHook } from "@testing-library/react";
 import { useChartDrawingTool } from "@/hooks/useChartDrawingTool";
 
@@ -7,88 +7,61 @@ const STORAGE_KEY = "perc:chart:drawing-tool";
 describe("useChartDrawingTool", () => {
   beforeEach(() => {
     window.localStorage.clear();
-    vi.restoreAllMocks();
   });
 
-  it("defaults to pointer when nothing is stored", () => {
+  it("defaults to pointer on every fresh mount", () => {
     const { result } = renderHook(() => useChartDrawingTool());
     expect(result.current.tool).toBe("pointer");
   });
 
-  it("hydrates from localStorage when a valid value is stored", () => {
+  it("does NOT hydrate from localStorage — tool selection is session-local", () => {
+    // The earlier persisted-tool design trapped returning users: a
+    // session left in trend mode silently dropped a trend anchor on
+    // the next visit's first click. Tool is intentionally ephemeral
+    // now; drawings still persist per-slab, only the tool resets.
     window.localStorage.setItem(STORAGE_KEY, "trend");
     const { result } = renderHook(() => useChartDrawingTool());
-    expect(result.current.tool).toBe("trend");
+    expect(result.current.tool).toBe("pointer");
   });
 
-  it.each(["pointer", "trend", "horizontal", "rectangle"] as const)(
-    "accepts each valid tool kind on hydrate (%s)",
-    (kind) => {
-      window.localStorage.setItem(STORAGE_KEY, kind);
-      const { result } = renderHook(() => useChartDrawingTool());
-      expect(result.current.tool).toBe(kind);
-    },
-  );
-
-  it.each([
-    "ellipse",
-    "vertical",
-    "",
-    "POINTER",
-    "{}",
-    "null",
-  ])(
-    "ignores invalid stored value (%s) and stays on pointer default",
-    (stored) => {
-      window.localStorage.setItem(STORAGE_KEY, stored);
-      const { result } = renderHook(() => useChartDrawingTool());
-      expect(result.current.tool).toBe("pointer");
-    },
-  );
-
-  it("setTool updates state and persists to localStorage", () => {
+  it("setTool updates in-memory state", () => {
     const { result } = renderHook(() => useChartDrawingTool());
     act(() => {
       result.current.setTool("rectangle");
     });
     expect(result.current.tool).toBe("rectangle");
-    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("rectangle");
+  });
+
+  it("setTool does NOT write to localStorage", () => {
+    const { result } = renderHook(() => useChartDrawingTool());
+    act(() => {
+      result.current.setTool("trend");
+    });
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
   });
 
   it("setTool can return to pointer (deselect via toolbar click)", () => {
-    window.localStorage.setItem(STORAGE_KEY, "trend");
     const { result } = renderHook(() => useChartDrawingTool());
+    act(() => {
+      result.current.setTool("trend");
+    });
     expect(result.current.tool).toBe("trend");
     act(() => {
       result.current.setTool("pointer");
     });
     expect(result.current.tool).toBe("pointer");
-    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("pointer");
   });
 
-  it("swallows quota errors on write without rolling back state", () => {
-    const setItemSpy = vi
-      .spyOn(window.localStorage.__proto__, "setItem")
-      .mockImplementation(() => {
-        throw new Error("QuotaExceededError");
+  it.each(["pointer", "trend", "horizontal", "rectangle"] as const)(
+    "accepts each valid tool kind via setTool (%s)",
+    (kind) => {
+      const { result } = renderHook(() => useChartDrawingTool());
+      act(() => {
+        result.current.setTool(kind);
       });
-    const { result } = renderHook(() => useChartDrawingTool());
-    act(() => {
-      result.current.setTool("trend");
-    });
-    expect(result.current.tool).toBe("trend"); // in-memory state still updates
-    expect(setItemSpy).toHaveBeenCalled();
-  });
-
-  it("does not crash when localStorage.getItem throws (Safari Private Mode)", () => {
-    vi.spyOn(window.localStorage.__proto__, "getItem").mockImplementation(
-      () => {
-        throw new Error("QuotaExceededError");
-      },
-    );
-    const { result } = renderHook(() => useChartDrawingTool());
-    expect(result.current.tool).toBe("pointer");
-  });
+      expect(result.current.tool).toBe(kind);
+    },
+  );
 
   it("setTool reference is stable across re-renders", () => {
     const { result, rerender } = renderHook(() => useChartDrawingTool());

--- a/app/__tests__/hooks/useChartDrawingTool.test.ts
+++ b/app/__tests__/hooks/useChartDrawingTool.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useChartDrawingTool } from "@/hooks/useChartDrawingTool";
+
+const STORAGE_KEY = "perc:chart:drawing-tool";
+
+describe("useChartDrawingTool", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("defaults to pointer when nothing is stored", () => {
+    const { result } = renderHook(() => useChartDrawingTool());
+    expect(result.current.tool).toBe("pointer");
+  });
+
+  it("hydrates from localStorage when a valid value is stored", () => {
+    window.localStorage.setItem(STORAGE_KEY, "trend");
+    const { result } = renderHook(() => useChartDrawingTool());
+    expect(result.current.tool).toBe("trend");
+  });
+
+  it.each(["pointer", "trend", "horizontal", "rectangle"] as const)(
+    "accepts each valid tool kind on hydrate (%s)",
+    (kind) => {
+      window.localStorage.setItem(STORAGE_KEY, kind);
+      const { result } = renderHook(() => useChartDrawingTool());
+      expect(result.current.tool).toBe(kind);
+    },
+  );
+
+  it.each([
+    "ellipse",
+    "vertical",
+    "",
+    "POINTER",
+    "{}",
+    "null",
+  ])(
+    "ignores invalid stored value (%s) and stays on pointer default",
+    (stored) => {
+      window.localStorage.setItem(STORAGE_KEY, stored);
+      const { result } = renderHook(() => useChartDrawingTool());
+      expect(result.current.tool).toBe("pointer");
+    },
+  );
+
+  it("setTool updates state and persists to localStorage", () => {
+    const { result } = renderHook(() => useChartDrawingTool());
+    act(() => {
+      result.current.setTool("rectangle");
+    });
+    expect(result.current.tool).toBe("rectangle");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("rectangle");
+  });
+
+  it("setTool can return to pointer (deselect via toolbar click)", () => {
+    window.localStorage.setItem(STORAGE_KEY, "trend");
+    const { result } = renderHook(() => useChartDrawingTool());
+    expect(result.current.tool).toBe("trend");
+    act(() => {
+      result.current.setTool("pointer");
+    });
+    expect(result.current.tool).toBe("pointer");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("pointer");
+  });
+
+  it("swallows quota errors on write without rolling back state", () => {
+    const setItemSpy = vi
+      .spyOn(window.localStorage.__proto__, "setItem")
+      .mockImplementation(() => {
+        throw new Error("QuotaExceededError");
+      });
+    const { result } = renderHook(() => useChartDrawingTool());
+    act(() => {
+      result.current.setTool("trend");
+    });
+    expect(result.current.tool).toBe("trend"); // in-memory state still updates
+    expect(setItemSpy).toHaveBeenCalled();
+  });
+
+  it("does not crash when localStorage.getItem throws (Safari Private Mode)", () => {
+    vi.spyOn(window.localStorage.__proto__, "getItem").mockImplementation(
+      () => {
+        throw new Error("QuotaExceededError");
+      },
+    );
+    const { result } = renderHook(() => useChartDrawingTool());
+    expect(result.current.tool).toBe("pointer");
+  });
+
+  it("setTool reference is stable across re-renders", () => {
+    const { result, rerender } = renderHook(() => useChartDrawingTool());
+    const firstRef = result.current.setTool;
+    rerender();
+    expect(result.current.setTool).toBe(firstRef);
+  });
+});

--- a/app/__tests__/hooks/useChartDrawings.test.ts
+++ b/app/__tests__/hooks/useChartDrawings.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useChartDrawings } from "@/hooks/useChartDrawings";
+import {
+  DRAWINGS_STORAGE_VERSION,
+  MAX_DRAWINGS_PER_SLAB,
+  type Drawing,
+} from "@/lib/chart-drawings";
+
+// Real Solana base58 pubkeys (44 chars). Two distinct values so the
+// per-slab isolation tests exercise actual key namespacing rather than
+// the trivial empty-string path.
+const SLAB_A = "So11111111111111111111111111111111111111112";
+const SLAB_B = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const STORAGE_KEY_A = `perc:chart:drawings:${SLAB_A}`;
+const STORAGE_KEY_B = `perc:chart:drawings:${SLAB_B}`;
+
+function envelope(drawings: Drawing[]): string {
+  return JSON.stringify({ version: DRAWINGS_STORAGE_VERSION, drawings });
+}
+
+describe("useChartDrawings", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("returns an empty list on first mount with no stored data", () => {
+    const { result } = renderHook(() => useChartDrawings(SLAB_A));
+    expect(result.current.drawings).toEqual([]);
+  });
+
+  it("hydrates from localStorage on mount when stored data exists", () => {
+    const stored: Drawing = {
+      id: "h-1",
+      kind: "horizontal",
+      price: 100,
+    };
+    window.localStorage.setItem(STORAGE_KEY_A, envelope([stored]));
+    const { result } = renderHook(() => useChartDrawings(SLAB_A));
+    expect(result.current.drawings).toEqual([stored]);
+  });
+
+  it("addDrawing appends a new drawing with a generated id and persists", () => {
+    const { result } = renderHook(() => useChartDrawings(SLAB_A));
+    act(() => {
+      result.current.addDrawing({ kind: "horizontal", price: 100 });
+    });
+    expect(result.current.drawings).toHaveLength(1);
+    expect(result.current.drawings[0].kind).toBe("horizontal");
+    expect(result.current.drawings[0].id).toMatch(/^[0-9a-f-]{36}$/i);
+    // Persisted under the slab key.
+    const persisted = JSON.parse(
+      window.localStorage.getItem(STORAGE_KEY_A) ?? "{}",
+    );
+    expect(persisted.version).toBe(DRAWINGS_STORAGE_VERSION);
+    expect(persisted.drawings).toHaveLength(1);
+  });
+
+  it("addDrawing accepts each drawing kind with the correct shape", () => {
+    const { result } = renderHook(() => useChartDrawings(SLAB_A));
+    act(() => {
+      result.current.addDrawing({
+        kind: "trend",
+        p1: { time: 1_700_000_000_000, price: 100 },
+        p2: { time: 1_700_000_060_000, price: 110 },
+      });
+      result.current.addDrawing({ kind: "horizontal", price: 105 });
+      result.current.addDrawing({
+        kind: "rectangle",
+        p1: { time: 1_700_000_000_000, price: 90 },
+        p2: { time: 1_700_000_120_000, price: 120 },
+      });
+    });
+    expect(result.current.drawings.map((d) => d.kind)).toEqual([
+      "trend",
+      "horizontal",
+      "rectangle",
+    ]);
+  });
+
+  it("deleteDrawing removes by id and persists", () => {
+    const { result } = renderHook(() => useChartDrawings(SLAB_A));
+    act(() => {
+      result.current.addDrawing({ kind: "horizontal", price: 100 });
+      result.current.addDrawing({ kind: "horizontal", price: 200 });
+    });
+    const targetId = result.current.drawings[0].id;
+    act(() => {
+      result.current.deleteDrawing(targetId);
+    });
+    expect(result.current.drawings).toHaveLength(1);
+    expect(result.current.drawings[0].id).not.toBe(targetId);
+    const persisted = JSON.parse(
+      window.localStorage.getItem(STORAGE_KEY_A) ?? "{}",
+    );
+    expect(persisted.drawings).toHaveLength(1);
+  });
+
+  it("clearAll empties the list and persists empty", () => {
+    const { result } = renderHook(() => useChartDrawings(SLAB_A));
+    act(() => {
+      result.current.addDrawing({ kind: "horizontal", price: 100 });
+      result.current.addDrawing({ kind: "horizontal", price: 200 });
+    });
+    act(() => {
+      result.current.clearAll();
+    });
+    expect(result.current.drawings).toEqual([]);
+    const persisted = JSON.parse(
+      window.localStorage.getItem(STORAGE_KEY_A) ?? "{}",
+    );
+    expect(persisted.drawings).toEqual([]);
+  });
+
+  it("addDrawing past the cap drops the OLDEST entry (FIFO)", () => {
+    const { result } = renderHook(() => useChartDrawings(SLAB_A));
+    act(() => {
+      for (let i = 0; i < MAX_DRAWINGS_PER_SLAB; i++) {
+        result.current.addDrawing({ kind: "horizontal", price: i });
+      }
+    });
+    const firstId = result.current.drawings[0].id;
+    expect(result.current.drawings).toHaveLength(MAX_DRAWINGS_PER_SLAB);
+
+    act(() => {
+      result.current.addDrawing({ kind: "horizontal", price: 9999 });
+    });
+    expect(result.current.drawings).toHaveLength(MAX_DRAWINGS_PER_SLAB);
+    expect(result.current.drawings[0].id).not.toBe(firstId); // oldest dropped
+    expect(
+      result.current.drawings[MAX_DRAWINGS_PER_SLAB - 1],
+    ).toMatchObject({ kind: "horizontal", price: 9999 });
+  });
+
+  it("re-hydrates with the new slab's data when slabAddress changes", () => {
+    const drawingA: Drawing = { id: "a", kind: "horizontal", price: 100 };
+    const drawingB: Drawing = { id: "b", kind: "horizontal", price: 200 };
+    window.localStorage.setItem(STORAGE_KEY_A, envelope([drawingA]));
+    window.localStorage.setItem(STORAGE_KEY_B, envelope([drawingB]));
+
+    const { result, rerender } = renderHook(
+      ({ slab }: { slab: string }) => useChartDrawings(slab),
+      { initialProps: { slab: SLAB_A } },
+    );
+    expect(result.current.drawings).toEqual([drawingA]);
+
+    rerender({ slab: SLAB_B });
+    expect(result.current.drawings).toEqual([drawingB]);
+  });
+
+  it("isolates writes per slab (slab A's writes don't leak into slab B)", () => {
+    const { result, rerender } = renderHook(
+      ({ slab }: { slab: string }) => useChartDrawings(slab),
+      { initialProps: { slab: SLAB_A } },
+    );
+    act(() => {
+      result.current.addDrawing({ kind: "horizontal", price: 100 });
+    });
+    rerender({ slab: SLAB_B });
+    expect(result.current.drawings).toEqual([]);
+    act(() => {
+      result.current.addDrawing({ kind: "horizontal", price: 200 });
+    });
+    expect(result.current.drawings).toHaveLength(1);
+
+    rerender({ slab: SLAB_A });
+    expect(result.current.drawings).toHaveLength(1);
+    expect(result.current.drawings[0]).toMatchObject({ price: 100 });
+  });
+
+  it("returns an empty list and skips storage for an invalid slab address", () => {
+    const writeSpy = vi.spyOn(window.localStorage.__proto__, "setItem");
+    const readSpy = vi.spyOn(window.localStorage.__proto__, "getItem");
+
+    const { result } = renderHook(() => useChartDrawings(""));
+    expect(result.current.drawings).toEqual([]);
+    // Read was not attempted for the invalid slab.
+    expect(
+      readSpy.mock.calls.some((call) =>
+        String(call[0]).startsWith("perc:chart:drawings:"),
+      ),
+    ).toBe(false);
+
+    act(() => {
+      result.current.addDrawing({ kind: "horizontal", price: 100 });
+    });
+    // Write was not attempted for the invalid slab — bucket can't be poisoned.
+    expect(
+      writeSpy.mock.calls.some((call) =>
+        String(call[0]).startsWith("perc:chart:drawings:"),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a slab address that doesn't match the base58 pubkey shape", () => {
+    const writeSpy = vi.spyOn(window.localStorage.__proto__, "setItem");
+    const { result } = renderHook(() =>
+      useChartDrawings("not-a-valid-pubkey"),
+    );
+    act(() => {
+      result.current.addDrawing({ kind: "horizontal", price: 100 });
+    });
+    expect(result.current.drawings).toHaveLength(1); // in-memory still works
+    expect(
+      writeSpy.mock.calls.some((call) =>
+        String(call[0]).startsWith("perc:chart:drawings:"),
+      ),
+    ).toBe(false);
+  });
+
+  it("swallows quota errors on write without rolling back in-memory state", () => {
+    const setItemSpy = vi
+      .spyOn(window.localStorage.__proto__, "setItem")
+      .mockImplementation(() => {
+        throw new Error("QuotaExceededError");
+      });
+
+    const { result } = renderHook(() => useChartDrawings(SLAB_A));
+    act(() => {
+      result.current.addDrawing({ kind: "horizontal", price: 100 });
+    });
+    expect(result.current.drawings).toHaveLength(1);
+    expect(setItemSpy).toHaveBeenCalled();
+  });
+
+  it("treats a localStorage value with the wrong version as empty", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY_A,
+      JSON.stringify({
+        version: DRAWINGS_STORAGE_VERSION + 1,
+        drawings: [{ id: "future", kind: "horizontal", price: 100 }],
+      }),
+    );
+    const { result } = renderHook(() => useChartDrawings(SLAB_A));
+    expect(result.current.drawings).toEqual([]);
+  });
+
+  it("treats a non-JSON localStorage value as empty (does not crash)", () => {
+    window.localStorage.setItem(STORAGE_KEY_A, "{not valid json");
+    const { result } = renderHook(() => useChartDrawings(SLAB_A));
+    expect(result.current.drawings).toEqual([]);
+  });
+});

--- a/app/__tests__/hooks/useChartDrawings.test.ts
+++ b/app/__tests__/hooks/useChartDrawings.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act, renderHook } from "@testing-library/react";
 import { useChartDrawings } from "@/hooks/useChartDrawings";
 import {
@@ -19,10 +19,27 @@ function envelope(drawings: Drawing[]): string {
   return JSON.stringify({ version: DRAWINGS_STORAGE_VERSION, drawings });
 }
 
+/** Persistence is debounced by 250 ms. Most tests assert localStorage
+ *  state right after a mutation, so the trailing timer needs to fire
+ *  inline. Wrap in act() so any synchronous React-state side effects
+ *  from the timer's callback flush within React's batch. */
+function flushPersist(): void {
+  act(() => {
+    vi.runAllTimers();
+  });
+}
+
 describe("useChartDrawings", () => {
   beforeEach(() => {
     window.localStorage.clear();
     vi.restoreAllMocks();
+    // Fake only timer-related globals; leave Date / performance.now
+    // alone so other code that timestamps doesn't get warped.
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("returns an empty list on first mount with no stored data", () => {
@@ -49,6 +66,8 @@ describe("useChartDrawings", () => {
     expect(result.current.drawings).toHaveLength(1);
     expect(result.current.drawings[0].kind).toBe("horizontal");
     expect(result.current.drawings[0].id).toMatch(/^[0-9a-f-]{36}$/i);
+    // Flush the 250 ms persist debounce before reading localStorage.
+    flushPersist();
     // Persisted under the slab key.
     const persisted = JSON.parse(
       window.localStorage.getItem(STORAGE_KEY_A) ?? "{}",
@@ -91,6 +110,7 @@ describe("useChartDrawings", () => {
     });
     expect(result.current.drawings).toHaveLength(1);
     expect(result.current.drawings[0].id).not.toBe(targetId);
+    flushPersist();
     const persisted = JSON.parse(
       window.localStorage.getItem(STORAGE_KEY_A) ?? "{}",
     );
@@ -107,6 +127,7 @@ describe("useChartDrawings", () => {
       result.current.clearAll();
     });
     expect(result.current.drawings).toEqual([]);
+    flushPersist();
     const persisted = JSON.parse(
       window.localStorage.getItem(STORAGE_KEY_A) ?? "{}",
     );
@@ -185,6 +206,10 @@ describe("useChartDrawings", () => {
     act(() => {
       result.current.addDrawing({ kind: "horizontal", price: 100 });
     });
+    // Flush in case any timer is pending (it shouldn't be; the
+    // invalid-slab guard rejects the schedule entirely, but assert
+    // post-flush so the test fails closed if that guard ever moves).
+    flushPersist();
     // Write was not attempted for the invalid slab — bucket can't be poisoned.
     expect(
       writeSpy.mock.calls.some((call) =>
@@ -201,6 +226,7 @@ describe("useChartDrawings", () => {
     act(() => {
       result.current.addDrawing({ kind: "horizontal", price: 100 });
     });
+    flushPersist();
     expect(result.current.drawings).toHaveLength(1); // in-memory still works
     expect(
       writeSpy.mock.calls.some((call) =>
@@ -220,6 +246,7 @@ describe("useChartDrawings", () => {
     act(() => {
       result.current.addDrawing({ kind: "horizontal", price: 100 });
     });
+    flushPersist();
     expect(result.current.drawings).toHaveLength(1);
     expect(setItemSpy).toHaveBeenCalled();
   });
@@ -273,6 +300,7 @@ describe("useChartDrawings", () => {
     act(() => {
       add({ kind: "horizontal", price: 100 });
     });
+    flushPersist();
     // Write must land under SLAB_B's key.
     const persistedB = window.localStorage.getItem(STORAGE_KEY_B);
     expect(persistedB).toBeTruthy();
@@ -282,6 +310,51 @@ describe("useChartDrawings", () => {
     const persistedA = window.localStorage.getItem(STORAGE_KEY_A);
     const parsedA = JSON.parse(persistedA ?? "{}");
     expect(parsedA.drawings ?? []).toEqual([]);
+  });
+
+  it("coalesces a burst of mutations within the debounce window into one setItem", () => {
+    // The audit's perf concern: 30 mutations in 30 seconds = 30
+    // blocking setItem calls without debouncing. With a 250 ms
+    // trailing window, a tight burst should flush exactly once.
+    const setItemSpy = vi.spyOn(window.localStorage.__proto__, "setItem");
+    const { result } = renderHook(() => useChartDrawings(SLAB_A));
+    act(() => {
+      result.current.addDrawing({ kind: "horizontal", price: 100 });
+      result.current.addDrawing({ kind: "horizontal", price: 200 });
+      result.current.addDrawing({ kind: "horizontal", price: 300 });
+    });
+    // Mid-burst (timer still pending): no write has landed yet.
+    const drawingsKeyWritesMidBurst = setItemSpy.mock.calls.filter((c) =>
+      String(c[0]).startsWith("perc:chart:drawings:"),
+    );
+    expect(drawingsKeyWritesMidBurst).toHaveLength(0);
+    // Trailing fire flushes once with the final state.
+    flushPersist();
+    const drawingsKeyWritesAfter = setItemSpy.mock.calls.filter((c) =>
+      String(c[0]).startsWith("perc:chart:drawings:"),
+    );
+    expect(drawingsKeyWritesAfter).toHaveLength(1);
+    const finalEnvelope = JSON.parse(drawingsKeyWritesAfter[0][1] as string);
+    expect(finalEnvelope.drawings).toHaveLength(3);
+  });
+
+  it("pagehide flushes a pending write immediately", () => {
+    // Mobile users closing the tab inside the 250 ms window would
+    // otherwise lose the last drawing. The pagehide handler flushes
+    // the pending write before the tab dies. Note: beforeunload is
+    // unreliable on iOS Safari for mobile tabs; pagehide is the
+    // documented choice.
+    const setItemSpy = vi.spyOn(window.localStorage.__proto__, "setItem");
+    const { result } = renderHook(() => useChartDrawings(SLAB_A));
+    act(() => {
+      result.current.addDrawing({ kind: "horizontal", price: 100 });
+    });
+    // Fire pagehide before the trailing timer would have expired.
+    window.dispatchEvent(new Event("pagehide"));
+    const drawingsKeyWrites = setItemSpy.mock.calls.filter((c) =>
+      String(c[0]).startsWith("perc:chart:drawings:"),
+    );
+    expect(drawingsKeyWrites).toHaveLength(1);
   });
 
   it("generateId runs outside the state updater (single uuid per logical add)", () => {

--- a/app/__tests__/hooks/useChartDrawings.test.ts
+++ b/app/__tests__/hooks/useChartDrawings.test.ts
@@ -241,4 +241,68 @@ describe("useChartDrawings", () => {
     const { result } = renderHook(() => useChartDrawings(SLAB_A));
     expect(result.current.drawings).toEqual([]);
   });
+
+  it("does not crash when localStorage.getItem throws (Safari Private Mode)", () => {
+    // Safari throws on getItem in some private-mode configurations.
+    // The effect's try/catch must cover the read path AND the parse
+    // path — narrowing it to JSON.parse only would crash render here.
+    vi.spyOn(window.localStorage.__proto__, "getItem").mockImplementation(
+      () => {
+        throw new Error("QuotaExceededError");
+      },
+    );
+    const { result } = renderHook(() => useChartDrawings(SLAB_A));
+    expect(result.current.drawings).toEqual([]);
+  });
+
+  it("addDrawing writes to the NEW slab when called immediately after a slab change", () => {
+    // Race: slabAddress prop changes from A to B. The hydration effect
+    // for B will fire after commit, but a setter fired between the
+    // commit and that effect must persist to the NEW slab. The fix is
+    // to assign slabRef.current synchronously during render — this
+    // test pins that contract.
+    window.localStorage.setItem(STORAGE_KEY_A, envelope([]));
+    const { result, rerender } = renderHook(
+      ({ slab }: { slab: string }) => useChartDrawings(slab),
+      { initialProps: { slab: SLAB_A } },
+    );
+    rerender({ slab: SLAB_B });
+    // Capture addDrawing AFTER the rerender (post-render-time ref
+    // assignment) and call it immediately.
+    const add = result.current.addDrawing;
+    act(() => {
+      add({ kind: "horizontal", price: 100 });
+    });
+    // Write must land under SLAB_B's key.
+    const persistedB = window.localStorage.getItem(STORAGE_KEY_B);
+    expect(persistedB).toBeTruthy();
+    const parsedB = JSON.parse(persistedB ?? "{}");
+    expect(parsedB.drawings).toHaveLength(1);
+    // SLAB_A's key must NOT have received the new drawing.
+    const persistedA = window.localStorage.getItem(STORAGE_KEY_A);
+    const parsedA = JSON.parse(persistedA ?? "{}");
+    expect(parsedA.drawings ?? []).toEqual([]);
+  });
+
+  it("generateId runs outside the state updater (single uuid per logical add)", () => {
+    // React 18 may invoke state updater functions twice (Strict Mode in
+    // dev, discarded renders in concurrent mode). generateId must run
+    // OUTSIDE the updater so a single addDrawing call produces exactly
+    // one uuid. If it were inside, double-invocation would produce two
+    // different uuids and the disk persisted under each, leaving a
+    // brief window where in-memory state and disk disagree.
+    let uuidCallCount = 0;
+    const realRandomUUID = crypto.randomUUID.bind(crypto);
+    vi.spyOn(crypto, "randomUUID").mockImplementation(() => {
+      uuidCallCount++;
+      return realRandomUUID();
+    });
+
+    const { result } = renderHook(() => useChartDrawings(SLAB_A));
+    act(() => {
+      result.current.addDrawing({ kind: "horizontal", price: 100 });
+    });
+    expect(uuidCallCount).toBe(1);
+    expect(result.current.drawings).toHaveLength(1);
+  });
 });

--- a/app/__tests__/lib/chart-canvas.test.ts
+++ b/app/__tests__/lib/chart-canvas.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from "vitest";
+import { sizeCanvasForDpr } from "@/lib/chart-canvas";
+
+/** Build a stand-in HTMLCanvasElement that exposes only the fields
+ *  sizeCanvasForDpr touches. jsdom's real canvas doesn't return a 2D
+ *  context without node-canvas; faking the surface keeps the test
+ *  pure. */
+function fakeCanvas(): HTMLCanvasElement {
+  return {
+    width: 0,
+    height: 0,
+    style: { width: "", height: "" } as CSSStyleDeclaration,
+  } as unknown as HTMLCanvasElement;
+}
+
+function fakeCtx(): {
+  ctx: CanvasRenderingContext2D;
+  setTransform: ReturnType<typeof vi.fn>;
+} {
+  const setTransform = vi.fn();
+  return {
+    ctx: { setTransform } as unknown as CanvasRenderingContext2D,
+    setTransform,
+  };
+}
+
+describe("sizeCanvasForDpr", () => {
+  it("scales backing-store dimensions by dpr", () => {
+    const canvas = fakeCanvas();
+    const { ctx } = fakeCtx();
+    sizeCanvasForDpr(canvas, ctx, 800, 600, 2);
+    expect(canvas.width).toBe(1600);
+    expect(canvas.height).toBe(1200);
+  });
+
+  it("keeps CSS dimensions at the logical (display) size in px", () => {
+    const canvas = fakeCanvas();
+    const { ctx } = fakeCtx();
+    sizeCanvasForDpr(canvas, ctx, 800, 600, 2);
+    expect(canvas.style.width).toBe("800px");
+    expect(canvas.style.height).toBe("600px");
+  });
+
+  it("sets the context transform to scale draw calls by dpr", () => {
+    const canvas = fakeCanvas();
+    const { ctx, setTransform } = fakeCtx();
+    sizeCanvasForDpr(canvas, ctx, 800, 600, 2);
+    expect(setTransform).toHaveBeenCalledTimes(1);
+    expect(setTransform).toHaveBeenCalledWith(2, 0, 0, 2, 0, 0);
+  });
+
+  it("rounds non-integer dpr backing dimensions (1.5x display)", () => {
+    const canvas = fakeCanvas();
+    const { ctx, setTransform } = fakeCtx();
+    sizeCanvasForDpr(canvas, ctx, 800, 600, 1.5);
+    expect(canvas.width).toBe(1200);
+    expect(canvas.height).toBe(900);
+    expect(setTransform).toHaveBeenCalledWith(1.5, 0, 0, 1.5, 0, 0);
+  });
+
+  it("handles dpr=1 (standard display)", () => {
+    const canvas = fakeCanvas();
+    const { ctx, setTransform } = fakeCtx();
+    sizeCanvasForDpr(canvas, ctx, 800, 600, 1);
+    expect(canvas.width).toBe(800);
+    expect(canvas.height).toBe(600);
+    expect(canvas.style.width).toBe("800px");
+    expect(canvas.style.height).toBe("600px");
+    expect(setTransform).toHaveBeenCalledWith(1, 0, 0, 1, 0, 0);
+  });
+
+  it("handles dpr=3 (high-DPI mobile)", () => {
+    const canvas = fakeCanvas();
+    const { ctx } = fakeCtx();
+    sizeCanvasForDpr(canvas, ctx, 400, 800, 3);
+    expect(canvas.width).toBe(1200);
+    expect(canvas.height).toBe(2400);
+  });
+
+  it("clamps backing dimensions to a minimum of 1 (avoids 0×0 canvas)", () => {
+    // ResizeObserver can briefly hand us 0×0 during layout transitions
+    // (drawer collapse, modal open). Drawing on a 0-sized canvas
+    // throws; the clamp keeps the cleanup path silent.
+    const canvas = fakeCanvas();
+    const { ctx } = fakeCtx();
+    sizeCanvasForDpr(canvas, ctx, 0, 0, 2);
+    expect(canvas.width).toBe(1);
+    expect(canvas.height).toBe(1);
+    // CSS dims are still 0 — layout-empty matches the container's
+    // actual size; only the backing store is clamped.
+    expect(canvas.style.width).toBe("0px");
+    expect(canvas.style.height).toBe("0px");
+  });
+
+  it("rounds half-pixel display sizes consistently", () => {
+    // 800.4 × 1.5 = 1200.6 → rounds to 1201
+    const canvas = fakeCanvas();
+    const { ctx } = fakeCtx();
+    sizeCanvasForDpr(canvas, ctx, 800.4, 600.4, 1.5);
+    expect(canvas.width).toBe(1201); // round(1200.6)
+    expect(canvas.height).toBe(901); // round(900.6)
+  });
+});

--- a/app/__tests__/lib/chart-coords.test.ts
+++ b/app/__tests__/lib/chart-coords.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Time, UTCTimestamp } from "lightweight-charts";
+import {
+  pricePointToPixel,
+  pixelToPricePoint,
+  type PriceConverter,
+  type TimeConverter,
+} from "@/lib/chart-coords";
+
+/** Build a PriceConverter mock that linearly maps price → coordinate
+ *  with `coord = (price - priceAtZero) * pixelsPerPrice`, and the
+ *  inverse for the other direction. `null` returns are simulated by
+ *  passing `pixelsPerPrice = null`. */
+function priceConverter(
+  pricePerPixel = 1,
+  priceAtY0 = 0,
+  forceNull: "to" | "from" | null = null,
+): PriceConverter {
+  return {
+    priceToCoordinate: (price) =>
+      forceNull === "to" ? null : (price - priceAtY0) / pricePerPixel,
+    coordinateToPrice: (coord) =>
+      forceNull === "from" ? null : priceAtY0 + coord * pricePerPixel,
+  };
+}
+
+/** Build a TimeConverter mock. Maps time-in-seconds → coordinate
+ *  linearly: `coord = (timeS - timeAtX0) * pixelsPerSecond`. `null`
+ *  returns are simulated by `forceNull`. */
+function timeConverter(
+  pixelsPerSecond = 1,
+  timeAtX0 = 0,
+  forceNull: "to" | "from" | null = null,
+  returnsBusinessDay = false,
+): TimeConverter {
+  return {
+    timeToCoordinate: (time) =>
+      forceNull === "to" ? null : (time - timeAtX0) * pixelsPerSecond,
+    coordinateToTime: (coord) => {
+      if (forceNull === "from") return null;
+      if (returnsBusinessDay) {
+        return { year: 2024, month: 1, day: 1 } as unknown as Time;
+      }
+      return (timeAtX0 + coord / pixelsPerSecond) as Time;
+    },
+  };
+}
+
+describe("pricePointToPixel", () => {
+  it("maps price/time to pixel via the converters", () => {
+    const series = priceConverter(0.1, 100); // each price unit = 10 px, y=0 at price 100
+    const ts = timeConverter(2, 1_700_000_000); // 2 px per second, x=0 at this timestamp
+    const result = pricePointToPixel(series, ts, {
+      time: 1_700_000_010_000, // 10 s past the origin
+      price: 105,
+    });
+    expect(result).toEqual({ x: 20, y: 50 }); // 10s * 2px = 20; (105-100)/0.1 = 50
+  });
+
+  it("converts ms to seconds at the lightweight-charts boundary", () => {
+    const series = priceConverter();
+    const spy = vi.fn().mockReturnValue(42);
+    const ts: TimeConverter = {
+      timeToCoordinate: spy,
+      coordinateToTime: () => null,
+    };
+    pricePointToPixel(series, ts, {
+      time: 1_700_000_000_000, // ms
+      price: 100,
+    });
+    // Spy was called with seconds (ms / 1000), not raw ms.
+    expect(spy).toHaveBeenCalledWith(1_700_000_000);
+  });
+
+  it("floors sub-second time inputs (lightweight-charts is second-resolution)", () => {
+    const series = priceConverter();
+    const spy = vi.fn().mockReturnValue(0);
+    const ts: TimeConverter = {
+      timeToCoordinate: spy,
+      coordinateToTime: () => null,
+    };
+    pricePointToPixel(series, ts, {
+      time: 1_700_000_000_999, // 999 ms past a whole second
+      price: 100,
+    });
+    // Floored to whole seconds — sub-second precision is dropped.
+    expect(spy).toHaveBeenCalledWith(1_700_000_000);
+  });
+
+  it("returns null when the time axis maps off-scale", () => {
+    const series = priceConverter();
+    const ts = timeConverter(1, 0, "to"); // time→coord returns null
+    expect(
+      pricePointToPixel(series, ts, { time: 1_700_000_000_000, price: 100 }),
+    ).toBeNull();
+  });
+
+  it("returns null when the price axis maps off-scale", () => {
+    const series = priceConverter(1, 0, "to"); // price→coord returns null
+    const ts = timeConverter();
+    expect(
+      pricePointToPixel(series, ts, { time: 1_700_000_000_000, price: 100 }),
+    ).toBeNull();
+  });
+
+  it("returns null when both axes map off-scale", () => {
+    const series = priceConverter(1, 0, "to");
+    const ts = timeConverter(1, 0, "to");
+    expect(
+      pricePointToPixel(series, ts, { time: 1_700_000_000_000, price: 100 }),
+    ).toBeNull();
+  });
+
+  it.each([
+    ["NaN time", { time: NaN, price: 100 }],
+    ["Infinity time", { time: Infinity, price: 100 }],
+    ["NaN price", { time: 1_700_000_000_000, price: NaN }],
+    ["Infinity price", { time: 1_700_000_000_000, price: Infinity }],
+  ])("returns null for non-finite input (%s)", (_label, point) => {
+    const series = priceConverter();
+    const ts = timeConverter();
+    expect(pricePointToPixel(series, ts, point)).toBeNull();
+  });
+});
+
+describe("pixelToPricePoint", () => {
+  it("maps pixel coords to price/time via the converters", () => {
+    const series = priceConverter(0.1, 100); // y=0 at price 100, 0.1 price per pixel
+    const ts = timeConverter(2, 1_700_000_000); // x=0 at this timestamp, 2 px per second
+    const result = pixelToPricePoint(series, ts, 20, 50);
+    expect(result).toEqual({
+      time: 1_700_000_010_000, // 20 / 2 = 10 s past origin → ms
+      price: 105,
+    });
+  });
+
+  it("converts seconds to ms at the lightweight-charts boundary", () => {
+    const series = priceConverter();
+    const ts: TimeConverter = {
+      timeToCoordinate: () => null,
+      coordinateToTime: () => 1_700_000_000 as Time,
+    };
+    const result = pixelToPricePoint(series, ts, 0, 0);
+    // Result.time is ms (× 1000), not raw seconds.
+    expect(result?.time).toBe(1_700_000_000_000);
+  });
+
+  it("returns null when coordinateToTime returns null (off-scale)", () => {
+    const series = priceConverter();
+    const ts = timeConverter(1, 0, "from");
+    expect(pixelToPricePoint(series, ts, 0, 0)).toBeNull();
+  });
+
+  it("returns null when coordinateToPrice returns null (off-scale)", () => {
+    const series = priceConverter(1, 0, "from");
+    const ts = timeConverter();
+    expect(pixelToPricePoint(series, ts, 0, 0)).toBeNull();
+  });
+
+  it("returns null when timeScale hands back a BusinessDay (defensive)", () => {
+    const series = priceConverter();
+    const ts = timeConverter(1, 0, null, /* returnsBusinessDay */ true);
+    expect(pixelToPricePoint(series, ts, 0, 0)).toBeNull();
+  });
+
+  it("returns null when timeScale hands back a string Time (defensive)", () => {
+    const series = priceConverter();
+    const ts: TimeConverter = {
+      timeToCoordinate: () => null,
+      coordinateToTime: () => "2024-01-01" as Time,
+    };
+    expect(pixelToPricePoint(series, ts, 0, 0)).toBeNull();
+  });
+
+  it.each([
+    ["NaN x", NaN, 50],
+    ["NaN y", 50, NaN],
+    ["Infinity x", Infinity, 50],
+    ["Infinity y", 50, Infinity],
+  ])("returns null for non-finite pixel input (%s)", (_label, x, y) => {
+    const series = priceConverter();
+    const ts = timeConverter();
+    expect(pixelToPricePoint(series, ts, x, y)).toBeNull();
+  });
+});
+
+describe("round-trip", () => {
+  it("price → pixel → price returns the same value (identity at second-aligned input)", () => {
+    const series = priceConverter(0.1, 100);
+    const ts = timeConverter(2, 1_700_000_000);
+    const original = { time: 1_700_000_010_000, price: 105 }; // ms is multiple of 1000
+    const pixel = pricePointToPixel(series, ts, original);
+    expect(pixel).not.toBeNull();
+    const back = pixelToPricePoint(series, ts, pixel!.x, pixel!.y);
+    expect(back).toEqual(original);
+  });
+
+  it("price → pixel → price drops sub-second precision", () => {
+    const series = priceConverter(0.1, 100);
+    const ts = timeConverter(2, 1_700_000_000);
+    // Sub-second input gets floored on the way to seconds; round-trip
+    // returns the second-aligned value.
+    const original = { time: 1_700_000_010_999, price: 105 };
+    const pixel = pricePointToPixel(series, ts, original);
+    const back = pixelToPricePoint(series, ts, pixel!.x, pixel!.y);
+    expect(back).toEqual({ time: 1_700_000_010_000, price: 105 });
+  });
+});

--- a/app/__tests__/lib/chart-coords.test.ts
+++ b/app/__tests__/lib/chart-coords.test.ts
@@ -114,12 +114,84 @@ describe("pricePointToPixel", () => {
   it.each([
     ["NaN time", { time: NaN, price: 100 }],
     ["Infinity time", { time: Infinity, price: 100 }],
+    ["-Infinity time", { time: -Infinity, price: 100 }],
     ["NaN price", { time: 1_700_000_000_000, price: NaN }],
     ["Infinity price", { time: 1_700_000_000_000, price: Infinity }],
+    ["-Infinity price", { time: 1_700_000_000_000, price: -Infinity }],
   ])("returns null for non-finite input (%s)", (_label, point) => {
     const series = priceConverter();
     const ts = timeConverter();
     expect(pricePointToPixel(series, ts, point)).toBeNull();
+  });
+
+  it("converts negative ms to seconds via Math.trunc, not Math.floor", () => {
+    // Math.floor(-1.5) === -2 → would shift pre-epoch ms by a full
+    // second per conversion. Math.trunc(-1.5) === -1 truncates toward
+    // zero, which is the correct unit-conversion semantic. This pin
+    // catches a future "optimization" to `(timeMs / 1000) | 0` (also
+    // toward-zero) or back to floor.
+    const series = priceConverter();
+    const spy = vi.fn().mockReturnValue(0);
+    const ts: TimeConverter = {
+      timeToCoordinate: spy,
+      coordinateToTime: () => null,
+    };
+    pricePointToPixel(series, ts, { time: -1500, price: 100 });
+    // -1500 ms → trunc(-1.5) = -1 second (NOT -2 from floor).
+    expect(spy).toHaveBeenCalledWith(-1);
+  });
+
+  it("preserves fractional pixel coordinates (subpixel rendering)", () => {
+    // lightweight-charts can return subpixel coords at high zoom.
+    // pricePointToPixel must not round — a future Math.round
+    // "cleanup" would silently introduce drawing jitter.
+    const series: PriceConverter = {
+      priceToCoordinate: () => 100.25,
+      coordinateToPrice: () => 0,
+    };
+    const ts: TimeConverter = {
+      timeToCoordinate: () => 320.5,
+      coordinateToTime: () => null,
+    };
+    const result = pricePointToPixel(series, ts, {
+      time: 1_700_000_000_000,
+      price: 100,
+    });
+    expect(result).toEqual({ x: 320.5, y: 100.25 });
+  });
+
+  it("returns an object with exactly { x, y } keys (no extras)", () => {
+    const series = priceConverter();
+    const ts = timeConverter();
+    const result = pricePointToPixel(series, ts, {
+      time: 1_700_000_000_000,
+      price: 100,
+    });
+    expect(result).not.toBeNull();
+    expect(Object.keys(result!).sort()).toEqual(["x", "y"]);
+  });
+
+  it("calls timeScale.timeToCoordinate before series.priceToCoordinate", () => {
+    // Pin the call order. If it ever flips and a converter has a side
+    // effect (logging, chart-state mutation in commit 5+), behaviour
+    // would change silently.
+    const timeFn = vi.fn().mockReturnValue(10);
+    const priceFn = vi.fn().mockReturnValue(20);
+    const series: PriceConverter = {
+      priceToCoordinate: priceFn,
+      coordinateToPrice: () => 0,
+    };
+    const ts: TimeConverter = {
+      timeToCoordinate: timeFn,
+      coordinateToTime: () => null,
+    };
+    pricePointToPixel(series, ts, {
+      time: 1_700_000_000_000,
+      price: 100,
+    });
+    expect(timeFn.mock.invocationCallOrder[0]).toBeLessThan(
+      priceFn.mock.invocationCallOrder[0],
+    );
   });
 });
 
@@ -177,10 +249,37 @@ describe("pixelToPricePoint", () => {
     ["NaN y", 50, NaN],
     ["Infinity x", Infinity, 50],
     ["Infinity y", 50, Infinity],
+    ["-Infinity x", -Infinity, 50],
+    ["-Infinity y", 50, -Infinity],
   ])("returns null for non-finite pixel input (%s)", (_label, x, y) => {
     const series = priceConverter();
     const ts = timeConverter();
     expect(pixelToPricePoint(series, ts, x, y)).toBeNull();
+  });
+
+  it("returns an object with exactly { time, price } keys (no extras)", () => {
+    const series = priceConverter();
+    const ts = timeConverter();
+    const result = pixelToPricePoint(series, ts, 0, 0);
+    expect(result).not.toBeNull();
+    expect(Object.keys(result!).sort()).toEqual(["price", "time"]);
+  });
+
+  it("calls timeScale.coordinateToTime before series.coordinateToPrice", () => {
+    const timeFn = vi.fn().mockReturnValue(1_700_000_000 as Time);
+    const priceFn = vi.fn().mockReturnValue(100);
+    const series: PriceConverter = {
+      priceToCoordinate: () => 0,
+      coordinateToPrice: priceFn,
+    };
+    const ts: TimeConverter = {
+      timeToCoordinate: () => null,
+      coordinateToTime: timeFn,
+    };
+    pixelToPricePoint(series, ts, 50, 50);
+    expect(timeFn.mock.invocationCallOrder[0]).toBeLessThan(
+      priceFn.mock.invocationCallOrder[0],
+    );
   });
 });
 
@@ -198,11 +297,30 @@ describe("round-trip", () => {
   it("price → pixel → price drops sub-second precision", () => {
     const series = priceConverter(0.1, 100);
     const ts = timeConverter(2, 1_700_000_000);
-    // Sub-second input gets floored on the way to seconds; round-trip
+    // Sub-second input gets truncated on the way to seconds; round-trip
     // returns the second-aligned value.
     const original = { time: 1_700_000_010_999, price: 105 };
     const pixel = pricePointToPixel(series, ts, original);
     const back = pixelToPricePoint(series, ts, pixel!.x, pixel!.y);
     expect(back).toEqual({ time: 1_700_000_010_000, price: 105 });
+  });
+
+  it("is idempotent at second-aligned inputs (multiple round-trips don't drift)", () => {
+    // In production, anchors are always second-aligned because
+    // subscribeClick gives us seconds and we multiply by 1000. Pin
+    // that idempotency: a second-aligned PricePoint round-tripped N
+    // times equals itself, with no floating-point drift.
+    const series = priceConverter(0.1, 100);
+    const ts = timeConverter(2, 1_700_000_000);
+    let current: { time: number; price: number } = {
+      time: 1_700_000_010_000,
+      price: 105,
+    };
+    for (let i = 0; i < 10; i++) {
+      const pixel = pricePointToPixel(series, ts, current);
+      const back = pixelToPricePoint(series, ts, pixel!.x, pixel!.y);
+      expect(back).toEqual({ time: 1_700_000_010_000, price: 105 });
+      current = back!;
+    }
   });
 });

--- a/app/__tests__/lib/chart-drawings.test.ts
+++ b/app/__tests__/lib/chart-drawings.test.ts
@@ -105,6 +105,21 @@ describe("mergeDrawings", () => {
     ).toEqual([]);
   });
 
+  it.each([
+    ["missing version field", { drawings: [] }],
+    ["string-typed version", { version: "1", drawings: [] }],
+    ["NaN version", { version: NaN, drawings: [] }],
+    ["zero version", { version: 0, drawings: [] }],
+    ["negative version", { version: -1, drawings: [] }],
+    ["null version", { version: null, drawings: [] }],
+  ])("returns [] for envelope with %s", (_label, envelope) => {
+    // Strict equality on the version field means anything that isn't
+    // exactly DRAWINGS_STORAGE_VERSION (a number) drops the whole list.
+    // Pins each edge case so a future relaxation of the check fails a
+    // specific test rather than silently accepting weird payloads.
+    expect(mergeDrawings(envelope)).toEqual([]);
+  });
+
   it("returns [] for an envelope where drawings is not an array", () => {
     expect(
       mergeDrawings({
@@ -112,6 +127,45 @@ describe("mergeDrawings", () => {
         drawings: "not an array",
       }),
     ).toEqual([]);
+  });
+
+  it.each([
+    ["object", { version: DRAWINGS_STORAGE_VERSION, drawings: {} }],
+    ["null", { version: DRAWINGS_STORAGE_VERSION, drawings: null }],
+    ["undefined", { version: DRAWINGS_STORAGE_VERSION }],
+    ["number", { version: DRAWINGS_STORAGE_VERSION, drawings: 42 }],
+    ["boolean", { version: DRAWINGS_STORAGE_VERSION, drawings: true }],
+  ])(
+    "returns [] when envelope.drawings is non-array (%s)",
+    (_label, envelope) => {
+      expect(mergeDrawings(envelope)).toEqual([]);
+    },
+  );
+
+  it("rejects entries carrying __proto__ as an own key (prototype-pollution defuse)", () => {
+    // JSON.parse intentionally treats __proto__ as a string-key own
+    // property, NOT a prototype slot. isDrawing rejects entries with
+    // any prototype-related own key so future spread sites in the
+    // rendering pipeline can't re-apply the pollution.
+    const polluted = JSON.parse(
+      `{"version":${DRAWINGS_STORAGE_VERSION},"drawings":[{"id":"x","kind":"horizontal","price":100,"__proto__":{"polluted":true}}]}`,
+    );
+    expect(mergeDrawings(polluted)).toEqual([]);
+  });
+
+  it("rejects entries carrying constructor or prototype as own keys", () => {
+    expect(
+      isDrawing({
+        ...validHorizontal,
+        constructor: { polluted: true },
+      }),
+    ).toBe(false);
+    expect(
+      isDrawing({
+        ...validHorizontal,
+        prototype: { polluted: true },
+      }),
+    ).toBe(false);
   });
 
   it("accepts a well-formed envelope and returns the drawings", () => {

--- a/app/__tests__/lib/chart-drawings.test.ts
+++ b/app/__tests__/lib/chart-drawings.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from "vitest";
+import {
+  type Drawing,
+  type PricePoint,
+  DRAWINGS_STORAGE_VERSION,
+  MAX_DRAWINGS_PER_SLAB,
+  isDrawing,
+  mergeDrawings,
+} from "@/lib/chart-drawings";
+
+const validP1: PricePoint = { time: 1_700_000_000_000, price: 100 };
+const validP2: PricePoint = { time: 1_700_000_060_000, price: 110 };
+
+const validTrend: Drawing = {
+  id: "trend-1",
+  kind: "trend",
+  p1: validP1,
+  p2: validP2,
+};
+const validHorizontal: Drawing = {
+  id: "horiz-1",
+  kind: "horizontal",
+  price: 105,
+};
+const validRectangle: Drawing = {
+  id: "rect-1",
+  kind: "rectangle",
+  p1: validP1,
+  p2: validP2,
+};
+
+describe("isDrawing", () => {
+  it("accepts a well-formed trend line", () => {
+    expect(isDrawing(validTrend)).toBe(true);
+  });
+
+  it("accepts a well-formed horizontal line", () => {
+    expect(isDrawing(validHorizontal)).toBe(true);
+  });
+
+  it("accepts a well-formed rectangle", () => {
+    expect(isDrawing(validRectangle)).toBe(true);
+  });
+
+  it.each([null, undefined, 0, "", "string", true, []])(
+    "rejects non-object value %p",
+    (value) => {
+      expect(isDrawing(value)).toBe(false);
+    },
+  );
+
+  it("rejects a drawing with missing id", () => {
+    const { id: _id, ...rest } = validTrend;
+    expect(isDrawing(rest)).toBe(false);
+  });
+
+  it("rejects a drawing with empty-string id", () => {
+    expect(isDrawing({ ...validTrend, id: "" })).toBe(false);
+  });
+
+  it("rejects unknown kind values", () => {
+    expect(isDrawing({ ...validTrend, kind: "ellipse" })).toBe(false);
+  });
+
+  it("rejects a trend line with a missing endpoint", () => {
+    const { p2: _p2, ...rest } = validTrend;
+    expect(isDrawing(rest)).toBe(false);
+  });
+
+  it("rejects a horizontal line with non-finite price", () => {
+    expect(isDrawing({ ...validHorizontal, price: NaN })).toBe(false);
+    expect(isDrawing({ ...validHorizontal, price: Infinity })).toBe(false);
+  });
+
+  it("rejects a price-point with non-finite time", () => {
+    expect(
+      isDrawing({ ...validTrend, p1: { time: NaN, price: 100 } }),
+    ).toBe(false);
+    expect(
+      isDrawing({ ...validTrend, p1: { time: Infinity, price: 100 } }),
+    ).toBe(false);
+  });
+
+  it("rejects a price-point with non-finite price", () => {
+    expect(
+      isDrawing({ ...validTrend, p1: { time: 1_700_000_000_000, price: NaN } }),
+    ).toBe(false);
+  });
+});
+
+describe("mergeDrawings", () => {
+  it("returns [] for non-object inputs", () => {
+    expect(mergeDrawings(null)).toEqual([]);
+    expect(mergeDrawings(undefined)).toEqual([]);
+    expect(mergeDrawings("string")).toEqual([]);
+    expect(mergeDrawings(42)).toEqual([]);
+  });
+
+  it("returns [] for an envelope with the wrong version", () => {
+    expect(
+      mergeDrawings({
+        version: DRAWINGS_STORAGE_VERSION + 1,
+        drawings: [validTrend],
+      }),
+    ).toEqual([]);
+  });
+
+  it("returns [] for an envelope where drawings is not an array", () => {
+    expect(
+      mergeDrawings({
+        version: DRAWINGS_STORAGE_VERSION,
+        drawings: "not an array",
+      }),
+    ).toEqual([]);
+  });
+
+  it("accepts a well-formed envelope and returns the drawings", () => {
+    const result = mergeDrawings({
+      version: DRAWINGS_STORAGE_VERSION,
+      drawings: [validTrend, validHorizontal, validRectangle],
+    });
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual(validTrend);
+    expect(result[2]).toEqual(validRectangle);
+  });
+
+  it("accepts a bare-array payload defensively (legacy / future read)", () => {
+    expect(mergeDrawings([validTrend, validHorizontal])).toEqual([
+      validTrend,
+      validHorizontal,
+    ]);
+  });
+
+  it("drops malformed entries without rejecting the whole list", () => {
+    const result = mergeDrawings({
+      version: DRAWINGS_STORAGE_VERSION,
+      drawings: [
+        validTrend,
+        null,
+        { id: "bad", kind: "ellipse" },
+        { id: "", kind: "trend", p1: validP1, p2: validP2 },
+        validHorizontal,
+      ],
+    });
+    expect(result).toHaveLength(2);
+    expect(result.map((d) => d.id)).toEqual([validTrend.id, validHorizontal.id]);
+  });
+
+  it("dedupes drawings sharing an id (first wins)", () => {
+    const dup = { ...validHorizontal, id: validTrend.id, price: 200 };
+    const result = mergeDrawings({
+      version: DRAWINGS_STORAGE_VERSION,
+      drawings: [validTrend, dup],
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(validTrend);
+  });
+
+  it("trims at MAX_DRAWINGS_PER_SLAB on read", () => {
+    const drawings = Array.from({ length: MAX_DRAWINGS_PER_SLAB + 25 }, (_, i) => ({
+      id: `d-${i}`,
+      kind: "horizontal" as const,
+      price: i,
+    }));
+    const result = mergeDrawings({
+      version: DRAWINGS_STORAGE_VERSION,
+      drawings,
+    });
+    expect(result).toHaveLength(MAX_DRAWINGS_PER_SLAB);
+    // First N kept (cap counts valid entries only).
+    expect(result[0].id).toBe("d-0");
+    expect(result[MAX_DRAWINGS_PER_SLAB - 1].id).toBe(
+      `d-${MAX_DRAWINGS_PER_SLAB - 1}`,
+    );
+  });
+
+  it("counts only valid entries against the cap (junk entries don't consume budget)", () => {
+    const valid = Array.from({ length: MAX_DRAWINGS_PER_SLAB - 5 }, (_, i) => ({
+      id: `v-${i}`,
+      kind: "horizontal" as const,
+      price: i,
+    }));
+    const junk = Array.from({ length: 50 }, () => ({
+      id: "junk",
+      kind: "ellipse",
+    }));
+    const trailing = Array.from({ length: 10 }, (_, i) => ({
+      id: `t-${i}`,
+      kind: "horizontal" as const,
+      price: 1000 + i,
+    }));
+    const result = mergeDrawings({
+      version: DRAWINGS_STORAGE_VERSION,
+      drawings: [...valid, ...junk, ...trailing],
+    });
+    // 95 valid + 5 trailing = 100 (cap), 5 trailing left over dropped.
+    expect(result).toHaveLength(MAX_DRAWINGS_PER_SLAB);
+    expect(result[0].id).toBe("v-0");
+    expect(result[MAX_DRAWINGS_PER_SLAB - 1].id).toBe("t-4");
+  });
+
+  it("ignores unknown envelope fields", () => {
+    const result = mergeDrawings({
+      version: DRAWINGS_STORAGE_VERSION,
+      drawings: [validTrend],
+      futureField: { something: 42 },
+      anotherField: "ignored",
+    });
+    expect(result).toEqual([validTrend]);
+  });
+});

--- a/app/__tests__/lib/chart-hit-test.test.ts
+++ b/app/__tests__/lib/chart-hit-test.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect } from "vitest";
+import type { Time, UTCTimestamp } from "lightweight-charts";
+import {
+  distanceToSegment,
+  hitTestTrend,
+  hitTestHorizontal,
+  hitTestRectangle,
+  findHitDrawingId,
+  HIT_THRESHOLD_PX,
+} from "@/lib/chart-hit-test";
+import type { Drawing } from "@/lib/chart-drawings";
+import type {
+  PriceConverter,
+  TimeConverter,
+} from "@/lib/chart-coords";
+
+/** Identity-like converters: map price/time-in-seconds 1:1 to pixels.
+ *  Lets tests reason in pixel space directly. */
+const idSeries: PriceConverter = {
+  priceToCoordinate: (price) => price,
+  coordinateToPrice: (coord) => coord,
+};
+const idTime: TimeConverter = {
+  timeToCoordinate: (time) => time as number,
+  coordinateToTime: (coord) => coord as Time,
+};
+
+/** Off-scale converter: every projection returns null. */
+const nullSeries: PriceConverter = {
+  priceToCoordinate: () => null,
+  coordinateToPrice: () => null,
+};
+const nullTime: TimeConverter = {
+  timeToCoordinate: () => null,
+  coordinateToTime: () => null,
+};
+
+describe("distanceToSegment", () => {
+  it("returns 0 for a point on the segment", () => {
+    expect(distanceToSegment(5, 0, 0, 0, 10, 0)).toBe(0);
+  });
+
+  it("returns perpendicular distance for a point above the midpoint", () => {
+    expect(distanceToSegment(5, 3, 0, 0, 10, 0)).toBe(3);
+  });
+
+  it("returns endpoint distance when projection clamps to start", () => {
+    // Point is to the LEFT of the segment — projection clamps to (0,0).
+    expect(distanceToSegment(-3, 4, 0, 0, 10, 0)).toBe(5); // 3-4-5 triangle
+  });
+
+  it("returns endpoint distance when projection clamps to end", () => {
+    expect(distanceToSegment(13, 4, 0, 0, 10, 0)).toBe(5);
+  });
+
+  it("handles a degenerate (zero-length) segment as point-to-point", () => {
+    expect(distanceToSegment(3, 4, 5, 5, 5, 5)).toBeCloseTo(
+      Math.sqrt(4 + 1),
+    );
+  });
+
+  it("works for diagonal segments", () => {
+    // Segment from (0,0) to (10,10). Point (5,0) projects to (2.5, 2.5).
+    // Distance = sqrt(2.5^2 + 2.5^2) ≈ 3.535.
+    expect(distanceToSegment(5, 0, 0, 0, 10, 10)).toBeCloseTo(
+      Math.sqrt(2 * 2.5 * 2.5),
+    );
+  });
+});
+
+describe("hitTestTrend", () => {
+  // With identity converters, time-in-seconds maps to x-pixel and price
+  // maps to y-pixel. So a trend from (time=0s, price=0) to (time=10s,
+  // price=10) is a diagonal line from pixel (0,0) to pixel (10,10).
+  // BUT — our pricePointToPixel does Math.trunc(timeMs / 1000) before
+  // hitting timeToCoordinate, so test inputs use ms.
+  const trend: Extract<Drawing, { kind: "trend" }> = {
+    id: "t1",
+    kind: "trend",
+    p1: { time: 0, price: 0 },
+    p2: { time: 10_000, price: 10 }, // 10 seconds → x=10
+  };
+
+  it("hits a click ON the line", () => {
+    expect(hitTestTrend(trend, 5, 5, idSeries, idTime)).toBe(true);
+  });
+
+  it("hits a click WITHIN threshold of the line", () => {
+    // perpendicular offset of 3px from the diagonal at midpoint
+    expect(
+      hitTestTrend(
+        { ...trend, p1: { time: 0, price: 0 }, p2: { time: 10_000, price: 0 } },
+        5,
+        HIT_THRESHOLD_PX - 1,
+        idSeries,
+        idTime,
+      ),
+    ).toBe(true);
+  });
+
+  it("misses a click BEYOND threshold", () => {
+    expect(
+      hitTestTrend(
+        { ...trend, p1: { time: 0, price: 0 }, p2: { time: 10_000, price: 0 } },
+        5,
+        HIT_THRESHOLD_PX + 2,
+        idSeries,
+        idTime,
+      ),
+    ).toBe(false);
+  });
+
+  it("misses when an endpoint is off-scale (null projection)", () => {
+    expect(hitTestTrend(trend, 5, 5, nullSeries, idTime)).toBe(false);
+    expect(hitTestTrend(trend, 5, 5, idSeries, nullTime)).toBe(false);
+  });
+
+  it("hits at exactly the threshold (inclusive bound)", () => {
+    const horiz: Extract<Drawing, { kind: "trend" }> = {
+      id: "t",
+      kind: "trend",
+      p1: { time: 0, price: 0 },
+      p2: { time: 10_000, price: 0 },
+    };
+    expect(
+      hitTestTrend(horiz, 5, HIT_THRESHOLD_PX, idSeries, idTime),
+    ).toBe(true);
+  });
+});
+
+describe("hitTestHorizontal", () => {
+  const line: Extract<Drawing, { kind: "horizontal" }> = {
+    id: "h1",
+    kind: "horizontal",
+    price: 100,
+  };
+
+  it("hits a click on the line's y-coordinate", () => {
+    expect(hitTestHorizontal(line, 100, idSeries)).toBe(true);
+  });
+
+  it("hits a click within threshold above the line", () => {
+    expect(
+      hitTestHorizontal(line, 100 - HIT_THRESHOLD_PX + 1, idSeries),
+    ).toBe(true);
+  });
+
+  it("hits a click within threshold below the line", () => {
+    expect(
+      hitTestHorizontal(line, 100 + HIT_THRESHOLD_PX - 1, idSeries),
+    ).toBe(true);
+  });
+
+  it("misses a click beyond threshold", () => {
+    expect(
+      hitTestHorizontal(line, 100 + HIT_THRESHOLD_PX + 2, idSeries),
+    ).toBe(false);
+  });
+
+  it("misses when the price is off-scale (null projection)", () => {
+    expect(hitTestHorizontal(line, 100, nullSeries)).toBe(false);
+  });
+
+  it("hits at exactly threshold distance (inclusive)", () => {
+    expect(
+      hitTestHorizontal(line, 100 + HIT_THRESHOLD_PX, idSeries),
+    ).toBe(true);
+  });
+});
+
+describe("hitTestRectangle", () => {
+  // Rectangle from (time=0s, price=0) to (time=20s, price=20). With
+  // identity converters and time in ms → trunc to seconds:
+  // p1 pixels: (0, 0). p2 pixels: (20, 20).
+  const rect: Extract<Drawing, { kind: "rectangle" }> = {
+    id: "r1",
+    kind: "rectangle",
+    p1: { time: 0, price: 0 },
+    p2: { time: 20_000, price: 20 },
+  };
+
+  it("hits a click on the top edge", () => {
+    expect(hitTestRectangle(rect, 10, 0, idSeries, idTime)).toBe(true);
+  });
+
+  it("hits a click on the bottom edge", () => {
+    expect(hitTestRectangle(rect, 10, 20, idSeries, idTime)).toBe(true);
+  });
+
+  it("hits a click on the left edge", () => {
+    expect(hitTestRectangle(rect, 0, 10, idSeries, idTime)).toBe(true);
+  });
+
+  it("hits a click on the right edge", () => {
+    expect(hitTestRectangle(rect, 20, 10, idSeries, idTime)).toBe(true);
+  });
+
+  it("hits within threshold of an edge", () => {
+    // 4px outside the right edge — within 5px threshold.
+    expect(
+      hitTestRectangle(rect, 20 + HIT_THRESHOLD_PX - 1, 10, idSeries, idTime),
+    ).toBe(true);
+  });
+
+  it("MISSES a click in the rect's interior (edge-only hit-test)", () => {
+    // Far from any edge — 10,10 is the center of a 20×20 rect.
+    expect(hitTestRectangle(rect, 10, 10, idSeries, idTime)).toBe(false);
+  });
+
+  it("misses a click well outside the rect", () => {
+    expect(hitTestRectangle(rect, 100, 100, idSeries, idTime)).toBe(false);
+  });
+
+  it("normalises corner order (anchor from any corner)", () => {
+    // Same rectangle, anchored from (20, 20) → (0, 0) instead.
+    const flipped: Extract<Drawing, { kind: "rectangle" }> = {
+      ...rect,
+      p1: { time: 20_000, price: 20 },
+      p2: { time: 0, price: 0 },
+    };
+    expect(hitTestRectangle(flipped, 10, 0, idSeries, idTime)).toBe(true);
+    expect(hitTestRectangle(flipped, 0, 10, idSeries, idTime)).toBe(true);
+  });
+
+  it("misses when an endpoint is off-scale", () => {
+    expect(hitTestRectangle(rect, 10, 0, nullSeries, idTime)).toBe(false);
+  });
+});
+
+describe("findHitDrawingId", () => {
+  const trend: Drawing = {
+    id: "trend-1",
+    kind: "trend",
+    p1: { time: 0, price: 0 },
+    p2: { time: 10_000, price: 10 },
+  };
+  const horiz: Drawing = {
+    id: "horiz-1",
+    kind: "horizontal",
+    price: 50,
+  };
+  const rect: Drawing = {
+    id: "rect-1",
+    kind: "rectangle",
+    p1: { time: 0, price: 100 },
+    p2: { time: 30_000, price: 130 },
+  };
+
+  it("returns null for an empty drawings list", () => {
+    expect(findHitDrawingId([], 5, 5, idSeries, idTime)).toBeNull();
+  });
+
+  it("returns null when the click misses every drawing", () => {
+    expect(
+      findHitDrawingId([trend, horiz, rect], 500, 500, idSeries, idTime),
+    ).toBeNull();
+  });
+
+  it("finds a single drawing by id", () => {
+    expect(findHitDrawingId([trend], 5, 5, idSeries, idTime)).toBe("trend-1");
+    expect(findHitDrawingId([horiz], 100, 50, idSeries, idTime)).toBe("horiz-1");
+    expect(findHitDrawingId([rect], 0, 115, idSeries, idTime)).toBe("rect-1");
+  });
+
+  it("prefers the LAST drawing in the array on overlap (top-most wins)", () => {
+    // Two horizontals at the same price — the second one is "on top"
+    // visually because it was drawn last. Click should select it.
+    const a: Drawing = { id: "a", kind: "horizontal", price: 50 };
+    const b: Drawing = { id: "b", kind: "horizontal", price: 50 };
+    expect(findHitDrawingId([a, b], 100, 50, idSeries, idTime)).toBe("b");
+  });
+
+  it("falls back to earlier drawing when later misses but earlier hits", () => {
+    const farTrend: Drawing = {
+      id: "far",
+      kind: "trend",
+      p1: { time: 1_000_000, price: 1000 },
+      p2: { time: 2_000_000, price: 2000 },
+    };
+    expect(
+      findHitDrawingId([trend, farTrend], 5, 5, idSeries, idTime),
+    ).toBe("trend-1");
+  });
+});

--- a/app/components/trade/ChartDrawingOverlay.tsx
+++ b/app/components/trade/ChartDrawingOverlay.tsx
@@ -123,16 +123,22 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
    *  paints the preview line directly. */
   const previewP2Ref = useRef<PricePoint | null>(null);
 
-  // Reset overlay-local state on slab change OR tool change. Combined
-  // into one effect because both triggers want the same reset (clear
-  // selection AND any in-flight creation): a slab switch makes the
-  // previous selection irrelevant, and a tool switch invalidates a
-  // half-drawn anchor that the new tool can't act on.
+  // Reset overlay-local state on slab change, tool change, OR chart
+  // re-init. Combined because all three triggers want the same reset:
+  // - slab switch makes the previous selection irrelevant.
+  // - tool switch invalidates a half-drawn anchor.
+  // - chartReady false→true (Strict Mode double-mount, hot-reload,
+  //   any future code path that rebuilds the chart) invalidates
+  //   pendingP1's pixel projection — its time/price coords were
+  //   recorded against the OLD chart's coordinate system, and the
+  //   new chart may have a different visible range / bar density.
+  //   Committing a rectangle on the new chart with stale coords
+  //   produces a geometrically wrong drawing.
   useEffect(() => {
     setSelectedId(null);
     setPendingP1(null);
     previewP2Ref.current = null;
-  }, [slabAddress, tool]);
+  }, [slabAddress, tool, chartReady]);
 
   // If the selected drawing was removed (Delete / Backspace, slab
   // change clearing storage, etc.), drop the dangling id.
@@ -463,16 +469,35 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
   // commit, Escape, tool change, or chart unmount all flow through
   // here. Also wires the document-level mousemove/mouseup that drive
   // the live preview and the commit.
+  //
+  // Note: handleScroll suppresses BOTH chart pan AND wheel zoom for
+  // the duration of the drag; handleScale suppresses pinch and
+  // axis-drag zoom. Users finish the drag before they can wheel-
+  // zoom — acceptable trade-off vs fighting the drag gesture.
   useEffect(() => {
     if (!chartReady || tool !== "rectangle" || pendingP1 === null) return;
     const chart = chartRef.current;
     if (!chart) return;
     const el = chart.chartElement();
 
-    chart.applyOptions({
-      handleScroll: false,
-      handleScale: false,
-    });
+    // Snapshot the current scroll/scale options before disabling so
+    // the cleanup restores whatever shape the parent configured —
+    // not coarse `true` booleans. The chart-init in TradingChart
+    // uses object form (`handleScroll: { mouseWheel, ... }`); writing
+    // boolean `true` on cleanup widens any sub-flag the parent
+    // disabled to enabled, silently regressing pan/zoom config.
+    const previousScroll = chart.options().handleScroll;
+    const previousScale = chart.options().handleScale;
+    try {
+      chart.applyOptions({
+        handleScroll: false,
+        handleScale: false,
+      });
+    } catch {
+      // Chart torn down between effect setup and applyOptions call.
+      // The cleanup's matching try/catch will swallow any restore
+      // attempt symmetrically.
+    }
 
     const onMouseMove = (e: MouseEvent): void => {
       const series = seriesRef.current;
@@ -513,14 +538,21 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
       // to click instead of drag) and cancel without committing a
       // tiny, unselectable rectangle.
       const p1Px = pricePointToPixel(series, ts, pendingP1);
-      if (p1Px !== null) {
-        const dx = Math.abs(x - p1Px.x);
-        const dy = Math.abs(y - p1Px.y);
-        if (dx < 10 && dy < 10) {
-          setPendingP1(null);
-          previewP2Ref.current = null;
-          return;
-        }
+      if (p1Px === null) {
+        // Original anchor is no longer projectable (it scrolled off-
+        // scale during the drag). We can't validate jitter without
+        // p1 in pixel space — commit would produce a rectangle we
+        // can't size-check. Cancel rather than guess.
+        setPendingP1(null);
+        previewP2Ref.current = null;
+        return;
+      }
+      const dx = Math.abs(x - p1Px.x);
+      const dy = Math.abs(y - p1Px.y);
+      if (dx < 10 && dy < 10) {
+        setPendingP1(null);
+        previewP2Ref.current = null;
+        return;
       }
       addDrawingRef.current({
         kind: "rectangle",
@@ -538,12 +570,15 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
     return () => {
       document.removeEventListener("mousemove", onMouseMove);
       document.removeEventListener("mouseup", onMouseUp);
-      // Restore native pan/zoom regardless of how the drag ended
-      // (commit, cancel, Escape, slab change, tool change, unmount).
+      // Restore the SNAPSHOTTED scroll/scale options regardless of
+      // how the drag ended (commit, cancel, Escape, slab change,
+      // tool change, chart unmount). Writing the snapshot back
+      // preserves whatever shape the parent configured — coarse
+      // boolean OR granular object form.
       try {
         chart.applyOptions({
-          handleScroll: true,
-          handleScale: true,
+          handleScroll: previousScroll,
+          handleScale: previousScale,
         });
       } catch {
         // Chart was destroyed in a parallel cleanup; nothing to

--- a/app/components/trade/ChartDrawingOverlay.tsx
+++ b/app/components/trade/ChartDrawingOverlay.tsx
@@ -65,15 +65,26 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
+    // Cache the logical (CSS-pixel) dimensions used for the LAST resize.
+    // `redraw`'s clearRect uses these instead of recomputing from
+    // `canvas.width / window.devicePixelRatio` — that recompute reads a
+    // FRESH dpr on every redraw, but `canvas.width` was set with the
+    // dpr that was current at the last resize. If those disagree (user
+    // dragged the window between monitors of identical logical size,
+    // so DPR changed but the container didn't, so ResizeObserver
+    // didn't fire) the recompute under-clears and leaves ghost trails.
+    // The full fix for monitor-swap blur requires a matchMedia
+    // listener — deferred to v2 — but caching here at least keeps the
+    // clear correct for the canvas's current backing size.
+    let logicalW = 0;
+    let logicalH = 0;
+
     /** Clear the canvas. Future commits will iterate the active
      *  drawings list here and call per-kind render branches; for now
      *  the redraw exists only to prove the trigger plumbing fires on
      *  resize / pan / zoom / chart-rebuild. */
     const redraw = (): void => {
-      const dpr = window.devicePixelRatio ?? 1;
-      const w = canvas.width / dpr;
-      const h = canvas.height / dpr;
-      ctx.clearRect(0, 0, w, h);
+      ctx.clearRect(0, 0, logicalW, logicalH);
     };
 
     /** Re-size the canvas to the container's current dimensions (DPR-
@@ -81,9 +92,9 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
      *  ResizeObserver tick. */
     const resize = (): void => {
       const dpr = window.devicePixelRatio ?? 1;
-      const w = container.clientWidth;
-      const h = container.clientHeight;
-      sizeCanvasForDpr(canvas, ctx, w, h, dpr);
+      logicalW = container.clientWidth;
+      logicalH = container.clientHeight;
+      sizeCanvasForDpr(canvas, ctx, logicalW, logicalH, dpr);
       redraw();
     };
 
@@ -93,12 +104,23 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
     ro.observe(container);
 
     const ts = chart.timeScale();
-    ts.subscribeVisibleTimeRangeChange(redraw);
+    // subscribeVisibleLogicalRangeChange (NOT visibleTimeRangeChange):
+    // the time-range variant clamps to bar coverage and can stay
+    // frozen at the right-edge "future padding" zone during pan. The
+    // logical-range variant is the canonical "chart needs to redraw"
+    // hook and fires for every pan / zoom regardless of bar coverage.
+    ts.subscribeVisibleLogicalRangeChange(redraw);
+    // subscribeSizeChange catches internal chart reflows that DON'T
+    // change the container size — most commonly when the price-scale
+    // gutter widens because a price label grew a digit ($99 → $100,
+    // $9999 → $10000). ResizeObserver doesn't see those.
+    ts.subscribeSizeChange(redraw);
 
     return () => {
       ro.disconnect();
       try {
-        ts.unsubscribeVisibleTimeRangeChange(redraw);
+        ts.unsubscribeVisibleLogicalRangeChange(redraw);
+        ts.unsubscribeSizeChange(redraw);
       } catch {
         // Chart was destroyed in a parallel cleanup (Strict Mode
         // double-unmount, parent unmount). Refs are already dangling;

--- a/app/components/trade/ChartDrawingOverlay.tsx
+++ b/app/components/trade/ChartDrawingOverlay.tsx
@@ -564,12 +564,36 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
       // Tool stays in rectangle mode — TradingView convention.
     };
 
+    // Stuck-state recovery: a few ways the drag can end without a
+    // proper mouseup reaching us. All three call the same cancel
+    // path — drop pendingP1 + previewP2Ref so the cleanup-on-deps-
+    // change re-enables pan and removes the document listeners.
+    const cancel = (): void => {
+      setPendingP1(null);
+      previewP2Ref.current = null;
+    };
+    // 1. Right-click during drag opens the OS context menu. Firefox
+    //    skips the synthesizing mouseup entirely; Chrome may or may
+    //    not fire it. Either way, the user expects "cancel my drag"
+    //    semantics — stuck pendingP1 with the dashed preview frozen
+    //    is a UX trap.
+    const onContextMenu = (): void => cancel();
+    document.addEventListener("contextmenu", onContextMenu);
+    // 2. Window/tab blur (alt-tab, OS notification steals focus,
+    //    user dragged into another window). The mouseup will fire
+    //    on a different document we can't observe; cancelling here
+    //    keeps the chart's pan suppression from latching on.
+    const onWindowBlur = (): void => cancel();
+    window.addEventListener("blur", onWindowBlur);
+
     document.addEventListener("mousemove", onMouseMove);
     document.addEventListener("mouseup", onMouseUp);
 
     return () => {
       document.removeEventListener("mousemove", onMouseMove);
       document.removeEventListener("mouseup", onMouseUp);
+      document.removeEventListener("contextmenu", onContextMenu);
+      window.removeEventListener("blur", onWindowBlur);
       // Restore the SNAPSHOTTED scroll/scale options regardless of
       // how the drag ended (commit, cancel, Escape, slab change,
       // tool change, chart unmount). Writing the snapshot back

--- a/app/components/trade/ChartDrawingOverlay.tsx
+++ b/app/components/trade/ChartDrawingOverlay.tsx
@@ -195,18 +195,30 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
           timeScaleApi,
         );
       }
-      // In-flight creation preview: the trend tool draws a faded
-      // dashed line from the locked-in p1 to wherever the cursor
-      // currently is, so the user can see what they're about to
-      // commit on the second click.
+      // In-flight creation preview, dispatched by tool:
+      // - trend: faded dashed line from pendingP1 to cursor + dot at p1
+      // - rectangle: faded dashed rect from pendingP1 to cursor (no dots)
+      // pointer / horizontal don't have multi-step creation; pendingP1
+      // shouldn't be set in those modes.
       if (pendingP1 !== null) {
-        renderTrendPreview(
-          ctx,
-          pendingP1,
-          previewP2Ref.current,
-          series,
-          timeScaleApi,
-        );
+        const { tool } = stateRef.current;
+        if (tool === "trend") {
+          renderTrendPreview(
+            ctx,
+            pendingP1,
+            previewP2Ref.current,
+            series,
+            timeScaleApi,
+          );
+        } else if (tool === "rectangle") {
+          renderRectanglePreview(
+            ctx,
+            pendingP1,
+            previewP2Ref.current,
+            series,
+            timeScaleApi,
+          );
+        }
       }
     };
     redrawRef.current = redraw;
@@ -401,6 +413,144 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
   useEffect(() => {
     redrawRef.current();
   }, [drawings, selectedId, pendingP1]);
+
+  // Rectangle creation: drag-driven (mouse-down inside the chart sets
+  // p1, mouse-move tracks the opposite corner, mouse-up commits).
+  // chart.subscribeClick can't power this — clicks fire on
+  // mouse-down + up at the same place, which is exactly what we
+  // DON'T want for a drag. Instead we attach a native mousedown to
+  // chart.chartElement() (the chart's own DOM container, the only
+  // surface above the canvas with pointer-events). The follow-on
+  // move and up listeners attach to document so the user can drag
+  // out past the chart edges and release without the gesture
+  // breaking.
+  useEffect(() => {
+    if (!chartReady || tool !== "rectangle") return;
+    const chart = chartRef.current;
+    if (!chart) return;
+    const el = chart.chartElement();
+
+    const onMouseDown = (e: MouseEvent): void => {
+      // Left button only; ignore right-click / middle-click.
+      if (e.button !== 0) return;
+      // Mobile guard: drag-create on touch devices is its own UX
+      // problem (gesture conflicts with chart pan, no clear cancel
+      // affordance). Bail before pendingP1 is set.
+      if (
+        typeof window !== "undefined" &&
+        typeof window.matchMedia === "function" &&
+        window.matchMedia("(max-width: 767px)").matches
+      ) {
+        return;
+      }
+      const series = seriesRef.current;
+      if (!series) return;
+      const rect = el.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const ts = chart.timeScale() as unknown as TimeConverter;
+      const point = pixelToPricePoint(series, ts, x, y);
+      if (point === null) return;
+      setPendingP1(point);
+    };
+    el.addEventListener("mousedown", onMouseDown);
+    return () => el.removeEventListener("mousedown", onMouseDown);
+  }, [chartReady, tool, chartRef, seriesRef]);
+
+  // While a rectangle drag is in flight (pendingP1 set in rectangle
+  // mode), suppress the chart's built-in pan/zoom so the drag
+  // gesture doesn't double as a chart pan. Restored on cleanup —
+  // commit, Escape, tool change, or chart unmount all flow through
+  // here. Also wires the document-level mousemove/mouseup that drive
+  // the live preview and the commit.
+  useEffect(() => {
+    if (!chartReady || tool !== "rectangle" || pendingP1 === null) return;
+    const chart = chartRef.current;
+    if (!chart) return;
+    const el = chart.chartElement();
+
+    chart.applyOptions({
+      handleScroll: false,
+      handleScale: false,
+    });
+
+    const onMouseMove = (e: MouseEvent): void => {
+      const series = seriesRef.current;
+      if (!series) {
+        previewP2Ref.current = null;
+        return;
+      }
+      const rect = el.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const ts = chart.timeScale() as unknown as TimeConverter;
+      const point = pixelToPricePoint(series, ts, x, y);
+      previewP2Ref.current = point;
+      redrawRef.current();
+    };
+
+    const onMouseUp = (e: MouseEvent): void => {
+      const series = seriesRef.current;
+      if (!series) {
+        setPendingP1(null);
+        previewP2Ref.current = null;
+        return;
+      }
+      const rect = el.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const ts = chart.timeScale() as unknown as TimeConverter;
+      const p2 = pixelToPricePoint(series, ts, x, y);
+      // Drag ended off-scale (price or time can't project) — cancel
+      // rather than commit a partially-defined rectangle.
+      if (p2 === null) {
+        setPendingP1(null);
+        previewP2Ref.current = null;
+        return;
+      }
+      // Min-size guard: if the drag covered fewer than 10 CSS pixels
+      // in BOTH dimensions, treat it as click jitter (a user trying
+      // to click instead of drag) and cancel without committing a
+      // tiny, unselectable rectangle.
+      const p1Px = pricePointToPixel(series, ts, pendingP1);
+      if (p1Px !== null) {
+        const dx = Math.abs(x - p1Px.x);
+        const dy = Math.abs(y - p1Px.y);
+        if (dx < 10 && dy < 10) {
+          setPendingP1(null);
+          previewP2Ref.current = null;
+          return;
+        }
+      }
+      addDrawingRef.current({
+        kind: "rectangle",
+        p1: pendingP1,
+        p2,
+      });
+      setPendingP1(null);
+      previewP2Ref.current = null;
+      // Tool stays in rectangle mode — TradingView convention.
+    };
+
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+
+    return () => {
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+      // Restore native pan/zoom regardless of how the drag ended
+      // (commit, cancel, Escape, slab change, tool change, unmount).
+      try {
+        chart.applyOptions({
+          handleScroll: true,
+          handleScale: true,
+        });
+      } catch {
+        // Chart was destroyed in a parallel cleanup; nothing to
+        // restore.
+      }
+    };
+  }, [chartReady, tool, pendingP1, chartRef, seriesRef]);
 
   // Keyboard: Escape priority chain + Delete / Backspace removes the
   // selected drawing. Both guarded against firing while focus is in
@@ -602,5 +752,39 @@ function renderTrendPreview(
       ctx.stroke();
     }
   }
+  ctx.restore();
+}
+
+/** Live preview for an in-flight rectangle drag: faded dashed
+ *  outline + filled translucent body from the locked-in mouse-down
+ *  corner to the current cursor position. No anchor dots — the rect
+ *  shape itself communicates the drag in progress, and committed
+ *  rectangles only get corner dots when SELECTED (not during
+ *  creation). Returns silently if either endpoint projects off-scale
+ *  or before the cursor has moved (previewP2 === null — drag just
+ *  started, no opposite corner yet). */
+function renderRectanglePreview(
+  ctx: CanvasRenderingContext2D,
+  pendingP1: PricePoint,
+  previewP2: PricePoint | null,
+  series: PriceConverter,
+  timeScale: TimeConverter,
+): void {
+  if (previewP2 === null) return;
+  const p1 = pricePointToPixel(series, timeScale, pendingP1);
+  const p2 = pricePointToPixel(series, timeScale, previewP2);
+  if (p1 === null || p2 === null) return;
+  const x = Math.min(p1.x, p2.x);
+  const y = Math.min(p1.y, p2.y);
+  const w = Math.abs(p2.x - p1.x);
+  const h = Math.abs(p2.y - p1.y);
+  ctx.save();
+  ctx.fillStyle = ACCENT_FILL;
+  ctx.strokeStyle = ACCENT_STROKE;
+  ctx.globalAlpha = 0.6;
+  ctx.setLineDash([5, 5]);
+  ctx.lineWidth = DEFAULT_LINE_WIDTH;
+  ctx.fillRect(x, y, w, h);
+  ctx.strokeRect(x, y, w, h);
   ctx.restore();
 }

--- a/app/components/trade/ChartDrawingOverlay.tsx
+++ b/app/components/trade/ChartDrawingOverlay.tsx
@@ -420,9 +420,43 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
     chart.subscribeClick(onClick);
 
     // Crosshair-move drives the live preview during multi-click
-    // creation (trend tool only in this commit). Updates a ref —
-    // not React state — and triggers a redraw imperatively, so we
-    // don't burn a render cycle per mouse-move (~60 fps).
+    // creation (trend tool). lightweight-charts fires this on every
+    // pixel of cursor motion (~60 Hz on standard mice, higher on
+    // high-poll-rate gaming mice / 240 Hz trackpads). Coalesce to one
+    // redraw per frame via rAF — without this, a half-drawn trend
+    // hover at 100 drawings × ~4 canvas ops each saturates the main
+    // thread on lower-end laptops + battery.
+    //
+    // Scheduling uses a separate boolean flag from the rAF id: a
+    // synchronous rAF (used in tests) runs the callback inline and
+    // returns the id afterwards, which would otherwise leave a stale
+    // id stored under an "id == 0 means free" convention. Splitting
+    // the flag from the id keeps the scheduler correct for both
+    // sync and async rAF semantics.
+    let crosshairScheduled = false;
+    let crosshairRafId = 0;
+    let crosshairPending: { point: PricePoint | null; cursorLeft: boolean } | null = null;
+    const flushCrosshairPreview = (): void => {
+      crosshairScheduled = false;
+      crosshairRafId = 0;
+      if (crosshairPending === null) return;
+      const { tool, pendingP1 } = stateRef.current;
+      if (tool !== "trend" || pendingP1 === null) {
+        crosshairPending = null;
+        return;
+      }
+      const series = seriesRef.current;
+      if (!series) {
+        previewP2Ref.current = null;
+        crosshairPending = null;
+        return;
+      }
+      previewP2Ref.current = crosshairPending.cursorLeft
+        ? null
+        : crosshairPending.point;
+      crosshairPending = null;
+      redraw();
+    };
     const onCrosshairMove = (param: MouseEventParams<Time>): void => {
       const { tool, pendingP1 } = stateRef.current;
       if (tool !== "trend" || pendingP1 === null) return;
@@ -432,25 +466,34 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
         return;
       }
       if (!param.point) {
-        // Cursor left the chart — drop the preview.
-        previewP2Ref.current = null;
-        redraw();
-        return;
+        // Cursor left the chart — drop the preview on the next frame.
+        crosshairPending = { point: null, cursorLeft: true };
+      } else {
+        const timeScaleApi = chart.timeScale() as unknown as TimeConverter;
+        const point = pixelToPricePoint(
+          series,
+          timeScaleApi,
+          param.point.x,
+          param.point.y,
+        );
+        crosshairPending = { point, cursorLeft: false };
       }
-      const timeScaleApi = chart.timeScale() as unknown as TimeConverter;
-      const point = pixelToPricePoint(
-        series,
-        timeScaleApi,
-        param.point.x,
-        param.point.y,
-      );
-      previewP2Ref.current = point;
-      redraw();
+      if (!crosshairScheduled) {
+        crosshairScheduled = true;
+        crosshairRafId = window.requestAnimationFrame(flushCrosshairPreview);
+      }
     };
     chart.subscribeCrosshairMove(onCrosshairMove);
 
     return () => {
       ro.disconnect();
+      // Cancel any pending preview frame so a teardown mid-hover
+      // doesn't race a stale callback against a destroyed chart.
+      if (crosshairScheduled) {
+        window.cancelAnimationFrame(crosshairRafId);
+        crosshairScheduled = false;
+        crosshairRafId = 0;
+      }
       try {
         ts.unsubscribeVisibleLogicalRangeChange(redraw);
         ts.unsubscribeSizeChange(redraw);
@@ -564,19 +607,42 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
       // attempt symmetrically.
     }
 
-    const onMouseMove = (e: MouseEvent): void => {
+    // Rectangle drag mousemove: same rAF coalesce as the crosshair
+    // path. Browsers fire mousemove faster than vsync on high-poll
+    // mice (1000 Hz gaming mice, 240 Hz trackpads) — without
+    // coalescing, every event runs getBoundingClientRect +
+    // pixelToPricePoint + a full redraw. Store the latest client
+    // coords; defer projection + redraw to the next frame. The
+    // scheduled-flag-vs-id split is the same as the crosshair path
+    // and works under sync rAF too.
+    let dragScheduled = false;
+    let dragRafId = 0;
+    let dragPendingClient: { clientX: number; clientY: number } | null = null;
+    const flushDragPreview = (): void => {
+      dragScheduled = false;
+      dragRafId = 0;
+      const pending = dragPendingClient;
+      if (pending === null) return;
+      dragPendingClient = null;
       const series = seriesRef.current;
       if (!series) {
         previewP2Ref.current = null;
         return;
       }
       const rect = el.getBoundingClientRect();
-      const x = e.clientX - rect.left;
-      const y = e.clientY - rect.top;
+      const x = pending.clientX - rect.left;
+      const y = pending.clientY - rect.top;
       const ts = chart.timeScale() as unknown as TimeConverter;
       const point = pixelToPricePoint(series, ts, x, y);
       previewP2Ref.current = point;
       redrawRef.current();
+    };
+    const onMouseMove = (e: MouseEvent): void => {
+      dragPendingClient = { clientX: e.clientX, clientY: e.clientY };
+      if (!dragScheduled) {
+        dragScheduled = true;
+        dragRafId = window.requestAnimationFrame(flushDragPreview);
+      }
     };
 
     const onMouseUp = (e: MouseEvent): void => {
@@ -659,6 +725,14 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
       document.removeEventListener("mouseup", onMouseUp);
       document.removeEventListener("contextmenu", onContextMenu);
       window.removeEventListener("blur", onWindowBlur);
+      // Cancel any pending drag-preview frame so a teardown mid-drag
+      // doesn't race a stale callback that would write to
+      // previewP2Ref after the drag context is gone.
+      if (dragScheduled) {
+        window.cancelAnimationFrame(dragRafId);
+        dragScheduled = false;
+        dragRafId = 0;
+      }
       // Restore the SNAPSHOTTED scroll/scale options regardless of
       // how the drag ended (commit, cancel, Escape, slab change,
       // tool change, chart unmount). Writing the snapshot back

--- a/app/components/trade/ChartDrawingOverlay.tsx
+++ b/app/components/trade/ChartDrawingOverlay.tsx
@@ -273,11 +273,17 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
       if (e.key === "Delete" || e.key === "Backspace") {
         const { selectedId } = stateRef.current;
         if (selectedId !== null) {
+          // preventDefault on BOTH keys: Backspace is the obvious
+          // back-nav trigger, but Firefox configurations (and some
+          // screen-reader virtual cursors) bind Delete to navigation
+          // or "delete element" actions too. Symmetric prevention
+          // costs nothing and keeps the user's keystroke from
+          // escaping into the browser when a drawing was just
+          // removed.
+          e.preventDefault();
           deleteDrawing(selectedId);
           // selectedId resets via the "selected was removed" effect
-          // when drawings updates. preventDefault stops Backspace
-          // from triggering the browser's history-back nav.
-          e.preventDefault();
+          // when drawings updates.
         }
       }
     };
@@ -352,14 +358,23 @@ function renderDrawing(
       if (p1 === null || p2 === null) return;
       const x = Math.min(p1.x, p2.x);
       const y = Math.min(p1.y, p2.y);
-      const w = Math.abs(p2.x - p1.x);
-      const h = Math.abs(p2.y - p1.y);
+      const x2 = Math.max(p1.x, p2.x);
+      const y2 = Math.max(p1.y, p2.y);
+      const w = x2 - x;
+      const h = y2 - y;
       ctx.fillStyle = ACCENT_FILL;
       ctx.fillRect(x, y, w, h);
       ctx.strokeRect(x, y, w, h);
       if (selected) {
-        drawAnchor(ctx, p1.x, p1.y);
-        drawAnchor(ctx, p2.x, p2.y);
+        // All four corners get an anchor dot, not just the original
+        // p1 / p2. Hit-testing treats every edge as grabbable so the
+        // visual cue should match — two corners would imply only
+        // those two are interactive (they're not; v1 has no
+        // drag-edit, the dots are pure selection feedback).
+        drawAnchor(ctx, x, y);
+        drawAnchor(ctx, x2, y);
+        drawAnchor(ctx, x, y2);
+        drawAnchor(ctx, x2, y2);
       }
       return;
     }

--- a/app/components/trade/ChartDrawingOverlay.tsx
+++ b/app/components/trade/ChartDrawingOverlay.tsx
@@ -149,6 +149,17 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
   const stateRef = useRef({ drawings, selectedId, tool, pendingP1 });
   stateRef.current = { drawings, selectedId, tool, pendingP1 };
 
+  // addDrawing is also routed through a ref rather than being in the
+  // main effect's deps. The hook returns a useCallback-stable
+  // reference today, but parking it in deps would make the entire
+  // chart-subscription stack load-bearing on a hook two layers up —
+  // any future refactor that breaks that memoization would silently
+  // tear down + re-attach all four chart subscriptions on every
+  // render. The ref keeps the architecture's "subscribe once" contract
+  // intact regardless of upstream callback identity.
+  const addDrawingRef = useRef(addDrawing);
+  addDrawingRef.current = addDrawing;
+
   // Imperative redraw seam: the main effect populates this with a
   // closure that captures the canvas / ctx / converters; the
   // data-change effect below calls it without re-running the main
@@ -238,6 +249,24 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
       if (!param.point) return;
       const series = seriesRef.current;
       if (!series) return;
+      // Mobile guard: creation tools require the toolbar (which is
+      // hidden below md), the keyboard (no Escape on most mobile
+      // soft-keyboards), or both — none reliably available on phones.
+      // A desktop session can leave a creation tool persisted
+      // globally (`perc:chart:drawing-tool`); without this guard, a
+      // mobile user lands on the chart and every tap drops a
+      // horizontal / commits a trend with no escape route.
+      // Pointer mode stays available on every viewport (passive
+      // hit-test). matchMedia is undefined in some non-browser
+      // environments — defensive default is "treat as desktop."
+      if (
+        tool !== "pointer" &&
+        typeof window !== "undefined" &&
+        typeof window.matchMedia === "function" &&
+        window.matchMedia("(max-width: 767px)").matches
+      ) {
+        return;
+      }
       const timeScaleApi = chart.timeScale() as unknown as TimeConverter;
 
       switch (tool) {
@@ -256,7 +285,7 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
         case "horizontal": {
           const price = series.coordinateToPrice(param.point.y);
           if (price === null) return;
-          addDrawing({ kind: "horizontal", price });
+          addDrawingRef.current({ kind: "horizontal", price });
           // Tool stays in horizontal mode — TradingView convention.
           // User explicitly switches via toolbar or Escape to leave.
           return;
@@ -274,10 +303,27 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
             // click will commit {pendingP1, point}.
             setPendingP1(point);
           } else {
+            // Reject a zero-length trend: a double-click at the same
+            // pixel commits a trend with p1 === p2 that hit-tests as
+            // a single dot — visually broken and clutters persisted
+            // drawings. Keep pendingP1 set so the user can move and
+            // try again. Same-bar same-price equality is exact since
+            // pixelToPricePoint trunc'd both inputs through the same
+            // Math.trunc(ms/1000) boundary.
+            if (
+              point.time === pendingP1.time &&
+              point.price === pendingP1.price
+            ) {
+              return;
+            }
             // Second click — commit, then reset for the next trend.
             // Tool stays in trend mode; the user can keep drawing
             // until they explicitly change tools.
-            addDrawing({ kind: "trend", p1: pendingP1, p2: point });
+            addDrawingRef.current({
+              kind: "trend",
+              p1: pendingP1,
+              p2: point,
+            });
             setPendingP1(null);
             previewP2Ref.current = null;
           }
@@ -289,6 +335,11 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
           // an accidental click in rectangle mode doesn't drop a
           // zero-size rect.
           return;
+        default:
+          // Compile-error guard: a future DrawingTool kind added
+          // to the union without a case here will fail to type-
+          // check rather than silently no-op the click.
+          return assertNever(tool);
       }
     };
     chart.subscribeClick(onClick);
@@ -336,7 +387,7 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
       }
       redrawRef.current = () => {};
     };
-  }, [chartRef, containerRef, seriesRef, chartReady, addDrawing]);
+  }, [chartRef, containerRef, seriesRef, chartReady]);
 
   // Drive redraw when drawings, selection, or pending-creation state
   // change without tearing down + re-subscribing the main effect. The

--- a/app/components/trade/ChartDrawingOverlay.tsx
+++ b/app/components/trade/ChartDrawingOverlay.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useEffect, useRef, type FC, type RefObject } from "react";
+import type { IChartApi } from "lightweight-charts";
+import { sizeCanvasForDpr } from "@/lib/chart-canvas";
+
+interface ChartDrawingOverlayProps {
+  /** Live chart API ref managed by the parent's chart-init effect.
+   *  May be null briefly between mount and chart creation. */
+  chartRef: RefObject<IChartApi | null>;
+  /** The same div lightweight-charts mounts its canvas into. The
+   *  overlay's canvas tracks this div's dimensions via ResizeObserver
+   *  so it stays exactly aligned with the chart. */
+  containerRef: RefObject<HTMLDivElement | null>;
+  /** Flips true once the chart-init effect has populated chartRef.
+   *  Used as the re-subscription trigger — when chartReady transitions
+   *  false → true (mount, hot-reload, Strict Mode double-mount), the
+   *  effect tears down old subscriptions and attaches new ones to the
+   *  fresh chart instance. */
+  chartReady: boolean;
+}
+
+/**
+ * A transparent canvas layered above the chart, dedicated to user-drawn
+ * annotations (trend lines, horizontal lines, rectangles). Renders
+ * nothing visible until subsequent commits add the drawing-state props
+ * and per-kind render branches; this commit is just the plumbing —
+ * canvas mounts at the right size, stays aligned with the chart on
+ * resize / pan / zoom, and re-attaches to a new chart instance when
+ * the chart is rebuilt.
+ *
+ * Critical contract: `pointer-events: none` ALWAYS. The overlay never
+ * captures pointer events. Click handling for the drawing tools will
+ * route through `chart.subscribeClick` (next commits), which keeps
+ * lightweight-charts' native pan / zoom intact alongside drawing
+ * creation. If the overlay ever set `pointer-events: auto`, every
+ * pan / zoom interaction would die.
+ *
+ * Layout: `absolute inset-0` fills the chart container. DOM order
+ * places it AFTER the chart canvas (so it stacks above) but BEFORE
+ * the empty-state / hover-tooltip / position-summary overlays (which
+ * use `z-10` and stack above the drawing overlay — drawings should
+ * not occlude the position badge or the OHLCV tooltip).
+ *
+ * DPR: backing-store size scales by `devicePixelRatio` for sharp
+ * rendering on Retina / fractional-DPR screens; CSS size stays at the
+ * container's logical pixels so layout doesn't shift. The 2D context
+ * transform handles the multiplication so draw calls in subsequent
+ * commits work in CSS-pixel space without per-call DPR math.
+ */
+export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
+  chartRef,
+  containerRef,
+  chartReady,
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    if (!chartReady) return;
+    const chart = chartRef.current;
+    const container = containerRef.current;
+    const canvas = canvasRef.current;
+    if (!chart || !container || !canvas) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    /** Clear the canvas. Future commits will iterate the active
+     *  drawings list here and call per-kind render branches; for now
+     *  the redraw exists only to prove the trigger plumbing fires on
+     *  resize / pan / zoom / chart-rebuild. */
+    const redraw = (): void => {
+      const dpr = window.devicePixelRatio ?? 1;
+      const w = canvas.width / dpr;
+      const h = canvas.height / dpr;
+      ctx.clearRect(0, 0, w, h);
+    };
+
+    /** Re-size the canvas to the container's current dimensions (DPR-
+     *  aware) and redraw. Called on initial mount and on every
+     *  ResizeObserver tick. */
+    const resize = (): void => {
+      const dpr = window.devicePixelRatio ?? 1;
+      const w = container.clientWidth;
+      const h = container.clientHeight;
+      sizeCanvasForDpr(canvas, ctx, w, h, dpr);
+      redraw();
+    };
+
+    resize();
+
+    const ro = new ResizeObserver(resize);
+    ro.observe(container);
+
+    const ts = chart.timeScale();
+    ts.subscribeVisibleTimeRangeChange(redraw);
+
+    return () => {
+      ro.disconnect();
+      try {
+        ts.unsubscribeVisibleTimeRangeChange(redraw);
+      } catch {
+        // Chart was destroyed in a parallel cleanup (Strict Mode
+        // double-unmount, parent unmount). Refs are already dangling;
+        // the swallow keeps the cleanup pure and silent.
+      }
+    };
+  }, [chartRef, containerRef, chartReady]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="pointer-events-none absolute inset-0"
+      aria-hidden="true"
+    />
+  );
+};

--- a/app/components/trade/ChartDrawingOverlay.tsx
+++ b/app/components/trade/ChartDrawingOverlay.tsx
@@ -9,12 +9,15 @@ import type {
 import { sizeCanvasForDpr } from "@/lib/chart-canvas";
 import {
   pricePointToPixel,
+  pixelToPricePoint,
   type PriceConverter,
   type TimeConverter,
 } from "@/lib/chart-coords";
 import {
   type Drawing,
+  type DrawingInput,
   type DrawingTool,
+  type PricePoint,
 } from "@/lib/chart-drawings";
 import { findHitDrawingId } from "@/lib/chart-hit-test";
 import { assertNever } from "@/lib/exhaustive";
@@ -42,11 +45,14 @@ interface ChartDrawingOverlayProps {
   /** Persisted drawings for the active slab. Rendered every frame;
    *  hit-tested on click for selection. */
   drawings: readonly Drawing[];
+  /** Setter for adding a new drawing (creation flows: trend, horizontal,
+   *  rectangle). The hook generates the id + persists. */
+  addDrawing: (input: DrawingInput) => void;
   /** Setter for removing a drawing by id (Delete / Backspace path). */
   deleteDrawing: (id: string) => void;
-  /** Active drawing tool. Pointer is the only branch wired in this
-   *  commit; future commits add creation flows for trend / horizontal
-   *  / rectangle. */
+  /** Active drawing tool. Pointer hit-tests; trend uses two-click
+   *  creation; horizontal commits on a single click; rectangle uses
+   *  drag (separate commit). */
   tool: DrawingTool;
   /** Setter for the active tool. Used by the keyboard handler's
    *  Escape priority chain to fall back to pointer when nothing
@@ -92,6 +98,7 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
   containerRef,
   chartReady,
   drawings,
+  addDrawing,
   deleteDrawing,
   tool,
   setTool,
@@ -102,20 +109,30 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
    *  intentionally NOT persisted (a fresh page should start with
    *  nothing selected, and selection doesn't survive market switches). */
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  /** First click of a multi-click creation flow — locked-in anchor
+   *  waiting for the second click to commit (trend tool). State, not
+   *  ref, because the keyboard handler's Escape priority chain reads
+   *  it to decide whether to cancel the pending creation or fall
+   *  through to deselect / tool-reset. */
+  const [pendingP1, setPendingP1] = useState<PricePoint | null>(null);
+  /** Live preview anchor — where the second click WOULD commit if
+   *  the user clicked right now. Updated on every crosshair move
+   *  while pendingP1 is set. Ref (not state) because it changes at
+   *  ~60 fps during hover and re-rendering React on every move
+   *  would be wasteful — the redraw call after each ref update
+   *  paints the preview line directly. */
+  const previewP2Ref = useRef<PricePoint | null>(null);
 
-  // Reset selection when the active slab changes — the user switched
-  // markets, the previous selection no longer applies.
+  // Reset overlay-local state on slab change OR tool change. Combined
+  // into one effect because both triggers want the same reset (clear
+  // selection AND any in-flight creation): a slab switch makes the
+  // previous selection irrelevant, and a tool switch invalidates a
+  // half-drawn anchor that the new tool can't act on.
   useEffect(() => {
     setSelectedId(null);
-  }, [slabAddress]);
-
-  // Reset selection when the active tool changes. Switching to a
-  // creation tool while a drawing is selected would leave a stray
-  // highlight that the new tool can't act on; clearing here keeps
-  // overlay-local state consistent with what the user just chose.
-  useEffect(() => {
-    setSelectedId(null);
-  }, [tool]);
+    setPendingP1(null);
+    previewP2Ref.current = null;
+  }, [slabAddress, tool]);
 
   // If the selected drawing was removed (Delete / Backspace, slab
   // change clearing storage, etc.), drop the dangling id.
@@ -129,8 +146,8 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
   // putting these in the effect's deps array (which would tear down
   // and re-attach all subscriptions on every state change — defeats
   // the whole point of the overlay).
-  const stateRef = useRef({ drawings, selectedId, tool });
-  stateRef.current = { drawings, selectedId, tool };
+  const stateRef = useRef({ drawings, selectedId, tool, pendingP1 });
+  stateRef.current = { drawings, selectedId, tool, pendingP1 };
 
   // Imperative redraw seam: the main effect populates this with a
   // closure that captures the canvas / ctx / converters; the
@@ -156,13 +173,26 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
       const series = seriesRef.current;
       if (!series) return;
       const timeScaleApi = chart.timeScale() as unknown as TimeConverter;
-      const { drawings, selectedId } = stateRef.current;
+      const { drawings, selectedId, pendingP1 } = stateRef.current;
       for (const drawing of drawings) {
         renderDrawing(
           ctx,
           logicalW,
           drawing,
           drawing.id === selectedId,
+          series,
+          timeScaleApi,
+        );
+      }
+      // In-flight creation preview: the trend tool draws a faded
+      // dashed line from the locked-in p1 to wherever the cursor
+      // currently is, so the user can see what they're about to
+      // commit on the second click.
+      if (pendingP1 !== null) {
+        renderTrendPreview(
+          ctx,
+          pendingP1,
+          previewP2Ref.current,
           series,
           timeScaleApi,
         );
@@ -189,33 +219,109 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
 
     // Click dispatch via chart.subscribeClick. Routes through the
     // chart's own canvas (which has pointer-events) so lightweight-
-    // charts' pan / zoom keeps working. Future commits add branches
-    // for trend / horizontal / rectangle creation flows; for now,
-    // pointer is the only one wired.
+    // charts' pan / zoom keeps working. Per-tool branches:
+    // - pointer: hit-test against drawings, set / clear selection
+    // - horizontal: single-click commits a horizontal at the click's
+    //   price level
+    // - trend: two-click flow — click 1 sets pendingP1, click 2
+    //   commits {p1, p2} as a trend drawing and resets pendingP1
+    // - rectangle: separate commit (drag-driven, not click-driven)
     //
     // Mobile note: the toolbar is `hidden md:flex` so a phone user
     // can't change the tool, but a desktop session may have left
     // a creation tool persisted. Pointer mode is safe everywhere
-    // (passive read); creation tools will need their own mobile
-    // guards when they land.
+    // (passive read); creation tools also fire here on mobile but
+    // a phone user has no way to back out — see the mobile guard
+    // todo for the rectangle commit.
     const onClick = (param: MouseEventParams<Time>): void => {
-      const { tool, drawings } = stateRef.current;
-      if (tool !== "pointer") return;
+      const { tool, drawings, pendingP1 } = stateRef.current;
       if (!param.point) return;
       const series = seriesRef.current;
       if (!series) return;
       const timeScaleApi = chart.timeScale() as unknown as TimeConverter;
-      const hitId = findHitDrawingId(
-        drawings,
-        param.point.x,
-        param.point.y,
-        series,
-        timeScaleApi,
-      );
-      // setSelectedId always — even if hitId is null (deselect).
-      setSelectedId(hitId);
+
+      switch (tool) {
+        case "pointer": {
+          const hitId = findHitDrawingId(
+            drawings,
+            param.point.x,
+            param.point.y,
+            series,
+            timeScaleApi,
+          );
+          // setSelectedId always — even if hitId is null (deselect).
+          setSelectedId(hitId);
+          return;
+        }
+        case "horizontal": {
+          const price = series.coordinateToPrice(param.point.y);
+          if (price === null) return;
+          addDrawing({ kind: "horizontal", price });
+          // Tool stays in horizontal mode — TradingView convention.
+          // User explicitly switches via toolbar or Escape to leave.
+          return;
+        }
+        case "trend": {
+          const point = pixelToPricePoint(
+            series,
+            timeScaleApi,
+            param.point.x,
+            param.point.y,
+          );
+          if (point === null) return;
+          if (pendingP1 === null) {
+            // First click — lock in the start point. The second
+            // click will commit {pendingP1, point}.
+            setPendingP1(point);
+          } else {
+            // Second click — commit, then reset for the next trend.
+            // Tool stays in trend mode; the user can keep drawing
+            // until they explicitly change tools.
+            addDrawing({ kind: "trend", p1: pendingP1, p2: point });
+            setPendingP1(null);
+            previewP2Ref.current = null;
+          }
+          return;
+        }
+        case "rectangle":
+          // Drag-driven creation lands in a separate commit. Click
+          // is not the trigger — left intentionally unhandled so
+          // an accidental click in rectangle mode doesn't drop a
+          // zero-size rect.
+          return;
+      }
     };
     chart.subscribeClick(onClick);
+
+    // Crosshair-move drives the live preview during multi-click
+    // creation (trend tool only in this commit). Updates a ref —
+    // not React state — and triggers a redraw imperatively, so we
+    // don't burn a render cycle per mouse-move (~60 fps).
+    const onCrosshairMove = (param: MouseEventParams<Time>): void => {
+      const { tool, pendingP1 } = stateRef.current;
+      if (tool !== "trend" || pendingP1 === null) return;
+      const series = seriesRef.current;
+      if (!series) {
+        previewP2Ref.current = null;
+        return;
+      }
+      if (!param.point) {
+        // Cursor left the chart — drop the preview.
+        previewP2Ref.current = null;
+        redraw();
+        return;
+      }
+      const timeScaleApi = chart.timeScale() as unknown as TimeConverter;
+      const point = pixelToPricePoint(
+        series,
+        timeScaleApi,
+        param.point.x,
+        param.point.y,
+      );
+      previewP2Ref.current = point;
+      redraw();
+    };
+    chart.subscribeCrosshairMove(onCrosshairMove);
 
     return () => {
       ro.disconnect();
@@ -223,22 +329,27 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
         ts.unsubscribeVisibleLogicalRangeChange(redraw);
         ts.unsubscribeSizeChange(redraw);
         chart.unsubscribeClick(onClick);
+        chart.unsubscribeCrosshairMove(onCrosshairMove);
       } catch {
         // Chart was destroyed in a parallel cleanup. Refs already
         // dangling; the swallow keeps cleanup pure and silent.
       }
       redrawRef.current = () => {};
     };
-  }, [chartRef, containerRef, seriesRef, chartReady]);
+  }, [chartRef, containerRef, seriesRef, chartReady, addDrawing]);
 
-  // Drive redraw when drawings or selection state change without
-  // tearing down + re-subscribing the main effect. The redrawRef is
-  // populated inside the main effect; if the main effect hasn't run
-  // yet (chartReady=false on initial mount), the no-op default kicks
-  // in and this is a cheap miss.
+  // Drive redraw when drawings, selection, or pending-creation state
+  // change without tearing down + re-subscribing the main effect. The
+  // redrawRef is populated inside the main effect; if the main effect
+  // hasn't run yet (chartReady=false on initial mount), the no-op
+  // default kicks in and this is a cheap miss.
+  //
+  // pendingP1 in the deps so the preview anchor dot appears the
+  // moment the first trend click lands (without waiting for the next
+  // crosshair move to repaint).
   useEffect(() => {
     redrawRef.current();
-  }, [drawings, selectedId]);
+  }, [drawings, selectedId, pendingP1]);
 
   // Keyboard: Escape priority chain + Delete / Backspace removes the
   // selected drawing. Both guarded against firing while focus is in
@@ -256,11 +367,20 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
         return;
       }
       if (e.key === "Escape") {
-        // Priority chain. Future tools (commit 6+) will insert a
-        // pending-anchor cancel BEFORE the selectedId clear so a
-        // half-drawn trend line cancels first, then a second
-        // Escape returns to pointer.
-        const { selectedId, tool } = stateRef.current;
+        // Priority chain (highest first):
+        // 1. Cancel pending creation (locked-in trend p1) — keep tool
+        // 2. Clear selection
+        // 3. Reset tool to pointer
+        // 4. No-op
+        // The order matches user expectation: a half-drawn anchor
+        // is the most recent action and the most "in flight," so
+        // it gets the first Escape.
+        const { pendingP1, selectedId, tool } = stateRef.current;
+        if (pendingP1 !== null) {
+          setPendingP1(null);
+          previewP2Ref.current = null;
+          return;
+        }
         if (selectedId !== null) {
           setSelectedId(null);
           return;
@@ -392,4 +512,44 @@ function drawAnchor(ctx: CanvasRenderingContext2D, x: number, y: number): void {
   ctx.beginPath();
   ctx.arc(x, y, ANCHOR_RADIUS, 0, Math.PI * 2);
   ctx.fill();
+}
+
+/** Live preview for an in-flight trend creation: faded dashed line
+ *  from the locked-in p1 to wherever the cursor currently is, with
+ *  a solid anchor dot at p1 to show the start point is committed.
+ *  No dot at p2 — that anchor isn't locked in yet (the next click
+ *  commits it). Returns silently if either endpoint projects off-
+ *  scale or if the cursor hasn't moved into the chart yet
+ *  (previewP2 === null). */
+function renderTrendPreview(
+  ctx: CanvasRenderingContext2D,
+  pendingP1: PricePoint,
+  previewP2: PricePoint | null,
+  series: PriceConverter,
+  timeScale: TimeConverter,
+): void {
+  const p1 = pricePointToPixel(series, timeScale, pendingP1);
+  if (p1 === null) return;
+  // Always paint the anchor dot (so the user knows their first
+  // click was registered) even if the cursor is off-chart.
+  ctx.save();
+  ctx.fillStyle = ACCENT_STROKE;
+  ctx.beginPath();
+  ctx.arc(p1.x, p1.y, ANCHOR_RADIUS, 0, Math.PI * 2);
+  ctx.fill();
+
+  if (previewP2 !== null) {
+    const p2 = pricePointToPixel(series, timeScale, previewP2);
+    if (p2 !== null) {
+      ctx.strokeStyle = ACCENT_STROKE;
+      ctx.globalAlpha = 0.6;
+      ctx.setLineDash([5, 5]);
+      ctx.lineWidth = DEFAULT_LINE_WIDTH;
+      ctx.beginPath();
+      ctx.moveTo(p1.x, p1.y);
+      ctx.lineTo(p2.x, p2.y);
+      ctx.stroke();
+    }
+  }
+  ctx.restore();
 }

--- a/app/components/trade/ChartDrawingOverlay.tsx
+++ b/app/components/trade/ChartDrawingOverlay.tsx
@@ -1,13 +1,34 @@
 "use client";
 
-import { useEffect, useRef, type FC, type RefObject } from "react";
-import type { IChartApi } from "lightweight-charts";
+import { useEffect, useRef, useState, type FC, type RefObject } from "react";
+import type {
+  IChartApi,
+  MouseEventParams,
+  Time,
+} from "lightweight-charts";
 import { sizeCanvasForDpr } from "@/lib/chart-canvas";
+import {
+  pricePointToPixel,
+  type PriceConverter,
+  type TimeConverter,
+} from "@/lib/chart-coords";
+import {
+  type Drawing,
+  type DrawingTool,
+} from "@/lib/chart-drawings";
+import { findHitDrawingId } from "@/lib/chart-hit-test";
+import { assertNever } from "@/lib/exhaustive";
 
 interface ChartDrawingOverlayProps {
   /** Live chart API ref managed by the parent's chart-init effect.
    *  May be null briefly between mount and chart creation. */
   chartRef: RefObject<IChartApi | null>;
+  /** Live price-pane series ref (the one lightweight-charts gives us
+   *  for the candle / line / area). Typed as PriceConverter — the
+   *  structural subset we need; the real ISeriesApi assigns to it.
+   *  Pass the PRICE-pane series, not an oscillator-pane series, or
+   *  drawings will project through the wrong scale. */
+  seriesRef: RefObject<PriceConverter | null>;
   /** The same div lightweight-charts mounts its canvas into. The
    *  overlay's canvas tracks this div's dimensions via ResizeObserver
    *  so it stays exactly aligned with the chart. */
@@ -18,23 +39,38 @@ interface ChartDrawingOverlayProps {
    *  effect tears down old subscriptions and attaches new ones to the
    *  fresh chart instance. */
   chartReady: boolean;
+  /** Persisted drawings for the active slab. Rendered every frame;
+   *  hit-tested on click for selection. */
+  drawings: readonly Drawing[];
+  /** Setter for removing a drawing by id (Delete / Backspace path). */
+  deleteDrawing: (id: string) => void;
+  /** Active drawing tool. Pointer is the only branch wired in this
+   *  commit; future commits add creation flows for trend / horizontal
+   *  / rectangle. */
+  tool: DrawingTool;
+  /** Setter for the active tool. Used by the keyboard handler's
+   *  Escape priority chain to fall back to pointer when nothing
+   *  selectable is in flight. */
+  setTool: (next: DrawingTool) => void;
+  /** The slab whose drawings these are. Used to reset overlay-local
+   *  selection state when the user navigates between markets. */
+  slabAddress: string;
 }
 
 /**
- * A transparent canvas layered above the chart, dedicated to user-drawn
- * annotations (trend lines, horizontal lines, rectangles). Renders
- * nothing visible until subsequent commits add the drawing-state props
- * and per-kind render branches; this commit is just the plumbing —
- * canvas mounts at the right size, stays aligned with the chart on
- * resize / pan / zoom, and re-attaches to a new chart instance when
- * the chart is rebuilt.
+ * Transparent canvas layered above the chart, dedicated to user-drawn
+ * annotations (trend lines, horizontal lines, rectangles). Owns:
+ * - render of the drawings list (per-kind branches with selected
+ *   highlight)
+ * - click dispatch for the active tool (pointer-mode hit-testing in
+ *   this commit; creation flows in subsequent commits)
+ * - keyboard handling (Escape priority chain + Delete / Backspace)
  *
  * Critical contract: `pointer-events: none` ALWAYS. The overlay never
- * captures pointer events. Click handling for the drawing tools will
- * route through `chart.subscribeClick` (next commits), which keeps
- * lightweight-charts' native pan / zoom intact alongside drawing
- * creation. If the overlay ever set `pointer-events: auto`, every
- * pan / zoom interaction would die.
+ * captures pointer events. Click handling routes through
+ * chart.subscribeClick so lightweight-charts' native pan / zoom keep
+ * working. Setting pointer-events: auto would silently kill every
+ * chart interaction.
  *
  * Layout: `absolute inset-0` fills the chart container. DOM order
  * places it AFTER the chart canvas (so it stacks above) but BEFORE
@@ -42,18 +78,65 @@ interface ChartDrawingOverlayProps {
  * use `z-10` and stack above the drawing overlay — drawings should
  * not occlude the position badge or the OHLCV tooltip).
  *
- * DPR: backing-store size scales by `devicePixelRatio` for sharp
- * rendering on Retina / fractional-DPR screens; CSS size stays at the
- * container's logical pixels so layout doesn't shift. The 2D context
- * transform handles the multiplication so draw calls in subsequent
- * commits work in CSS-pixel space without per-call DPR math.
+ * State architecture: the main effect (subscriptions + canvas setup)
+ * keys only on `[chartRef, containerRef, seriesRef, chartReady]` so it
+ * doesn't re-fire on every drawings / selectedId / tool change. A
+ * sibling effect drives redraws on data change without re-subscribing,
+ * and event handlers read latest state via `stateRef`. The redraw
+ * closure is published to `redrawRef` so the data-change effect can
+ * call it imperatively.
  */
 export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
   chartRef,
+  seriesRef,
   containerRef,
   chartReady,
+  drawings,
+  deleteDrawing,
+  tool,
+  setTool,
+  slabAddress,
 }) => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  /** Currently selected drawing's id, or null. Overlay-local state —
+   *  intentionally NOT persisted (a fresh page should start with
+   *  nothing selected, and selection doesn't survive market switches). */
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  // Reset selection when the active slab changes — the user switched
+  // markets, the previous selection no longer applies.
+  useEffect(() => {
+    setSelectedId(null);
+  }, [slabAddress]);
+
+  // Reset selection when the active tool changes. Switching to a
+  // creation tool while a drawing is selected would leave a stray
+  // highlight that the new tool can't act on; clearing here keeps
+  // overlay-local state consistent with what the user just chose.
+  useEffect(() => {
+    setSelectedId(null);
+  }, [tool]);
+
+  // If the selected drawing was removed (Delete / Backspace, slab
+  // change clearing storage, etc.), drop the dangling id.
+  useEffect(() => {
+    if (selectedId !== null && !drawings.some((d) => d.id === selectedId)) {
+      setSelectedId(null);
+    }
+  }, [drawings, selectedId]);
+
+  // Latest-state ref for handlers in the main effect to read without
+  // putting these in the effect's deps array (which would tear down
+  // and re-attach all subscriptions on every state change — defeats
+  // the whole point of the overlay).
+  const stateRef = useRef({ drawings, selectedId, tool });
+  stateRef.current = { drawings, selectedId, tool };
+
+  // Imperative redraw seam: the main effect populates this with a
+  // closure that captures the canvas / ctx / converters; the
+  // data-change effect below calls it without re-running the main
+  // effect.
+  const redrawRef = useRef<() => void>(() => {});
 
   useEffect(() => {
     if (!chartReady) return;
@@ -65,31 +148,28 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
-    // Cache the logical (CSS-pixel) dimensions used for the LAST resize.
-    // `redraw`'s clearRect uses these instead of recomputing from
-    // `canvas.width / window.devicePixelRatio` — that recompute reads a
-    // FRESH dpr on every redraw, but `canvas.width` was set with the
-    // dpr that was current at the last resize. If those disagree (user
-    // dragged the window between monitors of identical logical size,
-    // so DPR changed but the container didn't, so ResizeObserver
-    // didn't fire) the recompute under-clears and leaves ghost trails.
-    // The full fix for monitor-swap blur requires a matchMedia
-    // listener — deferred to v2 — but caching here at least keeps the
-    // clear correct for the canvas's current backing size.
     let logicalW = 0;
     let logicalH = 0;
 
-    /** Clear the canvas. Future commits will iterate the active
-     *  drawings list here and call per-kind render branches; for now
-     *  the redraw exists only to prove the trigger plumbing fires on
-     *  resize / pan / zoom / chart-rebuild. */
     const redraw = (): void => {
       ctx.clearRect(0, 0, logicalW, logicalH);
+      const series = seriesRef.current;
+      if (!series) return;
+      const timeScaleApi = chart.timeScale() as unknown as TimeConverter;
+      const { drawings, selectedId } = stateRef.current;
+      for (const drawing of drawings) {
+        renderDrawing(
+          ctx,
+          logicalW,
+          drawing,
+          drawing.id === selectedId,
+          series,
+          timeScaleApi,
+        );
+      }
     };
+    redrawRef.current = redraw;
 
-    /** Re-size the canvas to the container's current dimensions (DPR-
-     *  aware) and redraw. Called on initial mount and on every
-     *  ResizeObserver tick. */
     const resize = (): void => {
       const dpr = window.devicePixelRatio ?? 1;
       logicalW = container.clientWidth;
@@ -104,30 +184,106 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
     ro.observe(container);
 
     const ts = chart.timeScale();
-    // subscribeVisibleLogicalRangeChange (NOT visibleTimeRangeChange):
-    // the time-range variant clamps to bar coverage and can stay
-    // frozen at the right-edge "future padding" zone during pan. The
-    // logical-range variant is the canonical "chart needs to redraw"
-    // hook and fires for every pan / zoom regardless of bar coverage.
     ts.subscribeVisibleLogicalRangeChange(redraw);
-    // subscribeSizeChange catches internal chart reflows that DON'T
-    // change the container size — most commonly when the price-scale
-    // gutter widens because a price label grew a digit ($99 → $100,
-    // $9999 → $10000). ResizeObserver doesn't see those.
     ts.subscribeSizeChange(redraw);
+
+    // Click dispatch via chart.subscribeClick. Routes through the
+    // chart's own canvas (which has pointer-events) so lightweight-
+    // charts' pan / zoom keeps working. Future commits add branches
+    // for trend / horizontal / rectangle creation flows; for now,
+    // pointer is the only one wired.
+    //
+    // Mobile note: the toolbar is `hidden md:flex` so a phone user
+    // can't change the tool, but a desktop session may have left
+    // a creation tool persisted. Pointer mode is safe everywhere
+    // (passive read); creation tools will need their own mobile
+    // guards when they land.
+    const onClick = (param: MouseEventParams<Time>): void => {
+      const { tool, drawings } = stateRef.current;
+      if (tool !== "pointer") return;
+      if (!param.point) return;
+      const series = seriesRef.current;
+      if (!series) return;
+      const timeScaleApi = chart.timeScale() as unknown as TimeConverter;
+      const hitId = findHitDrawingId(
+        drawings,
+        param.point.x,
+        param.point.y,
+        series,
+        timeScaleApi,
+      );
+      // setSelectedId always — even if hitId is null (deselect).
+      setSelectedId(hitId);
+    };
+    chart.subscribeClick(onClick);
 
     return () => {
       ro.disconnect();
       try {
         ts.unsubscribeVisibleLogicalRangeChange(redraw);
         ts.unsubscribeSizeChange(redraw);
+        chart.unsubscribeClick(onClick);
       } catch {
-        // Chart was destroyed in a parallel cleanup (Strict Mode
-        // double-unmount, parent unmount). Refs are already dangling;
-        // the swallow keeps the cleanup pure and silent.
+        // Chart was destroyed in a parallel cleanup. Refs already
+        // dangling; the swallow keeps cleanup pure and silent.
+      }
+      redrawRef.current = () => {};
+    };
+  }, [chartRef, containerRef, seriesRef, chartReady]);
+
+  // Drive redraw when drawings or selection state change without
+  // tearing down + re-subscribing the main effect. The redrawRef is
+  // populated inside the main effect; if the main effect hasn't run
+  // yet (chartReady=false on initial mount), the no-op default kicks
+  // in and this is a cheap miss.
+  useEffect(() => {
+    redrawRef.current();
+  }, [drawings, selectedId]);
+
+  // Keyboard: Escape priority chain + Delete / Backspace removes the
+  // selected drawing. Both guarded against firing while focus is in
+  // an input (so the order form's Backspace clears a digit instead
+  // of deleting the user's drawing).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent): void => {
+      const active = document.activeElement;
+      if (
+        active != null &&
+        (active.tagName === "INPUT" ||
+          active.tagName === "TEXTAREA" ||
+          (active as HTMLElement).isContentEditable)
+      ) {
+        return;
+      }
+      if (e.key === "Escape") {
+        // Priority chain. Future tools (commit 6+) will insert a
+        // pending-anchor cancel BEFORE the selectedId clear so a
+        // half-drawn trend line cancels first, then a second
+        // Escape returns to pointer.
+        const { selectedId, tool } = stateRef.current;
+        if (selectedId !== null) {
+          setSelectedId(null);
+          return;
+        }
+        if (tool !== "pointer") {
+          setTool("pointer");
+        }
+        return;
+      }
+      if (e.key === "Delete" || e.key === "Backspace") {
+        const { selectedId } = stateRef.current;
+        if (selectedId !== null) {
+          deleteDrawing(selectedId);
+          // selectedId resets via the "selected was removed" effect
+          // when drawings updates. preventDefault stops Backspace
+          // from triggering the browser's history-back nav.
+          e.preventDefault();
+        }
       }
     };
-  }, [chartRef, containerRef, chartReady]);
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [setTool, deleteDrawing]);
 
   return (
     <canvas
@@ -137,3 +293,88 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
     />
   );
 };
+
+// =====================================================================
+// Render layer
+// =====================================================================
+
+/** Brand accent (--accent in the theme). Hardcoded as RGB so the
+ *  fill / stroke variants can derive different alphas without parsing
+ *  CSS variables on every frame. */
+const ACCENT_RGB = "153, 69, 255";
+const ACCENT_STROKE = `rgb(${ACCENT_RGB})`;
+const ACCENT_FILL = `rgba(${ACCENT_RGB}, 0.15)`;
+const SELECTED_LINE_WIDTH = 2.5;
+const DEFAULT_LINE_WIDTH = 1.5;
+const ANCHOR_RADIUS = 4;
+
+function renderDrawing(
+  ctx: CanvasRenderingContext2D,
+  canvasW: number,
+  drawing: Drawing,
+  selected: boolean,
+  series: PriceConverter,
+  timeScale: TimeConverter,
+): void {
+  ctx.strokeStyle = ACCENT_STROKE;
+  ctx.lineWidth = selected ? SELECTED_LINE_WIDTH : DEFAULT_LINE_WIDTH;
+
+  switch (drawing.kind) {
+    case "trend": {
+      const p1 = pricePointToPixel(series, timeScale, drawing.p1);
+      const p2 = pricePointToPixel(series, timeScale, drawing.p2);
+      if (p1 === null || p2 === null) return;
+      ctx.beginPath();
+      ctx.moveTo(p1.x, p1.y);
+      ctx.lineTo(p2.x, p2.y);
+      ctx.stroke();
+      if (selected) {
+        drawAnchor(ctx, p1.x, p1.y);
+        drawAnchor(ctx, p2.x, p2.y);
+      }
+      return;
+    }
+    case "horizontal": {
+      const y = series.priceToCoordinate(drawing.price);
+      if (y === null) return;
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(canvasW, y);
+      ctx.stroke();
+      // Horizontal lines have no point-anchors to dot — the entire
+      // line is the anchor. The thicker selected line stroke is the
+      // visual cue.
+      return;
+    }
+    case "rectangle": {
+      const p1 = pricePointToPixel(series, timeScale, drawing.p1);
+      const p2 = pricePointToPixel(series, timeScale, drawing.p2);
+      if (p1 === null || p2 === null) return;
+      const x = Math.min(p1.x, p2.x);
+      const y = Math.min(p1.y, p2.y);
+      const w = Math.abs(p2.x - p1.x);
+      const h = Math.abs(p2.y - p1.y);
+      ctx.fillStyle = ACCENT_FILL;
+      ctx.fillRect(x, y, w, h);
+      ctx.strokeRect(x, y, w, h);
+      if (selected) {
+        drawAnchor(ctx, p1.x, p1.y);
+        drawAnchor(ctx, p2.x, p2.y);
+      }
+      return;
+    }
+    default:
+      assertNever(drawing);
+  }
+}
+
+/** Filled accent dot at a drawing's anchor point. Used for selected
+ *  drawings to advertise where the user can grab to edit (drag-edit
+ *  is deferred to v2; the dots are the contract for future
+ *  interaction). */
+function drawAnchor(ctx: CanvasRenderingContext2D, x: number, y: number): void {
+  ctx.fillStyle = ACCENT_STROKE;
+  ctx.beginPath();
+  ctx.arc(x, y, ANCHOR_RADIUS, 0, Math.PI * 2);
+  ctx.fill();
+}

--- a/app/components/trade/ChartDrawingOverlay.tsx
+++ b/app/components/trade/ChartDrawingOverlay.tsx
@@ -123,22 +123,43 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
    *  paints the preview line directly. */
   const previewP2Ref = useRef<PricePoint | null>(null);
 
-  // Reset overlay-local state on slab change, tool change, OR chart
-  // re-init. Combined because all three triggers want the same reset:
-  // - slab switch makes the previous selection irrelevant.
-  // - tool switch invalidates a half-drawn anchor.
-  // - chartReady false→true (Strict Mode double-mount, hot-reload,
-  //   any future code path that rebuilds the chart) invalidates
-  //   pendingP1's pixel projection — its time/price coords were
-  //   recorded against the OLD chart's coordinate system, and the
-  //   new chart may have a different visible range / bar density.
-  //   Committing a rectangle on the new chart with stale coords
-  //   produces a geometrically wrong drawing.
+  // setTool is routed through a ref so the slab/chart-init reset
+  // effect below doesn't re-fire on every rerender just because the
+  // parent passes a new function reference each render. Same pattern
+  // as addDrawingRef — keeps the effect's deps minimal so it only
+  // fires on the events it actually cares about (slab change,
+  // chart re-init).
+  const setToolRef = useRef(setTool);
+  setToolRef.current = setTool;
+
+  // Slab change OR chart re-init: clear in-flight creation/selection
+  // AND drop the active tool back to pointer. Tool selection is
+  // global to the React tree (one toolbar, one chart) so without
+  // this reset, a user mid-trend on BTC who navigates to SOL would
+  // arrive on the new chart still in trend mode — the next click
+  // silently drops a creation anchor with no signal that a tool's
+  // still active. Pointer is the safe default for arriving at a
+  // new chart. chartReady's false→true edge (Strict Mode
+  // double-mount, hot-reload, any future code path that rebuilds
+  // the chart) also invalidates pendingP1's pixel projection
+  // because the new chart may have a different visible range.
   useEffect(() => {
     setSelectedId(null);
     setPendingP1(null);
     previewP2Ref.current = null;
-  }, [slabAddress, tool, chartReady]);
+    setToolRef.current("pointer");
+  }, [slabAddress, chartReady]);
+
+  // Tool change (user picked a different tool from the toolbar):
+  // clear in-flight creation/selection but DON'T touch the tool —
+  // the user just selected it. Separate from the slab/chartReady
+  // effect above so resetting the tool there doesn't bounce-fire
+  // its own deps in a feedback loop.
+  useEffect(() => {
+    setSelectedId(null);
+    setPendingP1(null);
+    previewP2Ref.current = null;
+  }, [tool]);
 
   // If the selected drawing was removed (Delete / Backspace, slab
   // change clearing storage, etc.), drop the dangling id.
@@ -191,6 +212,23 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
       if (!series) return;
       const timeScaleApi = chart.timeScale() as unknown as TimeConverter;
       const { drawings, selectedId, pendingP1 } = stateRef.current;
+      // Resolve fill once per frame so a theme switch repaints with
+      // the right alpha at the next redraw without an explicit
+      // subscription. Stroke uses pure accent regardless of theme.
+      const fillStyle = isLightTheme() ? ACCENT_FILL_LIGHT : ACCENT_FILL_DARK;
+      // Clip to the price pane's candle area. The drawing canvas
+      // covers the whole container including the volume sub-region
+      // and any oscillator panes (RSI/MACD via addPane), but the
+      // price-pane series' coord conversion is only valid within
+      // this band. Without clipping, drawings can paint into pane
+      // regions where they don't belong.
+      const bounds = getPriceAreaBounds(chart);
+      ctx.save();
+      if (bounds !== null) {
+        ctx.beginPath();
+        ctx.rect(0, bounds.top, logicalW, bounds.bottom - bounds.top);
+        ctx.clip();
+      }
       for (const drawing of drawings) {
         renderDrawing(
           ctx,
@@ -199,6 +237,7 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
           drawing.id === selectedId,
           series,
           timeScaleApi,
+          fillStyle,
         );
       }
       // In-flight creation preview, dispatched by tool:
@@ -223,9 +262,11 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
             previewP2Ref.current,
             series,
             timeScaleApi,
+            fillStyle,
           );
         }
       }
+      ctx.restore();
     };
     redrawRef.current = redraw;
 
@@ -267,21 +308,37 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
       if (!param.point) return;
       const series = seriesRef.current;
       if (!series) return;
-      // Mobile guard: creation tools require the toolbar (which is
-      // hidden below md), the keyboard (no Escape on most mobile
-      // soft-keyboards), or both — none reliably available on phones.
-      // A desktop session can leave a creation tool persisted
-      // globally (`perc:chart:drawing-tool`); without this guard, a
-      // mobile user lands on the chart and every tap drops a
-      // horizontal / commits a trend with no escape route.
-      // Pointer mode stays available on every viewport (passive
-      // hit-test). matchMedia is undefined in some non-browser
-      // environments — defensive default is "treat as desktop."
+      // Mobile guard: every tool short-circuits on touch viewports.
+      // - Creation tools (trend/horizontal/rectangle) need the toolbar
+      //   (hidden below md) and Escape (unreliable on soft keyboards),
+      //   neither of which is available on phones.
+      // - Pointer mode is also gated because mobile users have no
+      //   way to delete a selected drawing (Backspace/Delete don't
+      //   reach the document on most mobile soft keyboards). Letting
+      //   them select but not delete is a worse trap than not
+      //   selecting at all — drawings stay visible as static art on
+      //   touch viewports until the user returns to a desktop.
+      // matchMedia is undefined in some non-browser environments;
+      // defensive default is "treat as desktop."
       if (
-        tool !== "pointer" &&
         typeof window !== "undefined" &&
         typeof window.matchMedia === "function" &&
         window.matchMedia("(max-width: 767px)").matches
+      ) {
+        return;
+      }
+      // Pane bleed-through guard: reject clicks outside the price-
+      // pane's candle area (volume sub-region or any oscillator pane).
+      // The price-pane series' coordinateToPrice extrapolates rather
+      // than returning null for y values past the scale margins, so
+      // without this a click in the RSI pane would create a phantom
+      // horizontal at an extrapolated price the user can't see. The
+      // canvas itself is already clipped to this band on render;
+      // rejecting clicks too keeps creation symmetric with rendering.
+      const bounds = getPriceAreaBounds(chart);
+      if (
+        bounds !== null &&
+        (param.point.y < bounds.top || param.point.y > bounds.bottom)
       ) {
         return;
       }
@@ -454,6 +511,14 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
       const rect = el.getBoundingClientRect();
       const x = e.clientX - rect.left;
       const y = e.clientY - rect.top;
+      // Pane bleed-through guard: same y-bounds check as the click
+      // path. A mousedown in the volume sub-region or an oscillator
+      // pane would otherwise anchor a rectangle drag at an
+      // extrapolated price.
+      const bounds = getPriceAreaBounds(chart);
+      if (bounds !== null && (y < bounds.top || y > bounds.bottom)) {
+        return;
+      }
       const ts = chart.timeScale() as unknown as TimeConverter;
       const point = pixelToPricePoint(series, ts, x, y);
       if (point === null) return;
@@ -684,15 +749,67 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
 // Render layer
 // =====================================================================
 
-/** Brand accent (--accent in the theme). Hardcoded as RGB so the
- *  fill / stroke variants can derive different alphas without parsing
- *  CSS variables on every frame. */
+/** Brand accent (--accent in the theme, same hue in dark and light).
+ *  Hardcoded as RGB so the fill / stroke variants can derive different
+ *  alphas without parsing CSS variables on every frame. */
 const ACCENT_RGB = "153, 69, 255";
 const ACCENT_STROKE = `rgb(${ACCENT_RGB})`;
-const ACCENT_FILL = `rgba(${ACCENT_RGB}, 0.15)`;
+/** Fill alpha is theme-dependent: a 15% accent over near-white
+ *  (#FAFAFD light bg) reads as a pale lavender wash that's barely
+ *  visible — the rectangle's body IS its affordance, so we bump
+ *  alpha to 22% in light mode to keep the area legible. Stroke
+ *  contrast against light bg is ~5.5:1 unchanged, which clears the
+ *  WCAG AA 3:1 graphics threshold. */
+const ACCENT_FILL_DARK = `rgba(${ACCENT_RGB}, 0.15)`;
+const ACCENT_FILL_LIGHT = `rgba(${ACCENT_RGB}, 0.22)`;
 const SELECTED_LINE_WIDTH = 2.5;
 const DEFAULT_LINE_WIDTH = 1.5;
 const ANCHOR_RADIUS = 4;
+
+/** Read the document-level theme attribute set by the theme switcher
+ *  (mirrors useChartTheme's getThemeFromDOM). Called per-frame inside
+ *  the redraw closure so a theme switch picks up at the next paint
+ *  without an explicit subscribe. SSR-safe — defaults to dark when
+ *  document is undefined. */
+function isLightTheme(): boolean {
+  if (typeof document === "undefined") return false;
+  return document.documentElement.getAttribute("data-theme") === "light";
+}
+
+/** Y-bounds of the price pane's candle area (top scale margin to
+ *  bottom scale margin), in chart-canvas pixel coordinates. The
+ *  drawing canvas spans the whole container, but the price-pane
+ *  series' coordinateToPrice / priceToCoordinate map is only valid
+ *  within this band — outside (volume sub-region, RSI/MACD oscillator
+ *  panes) the conversion extrapolates and creates phantom drawings
+ *  at prices the user can't see. The redraw clips to this band, and
+ *  click dispatch rejects clicks outside it.
+ *
+ *  Returns null when the chart can't report panes/scale (early init,
+ *  test stub without these methods, chart torn down) — caller falls
+ *  back to no-clip / no-reject behaviour. */
+function getPriceAreaBounds(
+  chart: IChartApi,
+): { top: number; bottom: number } | null {
+  try {
+    const panes = chart.panes();
+    if (!Array.isArray(panes) || panes.length === 0) return null;
+    const pricePane = panes[0];
+    if (!pricePane || typeof pricePane.getHeight !== "function") return null;
+    const paneHeight = pricePane.getHeight();
+    if (!Number.isFinite(paneHeight) || paneHeight <= 0) return null;
+    const scale = chart.priceScale("right");
+    const margins = scale.options().scaleMargins;
+    const topMargin = margins?.top ?? 0;
+    const bottomMargin = margins?.bottom ?? 0;
+    return {
+      top: paneHeight * topMargin,
+      bottom: paneHeight * (1 - bottomMargin),
+    };
+  } catch {
+    return null;
+  }
+}
 
 function renderDrawing(
   ctx: CanvasRenderingContext2D,
@@ -701,6 +818,7 @@ function renderDrawing(
   selected: boolean,
   series: PriceConverter,
   timeScale: TimeConverter,
+  fillStyle: string,
 ): void {
   ctx.strokeStyle = ACCENT_STROKE;
   ctx.lineWidth = selected ? SELECTED_LINE_WIDTH : DEFAULT_LINE_WIDTH;
@@ -742,7 +860,7 @@ function renderDrawing(
       const y2 = Math.max(p1.y, p2.y);
       const w = x2 - x;
       const h = y2 - y;
-      ctx.fillStyle = ACCENT_FILL;
+      ctx.fillStyle = fillStyle;
       ctx.fillRect(x, y, w, h);
       ctx.strokeRect(x, y, w, h);
       if (selected) {
@@ -828,6 +946,7 @@ function renderRectanglePreview(
   previewP2: PricePoint | null,
   series: PriceConverter,
   timeScale: TimeConverter,
+  fillStyle: string,
 ): void {
   if (previewP2 === null) return;
   const p1 = pricePointToPixel(series, timeScale, pendingP1);
@@ -838,7 +957,7 @@ function renderRectanglePreview(
   const w = Math.abs(p2.x - p1.x);
   const h = Math.abs(p2.y - p1.y);
   ctx.save();
-  ctx.fillStyle = ACCENT_FILL;
+  ctx.fillStyle = fillStyle;
   ctx.strokeStyle = ACCENT_STROKE;
   ctx.globalAlpha = 0.6;
   ctx.setLineDash([5, 5]);

--- a/app/components/trade/ChartDrawingToolbar.tsx
+++ b/app/components/trade/ChartDrawingToolbar.tsx
@@ -99,13 +99,15 @@ const TOOLS: ReadonlyArray<ToolEntry> = [
  * vs. tap, anchor-drag handles, gesture conflicts with chart pan) are
  * a separate body of work and out of scope.
  *
- * ARIA: `role="toolbar"` + `aria-orientation="vertical"` on the bar so
- * screen readers announce it as a toolbar (one shot for all the
- * buttons rather than four unrelated buttons), and each tool is a
- * `<button aria-pressed>` for the toggle pattern (matches the
- * indicator menu). The buttons aren't grouped under a roving-tabindex
- * APG-toolbar contract because we don't implement arrow-key focus
- * management; Tab + Enter is the keyboard contract.
+ * ARIA: a labelled `<div aria-label="Drawing tools">` wrapping
+ * `<button aria-pressed>` toggle buttons (matches the indicator menu's
+ * toggle pattern). Deliberately NOT `role="toolbar"` — the APG
+ * toolbar contract requires roving tabindex + arrow-key focus
+ * management between toolbar items, which we don't implement. Tab +
+ * Enter is the full keyboard contract here, so promising the
+ * "toolbar" role would be misleading. Screen readers still announce
+ * each button with its label; users get accurate semantics without
+ * an unfulfilled contract.
  *
  * Keyboard: Escape returns to the pointer tool from any other tool.
  * Input-focus guarded: Escape inside an order-form INPUT or TEXTAREA
@@ -139,9 +141,7 @@ export const ChartDrawingToolbar: FC<ChartDrawingToolbarProps> = ({
 
   return (
     <div
-      role="toolbar"
       aria-label="Drawing tools"
-      aria-orientation="vertical"
       className="absolute left-2 top-2 z-10 hidden flex-col gap-1 rounded-none border border-[var(--border)] bg-[var(--bg-elevated)]/95 p-1 backdrop-blur-sm md:flex"
     >
       {TOOLS.map(({ kind, label, icon: Icon }) => {
@@ -161,10 +161,18 @@ export const ChartDrawingToolbar: FC<ChartDrawingToolbarProps> = ({
             title={label}
             onClick={onClick}
             className={[
+              // Inactive uses --text-secondary (not --text-dim) so the
+              // icon meets WCAG AA non-text contrast (3:1) against
+              // --bg-elevated in both themes — text-dim is reserved
+              // for true placeholders and renders ~1.4:1 / 2.0:1.
+              // focus-visible:outline restores a visible focus ring
+              // for sighted keyboard users (Tailwind's preflight
+              // strips the UA outline).
               "flex h-7 w-7 items-center justify-center rounded-none transition-colors",
+              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-1",
               isActive
                 ? "bg-[var(--accent)]/10 text-[var(--accent)]"
-                : "text-[var(--text-dim)] hover:bg-[var(--bg-surface)] hover:text-[var(--text)]",
+                : "text-[var(--text-secondary)] hover:bg-[var(--bg-surface)] hover:text-[var(--text)]",
             ].join(" ")}
           >
             <Icon />

--- a/app/components/trade/ChartDrawingToolbar.tsx
+++ b/app/components/trade/ChartDrawingToolbar.tsx
@@ -6,6 +6,18 @@ import type { DrawingTool } from "@/lib/chart-drawings";
 interface ChartDrawingToolbarProps {
   tool: DrawingTool;
   setTool: (next: DrawingTool) => void;
+  /** Number of drawings on the active slab. Drives the clear-all
+   *  button's enabled state and the count shown in the confirm
+   *  dialog. Pass `drawings.length`, not the array itself — the
+   *  toolbar only needs the count, and a primitive prop avoids a
+   *  re-render on every drawings-array identity change. */
+  drawingCount: number;
+  /** Wipe the active slab's drawings. Wired from the persistence
+   *  hook's clearAll. The toolbar prompts via window.confirm before
+   *  invoking, and resets the active tool to pointer afterwards
+   *  (the user shouldn't keep drawing in the same mode after a wipe;
+   *  pointer is the safe default for what comes next). */
+  clearAll: () => void;
 }
 
 /** Inline SVGs for each tool. Kept as small components so the TOOLS
@@ -71,6 +83,26 @@ const RectangleIcon = (): ReactNode => (
   </svg>
 );
 
+const TrashIcon = (): ReactNode => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 14 14"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M2 4h10" />
+    <path d="M5 4V2.5h4V4" />
+    <path d="M3.5 4l.5 8h6l.5-8" />
+    <path d="M5.5 6.5v3" />
+    <path d="M8.5 6.5v3" />
+  </svg>
+);
+
 interface ToolEntry {
   kind: DrawingTool;
   label: string;
@@ -118,7 +150,29 @@ const TOOLS: ReadonlyArray<ToolEntry> = [
 export const ChartDrawingToolbar: FC<ChartDrawingToolbarProps> = ({
   tool,
   setTool,
+  drawingCount,
+  clearAll,
 }) => {
+  const onClearAll = (): void => {
+    // Defensive: the button is `disabled` when count is 0, but a
+    // programmatic click would still bypass that. Skip the confirm
+    // dialog for an empty list — there's nothing to clear.
+    if (drawingCount === 0) return;
+    // window.confirm is blocking but free — no custom modal infra.
+    // Singular / plural to keep the prompt natural at count === 1.
+    const noun = drawingCount === 1 ? "drawing" : "drawings";
+    const confirmed = window.confirm(
+      `Clear all ${drawingCount} ${noun} on this market?`,
+    );
+    if (!confirmed) return;
+    clearAll();
+    // Drop back to pointer after a wipe. The user just signalled
+    // "I'm done with everything I drew"; staying in (say) trend mode
+    // would invite an immediate accidental new drawing on the next
+    // chart click. Pointer is the safe default for whatever's next.
+    setTool("pointer");
+  };
+
   return (
     <div
       aria-label="Drawing tools"
@@ -159,6 +213,37 @@ export const ChartDrawingToolbar: FC<ChartDrawingToolbarProps> = ({
           </button>
         );
       })}
+      {/* Separator — divides creation tools from the destructive
+          clear-all action so the user doesn't reach for it
+          accidentally while scanning for a tool. */}
+      <div
+        role="separator"
+        aria-orientation="horizontal"
+        className="my-0.5 h-px w-full bg-[var(--border)]"
+      />
+      <button
+        type="button"
+        aria-label="Clear all drawings"
+        title="Clear all drawings"
+        disabled={drawingCount === 0}
+        onClick={onClearAll}
+        className={[
+          "flex h-7 w-7 items-center justify-center rounded-none transition-colors",
+          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-1",
+          // Hover hint in red for the destructive action — same
+          // accent-foreground discipline as the active tools, but
+          // semantically different (this is a destructive op, not a
+          // selectable mode).
+          "text-[var(--text-secondary)] enabled:hover:bg-[var(--bg-surface)] enabled:hover:text-red-400",
+          // Disabled state: drop the cursor affordance and dim the
+          // icon further. The button still focuses (we don't add
+          // tabIndex=-1) so keyboard users can find it and learn
+          // it exists for when they DO have drawings.
+          "disabled:cursor-not-allowed disabled:opacity-40",
+        ].join(" ")}
+      >
+        <TrashIcon />
+      </button>
     </div>
   );
 };

--- a/app/components/trade/ChartDrawingToolbar.tsx
+++ b/app/components/trade/ChartDrawingToolbar.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useEffect, type FC, type ReactNode } from "react";
+import type { DrawingTool } from "@/lib/chart-drawings";
+
+interface ChartDrawingToolbarProps {
+  tool: DrawingTool;
+  setTool: (next: DrawingTool) => void;
+}
+
+/** Inline SVGs for each tool. Kept as small components so the TOOLS
+ *  table below stays a flat data structure with a single `icon` field
+ *  per row — adding a new tool means appending one row, no imports
+ *  to plumb. */
+const PointerIcon = (): ReactNode => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 14 14"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M2 2 L7 12 L8.5 8 L12 6.5 Z" />
+  </svg>
+);
+
+const TrendIcon = (): ReactNode => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 14 14"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    aria-hidden="true"
+  >
+    <line x1="2" y1="12" x2="12" y2="2" />
+  </svg>
+);
+
+const HorizontalIcon = (): ReactNode => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 14 14"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    aria-hidden="true"
+  >
+    <line x1="2" y1="7" x2="12" y2="7" />
+  </svg>
+);
+
+const RectangleIcon = (): ReactNode => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 14 14"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    aria-hidden="true"
+  >
+    <rect x="3" y="4" width="8" height="6" />
+  </svg>
+);
+
+interface ToolEntry {
+  kind: DrawingTool;
+  label: string;
+  icon: () => ReactNode;
+}
+
+/** Toolbar contents in display order (top → bottom). Pointer first
+ *  because it's the default and the most common action (select /
+ *  delete). Adding a new drawing kind: append a row, append a case to
+ *  the renderer, append a kind to the Drawing union. */
+const TOOLS: ReadonlyArray<ToolEntry> = [
+  { kind: "pointer", label: "Pointer (select)", icon: PointerIcon },
+  { kind: "trend", label: "Trend line", icon: TrendIcon },
+  { kind: "horizontal", label: "Horizontal line", icon: HorizontalIcon },
+  { kind: "rectangle", label: "Rectangle", icon: RectangleIcon },
+];
+
+/**
+ * Vertical toolbar at the chart's left edge with one button per drawing
+ * tool. Active tool gets the brand-accent highlight; clicking the
+ * active non-pointer tool returns to pointer (TradingView convention —
+ * a quick "cancel" without needing to find the pointer button).
+ *
+ * Hidden below the md breakpoint (< 768 px). Drawing tools are a
+ * desktop-only feature for v1 — touch interaction patterns (long-press
+ * vs. tap, anchor-drag handles, gesture conflicts with chart pan) are
+ * a separate body of work and out of scope.
+ *
+ * ARIA: `role="toolbar"` + `aria-orientation="vertical"` on the bar so
+ * screen readers announce it as a toolbar (one shot for all the
+ * buttons rather than four unrelated buttons), and each tool is a
+ * `<button aria-pressed>` for the toggle pattern (matches the
+ * indicator menu). The buttons aren't grouped under a roving-tabindex
+ * APG-toolbar contract because we don't implement arrow-key focus
+ * management; Tab + Enter is the keyboard contract.
+ *
+ * Keyboard: Escape returns to the pointer tool from any other tool.
+ * Input-focus guarded: Escape inside an order-form INPUT or TEXTAREA
+ * is ignored so it can do what the input expects (close a select,
+ * cancel autocomplete, etc.) without hijacking the user's keystroke.
+ */
+export const ChartDrawingToolbar: FC<ChartDrawingToolbarProps> = ({
+  tool,
+  setTool,
+}) => {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key !== "Escape") return;
+      // Input-focus guard: don't hijack Escape from form inputs.
+      const active = document.activeElement;
+      if (
+        active != null &&
+        (active.tagName === "INPUT" ||
+          active.tagName === "TEXTAREA" ||
+          (active as HTMLElement).isContentEditable)
+      ) {
+        return;
+      }
+      // Already pointer — no state change needed (avoids spurious renders).
+      if (tool === "pointer") return;
+      setTool("pointer");
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [tool, setTool]);
+
+  return (
+    <div
+      role="toolbar"
+      aria-label="Drawing tools"
+      aria-orientation="vertical"
+      className="absolute left-2 top-2 z-10 hidden flex-col gap-1 rounded-none border border-[var(--border)] bg-[var(--bg-elevated)]/95 p-1 backdrop-blur-sm md:flex"
+    >
+      {TOOLS.map(({ kind, label, icon: Icon }) => {
+        const isActive = tool === kind;
+        // Clicking the active non-pointer tool deselects to pointer.
+        // Clicking active pointer is a no-op set (same value, no
+        // re-render). Inactive: switch to that tool.
+        const onClick = (): void => {
+          setTool(isActive && kind !== "pointer" ? "pointer" : kind);
+        };
+        return (
+          <button
+            key={kind}
+            type="button"
+            aria-label={label}
+            aria-pressed={isActive}
+            title={label}
+            onClick={onClick}
+            className={[
+              "flex h-7 w-7 items-center justify-center rounded-none transition-colors",
+              isActive
+                ? "bg-[var(--accent)]/10 text-[var(--accent)]"
+                : "text-[var(--text-dim)] hover:bg-[var(--bg-surface)] hover:text-[var(--text)]",
+            ].join(" ")}
+          >
+            <Icon />
+          </button>
+        );
+      })}
+    </div>
+  );
+};

--- a/app/components/trade/ChartDrawingToolbar.tsx
+++ b/app/components/trade/ChartDrawingToolbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, type FC, type ReactNode } from "react";
+import { type FC, type ReactNode } from "react";
 import type { DrawingTool } from "@/lib/chart-drawings";
 
 interface ChartDrawingToolbarProps {
@@ -109,36 +109,16 @@ const TOOLS: ReadonlyArray<ToolEntry> = [
  * each button with its label; users get accurate semantics without
  * an unfulfilled contract.
  *
- * Keyboard: Escape returns to the pointer tool from any other tool.
- * Input-focus guarded: Escape inside an order-form INPUT or TEXTAREA
- * is ignored so it can do what the input expects (close a select,
- * cancel autocomplete, etc.) without hijacking the user's keystroke.
+ * Keyboard: handled by ChartDrawingOverlay. Escape there runs a
+ * priority chain (cancel-pending > deselect > reset-tool > no-op)
+ * so a half-drawn anchor cancels first, then a second Escape reaches
+ * the tool reset. Owning Escape there avoids two competing handlers
+ * racing on the same keystroke.
  */
 export const ChartDrawingToolbar: FC<ChartDrawingToolbarProps> = ({
   tool,
   setTool,
 }) => {
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent): void => {
-      if (e.key !== "Escape") return;
-      // Input-focus guard: don't hijack Escape from form inputs.
-      const active = document.activeElement;
-      if (
-        active != null &&
-        (active.tagName === "INPUT" ||
-          active.tagName === "TEXTAREA" ||
-          (active as HTMLElement).isContentEditable)
-      ) {
-        return;
-      }
-      // Already pointer — no state change needed (avoids spurious renders).
-      if (tool === "pointer") return;
-      setTool("pointer");
-    };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [tool, setTool]);
-
   return (
     <div
       aria-label="Drawing tools"

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -860,11 +860,15 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
 
         {/* Drawing tools toolbar — vertical bar at the chart's left edge.
             Hidden below the md breakpoint (touch interaction patterns
-            for drawing tools are out of scope for v1). */}
-        <ChartDrawingToolbar
-          tool={drawingTool}
-          setTool={setDrawingTool}
-        />
+            for drawing tools are out of scope for v1) AND hidden when
+            the empty-state overlay is shown (no chart to draw on, so
+            the toolbar would be a dead interaction). */}
+        {!showEmptyOverlay && (
+          <ChartDrawingToolbar
+            tool={drawingTool}
+            setTool={setDrawingTool}
+          />
+        )}
 
         {/* GH#1652: empty-state overlay — shown when no data yet, sits above canvas */}
         {showEmptyOverlay && (
@@ -934,10 +938,13 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
         {/* OHLCV tooltip — hover the chart to see the bar under the crosshair.
             Positioned top-left on mobile (where the drawing toolbar is hidden);
             shifted right on md+ to clear the drawing toolbar that occupies
-            the top-left corner there. Hidden entirely when not hovering. */}
+            the top-left corner there. left-14 (56px) gives ~10px of
+            breathing room past the toolbar's outer edge (8px left + 38px
+            wide = 46px right edge; left-12 = 48px would have been only
+            2px of clearance). Hidden entirely when not hovering. */}
         {hoverBar && !showEmptyOverlay && (
           <div
-            className="pointer-events-none absolute top-2 left-2 md:left-12 z-10 rounded-none border border-[var(--border)]/60 bg-[var(--bg)]/90 px-2 py-1 font-mono text-[10px] shadow-sm backdrop-blur-sm"
+            className="pointer-events-none absolute top-2 left-2 md:left-14 z-10 rounded-none border border-[var(--border)]/60 bg-[var(--bg)]/90 px-2 py-1 font-mono text-[10px] shadow-sm backdrop-blur-sm"
             aria-hidden="true"
           >
             <div className="flex items-center gap-3 whitespace-nowrap">

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -858,19 +858,29 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
             order (no explicit z) but below the empty-state / hover-tooltip
             / position-summary badges (which sit at z-10). pointer-events
             stay disabled — drawing-tool clicks route through
-            chart.subscribeClick so native pan/zoom keep working. */}
-        <ChartDrawingOverlay
-          chartRef={chartRef}
-          seriesRef={seriesRef}
-          containerRef={containerRef}
-          chartReady={chartReady}
-          drawings={drawings}
-          addDrawing={addDrawing}
-          deleteDrawing={deleteDrawing}
-          tool={drawingTool}
-          setTool={setDrawingTool}
-          slabAddress={slabAddress}
-        />
+            chart.subscribeClick so native pan/zoom keep working.
+
+            Gated on !showEmptyOverlay alongside the toolbar: the
+            empty-state's 91%-alpha backdrop would otherwise ghost
+            persisted drawings through the wash with no toolbar to
+            clear them — a UX dead-end on sparse markets. Unmounting
+            the overlay drops the canvas entirely; drawings re-appear
+            (still per-slab in localStorage) the moment data populates
+            and the empty-state lifts. */}
+        {!showEmptyOverlay && (
+          <ChartDrawingOverlay
+            chartRef={chartRef}
+            seriesRef={seriesRef}
+            containerRef={containerRef}
+            chartReady={chartReady}
+            drawings={drawings}
+            addDrawing={addDrawing}
+            deleteDrawing={deleteDrawing}
+            tool={drawingTool}
+            setTool={setDrawingTool}
+            slabAddress={slabAddress}
+          />
+        )}
 
         {/* Drawing tools toolbar — vertical bar at the chart's left edge.
             Hidden below the md breakpoint (touch interaction patterns

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -41,6 +41,8 @@ import { useIndicatorOverlays } from "./useIndicatorOverlays";
 import { useIndicatorOscillatorPane } from "./useIndicatorOscillatorPane";
 import { ChartIndicatorMenu } from "./ChartIndicatorMenu";
 import { ChartDrawingOverlay } from "./ChartDrawingOverlay";
+import { ChartDrawingToolbar } from "./ChartDrawingToolbar";
+import { useChartDrawingTool } from "@/hooks/useChartDrawingTool";
 import {
   isCandleStyle,
   candleStyleOptions,
@@ -160,6 +162,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
     updateIndicator,
     clearAll: clearAllIndicators,
   } = useChartIndicatorPrefs(slabAddress);
+  const { tool: drawingTool, setTool: setDrawingTool } = useChartDrawingTool();
   const [timeframe, setTimeframe] = useState<Timeframe>("1d");
   const [oraclePrices, setOraclePrices] = useState<PricePoint[]>([]);
 
@@ -855,6 +858,14 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
           chartReady={chartReady}
         />
 
+        {/* Drawing tools toolbar — vertical bar at the chart's left edge.
+            Hidden below the md breakpoint (touch interaction patterns
+            for drawing tools are out of scope for v1). */}
+        <ChartDrawingToolbar
+          tool={drawingTool}
+          setTool={setDrawingTool}
+        />
+
         {/* GH#1652: empty-state overlay — shown when no data yet, sits above canvas */}
         {showEmptyOverlay && (
           <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center backdrop-blur-[1px]" style={{ background: `${chartTheme.bg}e8` }}>
@@ -921,11 +932,12 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
         )}
 
         {/* OHLCV tooltip — hover the chart to see the bar under the crosshair.
-            Positioned top-left so it never sits under the PositionSummary badge
-            top-right. Hidden entirely when not hovering. */}
+            Positioned top-left on mobile (where the drawing toolbar is hidden);
+            shifted right on md+ to clear the drawing toolbar that occupies
+            the top-left corner there. Hidden entirely when not hovering. */}
         {hoverBar && !showEmptyOverlay && (
           <div
-            className="pointer-events-none absolute top-2 left-2 z-10 rounded-none border border-[var(--border)]/60 bg-[var(--bg)]/90 px-2 py-1 font-mono text-[10px] shadow-sm backdrop-blur-sm"
+            className="pointer-events-none absolute top-2 left-2 md:left-12 z-10 rounded-none border border-[var(--border)]/60 bg-[var(--bg)]/90 px-2 py-1 font-mono text-[10px] shadow-sm backdrop-blur-sm"
             aria-hidden="true"
           >
             <div className="flex items-center gap-3 whitespace-nowrap">

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -43,6 +43,7 @@ import { ChartIndicatorMenu } from "./ChartIndicatorMenu";
 import { ChartDrawingOverlay } from "./ChartDrawingOverlay";
 import { ChartDrawingToolbar } from "./ChartDrawingToolbar";
 import { useChartDrawingTool } from "@/hooks/useChartDrawingTool";
+import { useChartDrawings } from "@/hooks/useChartDrawings";
 import {
   isCandleStyle,
   candleStyleOptions,
@@ -163,6 +164,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
     clearAll: clearAllIndicators,
   } = useChartIndicatorPrefs(slabAddress);
   const { tool: drawingTool, setTool: setDrawingTool } = useChartDrawingTool();
+  const { drawings, deleteDrawing } = useChartDrawings(slabAddress);
   const [timeframe, setTimeframe] = useState<Timeframe>("1d");
   const [oraclePrices, setOraclePrices] = useState<PricePoint[]>([]);
 
@@ -854,8 +856,14 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
             chart.subscribeClick so native pan/zoom keep working. */}
         <ChartDrawingOverlay
           chartRef={chartRef}
+          seriesRef={seriesRef}
           containerRef={containerRef}
           chartReady={chartReady}
+          drawings={drawings}
+          deleteDrawing={deleteDrawing}
+          tool={drawingTool}
+          setTool={setDrawingTool}
+          slabAddress={slabAddress}
         />
 
         {/* Drawing tools toolbar — vertical bar at the chart's left edge.

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -164,7 +164,12 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
     clearAll: clearAllIndicators,
   } = useChartIndicatorPrefs(slabAddress);
   const { tool: drawingTool, setTool: setDrawingTool } = useChartDrawingTool();
-  const { drawings, addDrawing, deleteDrawing } = useChartDrawings(slabAddress);
+  const {
+    drawings,
+    addDrawing,
+    deleteDrawing,
+    clearAll: clearAllDrawings,
+  } = useChartDrawings(slabAddress);
   const [timeframe, setTimeframe] = useState<Timeframe>("1d");
   const [oraclePrices, setOraclePrices] = useState<PricePoint[]>([]);
 
@@ -876,6 +881,8 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
           <ChartDrawingToolbar
             tool={drawingTool}
             setTool={setDrawingTool}
+            drawingCount={drawings.length}
+            clearAll={clearAllDrawings}
           />
         )}
 

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -164,7 +164,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
     clearAll: clearAllIndicators,
   } = useChartIndicatorPrefs(slabAddress);
   const { tool: drawingTool, setTool: setDrawingTool } = useChartDrawingTool();
-  const { drawings, deleteDrawing } = useChartDrawings(slabAddress);
+  const { drawings, addDrawing, deleteDrawing } = useChartDrawings(slabAddress);
   const [timeframe, setTimeframe] = useState<Timeframe>("1d");
   const [oraclePrices, setOraclePrices] = useState<PricePoint[]>([]);
 
@@ -860,6 +860,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
           containerRef={containerRef}
           chartReady={chartReady}
           drawings={drawings}
+          addDrawing={addDrawing}
           deleteDrawing={deleteDrawing}
           tool={drawingTool}
           setTool={setDrawingTool}

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -40,6 +40,7 @@ import { isOverlayKind, isPaneKind } from "@/lib/indicator-registry";
 import { useIndicatorOverlays } from "./useIndicatorOverlays";
 import { useIndicatorOscillatorPane } from "./useIndicatorOscillatorPane";
 import { ChartIndicatorMenu } from "./ChartIndicatorMenu";
+import { ChartDrawingOverlay } from "./ChartDrawingOverlay";
 import {
   isCandleStyle,
   candleStyleOptions,
@@ -841,6 +842,18 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
         {/* Bumped desktop height 500 → 620 so the time axis has room to render
             below the candles + volume pane without getting visually clipped. */}
         <div ref={containerRef} className="w-full h-[45svh] lg:h-[620px]" />
+
+        {/* User-drawing overlay: transparent canvas tracking the chart
+            container's dimensions, layered above the chart canvas via DOM
+            order (no explicit z) but below the empty-state / hover-tooltip
+            / position-summary badges (which sit at z-10). pointer-events
+            stay disabled — drawing-tool clicks route through
+            chart.subscribeClick so native pan/zoom keep working. */}
+        <ChartDrawingOverlay
+          chartRef={chartRef}
+          containerRef={containerRef}
+          chartReady={chartReady}
+        />
 
         {/* GH#1652: empty-state overlay — shown when no data yet, sits above canvas */}
         {showEmptyOverlay && (

--- a/app/hooks/useChartDrawingTool.ts
+++ b/app/hooks/useChartDrawingTool.ts
@@ -1,70 +1,25 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useCallback } from "react";
 import type { DrawingTool } from "@/lib/chart-drawings";
-
-const STORAGE_KEY = "perc:chart:drawing-tool";
-
-/** Single source of truth for the tools the runtime validator accepts.
- *  Typed as `Record<DrawingTool, true>` so adding a tool to the union
- *  forces a compile error here (missing key). Mirrors the
- *  VALID_KIND_TABLE pattern in chart-drawings.ts. */
-const VALID_TOOL_TABLE: Record<DrawingTool, true> = {
-  pointer: true,
-  trend: true,
-  horizontal: true,
-  rectangle: true,
-};
-
-function isValidTool(value: unknown): value is DrawingTool {
-  return (
-    typeof value === "string" && Object.hasOwn(VALID_TOOL_TABLE, value)
-  );
-}
 
 export interface UseChartDrawingToolReturn {
   tool: DrawingTool;
   setTool: (next: DrawingTool) => void;
 }
 
-/** Persisted active drawing tool. Global (NOT per-slab) — when the user
- *  picks "trend line" on BTC and switches to SOL, they expect to still
- *  be in trend-line mode. Stored under a single localStorage key so the
- *  selection survives across markets and reloads.
- *
- *  Default: `pointer` (select / delete existing drawings without
- *  drawing anything new). Returns to default on:
- *  - First mount with no stored value.
- *  - Stored value that doesn't match a known kind (tolerant
- *    deserialisation; handles app-version downgrades that drop a kind).
- *  - localStorage unavailable (SSR, privacy mode, quota errors).
- *
- *  SSR-safe: returns `pointer` on the server and during the first
- *  client render, then hydrates from localStorage in an effect. */
+/** Active drawing tool. Ephemeral — every fresh load starts on `pointer`,
+ *  and the parent overlay also resets to `pointer` on slab change. The
+ *  earlier version persisted to localStorage globally, but that turned
+ *  the next visit's first click into a silent trend-anchor drop with
+ *  no signal — a real UX trap because the toolbar's accent tint is too
+ *  subtle for a returning user to scan for. Drawings still persist
+ *  per-slab (see `useChartDrawings`); only the tool selection is
+ *  intentionally session-local. */
 export function useChartDrawingTool(): UseChartDrawingToolReturn {
-  const [tool, setToolState] = useState<DrawingTool>("pointer");
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    try {
-      const raw = window.localStorage.getItem(STORAGE_KEY);
-      if (raw != null && isValidTool(raw)) {
-        setToolState(raw);
-      }
-    } catch {
-      // localStorage unavailable; keep default.
-    }
+  const [tool, setTool] = useState<DrawingTool>("pointer");
+  const setStable = useCallback((next: DrawingTool) => {
+    setTool(next);
   }, []);
-
-  const setTool = useCallback((next: DrawingTool) => {
-    setToolState(next);
-    if (typeof window === "undefined") return;
-    try {
-      window.localStorage.setItem(STORAGE_KEY, next);
-    } catch {
-      // Best-effort; ignore quota / privacy errors.
-    }
-  }, []);
-
-  return { tool, setTool };
+  return { tool, setTool: setStable };
 }

--- a/app/hooks/useChartDrawingTool.ts
+++ b/app/hooks/useChartDrawingTool.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import type { DrawingTool } from "@/lib/chart-drawings";
+
+const STORAGE_KEY = "perc:chart:drawing-tool";
+
+/** Single source of truth for the tools the runtime validator accepts.
+ *  Typed as `Record<DrawingTool, true>` so adding a tool to the union
+ *  forces a compile error here (missing key). Mirrors the
+ *  VALID_KIND_TABLE pattern in chart-drawings.ts. */
+const VALID_TOOL_TABLE: Record<DrawingTool, true> = {
+  pointer: true,
+  trend: true,
+  horizontal: true,
+  rectangle: true,
+};
+
+function isValidTool(value: unknown): value is DrawingTool {
+  return (
+    typeof value === "string" && Object.hasOwn(VALID_TOOL_TABLE, value)
+  );
+}
+
+export interface UseChartDrawingToolReturn {
+  tool: DrawingTool;
+  setTool: (next: DrawingTool) => void;
+}
+
+/** Persisted active drawing tool. Global (NOT per-slab) — when the user
+ *  picks "trend line" on BTC and switches to SOL, they expect to still
+ *  be in trend-line mode. Stored under a single localStorage key so the
+ *  selection survives across markets and reloads.
+ *
+ *  Default: `pointer` (select / delete existing drawings without
+ *  drawing anything new). Returns to default on:
+ *  - First mount with no stored value.
+ *  - Stored value that doesn't match a known kind (tolerant
+ *    deserialisation; handles app-version downgrades that drop a kind).
+ *  - localStorage unavailable (SSR, privacy mode, quota errors).
+ *
+ *  SSR-safe: returns `pointer` on the server and during the first
+ *  client render, then hydrates from localStorage in an effect. */
+export function useChartDrawingTool(): UseChartDrawingToolReturn {
+  const [tool, setToolState] = useState<DrawingTool>("pointer");
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (raw != null && isValidTool(raw)) {
+        setToolState(raw);
+      }
+    } catch {
+      // localStorage unavailable; keep default.
+    }
+  }, []);
+
+  const setTool = useCallback((next: DrawingTool) => {
+    setToolState(next);
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      // Best-effort; ignore quota / privacy errors.
+    }
+  }, []);
+
+  return { tool, setTool };
+}

--- a/app/hooks/useChartDrawings.ts
+++ b/app/hooks/useChartDrawings.ts
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  type Drawing,
+  type DrawingInput,
+  type DrawingsStorage,
+  DRAWINGS_STORAGE_VERSION,
+  MAX_DRAWINGS_PER_SLAB,
+  mergeDrawings,
+} from "@/lib/chart-drawings";
+
+export type { Drawing, DrawingInput } from "@/lib/chart-drawings";
+
+const STORAGE_KEY_PREFIX = "perc:chart:drawings:";
+
+/** Solana base58 pubkey: 32–44 chars from the base58 alphabet (no 0OIl).
+ *  Validating before forming the storage key prevents an empty / crafted
+ *  slab address from poisoning a shared bucket — the same protection we
+ *  added to the indicator persistence hook after the audit pass flagged
+ *  the latent footgun. */
+const SOLANA_PUBKEY_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+
+function isValidSlabAddress(slabAddress: string): boolean {
+  return SOLANA_PUBKEY_RE.test(slabAddress);
+}
+
+function storageKey(slabAddress: string): string {
+  return STORAGE_KEY_PREFIX + slabAddress;
+}
+
+function generateId(): string {
+  // crypto.randomUUID is supported in every modern browser. SSR-safe via
+  // the `typeof window` guard at every call site.
+  return crypto.randomUUID();
+}
+
+/** Return shape of `useChartDrawings`. Object form (not tuple) so consumers
+ *  can destructure only what they need — the overlay's pointer-tool branch
+ *  reads `drawings` and `deleteDrawing` only; the toolbar's clear-all reads
+ *  `drawings.length` and `clearAll`; the creation tools call `addDrawing`. */
+export interface UseChartDrawingsReturn {
+  drawings: Drawing[];
+  addDrawing: (input: DrawingInput) => void;
+  deleteDrawing: (id: string) => void;
+  clearAll: () => void;
+}
+
+/** Persisted chart drawings, scoped per slab address.
+ *
+ *  SSR-safe: returns [] on the server and during the first client render,
+ *  then hydrates from localStorage in an effect. Setters write through
+ *  to localStorage synchronously inside the React state updater.
+ *
+ *  Usage:
+ *
+ *      const { drawings, addDrawing, deleteDrawing, clearAll } =
+ *        useChartDrawings(slabAddress);
+ *
+ *      addDrawing({ kind: "trend", p1, p2 });
+ *      deleteDrawing(drawings[0].id);
+ *      clearAll();
+ *
+ *  Slab address change: the hook re-hydrates from the new key, replacing
+ *  the in-memory list with whatever the new market had stored. An invalid
+ *  or empty slab address no-ops the read and write so the shared
+ *  `perc:chart:drawings:` bucket isn't poisoned by hooks mounted before
+ *  the route param resolves. */
+export function useChartDrawings(slabAddress: string): UseChartDrawingsReturn {
+  const [drawings, setDrawings] = useState<Drawing[]>([]);
+  // Track the slab the in-memory state corresponds to, so setters write
+  // to the correct key even when called from stale closures.
+  const slabRef = useRef<string>(slabAddress);
+
+  useEffect(() => {
+    slabRef.current = slabAddress;
+    if (typeof window === "undefined") return;
+    if (!isValidSlabAddress(slabAddress)) {
+      setDrawings([]);
+      return;
+    }
+    try {
+      const raw = window.localStorage.getItem(storageKey(slabAddress));
+      if (raw == null) {
+        setDrawings([]);
+        return;
+      }
+      const parsed = JSON.parse(raw);
+      setDrawings(mergeDrawings(parsed));
+    } catch {
+      // localStorage unavailable, JSON parse failed, etc — start empty.
+      setDrawings([]);
+    }
+  }, [slabAddress]);
+
+  /** Persist the current list to localStorage. Best-effort — quota errors
+   *  and privacy-mode failures are swallowed. Wraps the list in the
+   *  versioned envelope. Skips the write entirely for invalid slab
+   *  addresses to avoid poisoning a shared bucket. */
+  const persist = useCallback((slab: string, list: Drawing[]) => {
+    if (typeof window === "undefined") return;
+    if (!isValidSlabAddress(slab)) return;
+    try {
+      const envelope: DrawingsStorage = {
+        version: DRAWINGS_STORAGE_VERSION,
+        drawings: list,
+      };
+      window.localStorage.setItem(storageKey(slab), JSON.stringify(envelope));
+    } catch {
+      // Best-effort; ignore quota / privacy errors.
+    }
+  }, []);
+
+  const addDrawing = useCallback(
+    (input: DrawingInput) => {
+      setDrawings((current) => {
+        const id = generateId();
+        // Spread + cast preserves the discriminated union: `input.kind` is
+        // narrowed at the call site, and adding a string `id` doesn't
+        // change the variant shape.
+        const next = { ...input, id } as Drawing;
+        // Cap at MAX_DRAWINGS_PER_SLAB — drop oldest (FIFO) on insertion
+        // past the cap. Matches the read-side behaviour in mergeDrawings
+        // so an over-cap localStorage payload converges on the same set
+        // whether trimmed by read or by write.
+        const list =
+          current.length >= MAX_DRAWINGS_PER_SLAB
+            ? [...current.slice(1), next]
+            : [...current, next];
+        persist(slabRef.current, list);
+        return list;
+      });
+    },
+    [persist],
+  );
+
+  const deleteDrawing = useCallback(
+    (id: string) => {
+      setDrawings((current) => {
+        const list = current.filter((d) => d.id !== id);
+        persist(slabRef.current, list);
+        return list;
+      });
+    },
+    [persist],
+  );
+
+  const clearAll = useCallback(() => {
+    setDrawings(() => {
+      persist(slabRef.current, []);
+      return [];
+    });
+  }, [persist]);
+
+  return { drawings, addDrawing, deleteDrawing, clearAll };
+}

--- a/app/hooks/useChartDrawings.ts
+++ b/app/hooks/useChartDrawings.ts
@@ -13,6 +13,15 @@ import {
 export type { Drawing, DrawingInput } from "@/lib/chart-drawings";
 
 const STORAGE_KEY_PREFIX = "perc:chart:drawings:";
+/** Debounce window for localStorage writes. A burst of mutations
+ *  (e.g. user redrawing a few rectangles in quick succession) coalesces
+ *  to one setItem instead of N — important because setItem can block
+ *  5–50 ms on contended storage backends, and a 30-rectangle burst
+ *  would otherwise stack 30 main-thread hitches inside a 30-second
+ *  window. Each mutation resets the timer; the trailing fire writes
+ *  the final state. Flushes on pagehide / unmount / slab change so
+ *  no in-flight write is lost. */
+const PERSIST_DEBOUNCE_MS = 250;
 
 /** Solana base58 pubkey: 32–44 chars from the base58 alphabet (no 0OIl).
  *  Validating before forming the storage key prevents an empty / crafted
@@ -54,7 +63,9 @@ export interface UseChartDrawingsReturn {
  *
  *  SSR-safe: returns [] on the server and during the first client render,
  *  then hydrates from localStorage in an effect. Setters write through
- *  to localStorage synchronously inside the React state updater.
+ *  to localStorage on a 250 ms trailing debounce; the timer is flushed
+ *  on pagehide, unmount, and slab change so no in-flight mutation is
+ *  lost.
  *
  *  Usage:
  *
@@ -86,31 +97,10 @@ export function useChartDrawings(slabAddress: string): UseChartDrawingsReturn {
   const slabRef = useRef<string>(slabAddress);
   slabRef.current = slabAddress;
 
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    if (!isValidSlabAddress(slabAddress)) {
-      setDrawings([]);
-      return;
-    }
-    try {
-      const raw = window.localStorage.getItem(storageKey(slabAddress));
-      if (raw == null) {
-        setDrawings([]);
-        return;
-      }
-      const parsed = JSON.parse(raw);
-      setDrawings(mergeDrawings(parsed));
-    } catch {
-      // localStorage unavailable, JSON parse failed, etc — start empty.
-      setDrawings([]);
-    }
-  }, [slabAddress]);
-
-  /** Persist the current list to localStorage. Best-effort — quota errors
-   *  and privacy-mode failures are swallowed. Wraps the list in the
-   *  versioned envelope. Skips the write entirely for invalid slab
-   *  addresses to avoid poisoning a shared bucket. */
-  const persist = useCallback((slab: string, list: Drawing[]) => {
+  /** Write the envelope synchronously. Best-effort — quota errors and
+   *  privacy-mode failures are swallowed. Skips invalid slab addresses
+   *  to avoid poisoning a shared bucket. */
+  const persistImmediate = useCallback((slab: string, list: Drawing[]) => {
     if (typeof window === "undefined") return;
     if (!isValidSlabAddress(slab)) return;
     try {
@@ -122,6 +112,103 @@ export function useChartDrawings(slabAddress: string): UseChartDrawingsReturn {
     } catch {
       // Best-effort; ignore quota / privacy errors.
     }
+  }, []);
+
+  // Debounced-persist machinery. The pending write captures the slab it
+  // was scheduled for so a slab change DOESN'T cause the trailing fire
+  // to write the new slab's list under the old key (or vice versa) —
+  // each scheduled write knows where it goes.
+  const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingPersistRef = useRef<{ slab: string; list: Drawing[] } | null>(
+    null,
+  );
+  /** Persist the most recent pending write immediately and clear the
+   *  trailing timer. Called on pagehide, unmount, and slab change. Safe
+   *  to call when nothing is pending. */
+  const flushPersist = useCallback(() => {
+    if (persistTimerRef.current !== null) {
+      clearTimeout(persistTimerRef.current);
+      persistTimerRef.current = null;
+    }
+    const pending = pendingPersistRef.current;
+    if (pending !== null) {
+      pendingPersistRef.current = null;
+      persistImmediate(pending.slab, pending.list);
+    }
+  }, [persistImmediate]);
+
+  /** Replace any in-flight pending write and (re)start the 250 ms timer.
+   *  Each mutation resets the timer — burst of N mutations within
+   *  250 ms collapses to one trailing setItem at the end. */
+  const schedulePersist = useCallback(
+    (slab: string, list: Drawing[]) => {
+      pendingPersistRef.current = { slab, list };
+      if (persistTimerRef.current !== null) {
+        clearTimeout(persistTimerRef.current);
+      }
+      persistTimerRef.current = setTimeout(() => {
+        persistTimerRef.current = null;
+        const pending = pendingPersistRef.current;
+        if (pending !== null) {
+          pendingPersistRef.current = null;
+          persistImmediate(pending.slab, pending.list);
+        }
+      }, PERSIST_DEBOUNCE_MS);
+    },
+    [persistImmediate],
+  );
+
+  // flushPersist routed through a ref so the hydration effect's cleanup
+  // can call it without listing flushPersist in deps (which would cause
+  // the effect to re-fire on every callback identity change).
+  const flushPersistRef = useRef(flushPersist);
+  flushPersistRef.current = flushPersist;
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (isValidSlabAddress(slabAddress)) {
+      try {
+        const raw = window.localStorage.getItem(storageKey(slabAddress));
+        if (raw == null) {
+          setDrawings([]);
+        } else {
+          const parsed = JSON.parse(raw);
+          setDrawings(mergeDrawings(parsed));
+        }
+      } catch {
+        // localStorage unavailable, JSON parse failed, etc — start empty.
+        setDrawings([]);
+      }
+    } else {
+      setDrawings([]);
+    }
+    // Cleanup is registered unconditionally (regardless of which
+    // hydration branch ran above) so the slabAddress change about to
+    // happen — or unmount — flushes any pending write. Without this,
+    // an early-return inside the try block would skip cleanup
+    // registration; a pending write scheduled before the slab change
+    // would then never land under the correct bucket.
+    return () => {
+      flushPersistRef.current();
+    };
+  }, [slabAddress]);
+
+  // Pagehide flush so the user closing the tab inside the 250 ms
+  // window doesn't lose their last drawing. pagehide fires reliably on
+  // tab close + bfcache transitions across modern browsers (including
+  // iOS Safari, where beforeunload is unreliable on mobile).
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onPageHide = (): void => {
+      flushPersistRef.current();
+    };
+    window.addEventListener("pagehide", onPageHide);
+    return () => {
+      window.removeEventListener("pagehide", onPageHide);
+      // Final flush on hook unmount — covers SPA navigation away from
+      // the trade page where pagehide doesn't fire.
+      flushPersistRef.current();
+    };
   }, []);
 
   const addDrawing = useCallback(
@@ -149,30 +236,30 @@ export function useChartDrawings(slabAddress: string): UseChartDrawingsReturn {
           current.length >= MAX_DRAWINGS_PER_SLAB
             ? [...current.slice(1), next]
             : [...current, next];
-        persist(slabRef.current, list);
+        schedulePersist(slabRef.current, list);
         return list;
       });
     },
-    [persist],
+    [schedulePersist],
   );
 
   const deleteDrawing = useCallback(
     (id: string) => {
       setDrawings((current) => {
         const list = current.filter((d) => d.id !== id);
-        persist(slabRef.current, list);
+        schedulePersist(slabRef.current, list);
         return list;
       });
     },
-    [persist],
+    [schedulePersist],
   );
 
   const clearAll = useCallback(() => {
     setDrawings(() => {
-      persist(slabRef.current, []);
+      schedulePersist(slabRef.current, []);
       return [];
     });
-  }, [persist]);
+  }, [schedulePersist]);
 
   return { drawings, addDrawing, deleteDrawing, clearAll };
 }

--- a/app/hooks/useChartDrawings.ts
+++ b/app/hooks/useChartDrawings.ts
@@ -38,9 +38,13 @@ function generateId(): string {
 /** Return shape of `useChartDrawings`. Object form (not tuple) so consumers
  *  can destructure only what they need — the overlay's pointer-tool branch
  *  reads `drawings` and `deleteDrawing` only; the toolbar's clear-all reads
- *  `drawings.length` and `clearAll`; the creation tools call `addDrawing`. */
+ *  `drawings.length` and `clearAll`; the creation tools call `addDrawing`.
+ *
+ *  `drawings` is `readonly` so consumers can't accidentally mutate React
+ *  state in place (`.push()`, `.sort()`) — those mutations would skip
+ *  the re-render and persistence path. */
 export interface UseChartDrawingsReturn {
-  drawings: Drawing[];
+  drawings: readonly Drawing[];
   addDrawing: (input: DrawingInput) => void;
   deleteDrawing: (id: string) => void;
   clearAll: () => void;
@@ -66,14 +70,23 @@ export interface UseChartDrawingsReturn {
  *  or empty slab address no-ops the read and write so the shared
  *  `perc:chart:drawings:` bucket isn't poisoned by hooks mounted before
  *  the route param resolves. */
+/** Single hook instance per slab is the supported usage. Two parallel
+ *  `useChartDrawings(SAME_SLAB)` calls each maintain independent useState —
+ *  writes from one don't propagate to the other without a remount or a
+ *  `storage` event listener (this hook has neither, by design — cross-tab
+ *  sync isn't a v1 concern). For the trade-page chart only one instance
+ *  ever mounts at a time so this is a non-issue in practice. */
 export function useChartDrawings(slabAddress: string): UseChartDrawingsReturn {
   const [drawings, setDrawings] = useState<Drawing[]>([]);
-  // Track the slab the in-memory state corresponds to, so setters write
-  // to the correct key even when called from stale closures.
+  // Track the slab the in-memory state corresponds to so setters write to
+  // the correct key. Updated synchronously DURING RENDER — not inside the
+  // hydration effect — so a setter fired in the brief window between a
+  // prop change and the effect commit can't write to the OLD slab's
+  // bucket. React's "latest value ref" pattern.
   const slabRef = useRef<string>(slabAddress);
+  slabRef.current = slabAddress;
 
   useEffect(() => {
-    slabRef.current = slabAddress;
     if (typeof window === "undefined") return;
     if (!isValidSlabAddress(slabAddress)) {
       setDrawings([]);
@@ -113,12 +126,21 @@ export function useChartDrawings(slabAddress: string): UseChartDrawingsReturn {
 
   const addDrawing = useCallback(
     (input: DrawingInput) => {
+      // Generate the id OUTSIDE the state updater. React 18's Strict Mode
+      // (and concurrent rendering's discard-and-retry path) intentionally
+      // double-invokes updater functions to surface impurity — calling
+      // generateId inside would produce two different uuids per logical
+      // add, persist both, and leave a brief window where in-memory
+      // state and disk disagree on which uuid won. The persist call
+      // below is also a side effect, but it's idempotent on identical
+      // inputs so the double-invoke is wasted work, not a correctness
+      // bug.
+      const id = generateId();
+      // Spread + cast preserves the discriminated union: `input.kind` is
+      // narrowed at the call site, and adding a string `id` doesn't
+      // change the variant shape.
+      const next = { ...input, id } as Drawing;
       setDrawings((current) => {
-        const id = generateId();
-        // Spread + cast preserves the discriminated union: `input.kind` is
-        // narrowed at the call site, and adding a string `id` doesn't
-        // change the variant shape.
-        const next = { ...input, id } as Drawing;
         // Cap at MAX_DRAWINGS_PER_SLAB — drop oldest (FIFO) on insertion
         // past the cap. Matches the read-side behaviour in mergeDrawings
         // so an over-cap localStorage payload converges on the same set

--- a/app/lib/chart-canvas.ts
+++ b/app/lib/chart-canvas.ts
@@ -1,0 +1,39 @@
+/** Canvas helpers for the drawing-tools overlay. Pure side-effecting
+ *  functions on a HTMLCanvasElement / CanvasRenderingContext2D pair —
+ *  no React, no chart library. Extracted so the math and effect order
+ *  are testable in isolation.
+ */
+
+/** Configure a canvas + 2D context for crisp rendering at the device's
+ *  pixel ratio.
+ *
+ *  - Backing-store size scales by `dpr` so high-DPI screens (Retina,
+ *    1.5×, 2×, 3×) get more actual pixels and lines render sharp.
+ *  - CSS size stays at the logical (display) dimensions so the canvas
+ *    occupies the same layout space regardless of DPR.
+ *  - Context transform is set so subsequent draw calls work in CSS-
+ *    pixel space — the caller passes integer-ish coordinates from
+ *    `priceToCoordinate` etc. and the transform handles the DPR
+ *    multiplication.
+ *
+ *  Backing-store dimensions are clamped to a minimum of 1 because a
+ *  zero-sized canvas throws when you try to draw on it. ResizeObserver
+ *  can briefly hand us 0×0 during layout transitions (drawer collapse,
+ *  modal open, etc.) and we'd rather skip a frame than crash.
+ *
+ *  `setTransform` replaces the current transform rather than composing
+ *  with it — that's correct here because we call this on every resize
+ *  and want a clean baseline. */
+export function sizeCanvasForDpr(
+  canvas: HTMLCanvasElement,
+  ctx: CanvasRenderingContext2D,
+  displayW: number,
+  displayH: number,
+  dpr: number,
+): void {
+  canvas.width = Math.max(1, Math.round(displayW * dpr));
+  canvas.height = Math.max(1, Math.round(displayH * dpr));
+  canvas.style.width = `${displayW}px`;
+  canvas.style.height = `${displayH}px`;
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+}

--- a/app/lib/chart-coords.ts
+++ b/app/lib/chart-coords.ts
@@ -21,20 +21,35 @@ import type { PricePoint } from "@/lib/chart-drawings";
 
 /** Subset of `ISeriesApi` we need: convert between price (in quote
  *  units) and pixel y-coordinate. Both methods return `null` when the
- *  input maps off-screen or before the chart has finished sizing. */
+ *  input maps off-screen or before the chart has finished sizing.
+ *
+ *  IMPORTANT: pass the PRICE-PANE candle/line series here, not an
+ *  oscillator-pane series. lightweight-charts v5's native panes give
+ *  each series its own price scale — feeding an RSI series (whose
+ *  scale is pinned 0–100) would silently map a $84 chart click
+ *  through the RSI scale and place the drawing at the wrong y. */
 export interface PriceConverter {
   priceToCoordinate(price: number): number | null;
   coordinateToPrice(coord: number): number | null;
 }
 
-/** Subset of `ITimeScaleApi` we need: convert between time (in
- *  lightweight-charts' UTCTimestamp seconds) and pixel x-coordinate.
+/** Subset of `ITimeScaleApi` we need: convert between time and pixel
+ *  x-coordinate.
+ *
+ *  `timeToCoordinate` accepts the full `Time` union (UTCTimestamp |
+ *  BusinessDay | string) — NOT just UTCTimestamp — so the real
+ *  `ITimeScaleApi` is structurally assignable to this interface
+ *  under `strictFunctionTypes`. (Function parameters are
+ *  contravariant: narrowing the param here would mean a wider real
+ *  signature can't fit, blocking direct production wiring of
+ *  `chart.timeScale()` into `pricePointToPixel`.)
+ *
  *  `coordinateToTime` returns `Time | null` — for our trade-page chart
  *  Time is always UTCTimestamp (a number). The defensive `typeof`
  *  check below collapses BusinessDay / string returns to `null` so
  *  callers don't have to. */
 export interface TimeConverter {
-  timeToCoordinate(time: UTCTimestamp): number | null;
+  timeToCoordinate(time: Time): number | null;
   coordinateToTime(coord: number): Time | null;
 }
 
@@ -44,10 +59,12 @@ export interface TimeConverter {
  *  laid out its price scale yet on first paint). Callers should
  *  treat `null` as "skip this drawing for this frame".
  *
- *  Time conversion: ms → seconds via `Math.floor(timeMs / 1000)`. The
+ *  Time conversion: ms → seconds via `Math.trunc(timeMs / 1000)`. The
  *  truncation costs sub-second precision which lightweight-charts
  *  doesn't render anyway — bars are second-aligned at finer than
- *  pixel resolution on any realistic candle interval. */
+ *  pixel resolution on any realistic candle interval. trunc (toward
+ *  zero) rather than floor (toward -∞) so negative ms inputs don't
+ *  shift by a full second. */
 export function pricePointToPixel(
   series: PriceConverter,
   timeScale: TimeConverter,
@@ -56,7 +73,11 @@ export function pricePointToPixel(
   if (!Number.isFinite(point.time) || !Number.isFinite(point.price)) {
     return null;
   }
-  const timeS = Math.floor(point.time / 1000) as UTCTimestamp;
+  // Math.trunc (NOT Math.floor) so negative ms convert to seconds via
+  // truncation toward zero. Math.floor(-1.5) === -2, which would shift
+  // pre-epoch timestamps by a full second on each conversion. trunc is
+  // the correct unit-conversion semantic.
+  const timeS = Math.trunc(point.time / 1000) as UTCTimestamp;
   const x = timeScale.timeToCoordinate(timeS);
   const y = series.priceToCoordinate(point.price);
   if (x === null || y === null) return null;

--- a/app/lib/chart-coords.ts
+++ b/app/lib/chart-coords.ts
@@ -1,0 +1,92 @@
+/** Coordinate transformer — bridges between internal price/time space
+ *  (ms since epoch + price-in-quote-units) and lightweight-charts' pixel
+ *  space (CSS pixels relative to the chart canvas).
+ *
+ *  This is the only file in the drawing-tools feature that knows about
+ *  lightweight-charts' `UTCTimestamp` (seconds since epoch). Every other
+ *  module — math, validation, hit testing, persistence — works in
+ *  milliseconds, matching `Date.now()` and the existing chart code's
+ *  internal format. Centralising the unit conversion in one file
+ *  removes a class of seconds-vs-ms mistakes from the rest of the
+ *  codebase.
+ *
+ *  Pure module — no React, no DOM, no chart instance. Both helpers
+ *  accept narrow capability interfaces (PriceConverter, TimeConverter)
+ *  that lightweight-charts' real `ISeriesApi` and `ITimeScaleApi`
+ *  satisfy structurally; tests pass plain object mocks.
+ */
+
+import type { Time, UTCTimestamp } from "lightweight-charts";
+import type { PricePoint } from "@/lib/chart-drawings";
+
+/** Subset of `ISeriesApi` we need: convert between price (in quote
+ *  units) and pixel y-coordinate. Both methods return `null` when the
+ *  input maps off-screen or before the chart has finished sizing. */
+export interface PriceConverter {
+  priceToCoordinate(price: number): number | null;
+  coordinateToPrice(coord: number): number | null;
+}
+
+/** Subset of `ITimeScaleApi` we need: convert between time (in
+ *  lightweight-charts' UTCTimestamp seconds) and pixel x-coordinate.
+ *  `coordinateToTime` returns `Time | null` — for our trade-page chart
+ *  Time is always UTCTimestamp (a number). The defensive `typeof`
+ *  check below collapses BusinessDay / string returns to `null` so
+ *  callers don't have to. */
+export interface TimeConverter {
+  timeToCoordinate(time: UTCTimestamp): number | null;
+  coordinateToTime(coord: number): Time | null;
+}
+
+/** Convert a price/time anchor into the pixel coordinate the chart
+ *  would render it at. Returns `null` if either axis maps off-scale
+ *  (e.g., the time is outside the visible range, or the chart hasn't
+ *  laid out its price scale yet on first paint). Callers should
+ *  treat `null` as "skip this drawing for this frame".
+ *
+ *  Time conversion: ms → seconds via `Math.floor(timeMs / 1000)`. The
+ *  truncation costs sub-second precision which lightweight-charts
+ *  doesn't render anyway — bars are second-aligned at finer than
+ *  pixel resolution on any realistic candle interval. */
+export function pricePointToPixel(
+  series: PriceConverter,
+  timeScale: TimeConverter,
+  point: PricePoint,
+): { x: number; y: number } | null {
+  if (!Number.isFinite(point.time) || !Number.isFinite(point.price)) {
+    return null;
+  }
+  const timeS = Math.floor(point.time / 1000) as UTCTimestamp;
+  const x = timeScale.timeToCoordinate(timeS);
+  const y = series.priceToCoordinate(point.price);
+  if (x === null || y === null) return null;
+  return { x, y };
+}
+
+/** Convert a pixel coordinate (e.g., the user's click position) into
+ *  the price/time anchor that lives there. Returns `null` if either
+ *  axis maps off-scale, OR if the time scale hands back a non-numeric
+ *  Time (BusinessDay / string), which our chart never produces but
+ *  the lightweight-charts type allows.
+ *
+ *  Time conversion: seconds → ms via `* 1000`. The result is exactly
+ *  the boundary value (the second start) — sub-second precision was
+ *  already discarded going the other way. Round-trips are stable
+ *  modulo that floor on the input. */
+export function pixelToPricePoint(
+  series: PriceConverter,
+  timeScale: TimeConverter,
+  x: number,
+  y: number,
+): PricePoint | null {
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+  const timeRaw = timeScale.coordinateToTime(x);
+  const price = series.coordinateToPrice(y);
+  if (timeRaw === null || price === null) return null;
+  // The runtime Time can be UTCTimestamp (number), BusinessDay (object),
+  // or a string. Our chart only ever uses UTCTimestamp, but defensively
+  // reject the other shapes so the caller sees a clean PricePoint or
+  // null — never a malformed object.
+  if (typeof timeRaw !== "number") return null;
+  return { time: timeRaw * 1000, price };
+}

--- a/app/lib/chart-drawings.ts
+++ b/app/lib/chart-drawings.ts
@@ -1,0 +1,173 @@
+/** Chart drawing tools — type definitions, validation, and persistence
+ *  envelope. Pure data layer; no React, no DOM, no chart-library dependency.
+ *
+ *  Time convention: `time` is milliseconds since epoch, matching Date.now()
+ *  and the rest of the chart code's internal format. Conversion to
+ *  lightweight-charts' UTCTimestamp (seconds) happens at the rendering
+ *  boundary in chart-coords.ts (commit 2). Keeping the math layer in ms
+ *  removes a class of unit-confusion bugs.
+ */
+
+/** A single anchor point on the chart — used as endpoints by trend lines
+ *  and rectangles. Drawings persist anchors in price/time space (NOT pixel
+ *  coordinates) so they stay glued to the same bar across pan, zoom, and
+ *  timeframe changes. */
+export interface PricePoint {
+  /** Milliseconds since epoch. */
+  time: number;
+  /** Price in the chart's quote units (USDC for SOL/USDC perp, etc.). */
+  price: number;
+}
+
+/** All drawing kinds supported in v1. Adding a new kind is a four-step
+ *  diff: append the variant here, append `isDrawing` validation, append
+ *  `renderConfig` branch in the overlay, append the toolbar button. The
+ *  exhaustive switch + assertNever in the renderer catches the missing
+ *  branch at compile time. */
+export type Drawing =
+  | { id: string; kind: "trend"; p1: PricePoint; p2: PricePoint }
+  | { id: string; kind: "horizontal"; price: number }
+  | { id: string; kind: "rectangle"; p1: PricePoint; p2: PricePoint };
+
+/** Discriminator helper — the set of valid `kind` values for runtime
+ *  validation against localStorage payloads. Mirrors VALID_KINDS in
+ *  indicator-registry.ts. Update both this and the Drawing union when
+ *  adding a kind. */
+export type DrawingKind = Drawing["kind"];
+const VALID_KINDS: ReadonlySet<DrawingKind> = new Set([
+  "trend",
+  "horizontal",
+  "rectangle",
+]);
+
+/** Active drawing tool from the user's toolbar. `pointer` is the default
+ *  (select / delete existing drawings). The other values match Drawing
+ *  kinds for the creation flow. Persisted separately from drawings
+ *  themselves (different key — drawings are per-slab; tool selection is
+ *  global so the user's tool of choice survives across markets). */
+export type DrawingTool = "pointer" | "trend" | "horizontal" | "rectangle";
+
+/** Distribute Omit over a discriminated union — built-in Omit collapses
+ *  to common keys via `keyof`, dropping per-variant fields like `p1` and
+ *  `price`. The conditional-type trick forces per-variant distribution. */
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
+  ? Omit<T, K>
+  : never;
+
+/** Shape accepted by `addDrawing` — the same as Drawing minus the `id`
+ *  field, which the hook generates via crypto.randomUUID() so callers
+ *  can't accidentally collide ids. Distributive so each variant retains
+ *  its per-kind fields. */
+export type DrawingInput = DistributiveOmit<Drawing, "id">;
+
+/** Versioned storage envelope. Bumping the version triggers a migration
+ *  path in mergeDrawings; v1 readers see future-version blobs and fall
+ *  back to defaults rather than crash-parsing. */
+export interface DrawingsStorage {
+  version: number;
+  drawings: Drawing[];
+}
+
+/** Current storage envelope version. Bump when the Drawing shape changes
+ *  in a backwards-incompatible way; mergeDrawings will then need a
+ *  per-version branch. */
+export const DRAWINGS_STORAGE_VERSION = 1;
+
+/** Per-slab cap on persisted drawings. Picked at 100 because:
+ *  - Far above any realistic single-trader workflow (< 20 typical).
+ *  - Well below localStorage's 5-10 MB per-origin limit even at
+ *    ~200 bytes per drawing.
+ *  - Bounded enough that mergeDrawings' linear scan stays sub-ms. */
+export const MAX_DRAWINGS_PER_SLAB = 100;
+
+// =====================================================================
+// Validation
+// =====================================================================
+
+/** Strict runtime check for the PricePoint shape. Both fields must be
+ *  finite numbers — NaN, Infinity, and missing values fail. */
+function isPricePoint(value: unknown): value is PricePoint {
+  if (value === null || typeof value !== "object") return false;
+  const p = value as Record<string, unknown>;
+  return (
+    typeof p.time === "number" &&
+    Number.isFinite(p.time) &&
+    typeof p.price === "number" &&
+    Number.isFinite(p.price)
+  );
+}
+
+/** Strict runtime check that a value is a well-formed Drawing. Intentionally
+ *  rejects unknown `kind` values rather than throwing — readers of older
+ *  app versions can encounter newer kinds and we'd rather drop them than
+ *  crash the chart. */
+export function isDrawing(value: unknown): value is Drawing {
+  if (value === null || typeof value !== "object") return false;
+  const d = value as Record<string, unknown>;
+  if (typeof d.id !== "string" || d.id.length === 0) return false;
+  if (typeof d.kind !== "string") return false;
+  if (!VALID_KINDS.has(d.kind as DrawingKind)) return false;
+  switch (d.kind as DrawingKind) {
+    case "trend":
+    case "rectangle":
+      return isPricePoint(d.p1) && isPricePoint(d.p2);
+    case "horizontal":
+      return typeof d.price === "number" && Number.isFinite(d.price);
+  }
+}
+
+// =====================================================================
+// Tolerant deserializer
+// =====================================================================
+
+/** Parse the raw localStorage payload into a clean Drawing[]. Tolerant
+ *  by design — malformed entries are silently dropped rather than
+ *  rejected wholesale, so a single corrupted drawing doesn't lose the
+ *  user's whole set.
+ *
+ *  Failure modes handled:
+ *  - Non-object payloads (string, number, null) → []
+ *  - Missing or future-version envelope → []
+ *  - `drawings` field not an array → []
+ *  - Individual entries that fail isDrawing → dropped (other entries kept)
+ *  - More than MAX_DRAWINGS_PER_SLAB entries → trimmed to the cap
+ *
+ *  Bare-array reads (a previous version of this format that wasn't
+ *  envelope-wrapped) are ALSO accepted defensively — if `parsed` is an
+ *  array directly, we treat it as a v1 drawings list. This lets a
+ *  hypothetical pre-envelope user upgrade without losing data, and
+ *  matches the indicator-registry's tolerant pattern. */
+export function mergeDrawings(parsed: unknown): Drawing[] {
+  if (parsed === null || typeof parsed !== "object") return [];
+
+  let raw: unknown;
+  if (Array.isArray(parsed)) {
+    // Bare-array legacy / defensive path.
+    raw = parsed;
+  } else {
+    const envelope = parsed as Record<string, unknown>;
+    // Future envelope versions: drop everything rather than guess. The
+    // current major version's reader must not interpret future-version
+    // payload shapes.
+    if (
+      typeof envelope.version === "number" &&
+      envelope.version !== DRAWINGS_STORAGE_VERSION
+    ) {
+      return [];
+    }
+    raw = envelope.drawings;
+  }
+
+  if (!Array.isArray(raw)) return [];
+
+  const result: Drawing[] = [];
+  const seenIds = new Set<string>();
+  for (const entry of raw) {
+    if (!isDrawing(entry)) continue;
+    if (seenIds.has(entry.id)) continue; // dedupe; first wins
+    seenIds.add(entry.id);
+    result.push(entry);
+    if (result.length >= MAX_DRAWINGS_PER_SLAB) break;
+  }
+  return result;
+}

--- a/app/lib/chart-drawings.ts
+++ b/app/lib/chart-drawings.ts
@@ -29,16 +29,19 @@ export type Drawing =
   | { id: string; kind: "horizontal"; price: number }
   | { id: string; kind: "rectangle"; p1: PricePoint; p2: PricePoint };
 
-/** Discriminator helper — the set of valid `kind` values for runtime
- *  validation against localStorage payloads. Mirrors VALID_KINDS in
- *  indicator-registry.ts. Update both this and the Drawing union when
- *  adding a kind. */
+/** Discriminator helper — every kind in the Drawing union. */
 export type DrawingKind = Drawing["kind"];
-const VALID_KINDS: ReadonlySet<DrawingKind> = new Set([
-  "trend",
-  "horizontal",
-  "rectangle",
-]);
+
+/** Single source of truth for the kinds the runtime validator accepts.
+ *  Typed as `Record<DrawingKind, true>` so adding a kind to the Drawing
+ *  union forces a compile error here (missing key). The previous
+ *  hand-maintained `Set<DrawingKind>` could silently desync from the
+ *  union and drop user-stored entries on read. */
+const VALID_KIND_TABLE: Record<DrawingKind, true> = {
+  trend: true,
+  horizontal: true,
+  rectangle: true,
+};
 
 /** Active drawing tool from the user's toolbar. `pointer` is the default
  *  (select / delete existing drawings). The other values match Drawing
@@ -68,9 +71,14 @@ export interface DrawingsStorage {
   drawings: Drawing[];
 }
 
-/** Current storage envelope version. Bump when the Drawing shape changes
- *  in a backwards-incompatible way; mergeDrawings will then need a
- *  per-version branch. */
+/** Current storage envelope version. Bump ONLY for backwards-INCOMPATIBLE
+ *  changes (renaming or removing a field, changing units, restructuring
+ *  the discriminator). Additive changes — adding an optional field to a
+ *  variant, adding a new kind — do NOT need a version bump because
+ *  isDrawing's tolerant validation accepts older payloads unchanged.
+ *  Reserving bumps for breaking changes lets v1 readers see additive v1
+ *  payloads from newer clients without losing the entire drawings list
+ *  to a version mismatch. */
 export const DRAWINGS_STORAGE_VERSION = 1;
 
 /** Per-slab cap on persisted drawings. Picked at 100 because:
@@ -100,19 +108,44 @@ function isPricePoint(value: unknown): value is PricePoint {
 /** Strict runtime check that a value is a well-formed Drawing. Intentionally
  *  rejects unknown `kind` values rather than throwing — readers of older
  *  app versions can encounter newer kinds and we'd rather drop them than
- *  crash the chart. */
+ *  crash the chart.
+ *
+ *  Also rejects entries carrying prototype-related own keys. `JSON.parse`
+ *  intentionally treats `__proto__` as an own string property, NOT a
+ *  prototype slot, so it doesn't pollute at parse time. But any future
+ *  consumer that spreads a drawing into an object literal
+ *  (`{ ...drawing, ...overrides }`) would re-apply the own `__proto__`
+ *  key as the actual prototype. Defusing here means every spread site in
+ *  the rendering pipeline can stay simple. */
 export function isDrawing(value: unknown): value is Drawing {
   if (value === null || typeof value !== "object") return false;
+  if (
+    Object.hasOwn(value, "__proto__") ||
+    Object.hasOwn(value, "constructor") ||
+    Object.hasOwn(value, "prototype")
+  ) {
+    return false;
+  }
   const d = value as Record<string, unknown>;
   if (typeof d.id !== "string" || d.id.length === 0) return false;
   if (typeof d.kind !== "string") return false;
-  if (!VALID_KINDS.has(d.kind as DrawingKind)) return false;
+  if (!Object.hasOwn(VALID_KIND_TABLE, d.kind)) return false;
   switch (d.kind as DrawingKind) {
     case "trend":
     case "rectangle":
       return isPricePoint(d.p1) && isPricePoint(d.p2);
     case "horizontal":
       return typeof d.price === "number" && Number.isFinite(d.price);
+    default: {
+      // Compile-error guard: if a future kind is added to the Drawing
+      // union without a case here, `_exhaustive: never` fails to type-
+      // check because `d.kind` (post-narrowing) still has the unhandled
+      // variant. VALID_KIND_TABLE above also fails to type-check on the
+      // missing key, so two independent compile-time failure points
+      // cover the four-step diff promised in the docs.
+      const _exhaustive: never = d.kind as never;
+      return false;
+    }
   }
 }
 
@@ -142,17 +175,16 @@ export function mergeDrawings(parsed: unknown): Drawing[] {
 
   let raw: unknown;
   if (Array.isArray(parsed)) {
-    // Bare-array legacy / defensive path.
+    // Bare-array legacy / defensive path. No version field — accept and
+    // let isDrawing filter individual entries.
     raw = parsed;
   } else {
     const envelope = parsed as Record<string, unknown>;
-    // Future envelope versions: drop everything rather than guess. The
-    // current major version's reader must not interpret future-version
-    // payload shapes.
-    if (
-      typeof envelope.version === "number" &&
-      envelope.version !== DRAWINGS_STORAGE_VERSION
-    ) {
+    // Strict equality on the version field. A missing, non-numeric, or
+    // wrong-numeric version drops the whole list — the current reader
+    // must not guess at envelope shapes it doesn't recognize. NaN never
+    // equals DRAWINGS_STORAGE_VERSION so it's correctly dropped here.
+    if (envelope.version !== DRAWINGS_STORAGE_VERSION) {
       return [];
     }
     raw = envelope.drawings;

--- a/app/lib/chart-hit-test.ts
+++ b/app/lib/chart-hit-test.ts
@@ -1,0 +1,155 @@
+/** Hit-test helpers for chart drawings. Pure math — given a Drawing
+ *  plus a click point in CSS-pixel space and the converters that
+ *  project price/time to pixels, return whether the click "hit" the
+ *  drawing within the threshold.
+ *
+ *  Threshold: 5 CSS pixels. Wide enough that a user clicking near a
+ *  thin line lands on it (the line itself is 1.5px wide; users miss
+ *  by 2-3px reliably with mouse precision and 5+ on touch — though
+ *  touch is out of scope for v1). Narrow enough that overlapping
+ *  drawings remain individually selectable.
+ *
+ *  Selection priority: top-level findHitDrawingId iterates in REVERSE
+ *  array order. The most recently drawn drawing wins on overlap,
+ *  which matches user expectation ("the one I just put down is the
+ *  one I want to grab"). The drawings array is creation-order, so
+ *  reverse-iterate to land on the visually-on-top drawing.
+ */
+
+import type { Drawing } from "@/lib/chart-drawings";
+import {
+  pricePointToPixel,
+  type PriceConverter,
+  type TimeConverter,
+} from "@/lib/chart-coords";
+import { assertNever } from "@/lib/exhaustive";
+
+/** Hit-test threshold in CSS pixels. Tuned for mouse precision; if
+ *  touch lands as a v2 follow-up, the threshold should grow to ~10. */
+export const HIT_THRESHOLD_PX = 5;
+
+/** Distance from point (px,py) to a line segment from (x1,y1) to
+ *  (x2,y2). Standard projection-with-clamp algorithm:
+ *  - Project the point onto the infinite line.
+ *  - Clamp the projection parameter `t` to [0, 1] to stay on the
+ *    segment (instead of running off either end).
+ *  - Distance from the clamped projection to the point.
+ *
+ *  Degenerate-segment guard: if the two endpoints coincide
+ *  (lenSq === 0), the "segment" is just a point and we fall back
+ *  to point-to-point distance — without this, the formula divides
+ *  by zero and returns NaN. */
+export function distanceToSegment(
+  px: number,
+  py: number,
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+): number {
+  const dx = x2 - x1;
+  const dy = y2 - y1;
+  const lenSq = dx * dx + dy * dy;
+  if (lenSq === 0) {
+    const ex = px - x1;
+    const ey = py - y1;
+    return Math.sqrt(ex * ex + ey * ey);
+  }
+  let t = ((px - x1) * dx + (py - y1) * dy) / lenSq;
+  t = Math.max(0, Math.min(1, t));
+  const cx = x1 + t * dx;
+  const cy = y1 + t * dy;
+  const ex = px - cx;
+  const ey = py - cy;
+  return Math.sqrt(ex * ex + ey * ey);
+}
+
+/** Hit-test a trend line: project both endpoints to pixels, then
+ *  distance-to-segment. If either endpoint is off-scale (returns null
+ *  from pricePointToPixel) we treat the drawing as not hittable for
+ *  this frame — half-on-screen trends are render-only, not selectable.
+ *  Selecting them would require a click on a pixel we never painted. */
+export function hitTestTrend(
+  drawing: Extract<Drawing, { kind: "trend" }>,
+  px: number,
+  py: number,
+  series: PriceConverter,
+  timeScale: TimeConverter,
+): boolean {
+  const p1 = pricePointToPixel(series, timeScale, drawing.p1);
+  const p2 = pricePointToPixel(series, timeScale, drawing.p2);
+  if (p1 === null || p2 === null) return false;
+  return distanceToSegment(px, py, p1.x, p1.y, p2.x, p2.y) <= HIT_THRESHOLD_PX;
+}
+
+/** Hit-test a horizontal line: project the price to a y-pixel, then
+ *  vertical distance only (the line spans the entire x range). */
+export function hitTestHorizontal(
+  drawing: Extract<Drawing, { kind: "horizontal" }>,
+  py: number,
+  series: PriceConverter,
+): boolean {
+  const lineY = series.priceToCoordinate(drawing.price);
+  if (lineY === null) return false;
+  return Math.abs(py - lineY) <= HIT_THRESHOLD_PX;
+}
+
+/** Hit-test a rectangle: distance to any of the four EDGES (not
+ *  inside-fill). Clicking inside the rect should NOT select it —
+ *  users want to interact with the chart visible through the
+ *  rectangle. Selecting requires clicking near an edge. */
+export function hitTestRectangle(
+  drawing: Extract<Drawing, { kind: "rectangle" }>,
+  px: number,
+  py: number,
+  series: PriceConverter,
+  timeScale: TimeConverter,
+): boolean {
+  const p1 = pricePointToPixel(series, timeScale, drawing.p1);
+  const p2 = pricePointToPixel(series, timeScale, drawing.p2);
+  if (p1 === null || p2 === null) return false;
+  // Normalise to a canonical (top-left, bottom-right) so the user can
+  // anchor the rect from any corner.
+  const minX = Math.min(p1.x, p2.x);
+  const maxX = Math.max(p1.x, p2.x);
+  const minY = Math.min(p1.y, p2.y);
+  const maxY = Math.max(p1.y, p2.y);
+  const distTop = distanceToSegment(px, py, minX, minY, maxX, minY);
+  const distBottom = distanceToSegment(px, py, minX, maxY, maxX, maxY);
+  const distLeft = distanceToSegment(px, py, minX, minY, minX, maxY);
+  const distRight = distanceToSegment(px, py, maxX, minY, maxX, maxY);
+  const minDist = Math.min(distTop, distBottom, distLeft, distRight);
+  return minDist <= HIT_THRESHOLD_PX;
+}
+
+/** Top-level hit-test dispatcher. Iterates drawings in REVERSE order
+ *  (last-drawn first wins on overlap — matches user expectation
+ *  "select what's on top") and returns the id of the first hit, or
+ *  `null` if no drawing was within threshold. */
+export function findHitDrawingId(
+  drawings: readonly Drawing[],
+  px: number,
+  py: number,
+  series: PriceConverter,
+  timeScale: TimeConverter,
+): string | null {
+  for (let i = drawings.length - 1; i >= 0; i--) {
+    const d = drawings[i];
+    let hit = false;
+    switch (d.kind) {
+      case "trend":
+        hit = hitTestTrend(d, px, py, series, timeScale);
+        break;
+      case "horizontal":
+        hit = hitTestHorizontal(d, py, series);
+        break;
+      case "rectangle":
+        hit = hitTestRectangle(d, px, py, series, timeScale);
+        break;
+      default:
+        return assertNever(d);
+    }
+    if (hit) return d.id;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

Adds user-drawing primitives to the price chart — trend lines, horizontal lines, and rectangles — with a left-edge toolbar, pointer-mode select / delete, and a per-slab clear-all. Drawings persist in localStorage scoped per slab address.

## Architecture

- **Data layer** ([chart-drawings.ts](app/lib/chart-drawings.ts)): discriminated union `Drawing = trend | horizontal | rectangle`, versioned storage envelope, `MAX_DRAWINGS_PER_SLAB = 100` cap with FIFO drop-oldest, tolerant deserializer that drops malformed entries, `Record<Kind, true>` validation tables that fail compile-closed when a new variant is added without a matching key.
- **Persistence hook** ([useChartDrawings.ts](app/hooks/useChartDrawings.ts)): per-slab localStorage bucket keyed by Solana base58 pubkey (validated against `/^[1-9A-HJ-NP-Za-km-z]{32,44}$/`). Writes are debounced 250 ms trailing; flushes on slab change, unmount, and pagehide so no in-flight write is lost.
- **Coordinate transformer** ([chart-coords.ts](app/lib/chart-coords.ts)): structural `PriceConverter` / `TimeConverter` interfaces over the lightweight-charts series + timescale APIs. `Math.trunc(ms/1000)` for ms→s conversion to keep pre-epoch semantics consistent.
- **Hit testing** ([chart-hit-test.ts](app/lib/chart-hit-test.ts)): per-kind distance-to-segment with degenerate-segment fallback, edge-only rectangle hit-test, reverse-iteration so the top-most-drawn drawing wins.
- **Canvas helper** ([chart-canvas.ts](app/lib/chart-canvas.ts)): DPR-aware sizing with min-1 clamps to avoid 0×0 crashes.
- **Tool state** ([useChartDrawingTool.ts](app/hooks/useChartDrawingTool.ts)): session-local active tool. Intentionally NOT persisted across sessions — leaving a creation tool active across page loads silently dropped a creation anchor on the next visit's first click.
- **Overlay** ([ChartDrawingOverlay.tsx](app/components/trade/ChartDrawingOverlay.tsx)): transparent canvas with \`pointer-events: none\`. Click dispatch routes through \`chart.subscribeClick\` so native pan / zoom keep working. Subscription deps key only on chart refs + chartReady (subscribe-once); state changes flow via refs and an imperative redrawRef. Crosshair-move and rectangle-drag mousemove rAF-coalesce to one redraw per vsync. Canvas clips to the price-pane's candle-area bounds (top scaleMargin → 1-bottom scaleMargin) so drawings can't paint into volume / oscillator panes; clicks outside that band are rejected so phantom drawings can't anchor at extrapolated prices.
- **Toolbar** ([ChartDrawingToolbar.tsx](app/components/trade/ChartDrawingToolbar.tsx)): vertical bar at the chart's top-left. Hidden \`md:flex\` (drawing tools are desktop-only for v1) and gated on \`!showEmptyOverlay\`. Labelled \`<div>\` with \`<button aria-pressed>\` toggles — deliberately not \`role=\"toolbar\"\` because we don't implement APG roving tabindex. Clear-all uses \`window.confirm\` with singular / plural wording and resets the active tool to pointer afterwards.

## Mobile

Touch viewports short-circuit every tool at click dispatch (creation tools have no toolbar to back out of, pointer mode has no Backspace / Delete to clean up a selection). Drawings created on desktop still render on mobile as static art.

## Theme awareness

Stroke is the brand accent in both themes. Fill alpha resolves per-frame via \`document.documentElement[data-theme]\` — 15 % on dark, 22 % on light (the lower alpha washes out against the near-white light bg). Stroke contrast meets WCAG AA 3:1 for graphics in both themes.

## Test plan

- [x] Unit tests for the data layer, hit-test math, coordinate transformer, canvas sizing, persistence hook, and tool hook
- [x] Component tests for the toolbar (ARIA contract, active-tool feedback, clear-all confirm flow) and overlay (subscription lifecycle, click dispatch per tool, keyboard priority chain, rectangle drag including stuck-state recovery via contextmenu + window blur, slab-change reset, pane-bounds clipping)
- [x] \`tsc --noEmit\` clean for the feature files
- [x] Full app suite passes locally (chart-drawing tests: all green)
- [ ] Manual smoke: draw each kind on devnet BTC market, switch slab, refresh, verify per-slab persistence
- [ ] Manual smoke: hover-preview on a slow laptop to confirm rAF coalescing keeps frames smooth
- [ ] Manual smoke: light theme drawings legible against \`#FAFAFD\` bg
- [ ] Manual smoke: rectangle drag → contextmenu / alt-tab cancels cleanly without latching pan-suppression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added chart drawing tools: pointer, trend line, horizontal line, and rectangle for annotating charts
  * Drawing toolbar with clear all functionality to manage annotations
  * Persistent drawing storage across sessions
  * Keyboard support: Escape to cancel, Delete/Backspace to delete drawings

* **Tests**
  * Added comprehensive test coverage for drawing components and utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->