### PR TITLE
Bump market info bar labels to primary text

### DIFF
--- a/app/components/trade/MarketInfoBar.tsx
+++ b/app/components/trade/MarketInfoBar.tsx
@@ -106,7 +106,7 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol, log
         <MarketLogo logoUrl={logoUrl} mintAddress={mintAddress} symbol={symbol} size="sm" />
         <span className="text-sm font-bold text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>
           {symbol}/USD
-          <span className="ml-1.5 text-[9px] font-normal uppercase tracking-[0.12em] text-[var(--text-dim)]">PERP</span>
+          <span className="ml-1.5 text-[9px] font-normal uppercase tracking-[0.12em] text-[var(--text)]">PERP</span>
         </span>
       </div>
 
@@ -139,7 +139,7 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol, log
       <div className="flex flex-1 items-center gap-4 min-w-0">
         {/* Volume 24h */}
         <div className="flex flex-col shrink-0">
-          <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">Vol 24h</span>
+          <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text)]">Vol 24h</span>
           <span className="text-xs font-medium text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>
             {formatCompact(volume as number)}
           </span>
@@ -147,7 +147,7 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol, log
 
         {/* OI */}
         <div className="flex flex-col shrink-0">
-          <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">Open Interest</span>
+          <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text)]">Open Interest</span>
           <span className="text-xs font-medium text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>
             {formatCompact(oi as number)}
           </span>
@@ -155,7 +155,7 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol, log
 
         {/* 5.6: 24h High */}
         <div className="flex flex-col shrink-0">
-          <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">24h High</span>
+          <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text)]">24h High</span>
           <span className="text-xs font-medium text-[var(--long)]" style={{ fontFamily: "var(--font-mono)" }}>
             {formatUsdFromNumber(high24h)}
           </span>
@@ -163,7 +163,7 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol, log
 
         {/* 5.6: 24h Low */}
         <div className="flex flex-col shrink-0">
-          <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">24h Low</span>
+          <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text)]">24h Low</span>
           <span className="text-xs font-medium text-[var(--short)]" style={{ fontFamily: "var(--font-mono)" }}>
             {formatUsdFromNumber(low24h)}
           </span>
@@ -172,7 +172,7 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol, log
         {/* Funding Rate — P3-6: pr-2 padding prevents right-edge clipping */}
         {funding8h != null && (
           <div className="flex flex-col shrink-0 pr-2">
-            <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">Funding / 8h</span>
+            <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text)]">Funding / 8h</span>
             <span className={`text-xs font-semibold ${fundingColor}`} style={{ fontFamily: "var(--font-mono)" }}>
               {funding8h >= 0 ? "+" : ""}{funding8h.toFixed(4)}%
             </span>


### PR DESCRIPTION
## Summary

The market info bar's five stat labels (Vol 24h, Open Interest, 24h High, 24h Low, Funding / 8h) and the \`PERP\` tag next to the symbol were rendering at \`--text-dim\` — a token meant for placeholder-style metadata. At 9 px uppercase, sitting on the dark bg, the text was nearly illegible without bumping display brightness. Promoting them to \`--text\` matches the \`{SYMBOL}/USD\` symbol header and the bar's other primary content.

The visual hierarchy is preserved by font-size + uppercase tracking (labels stay 9 px / tracking-[0.1em], values stay 12 px / mono) instead of by brightness.

## What changes

| Element | Before | After |
|---------|--------|-------|
| \`PERP\` tag | \`--text-dim\` | \`--text\` |
| \"Vol 24h\" label | \`--text-dim\` | \`--text\` |
| \"Open Interest\" label | \`--text-dim\` | \`--text\` |
| \"24h High\" label | \`--text-dim\` | \`--text\` |
| \"24h Low\" label | \`--text-dim\` | \`--text\` |
| \"Funding / 8h\" label | \`--text-dim\` | \`--text\` |

Stat *values* are untouched — volumes / OI stay \`--text\`, 24h high stays \`--long\`, 24h low stays \`--short\`, funding stays its directional colour.

## Test plan

- [x] \`vitest run\` for \`gh1654-market-info-bar-visibility\` and \`trading-ui-phase2\` — 17/17 passing
- [ ] Manual smoke: open the trade page, verify the labels read clearly without bumping monitor brightness
- [ ] Manual smoke: light theme — confirm \`--text\` still has adequate contrast on the lighter info-bar surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)