### PR TITLE
Bump inactive chart toolbar contrast to match Line dropdown

### DIFF
--- a/app/components/trade/ChartDisplayMenu.tsx
+++ b/app/components/trade/ChartDisplayMenu.tsx
@@ -107,10 +107,14 @@ export const ChartDisplayMenu: FC<ChartDisplayMenuProps> = ({ prefs, onToggle })
               tabIndex={open ? 0 : -1}
               onClick={() => handleToggle(key)}
               className={[
-                "flex w-full items-center justify-between px-3 py-1.5 text-xs transition-colors",
+                // Row hover bg matches the ChartStyleMenu (Line) options
+                // so every dropdown in the chart toolbar uses the same
+                // hover affordance — text brightens AND the row gets a
+                // subtle surface highlight.
+                "flex w-full items-center justify-between px-3 py-1.5 text-xs transition-colors hover:bg-[var(--bg-surface)]",
                 enabled
                   ? "text-[var(--text)]"
-                  : "text-[var(--text-dim)] hover:text-[var(--text-secondary)]",
+                  : "text-[var(--text-secondary)] hover:text-[var(--text)]",
               ].join(" ")}
             >
               <span>{OVERLAY_LABELS[key]}</span>

--- a/app/components/trade/ChartIndicatorMenu.tsx
+++ b/app/components/trade/ChartIndicatorMenu.tsx
@@ -167,7 +167,7 @@ export const ChartIndicatorMenu: FC<ChartIndicatorMenuProps> = ({
           type="button"
           onClick={handleClearAll}
           disabled={indicators.length === 0}
-          className="w-full px-3 py-2 text-xs text-[var(--text-dim)] hover:text-[var(--text)] hover:bg-[var(--bg-surface)] border-t border-[var(--border)] disabled:cursor-not-allowed disabled:opacity-40"
+          className="w-full px-3 py-2 text-xs text-[var(--text-secondary)] hover:text-[var(--text)] hover:bg-[var(--bg-surface)] border-t border-[var(--border)] disabled:cursor-not-allowed disabled:opacity-40"
         >
           Clear all
         </button>
@@ -195,7 +195,7 @@ const ChartIndicatorRow: FC<ChartIndicatorRowProps> = ({
 }) => {
   const enabled = config !== null;
   return (
-    <div className="px-3 py-2 border-b border-[var(--border)]/50 last:border-b-0">
+    <div className="group px-3 py-2 border-b border-[var(--border)]/50 last:border-b-0 transition-colors hover:bg-[var(--bg-surface)]">
       <div className="flex items-center justify-between gap-2">
         <button
           type="button"
@@ -205,9 +205,12 @@ const ChartIndicatorRow: FC<ChartIndicatorRowProps> = ({
         >
           <ToggleSwitch on={enabled} />
           <span
-            className={
-              enabled ? "text-[var(--text)]" : "text-[var(--text-dim)]"
-            }
+            className={[
+              "transition-colors",
+              enabled
+                ? "text-[var(--text)]"
+                : "text-[var(--text-secondary)] group-hover:text-[var(--text)]",
+            ].join(" ")}
           >
             {INDICATOR_LABELS[kind]}
           </span>

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -827,7 +827,7 @@ export const TradingChart: FC<{ slabAddress: string; mintAddress?: string }> = (
                 className={`rounded-none px-1.5 sm:px-2 py-1 text-xs transition-colors ${
                   timeframe === tf
                     ? "bg-[var(--accent)]/10 text-[var(--accent)]"
-                    : "text-[var(--text-dim)] hover:text-[var(--text-secondary)]"
+                    : "text-[var(--text-secondary)] hover:bg-[var(--bg-surface)] hover:text-[var(--text)]"
                 }`}
               >
                 {tf}


### PR DESCRIPTION
## Summary

The Display dropdown's off-toggle rows, the f(x) menu's off-indicator labels, and the timeframe bar's inactive buttons were using \`--text-dim\` at rest — a token meant for placeholder-style metadata. On the dark chart bg the text reads as nearly illegible, requiring users to bump display brightness to scan options. ChartStyleMenu (Line) already uses \`--text-secondary\` for its non-selected rows; this PR aligns the other three controls to the same scheme.

## What changes

| Surface | Before (rest / hover) | After (rest / hover) |
|---------|------------------------|----------------------|
| ChartStyleMenu (Line) — reference | secondary / text + bg-surface | unchanged |
| ChartDisplayMenu off rows | dim / secondary, no bg | secondary / text + bg-surface |
| ChartIndicatorMenu off labels | dim / dim, no bg | secondary / text + bg-surface (via row \`group-hover:\`) |
| ChartIndicatorMenu \"Clear all\" | dim / text + bg-surface | secondary / text + bg-surface |
| Timeframe buttons (inactive) | dim / secondary, no bg | secondary / text + bg-surface |

## Implementation notes

- ChartIndicatorRow wraps in \`group\` + \`hover:bg-[var(--bg-surface)]\` and the label span uses \`group-hover:text-[var(--text)]\` so the row's hover state drives the label brightening. Cleaner than per-span hover handlers because the row also contains a colour swatch and per-config inputs when the indicator is enabled — those keep their own backgrounds (\`bg-[var(--bg)]\` on inputs, indicator-color on swatch) so they don't get washed out by the row tint.
- Clear-all button kept its \`disabled:opacity-40\` fallback so 'no indicators yet' still reads visually disabled.
- Active states untouched: timeframe stays accent-tinted, Display 'on' rows stay full-bright text, indicator 'on' labels stay full-bright.

## Test plan

- [x] \`vitest run\` for ChartDisplayMenu and ChartIndicatorMenu — 36/36 passing
- [ ] Manual smoke: open the chart, scan the toolbar — Display, f(x), timeframes should all read at the same brightness as the Line dropdown's options
- [ ] Manual smoke: hover each off-state row — text should brighten and the row should pick up a subtle surface tint, identical to the Line dropdown's hover
- [ ] Manual smoke: light theme — confirm new \`--text-secondary\` clears AA on \`#FAFAFD\` bg as expected (it already does for Line; this just extends the same pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined visual styling for chart overlay toggles with updated disabled text colors and enhanced hover highlighting.
  * Enhanced indicator menu styling with improved text color consistency and interactive hover effects.
  * Improved timeframe selector button interactions with updated hover state styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->