### PR TITLE
Bump label / informational text contrast across the trade, markets, portfolio, and create flows

### DIFF
--- a/app/app/create/page.tsx
+++ b/app/app/create/page.tsx
@@ -43,7 +43,7 @@ function CreatePageInner() {
         <div className="mb-4">
           <Link
             href="/markets"
-            className="inline-flex items-center gap-1.5 text-[11px] font-mono text-[var(--text-muted)] transition-colors hover:text-[var(--text)] uppercase tracking-[0.1em]"
+            className="inline-flex items-center gap-1.5 text-[11px] font-mono text-[var(--text-secondary)] transition-colors hover:text-[var(--text)] uppercase tracking-[0.1em]"
           >
             ← Markets
           </Link>
@@ -59,13 +59,13 @@ function CreatePageInner() {
               className="text-xl font-medium tracking-[-0.01em] text-[var(--text)] sm:text-2xl"
               style={{ fontFamily: "var(--font-heading)" }}
             >
-              <span className="font-normal text-[var(--text-muted)]">Launch a </span>Market
+              <span className="font-normal text-[var(--text)]">Launch a </span>Market
             </h1>
             <p className="mt-2 text-[13px] text-[var(--text-secondary)]">
               Deploy a perpetual futures market in ~60 seconds.
             </p>
             <div
-              className="mt-2 text-[11px] text-[var(--text-dim)]"
+              className="mt-2 text-[11px] text-[var(--text-secondary)]"
               style={{ fontFamily: "var(--font-mono)" }}
             >
               small: ~0.45 SOL &middot; medium: ~1.8 SOL &middot; large: ~7 SOL

--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -580,7 +580,7 @@ function MarketsPageInner() {
                 // browse
               </div>
               <h1 className="text-xl font-medium tracking-[-0.01em] text-[var(--text)] sm:text-2xl" style={{ fontFamily: "var(--font-heading)" }}>
-                <span className="font-normal text-[var(--text)]/50">All </span>Markets
+                <span className="font-normal text-[var(--text)]">All </span>Markets
               </h1>
               <p className="mt-2 text-[13px] text-[var(--text-secondary)]">perpetual futures, pick your poison.</p>
             </div>
@@ -609,7 +609,7 @@ function MarketsPageInner() {
               {hasSearch && (
                 <button
                   onClick={clearSearch}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-[var(--text-dim)] hover:text-[var(--text-secondary)] p-1 min-h-[44px] min-w-[44px] flex items-center justify-center"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-[var(--text-secondary)] hover:text-[var(--text)] transition-colors p-1 min-h-[44px] min-w-[44px] flex items-center justify-center"
                   title="Clear search"
                   aria-label="Clear search"
                 >
@@ -635,7 +635,7 @@ function MarketsPageInner() {
                       "rounded-sm px-3 py-2 sm:py-1.5 text-[10px] font-bold uppercase tracking-[0.08em] transition-all duration-200 min-h-[40px]",
                       sortBy === opt.key
                         ? "bg-[var(--accent)]/10 text-[var(--accent)]"
-                        : "text-[var(--text-muted)] hover:text-[var(--text)]",
+                        : "text-[var(--text-secondary)] hover:text-[var(--text)]",
                     ].join(" ")}
                     aria-pressed={sortBy === opt.key}
                     aria-label={`Sort by ${opt.label}`}
@@ -661,7 +661,7 @@ function MarketsPageInner() {
 
           {/* Row 2: Filter pills — single scrollable row on mobile */}
           <div className="mb-6 flex items-center gap-2 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
-            <span className="hidden sm:inline-block text-[10px] font-semibold uppercase tracking-[0.15em] text-[var(--text-muted)] shrink-0">FILTER:</span>
+            <span className="hidden sm:inline-block text-[10px] font-semibold uppercase tracking-[0.15em] text-[var(--text)] shrink-0">FILTER:</span>
 
             {/* USD/Token toggle */}
             <div className="flex gap-1 rounded-sm border border-[var(--border)] bg-[var(--bg-elevated)] p-0.5 shrink-0" role="group" aria-label="Display currency">
@@ -671,7 +671,7 @@ function MarketsPageInner() {
                   "rounded-sm px-2.5 py-1.5 sm:py-1 text-[10px] font-bold uppercase tracking-[0.08em] transition-all duration-200 min-h-[36px] sm:min-h-[32px]",
                   !showUsd
                     ? "bg-[var(--accent)]/10 text-[var(--accent)]"
-                    : "text-[var(--text-muted)] hover:text-[var(--text)]",
+                    : "text-[var(--text-secondary)] hover:text-[var(--text)]",
                 ].join(" ")}
                 aria-pressed={!showUsd}
                 aria-label="Display in tokens"
@@ -684,7 +684,7 @@ function MarketsPageInner() {
                   "rounded-sm px-2.5 py-1.5 sm:py-1 text-[10px] font-bold uppercase tracking-[0.08em] transition-all duration-200 min-h-[36px] sm:min-h-[32px]",
                   showUsd
                     ? "bg-[var(--accent)]/10 text-[var(--accent)]"
-                    : "text-[var(--text-muted)] hover:text-[var(--text)]",
+                    : "text-[var(--text-secondary)] hover:text-[var(--text)]",
                 ].join(" ")}
                 aria-pressed={showUsd}
                 aria-label="Display in USD"
@@ -712,7 +712,7 @@ function MarketsPageInner() {
                     "rounded-sm px-2.5 py-1.5 sm:py-1 text-[10px] font-bold uppercase tracking-[0.08em] transition-all duration-200 min-h-[36px] sm:min-h-[32px]",
                     leverageFilter === opt.key
                       ? "bg-[var(--accent)]/10 text-[var(--accent)]"
-                      : "text-[var(--text-muted)] hover:text-[var(--text)]",
+                      : "text-[var(--text-secondary)] hover:text-[var(--text)]",
                   ].join(" ")}
                   aria-pressed={leverageFilter === opt.key}
                   aria-label={`Filter leverage ${opt.label}`}
@@ -740,7 +740,7 @@ function MarketsPageInner() {
                     "rounded-sm px-2.5 py-1.5 sm:py-1 text-[10px] font-bold uppercase tracking-[0.08em] transition-all duration-200 min-h-[36px] sm:min-h-[32px]",
                     oracleFilter === opt.key
                       ? "bg-[var(--accent)]/10 text-[var(--accent)]"
-                      : "text-[var(--text-muted)] hover:text-[var(--text)]",
+                      : "text-[var(--text-secondary)] hover:text-[var(--text)]",
                   ].join(" ")}
                   aria-pressed={oracleFilter === opt.key}
                   aria-label={`Filter oracle ${opt.label}`}
@@ -835,7 +835,7 @@ function MarketsPageInner() {
                 {/* GH#1775: sticky inside overflow-x-auto is broken by CSS spec (overflow clips stacking context).
                     Removed sticky top-0 z-10 — header scrolls with content on mobile.
                     Desktop (sm+) is unaffected since the table fits in viewport width. */}
-                <div className="grid w-full min-w-[500px] sm:min-w-[700px] grid-cols-[minmax(120px,2.5fr)_minmax(80px,1.2fr)_minmax(50px,0.6fr)_minmax(75px,0.8fr)] sm:grid-cols-[minmax(160px,3fr)_minmax(90px,1.2fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(65px,0.8fr)_minmax(80px,0.9fr)] gap-2 sm:gap-4 border-b border-[var(--border)] bg-[var(--bg-surface)] px-3 sm:px-5 py-2.5 text-[9px] sm:text-[10px] font-semibold uppercase tracking-[0.15em] text-[var(--text-dim)]">
+                <div className="grid w-full min-w-[500px] sm:min-w-[700px] grid-cols-[minmax(120px,2.5fr)_minmax(80px,1.2fr)_minmax(50px,0.6fr)_minmax(75px,0.8fr)] sm:grid-cols-[minmax(160px,3fr)_minmax(90px,1.2fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(90px,1fr)_minmax(65px,0.8fr)_minmax(80px,0.9fr)] gap-2 sm:gap-4 border-b border-[var(--border)] bg-[var(--bg-surface)] px-3 sm:px-5 py-2.5 text-[9px] sm:text-[10px] font-semibold uppercase tracking-[0.15em] text-[var(--text)]">
                   <div>token</div>
                   <div className="text-right">price</div>
                   <div className="hidden sm:block text-right">OI</div>
@@ -990,7 +990,7 @@ function MarketsPageInner() {
                             {displaySymbol ? `${displaySymbol}/USD` : shortenAddress(m.slabAddress)}
                           </span>
                           {m.isAdminOracle && (
-                            <span className="border border-[var(--text-dim)]/30 bg-[var(--text-dim)]/[0.08] px-1.5 py-0.5 text-[8px] font-medium uppercase tracking-wider text-[var(--text-dim)]">manual</span>
+                            <span className="border border-[var(--text-dim)]/30 bg-[var(--text-dim)]/[0.08] px-1.5 py-0.5 text-[8px] font-medium uppercase tracking-wider text-[var(--text-secondary)]">manual</span>
                           )}
                           {/* GH#1233: warn when admin-oracle market has no price — users cannot open positions */}
                           {m.isAdminOracle && lastPrice === null && (
@@ -1003,7 +1003,7 @@ function MarketsPageInner() {
                             </span>
                           )}
                         </div>
-                        <div className="text-[10px] text-[var(--text-dim)]" style={{ fontFamily: "var(--font-mono)" }}>
+                        <div className="text-[10px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-mono)" }}>
                           {displayName ? `${displayName} · ${shortenAddress(subtitleAddress)}` : shortenAddress(subtitleAddress)}
                         </div>
                       </div>
@@ -1033,7 +1033,7 @@ function MarketsPageInner() {
                 </div>
               ) : filtered.length > 20 ? (
                 <div className="flex items-center justify-center gap-3 py-4">
-                  <span className="text-[11px] text-[var(--text-dim)]" style={{ fontFamily: "var(--font-mono)" }}>
+                  <span className="text-[11px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-mono)" }}>
                     all {filtered.length} market{filtered.length !== 1 ? "s" : ""} loaded
                   </span>
                   <button

--- a/app/app/portfolio/page.tsx
+++ b/app/app/portfolio/page.tsx
@@ -114,7 +114,7 @@ export default function PortfolioPage() {
             // portfolio
           </div>
           <h1 className="text-xl font-medium tracking-[-0.01em] text-[var(--text)] sm:text-2xl" style={{ fontFamily: "var(--font-heading)" }}>
-            <span className="font-normal text-[var(--text-muted)]">Your </span>Positions
+            <span className="font-normal text-[var(--text)]">Your </span>Positions
           </h1>
           <p className="mt-2 mb-8 text-[13px] text-[var(--text-secondary)]">View all your positions across markets</p>
           <div className="border border-[var(--border)] bg-[var(--panel-bg)] p-10 text-center">
@@ -140,7 +140,7 @@ export default function PortfolioPage() {
                 // portfolio
               </div>
               <h1 className="text-xl font-medium tracking-[-0.01em] text-[var(--text)] sm:text-2xl" style={{ fontFamily: "var(--font-heading)" }}>
-                <span className="font-normal text-[var(--text-muted)]">Your </span>Positions
+                <span className="font-normal text-[var(--text)]">Your </span>Positions
               </h1>
               <p className="mt-2 text-[13px] text-[var(--text-secondary)]">
                 All positions across Percolator markets
@@ -176,7 +176,7 @@ export default function PortfolioPage() {
               {
                 label: "Total Deposited",
                 value: !walletConnected ? "—" : (loading || tokenMetasLoading) ? "\u2026" : `$${usdTotals.depositedUsd.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
-                color: !walletConnected ? "text-[var(--text-dim)]" : "text-[var(--text-secondary)]",
+                color: !walletConnected ? "text-[var(--text-dim)]" : "text-[var(--text)]",
               },
               {
                 label: "Unrealized PnL",
@@ -187,7 +187,7 @@ export default function PortfolioPage() {
               {
                 label: "LP Value",
                 value: !walletConnected ? "—" : lpPositions.loading ? "\u2026" : `$${lpPositions.totalRedeemable.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
-                color: !walletConnected ? "text-[var(--text-dim)]" : lpPositions.totalRedeemable > 0 ? "text-[var(--cyan)]" : "text-[var(--text-dim)]",
+                color: !walletConnected ? "text-[var(--text-dim)]" : lpPositions.totalRedeemable > 0 ? "text-[var(--cyan)]" : "text-[var(--text-secondary)]",
                 sub: walletConnected && lpPositions.positions.length > 0
                   ? `${lpPositions.positions.length} pool${lpPositions.positions.length > 1 ? "s" : ""}`
                   : undefined,
@@ -201,7 +201,7 @@ export default function PortfolioPage() {
               },
             ].map((stat, idx, arr) => (
               <div key={stat.label} className={`bg-[var(--panel-bg)] p-5 transition-colors duration-200 hover:bg-[var(--bg-elevated)]${idx === arr.length - 1 && arr.length % 2 !== 0 ? " col-span-2 sm:col-span-1" : ""}`}>
-                <p className="mb-2 text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-dim)]">{stat.label}</p>
+                <p className="mb-2 text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text)]">{stat.label}</p>
                 <p className={`text-xl font-bold tabular-nums ${stat.color}`} style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>
                   {stat.value}
                 </p>
@@ -337,31 +337,31 @@ export default function PortfolioPage() {
                       {/* Row 2: Details grid */}
                       <div className="mt-3 grid grid-cols-2 gap-x-6 gap-y-1.5 sm:grid-cols-6">
                         <div>
-                          <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">Size</p>
+                          <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text)]">Size</p>
                           <p className="text-[12px] text-[var(--text)]" style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>
                             {formatTokenAmount(sizeAbs, getDecimals(pos))}
                           </p>
                         </div>
                         <div>
-                          <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">Entry</p>
+                          <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text)]">Entry</p>
                           <p className="text-[12px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>
                             {formatUsdPriceE6(posEntry)}
                           </p>
                         </div>
                         <div>
-                          <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">Mark Price</p>
+                          <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text)]">Mark Price</p>
                           <p className="text-[12px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>
                             {oraclePriceE6 > 0n ? formatUsdPriceE6(oraclePriceE6) : "—"}
                           </p>
                         </div>
                         <div>
-                          <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">Capital</p>
+                          <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text)]">Capital</p>
                           <p className="text-[12px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>
                             {formatTokenAmount(posCapital, getDecimals(pos))}
                           </p>
                         </div>
                         <div>
-                          <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]" title={RISK_LEVERAGE_TITLE}>
+                          <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text)]" title={RISK_LEVERAGE_TITLE}>
                             {RISK_LEVERAGE_LABEL}
                           </p>
                           <p className="text-[12px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>
@@ -369,7 +369,7 @@ export default function PortfolioPage() {
                           </p>
                         </div>
                         <div>
-                          <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">Liq. Price</p>
+                          <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text)]">Liq. Price</p>
                           <div className="flex items-center gap-1.5">
                             {/* Liquidation severity dot */}
                             {hasPosition && (
@@ -404,14 +404,14 @@ export default function PortfolioPage() {
                       {/* Liquidation distance bar */}
                       {hasPosition && liquidationDistancePct < 100 && (
                         <div className="mt-3">
-                          <div className="flex items-center justify-between text-[9px] text-[var(--text-dim)]">
+                          <div className="flex items-center justify-between text-[9px] text-[var(--text)]">
                             <span>Liquidation Distance</span>
                             <span className={
                               severity === "danger"
                                 ? "font-bold text-[var(--short)]"
                                 : severity === "warning"
                                 ? "font-bold text-[var(--warning)]"
-                                : "text-[var(--text-muted)]"
+                                : "text-[var(--text-secondary)]"
                             }>
                               {liquidationDistancePct.toFixed(1)}%
                             </span>

--- a/app/app/trade/[slab]/page.tsx
+++ b/app/app/trade/[slab]/page.tsx
@@ -110,7 +110,7 @@ function Tabs({ tabs, children, defaultTab }: { tabs: string[]; children: React.
               className={`shrink-0 px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.15em] transition-colors border-b-2 ${
                 active === i
                   ? "border-[var(--accent)] text-[var(--accent)]"
-                  : "border-transparent text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:border-[var(--border)]"
+                  : "border-transparent text-[var(--text-secondary)] hover:text-[var(--text)] hover:border-[var(--border)]"
               }`}
             >
               {label}

--- a/app/components/create/CostEstimate.tsx
+++ b/app/components/create/CostEstimate.tsx
@@ -77,7 +77,7 @@ export const CostEstimate: FC<CostEstimateProps> = ({
   return (
     <div className={`border border-[var(--border)] bg-[var(--bg)] ${className}`}>
       <div className="px-4 py-3 border-b border-[var(--border)]">
-        <h4 className="text-[10px] font-semibold uppercase tracking-[0.15em] text-[var(--text-muted)]">
+        <h4 className="text-[10px] font-semibold uppercase tracking-[0.15em] text-[var(--text)]">
           Cost Estimate
         </h4>
       </div>
@@ -85,17 +85,17 @@ export const CostEstimate: FC<CostEstimateProps> = ({
       {/* SOL Costs */}
       <div className="px-4 py-3 space-y-2 border-b border-[var(--border)]">
         <div className="flex items-center justify-between text-[11px]">
-          <span className="text-[var(--text-muted)]">
+          <span className="text-[var(--text-secondary)]">
             Slab account rent ({estimate.tierLabel}, {estimate.tierSlots} slots)
           </span>
           <span className="font-mono text-[var(--text)]">{estimate.slabRentSol} SOL</span>
         </div>
         <div className="flex items-center justify-between text-[11px]">
-          <span className="text-[var(--text-muted)]">Token accounts & mints</span>
+          <span className="text-[var(--text-secondary)]">Token accounts & mints</span>
           <span className="font-mono text-[var(--text)]">{estimate.tokenAccountRentSol} SOL</span>
         </div>
         <div className="flex items-center justify-between text-[11px]">
-          <span className="text-[var(--text-muted)]">Transaction fees (5 txs)</span>
+          <span className="text-[var(--text-secondary)]">Transaction fees (5 txs)</span>
           <span className="font-mono text-[var(--text)]">{estimate.txFeeSol} SOL</span>
         </div>
         <div className="flex items-center justify-between pt-2 border-t border-[var(--border)]">
@@ -109,19 +109,19 @@ export const CostEstimate: FC<CostEstimateProps> = ({
       {/* Token Costs */}
       <div className="px-4 py-3 space-y-2">
         <div className="flex items-center justify-between text-[11px]">
-          <span className="text-[var(--text-muted)]">Vault Seed (required)</span>
+          <span className="text-[var(--text-secondary)]">Vault Seed (required)</span>
           <span className="font-mono text-[var(--text)]">
             {estimate.seedTokens.toLocaleString()} {tokenSymbol}
           </span>
         </div>
         <div className="flex items-center justify-between text-[11px]">
-          <span className="text-[var(--text-muted)]">LP Collateral</span>
+          <span className="text-[var(--text-secondary)]">LP Collateral</span>
           <span className="font-mono text-[var(--text)]">
             {estimate.lpTokens > 0 ? estimate.lpTokens.toLocaleString() : "—"} {tokenSymbol}
           </span>
         </div>
         <div className="flex items-center justify-between text-[11px]">
-          <span className="text-[var(--text-muted)]">Insurance Fund</span>
+          <span className="text-[var(--text-secondary)]">Insurance Fund</span>
           <span className="font-mono text-[var(--text)]">
             {estimate.insTokens > 0 ? estimate.insTokens.toLocaleString() : "—"} {tokenSymbol}
           </span>
@@ -133,7 +133,7 @@ export const CostEstimate: FC<CostEstimateProps> = ({
               {estimate.totalTokens > 0 ? estimate.totalTokens.toLocaleString() : "—"} {tokenSymbol}
             </span>
             {estimate.tokenUsdValue !== null && estimate.tokenUsdValue > 0 && (
-              <p className="text-[10px] text-[var(--text-dim)]">
+              <p className="text-[10px] text-[var(--text-secondary)]">
                 ≈ ${estimate.tokenUsdValue.toLocaleString(undefined, { maximumFractionDigits: 2 })}
               </p>
             )}

--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -753,7 +753,7 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
               setResumeFromStep(null);
               resetCreate();
             }}
-            className="flex-shrink-0 text-[10px] text-[var(--text-dim)] hover:text-[var(--text)] transition-colors px-2 py-1 border border-[var(--border)]"
+            className="flex-shrink-0 text-[10px] text-[var(--text-secondary)] hover:text-[var(--text)] transition-colors px-2 py-1 border border-[var(--border)]"
           >
             CANCEL
           </button>
@@ -783,7 +783,7 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
         {/* GH#1615: Use display step/total/label so Quick Launch shows "STEP 2 / 3 — Slab Tier"
             instead of the confusing "STEP 2 / 4 — Oracle ✓" while rendering slab content. */}
         <div className="mb-5 pb-4 border-b border-[var(--border)]">
-          <p className="text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">
+          <p className="text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text)]">
             STEP {headerStepNum} / {headerStepTotal} — {headerStepLabel}
           </p>
         </div>
@@ -809,7 +809,7 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
               <p className="text-[11px] text-[var(--text-secondary)] mb-4">
                 Choose your market size. Larger slabs support more concurrent traders but cost more SOL to deploy.
               </p>
-              <label className="block text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)] mb-3">
+              <label className="block text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text)] mb-3">
                 Slab Tier
               </label>
               <SlabTierPicker value={wizard.slabTier} onChange={setSlabTier} />
@@ -826,7 +826,7 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
                 ✓ DEX pool detected — permissionless on-chain pricing (no keeper needed)
               </p>
             ) : (
-              <p className="text-[10px] text-[var(--text-dim)]">
+              <p className="text-[10px] text-[var(--text-secondary)]">
                 ℹ Admin oracle — you&apos;ll control pricing (devnet token)
               </p>
             )}

--- a/app/components/create/FeeSlider.tsx
+++ b/app/components/create/FeeSlider.tsx
@@ -34,7 +34,7 @@ export const FeeSlider: FC<FeeSliderProps> = ({
     <div>
       <div className="flex items-center justify-between mb-2">
         <label
-          className="text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)]"
+          className="text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text)]"
           htmlFor={`slider-${label.replace(/\s+/g, "-").toLowerCase()}`}
         >
           {label}
@@ -44,7 +44,7 @@ export const FeeSlider: FC<FeeSliderProps> = ({
             {value} bps
           </span>
           {showPercent && (
-            <span className="text-[10px] text-[var(--text-dim)]">
+            <span className="text-[10px] text-[var(--text-secondary)]">
               = {percent}% per trade
             </span>
           )}
@@ -69,8 +69,8 @@ export const FeeSlider: FC<FeeSliderProps> = ({
         />
       </div>
       <div className="flex items-center justify-between mt-1">
-        <span className="text-[9px] text-[var(--text-dim)]">{min} bps</span>
-        <span className="text-[9px] text-[var(--text-dim)]">{max} bps</span>
+        <span className="text-[9px] text-[var(--text-secondary)]">{min} bps</span>
+        <span className="text-[9px] text-[var(--text-secondary)]">{max} bps</span>
       </div>
     </div>
   );

--- a/app/components/create/LaunchProgress.tsx
+++ b/app/components/create/LaunchProgress.tsx
@@ -68,7 +68,7 @@ export const LaunchProgress: FC<LaunchProgressProps> = ({ state, onReset, onRetr
                   </span>
                 )}
                 {status === "pending" && (
-                  <span className="flex h-6 w-6 items-center justify-center border border-[var(--border)] bg-[var(--bg-surface)] text-[10px] text-[var(--text-dim)]">
+                  <span className="flex h-6 w-6 items-center justify-center border border-[var(--border)] bg-[var(--bg-surface)] text-[10px] text-[var(--text-secondary)]">
                     {i + 1}
                   </span>
                 )}
@@ -84,7 +84,7 @@ export const LaunchProgress: FC<LaunchProgressProps> = ({ state, onReset, onRetr
                         ? "font-medium text-[var(--text)]"
                         : status === "error"
                           ? "text-[var(--short)]"
-                          : "text-[var(--text-dim)]"
+                          : "text-[var(--text-secondary)]"
                   }`}
                 >
                   {label}
@@ -114,7 +114,7 @@ export const LaunchProgress: FC<LaunchProgressProps> = ({ state, onReset, onRetr
                       href={`https://explorer.solana.com/tx/${state.txSigs[i]}?cluster=devnet`}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="font-mono text-[10px] text-[var(--text-dim)] hover:text-[var(--accent)] transition-colors"
+                      className="font-mono text-[10px] text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors"
                     >
                       tx: {state.txSigs[i].slice(0, 8)}...
                     </a>

--- a/app/components/create/LaunchSuccess.tsx
+++ b/app/components/create/LaunchSuccess.tsx
@@ -122,7 +122,7 @@ export const LaunchSuccess: FC<LaunchSuccessProps> = ({
         <button
           type="button"
           onClick={handleCopy}
-          className="border border-[var(--border)] px-2 py-1.5 text-[9px] font-medium text-[var(--text-muted)] hover:text-[var(--accent)] hover:border-[var(--accent)]/30 transition-colors"
+          className="border border-[var(--border)] px-2 py-1.5 text-[9px] font-medium text-[var(--text-secondary)] hover:text-[var(--accent)] hover:border-[var(--accent)]/30 transition-colors"
           title="Copy address"
         >
           {copied ? "✓" : "copy"}
@@ -131,7 +131,7 @@ export const LaunchSuccess: FC<LaunchSuccessProps> = ({
           href={`https://explorer.solana.com/address/${marketAddress}?cluster=devnet`}
           target="_blank"
           rel="noopener noreferrer"
-          className="border border-[var(--border)] px-2 py-1.5 text-[9px] font-medium text-[var(--text-muted)] hover:text-[var(--accent)] hover:border-[var(--accent)]/30 transition-colors"
+          className="border border-[var(--border)] px-2 py-1.5 text-[9px] font-medium text-[var(--text-secondary)] hover:text-[var(--accent)] hover:border-[var(--accent)]/30 transition-colors"
           title="View on Solscan"
         >
           Explorer ↗
@@ -147,11 +147,11 @@ export const LaunchSuccess: FC<LaunchSuccessProps> = ({
           <div>
             <p className="text-[13px] font-bold text-[var(--text)]">{tokenSymbol}-PERP</p>
             <div className="flex items-center gap-1.5 mt-0.5">
-              <span className="text-[9px] text-[var(--text-dim)]">Fee: {tradingFeeBps} bps</span>
-              <span className="text-[9px] text-[var(--text-dim)]">·</span>
-              <span className="text-[9px] text-[var(--text-dim)]">Leverage: {maxLeverage}x</span>
-              <span className="text-[9px] text-[var(--text-dim)]">·</span>
-              <span className="text-[9px] text-[var(--text-dim)]">Slab: {slabLabel}</span>
+              <span className="text-[9px] text-[var(--text-secondary)]">Fee: {tradingFeeBps} bps</span>
+              <span className="text-[9px] text-[var(--text-secondary)]">·</span>
+              <span className="text-[9px] text-[var(--text-secondary)]">Leverage: {maxLeverage}x</span>
+              <span className="text-[9px] text-[var(--text-secondary)]">·</span>
+              <span className="text-[9px] text-[var(--text-secondary)]">Slab: {slabLabel}</span>
             </div>
           </div>
         </div>
@@ -166,7 +166,7 @@ export const LaunchSuccess: FC<LaunchSuccessProps> = ({
           <p className="text-[11px] text-[var(--text-secondary)] leading-relaxed">
             Your market is <strong className="text-[var(--text)]">live and tradeable</strong>. The Insurance LP Mint transaction timed out on devnet — this is non-blocking.
           </p>
-          <p className="text-[11px] text-[var(--text-dim)] mt-1.5 leading-relaxed">
+          <p className="text-[11px] text-[var(--text-secondary)] mt-1.5 leading-relaxed">
             Insurance LP deposits will be unavailable until the mint is created. You can retry from the market settings page later.
           </p>
         </div>
@@ -184,20 +184,20 @@ export const LaunchSuccess: FC<LaunchSuccessProps> = ({
               <span className="text-[var(--long)]">✓</span>
               <span className="text-[var(--text)]">
                 Airdropped <strong>{devnetAirdropAmount.toLocaleString(undefined, { maximumFractionDigits: 2 })} {devnetAirdropSymbol}</strong>{" "}
-                <span className="text-[var(--text-dim)]">(~$500 worth)</span>
+                <span className="text-[var(--text-secondary)]">(~$500 worth)</span>
               </span>
             </div>
           )}
 
           {devnetMint && (
             <div className="space-y-1">
-              <p className="text-[10px] text-[var(--text-muted)]">
+              <p className="text-[10px] text-[var(--text-secondary)]">
                 ⚠️ Devnet uses a <strong>different mint address</strong> than mainnet:
               </p>
               {mainnetCA && (
                 <div className="flex items-center gap-2 text-[10px]">
-                  <span className="text-[var(--text-dim)] w-16 flex-shrink-0">Mainnet:</span>
-                  <code className="font-mono text-[9px] text-[var(--text-dim)] truncate">{mainnetCA}</code>
+                  <span className="text-[var(--text-secondary)] w-16 flex-shrink-0">Mainnet:</span>
+                  <code className="font-mono text-[9px] text-[var(--text-secondary)] truncate">{mainnetCA}</code>
                 </div>
               )}
               <div className="flex items-center gap-2 text-[10px]">
@@ -212,12 +212,12 @@ export const LaunchSuccess: FC<LaunchSuccessProps> = ({
                       setTimeout(() => setCopiedDevnet(false), 2000);
                     } catch {}
                   }}
-                  className="border border-[var(--border)] px-1.5 py-0.5 text-[8px] font-medium text-[var(--text-muted)] hover:text-[var(--accent)] hover:border-[var(--accent)]/30 transition-colors flex-shrink-0"
+                  className="border border-[var(--border)] px-1.5 py-0.5 text-[8px] font-medium text-[var(--text-secondary)] hover:text-[var(--accent)] hover:border-[var(--accent)]/30 transition-colors flex-shrink-0"
                 >
                   {copiedDevnet ? "✓" : "copy"}
                 </button>
               </div>
-              <p className="text-[9px] text-[var(--text-dim)] mt-1">
+              <p className="text-[9px] text-[var(--text-secondary)] mt-1">
                 Use the devnet mint address when adding tokens to your wallet or trading.
               </p>
             </div>
@@ -245,7 +245,7 @@ export const LaunchSuccess: FC<LaunchSuccessProps> = ({
 
       {/* Devnet mint error — show inline error (minting is automatic, no manual faucet link) */}
       {isDevnet && devnetMintError && !devnetMint && !devnetAirdropAmount && (
-        <div className="mb-6 text-[11px] text-[var(--text-dim)]">
+        <div className="mb-6 text-[11px] text-[var(--text-secondary)]">
           Auto-mint failed ({devnetMintError}). Click &ldquo;Trade This Market&rdquo; and use the airdrop button to get devnet tokens.
         </div>
       )}
@@ -294,7 +294,7 @@ export const LaunchSuccess: FC<LaunchSuccessProps> = ({
       {/* Transaction signatures */}
       {txSigs.length > 0 && (
         <div className="mt-5 border-t border-[var(--border)] pt-4">
-          <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)] mb-2">
+          <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text)] mb-2">
             Transactions
           </p>
           <div className="flex flex-wrap justify-center gap-2">
@@ -304,7 +304,7 @@ export const LaunchSuccess: FC<LaunchSuccessProps> = ({
                 href={`https://explorer.solana.com/tx/${sig}?cluster=devnet`}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="font-mono text-[10px] text-[var(--text-dim)] hover:text-[var(--accent)] transition-colors"
+                className="font-mono text-[10px] text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors"
               >
                 Step {i + 1}: {sig.slice(0, 8)}... ↗
               </a>

--- a/app/components/create/LogoUpload.tsx
+++ b/app/components/create/LogoUpload.tsx
@@ -79,7 +79,7 @@ export const LogoUpload: FC<LogoUploadProps> = ({ slabAddress, mintAddress, symb
 
   return (
     <div className="mt-4 border border-[var(--border)] bg-[var(--panel-bg)] p-4">
-      <p className="mb-3 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-muted)]">
+      <p className="mb-3 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text)]">
         Token Logo
       </p>
 
@@ -102,7 +102,7 @@ export const LogoUpload: FC<LogoUploadProps> = ({ slabAddress, mintAddress, symb
               <p className="text-[11px] text-[var(--accent)]">Logo uploaded</p>
               <button
                 onClick={() => { setLogoUrl(null); setError(null); }}
-                className="mt-1 text-[10px] text-[var(--text-dim)] underline hover:text-[var(--text-muted)]"
+                className="mt-1 text-[10px] text-[var(--text-secondary)] underline hover:text-[var(--text)]"
               >
                 Replace
               </button>
@@ -123,7 +123,7 @@ export const LogoUpload: FC<LogoUploadProps> = ({ slabAddress, mintAddress, symb
               >
                 {uploading ? "Uploading..." : "Upload Logo"}
               </button>
-              <p className="mt-1 text-[10px] text-[var(--text-dim)]">
+              <p className="mt-1 text-[10px] text-[var(--text-secondary)]">
                 PNG, JPEG, WebP, or GIF. Max 2MB.
               </p>
             </>

--- a/app/components/create/MarketPreview.tsx
+++ b/app/components/create/MarketPreview.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { FC } from "react";
+
+interface MarketPreviewProps {
+  symbol: string;
+  name: string;
+  tokenMint: string;
+  oracleMode: string;
+  oracleLabel: string;
+  tradingFeeBps: number;
+  initialMarginBps: number;
+  maxLeverage: number;
+  lpCollateral: string;
+  insuranceAmount: string;
+  tierLabel: string;
+  tierSlots: number;
+  tokenDecimals: number;
+  priceUsd?: number;
+  inverted: boolean;
+  vammEnabled: boolean;
+  className?: string;
+}
+
+/**
+ * Visual preview of the market as it will appear once created.
+ * Mimics the trade page header / market card layout.
+ */
+export const MarketPreview: FC<MarketPreviewProps> = ({
+  symbol,
+  name,
+  tokenMint,
+  oracleMode,
+  oracleLabel,
+  tradingFeeBps,
+  initialMarginBps,
+  maxLeverage,
+  lpCollateral,
+  insuranceAmount,
+  tierLabel,
+  tierSlots,
+  tokenDecimals,
+  priceUsd,
+  inverted,
+  vammEnabled,
+  className = "",
+}) => {
+  const maintenanceMarginBps = Math.floor(initialMarginBps / 2);
+
+  return (
+    <div className={`border border-[var(--accent)]/20 bg-[var(--accent)]/[0.02] ${className}`}>
+      {/* Header — mimics trade page market header */}
+      <div className="flex items-center justify-between px-5 py-4 border-b border-[var(--accent)]/10">
+        <div className="flex items-center gap-3">
+          <div className="flex h-9 w-9 items-center justify-center border border-[var(--accent)]/30 bg-[var(--accent)]/[0.08] text-[12px] font-bold text-[var(--accent)]">
+            {symbol.slice(0, 2).toUpperCase()}
+          </div>
+          <div>
+            <h3 className="text-[14px] font-bold text-white" style={{ fontFamily: "var(--font-heading)" }}>
+              {symbol}/USD
+            </h3>
+            <p className="text-[10px] text-[var(--text-secondary)]">{name} · Perpetual</p>
+          </div>
+        </div>
+        <div className="text-right">
+          {priceUsd && priceUsd > 0 ? (
+            <p className="text-[14px] font-bold font-mono text-white">
+              ${priceUsd.toLocaleString(undefined, { maximumFractionDigits: 6 })}
+            </p>
+          ) : (
+            <p className="text-[12px] text-[var(--text-dim)]">Price TBD</p>
+          )}
+          <span className="border border-[var(--accent)]/20 bg-[var(--accent)]/[0.06] px-1.5 py-0.5 text-[8px] font-bold uppercase tracking-[0.1em] text-[var(--accent)]">
+            {tierLabel}
+          </span>
+        </div>
+      </div>
+
+      {/* Stats Grid — mimics trade page stats */}
+      <div className="grid grid-cols-4 gap-px bg-[var(--border)]">
+        {[
+          { label: "Max Leverage", value: `${maxLeverage}x` },
+          { label: "Trading Fee", value: `${(tradingFeeBps / 100).toFixed(2)}%` },
+          { label: "Init Margin", value: `${(initialMarginBps / 100).toFixed(0)}%` },
+          { label: "Maint Margin", value: `${(maintenanceMarginBps / 100).toFixed(1)}%` },
+        ].map((stat) => (
+          <div key={stat.label} className="bg-[var(--panel-bg)] px-3 py-3 text-center">
+            <p className="text-[8px] font-medium uppercase tracking-[0.2em] text-[var(--text)]">{stat.label}</p>
+            <p className="mt-1 text-[13px] font-bold text-[var(--text)]">{stat.value}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Market Details */}
+      <div className="px-5 py-4 space-y-3">
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <p className="text-[8px] font-medium uppercase tracking-[0.2em] text-[var(--text)]">LP Collateral</p>
+            <p className="mt-0.5 text-[12px] font-semibold text-[var(--text)]">
+              {parseFloat(lpCollateral) > 0 ? `${parseFloat(lpCollateral).toLocaleString()} ${symbol}` : "—"}
+            </p>
+          </div>
+          <div>
+            <p className="text-[8px] font-medium uppercase tracking-[0.2em] text-[var(--text)]">Insurance Fund</p>
+            <p className="mt-0.5 text-[12px] font-semibold text-[var(--text)]">
+              {parseFloat(insuranceAmount) > 0 ? `${parseFloat(insuranceAmount).toLocaleString()} ${symbol}` : "—"}
+            </p>
+          </div>
+        </div>
+
+        {/* Tags */}
+        <div className="flex flex-wrap gap-1.5">
+          <span className="border border-[var(--border)] bg-[var(--bg-surface)] px-2 py-0.5 text-[9px] font-medium text-[var(--text-secondary)]">
+            {oracleMode === "auto" ? "Auto Oracle" : oracleMode === "dex" ? "DEX Oracle" : oracleMode === "pyth" ? "Pyth Oracle" : "Admin Oracle"}
+          </span>
+          <span className="border border-[var(--border)] bg-[var(--bg-surface)] px-2 py-0.5 text-[9px] font-medium text-[var(--text-secondary)]">
+            {tierSlots} Slots
+          </span>
+          <span className="border border-[var(--border)] bg-[var(--bg-surface)] px-2 py-0.5 text-[9px] font-medium text-[var(--text-secondary)]">
+            {tokenDecimals} Decimals
+          </span>
+          {inverted && (
+            <span className="border border-[var(--warning)]/30 bg-[var(--warning)]/[0.06] px-2 py-0.5 text-[9px] font-medium text-[var(--warning)]">
+              Inverted
+            </span>
+          )}
+          {vammEnabled && (
+            <span className="border border-[var(--accent)]/30 bg-[var(--accent)]/[0.06] px-2 py-0.5 text-[9px] font-medium text-[var(--accent)]">
+              vAMM
+            </span>
+          )}
+        </div>
+
+        {/* Mint Address */}
+        <div>
+          <p className="text-[8px] font-medium uppercase tracking-[0.2em] text-[var(--text)]">Token Mint</p>
+          <p className="mt-0.5 font-mono text-[10px] text-[var(--text-secondary)] break-all">{tokenMint}</p>
+        </div>
+
+        {/* Oracle Info */}
+        <div>
+          <p className="text-[8px] font-medium uppercase tracking-[0.2em] text-[var(--text)]">Oracle Source</p>
+          <p className="mt-0.5 text-[11px] text-[var(--text-secondary)]">{oracleLabel}</p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/app/components/create/ModeSelector.tsx
+++ b/app/components/create/ModeSelector.tsx
@@ -56,7 +56,7 @@ export const ModeSelector: FC<ModeSelectorProps> = ({ mode, onModeChange }) => {
               </span>
               <span
                 className={`text-[12px] font-semibold uppercase tracking-[0.1em] ${
-                  active ? "text-[var(--text)]" : "text-[var(--text-secondary)]"
+                  active ? "text-[var(--text)]" : "text-[var(--text)]"
                 }`}
               >
                 {tab.label}
@@ -64,21 +64,21 @@ export const ModeSelector: FC<ModeSelectorProps> = ({ mode, onModeChange }) => {
             </div>
             <p
               className={`text-[11px] ${
-                active ? "text-[var(--text-secondary)]" : "text-[var(--text-dim)]"
+                active ? "text-[var(--text-secondary)]" : "text-[var(--text-secondary)]"
               }`}
             >
               {tab.desc}
             </p>
             <p
               className={`text-[10px] ${
-                active ? "text-[var(--text-dim)]" : "text-[var(--text-dim)]"
+                active ? "text-[var(--text-secondary)]" : "text-[var(--text-secondary)]"
               }`}
             >
               {tab.detail}
             </p>
             <span
               className={`mt-2 inline-block text-[9px] font-medium uppercase tracking-[0.1em] ${
-                active ? "text-[var(--accent)]" : "text-[var(--text-dim)]"
+                active ? "text-[var(--accent)]" : "text-[var(--text-secondary)]"
               }`}
             >
               {tab.badge}

--- a/app/components/create/OracleBadge.tsx
+++ b/app/components/create/OracleBadge.tsx
@@ -17,7 +17,7 @@ export const OracleBadge: FC<OracleBadgeProps> = ({ type, label, feedId }) => {
     return (
       <div className="flex items-center gap-2 border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5">
         <span className="h-3.5 w-3.5 animate-spin border border-[var(--border)] border-t-[var(--accent)]" />
-        <span className="text-[11px] text-[var(--text-muted)]">Detecting oracle source...</span>
+        <span className="text-[11px] text-[var(--text-secondary)]">Detecting oracle source...</span>
       </div>
     );
   }
@@ -65,7 +65,7 @@ export const OracleBadge: FC<OracleBadgeProps> = ({ type, label, feedId }) => {
           {config.prefix} {label || "Unknown"}
         </span>
         {feedId && (
-          <p className="text-[10px] text-[var(--text-dim)] font-mono truncate mt-0.5">
+          <p className="text-[10px] text-[var(--text-secondary)] font-mono truncate mt-0.5">
             {feedId.length > 20 ? `${feedId.slice(0, 10)}...${feedId.slice(-6)}` : feedId}
           </p>
         )}

--- a/app/components/create/RecoverSolBanner.tsx
+++ b/app/components/create/RecoverSolBanner.tsx
@@ -54,11 +54,11 @@ export const RecoverSolBanner: FC<RecoverSolBannerProps> = ({ onResume, onReset,
         <div className="flex items-start justify-between gap-3">
           <div className="flex-1">
             <div className="flex items-center gap-2 mb-1">
-              <span className="text-[11px] font-medium text-[var(--text-muted)]">
+              <span className="text-[11px] font-medium text-[var(--text)]">
                 ℹ Previous attempt detected
               </span>
             </div>
-            <p className="text-[11px] text-[var(--text-dim)]">
+            <p className="text-[11px] text-[var(--text-secondary)]">
               A previous market creation attempt was found but the transaction was
               rolled back. No SOL was lost. You can safely start a new market.
             </p>
@@ -69,7 +69,7 @@ export const RecoverSolBanner: FC<RecoverSolBannerProps> = ({ onResume, onReset,
               clearStuck();
               setDismissed(true);
             }}
-            className="flex-shrink-0 text-[10px] text-[var(--text-dim)] hover:text-[var(--text)] transition-colors px-2 py-1"
+            className="flex-shrink-0 text-[10px] text-[var(--text-secondary)] hover:text-[var(--text)] transition-colors px-2 py-1"
             aria-label="Dismiss"
           >
             ✕
@@ -111,7 +111,7 @@ export const RecoverSolBanner: FC<RecoverSolBannerProps> = ({ onResume, onReset,
                 {stuckSlab.publicKey.toBase58().slice(-4)}
               </code>
             </p>
-            <p className="text-[10px] text-[var(--text-dim)]">
+            <p className="text-[10px] text-[var(--text-secondary)]">
               The slab account is initialized ({rentSol} SOL in rent).
               Resume to complete setup (oracle, LP, insurance).
             </p>
@@ -119,7 +119,7 @@ export const RecoverSolBanner: FC<RecoverSolBannerProps> = ({ onResume, onReset,
           <button
             type="button"
             onClick={() => setDismissed(true)}
-            className="flex-shrink-0 text-[10px] text-[var(--text-dim)] hover:text-[var(--text)] transition-colors px-2 py-1"
+            className="flex-shrink-0 text-[10px] text-[var(--text-secondary)] hover:text-[var(--text)] transition-colors px-2 py-1"
             aria-label="Dismiss"
           >
             ✕
@@ -268,7 +268,7 @@ const UninitialisedSlabBanner: FC<{
             </code>{" "}
             but market initialisation didn&apos;t complete.
           </p>
-          <p className="text-[10px] text-[var(--text-dim)]">
+          <p className="text-[10px] text-[var(--text-secondary)]">
             <strong className="text-[var(--warning)]">{rentSol} SOL</strong> is
             locked as rent. You can reclaim it now, retry initialisation, or start fresh.
           </p>
@@ -281,7 +281,7 @@ const UninitialisedSlabBanner: FC<{
         <button
           type="button"
           onClick={() => setDismissed(true)}
-          className="flex-shrink-0 text-[10px] text-[var(--text-dim)] hover:text-[var(--text)] transition-colors px-2 py-1"
+          className="flex-shrink-0 text-[10px] text-[var(--text-secondary)] hover:text-[var(--text)] transition-colors px-2 py-1"
           aria-label="Dismiss"
         >
           ✕
@@ -326,7 +326,7 @@ const UninitialisedSlabBanner: FC<{
           href={`https://explorer.solana.com/address/${stuckSlab.publicKey.toBase58()}?cluster=devnet`}
           target="_blank"
           rel="noopener noreferrer"
-          className="border border-[var(--border)] px-4 py-2 text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text-dim)] hover:text-[var(--text)] transition-colors"
+          className="border border-[var(--border)] px-4 py-2 text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text-secondary)] hover:text-[var(--text)] transition-colors"
         >
           VIEW ON EXPLORER ↗
         </a>

--- a/app/components/create/SlabTierPicker.tsx
+++ b/app/components/create/SlabTierPicker.tsx
@@ -62,7 +62,7 @@ export const SlabTierPicker: FC<SlabTierPickerProps> = ({ value, onChange }) => 
                 >
                   {tier.label}
                 </span>
-                <p className="text-[10px] text-[var(--text-dim)] mt-0.5">
+                <p className="text-[10px] text-[var(--text-secondary)] mt-0.5">
                   {TIER_DESCRIPTIONS[key]} · {tier.maxAccounts} slots
                 </p>
               </div>

--- a/app/components/create/StepOracleSelect.tsx
+++ b/app/components/create/StepOracleSelect.tsx
@@ -165,10 +165,10 @@ export const StepOracleSelect: FC<StepOracleSelectProps> = ({
               <p className="mt-2 text-[11px] text-[var(--text-secondary)]">
                 {opt.desc}
               </p>
-              <p className="mt-1 text-[10px] text-[var(--text-dim)]">{opt.detail}</p>
+              <p className="mt-1 text-[10px] text-[var(--text-secondary)]">{opt.detail}</p>
               <p
                 className={`mt-2 text-[9px] ${
-                  selected ? "text-[var(--accent)]" : "text-[var(--text-dim)]"
+                  selected ? "text-[var(--accent)]" : "text-[var(--text-secondary)]"
                 }`}
               >
                 {opt.note}
@@ -199,7 +199,7 @@ export const StepOracleSelect: FC<StepOracleSelectProps> = ({
         <div className="space-y-2">
           <label
             htmlFor="pyth-feed"
-            className="block text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)]"
+            className="block text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text)]"
           >
             Pyth Feed ID
           </label>
@@ -217,7 +217,7 @@ export const StepOracleSelect: FC<StepOracleSelectProps> = ({
                   className="flex w-full items-center justify-between border border-[var(--border)] px-3 py-2 text-left text-[12px] hover:border-[var(--accent)]/30 hover:bg-[var(--accent)]/[0.04] transition-colors"
                 >
                   <span className="font-medium text-[var(--text)]">{f.displayName}</span>
-                  <span className="font-mono text-[10px] text-[var(--text-dim)]">
+                  <span className="font-mono text-[10px] text-[var(--text-secondary)]">
                     {f.id.slice(0, 12)}...
                   </span>
                 </button>
@@ -268,7 +268,7 @@ export const StepOracleSelect: FC<StepOracleSelectProps> = ({
         <div className="space-y-2">
           <label
             htmlFor="dex-pool"
-            className="block text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)]"
+            className="block text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text)]"
           >
             DEX Pool Address
           </label>
@@ -288,11 +288,11 @@ export const StepOracleSelect: FC<StepOracleSelectProps> = ({
                 >
                   <div>
                     <span className="font-medium text-[var(--text)]">{pool.pairLabel}</span>
-                    <span className="ml-2 text-[10px] text-[var(--text-dim)] capitalize">
+                    <span className="ml-2 text-[10px] text-[var(--text-secondary)] capitalize">
                       {pool.dexId}
                     </span>
                   </div>
-                  <span className="text-[10px] text-[var(--text-muted)]">
+                  <span className="text-[10px] text-[var(--text-secondary)]">
                     ${pool.liquidityUsd.toLocaleString()} liq
                   </span>
                 </button>
@@ -325,7 +325,7 @@ export const StepOracleSelect: FC<StepOracleSelectProps> = ({
           {isMainnet && selectedDexPool && selectedDexPool.liquidityUsd < MIN_MAINNET_POOL_DEPTH_USD && (
             <div className="border border-[var(--short)]/40 bg-[var(--short)]/[0.06] px-4 py-3 text-[11px]">
               <p className="text-[var(--short)] font-medium">✗ Insufficient pool depth for mainnet</p>
-              <p className="text-[var(--text-muted)] mt-1">
+              <p className="text-[var(--text-secondary)] mt-1">
                 Pool has ${(selectedDexPool.liquidityUsd / 1000).toFixed(0)}K liquidity. Mainnet requires $2M+ DEX pool depth to prevent oracle manipulation.
               </p>
             </div>

--- a/app/components/create/StepParameters.tsx
+++ b/app/components/create/StepParameters.tsx
@@ -61,7 +61,7 @@ export const StepParameters: FC<StepParametersProps> = ({
     <div className="space-y-6">
       {/* Slab Tier */}
       <div>
-        <label className="block text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)] mb-3">
+        <label className="block text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text)] mb-3">
           Slab Tier
         </label>
         <SlabTierPicker value={slabTier} onChange={onSlabTierChange} />
@@ -80,14 +80,14 @@ export const StepParameters: FC<StepParametersProps> = ({
       {/* Leverage (derived, read-only) */}
       <div className="border border-[var(--border)] bg-[var(--bg)] px-4 py-3">
         <div className="flex items-center justify-between">
-          <span className="text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)]">
+          <span className="text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text)]">
             Max Leverage
           </span>
           <span className="text-[14px] font-bold text-[var(--text)]">
             {maxLeverage}x
           </span>
         </div>
-        <p className="text-[10px] text-[var(--text-dim)] mt-1">
+        <p className="text-[10px] text-[var(--text-secondary)] mt-1">
           Auto from margin: {initialMarginBps} bps ({(initialMarginBps / 100).toFixed(0)}%)
         </p>
       </div>
@@ -108,9 +108,9 @@ export const StepParameters: FC<StepParametersProps> = ({
       {isMainnet && (
         <div className="border border-[var(--accent)]/30 bg-[var(--accent)]/[0.04] px-4 py-3 text-[11px] space-y-1">
           <p className="text-[var(--accent)] font-medium">⚡ Mainnet Phase 1 Guards Active</p>
-          <p className="text-[var(--text-muted)]">• $10K OI cap per market during beta</p>
-          <p className="text-[var(--text-muted)]">• 2x max leverage enforced on-chain</p>
-          <p className="text-[var(--text-muted)]">• Guards auto-lift when caps are raised by DAO</p>
+          <p className="text-[var(--text)]">• $10K OI cap per market during beta</p>
+          <p className="text-[var(--text)]">• 2x max leverage enforced on-chain</p>
+          <p className="text-[var(--text)]">• Guards auto-lift when caps are raised by DAO</p>
         </div>
       )}
 
@@ -125,7 +125,7 @@ export const StepParameters: FC<StepParametersProps> = ({
         <div>
           <label
             htmlFor="admin-price"
-            className="block text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)] mb-2"
+            className="block text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text)] mb-2"
           >
             Initial Price (admin oracle)
           </label>
@@ -137,7 +137,7 @@ export const StepParameters: FC<StepParametersProps> = ({
             placeholder="1.000000"
             className="w-full border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-[12px] font-mono text-[var(--text)] placeholder:text-[var(--text-dim)] focus:border-[var(--accent)]/40 focus:outline-none"
           />
-          <p className="mt-1 text-[10px] text-[var(--text-dim)]">
+          <p className="mt-1 text-[10px] text-[var(--text-secondary)]">
             This sets the starting mark price. Update via your crank.
           </p>
         </div>
@@ -147,11 +147,11 @@ export const StepParameters: FC<StepParametersProps> = ({
       <div>
         <label
           htmlFor="lp-collateral"
-          className="block text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)] mb-2"
+          className="block text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text)] mb-2"
         >
           Seed Deposit (LP collateral){" "}
           {tokenSymbol && (
-            <span className="normal-case tracking-normal text-[var(--text-dim)]">
+            <span className="normal-case tracking-normal text-[var(--text-secondary)]">
               in {tokenSymbol}
             </span>
           )}
@@ -165,7 +165,7 @@ export const StepParameters: FC<StepParametersProps> = ({
           className="w-full border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-[12px] text-[var(--text)] placeholder:text-[var(--text-dim)] focus:border-[var(--accent)]/40 focus:outline-none"
         />
         {walletBalance && (
-          <p className="mt-1 text-[10px] font-mono text-[var(--text-dim)]">
+          <p className="mt-1 text-[10px] font-mono text-[var(--text-secondary)]">
             Wallet balance: {walletBalance} {tokenSymbol}
           </p>
         )}
@@ -175,11 +175,11 @@ export const StepParameters: FC<StepParametersProps> = ({
       <div>
         <label
           htmlFor="insurance-amount"
-          className="block text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)] mb-2"
+          className="block text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text)] mb-2"
         >
           Insurance Fund Seed{" "}
           {tokenSymbol && (
-            <span className="normal-case tracking-normal text-[var(--text-dim)]">
+            <span className="normal-case tracking-normal text-[var(--text-secondary)]">
               in {tokenSymbol}
             </span>
           )}
@@ -192,7 +192,7 @@ export const StepParameters: FC<StepParametersProps> = ({
           placeholder="100"
           className="w-full border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-[12px] text-[var(--text)] placeholder:text-[var(--text-dim)] focus:border-[var(--accent)]/40 focus:outline-none"
         />
-        <p className="mt-1 text-[10px] text-[var(--text-dim)]">
+        <p className="mt-1 text-[10px] text-[var(--text-secondary)]">
           Minimum: 100 tokens
         </p>
       </div>

--- a/app/components/create/StepReview.tsx
+++ b/app/components/create/StepReview.tsx
@@ -134,7 +134,7 @@ export const StepReview: FC<StepReviewProps> = ({
 
       {/* Market Preview Card */}
       <div>
-        <p className="mb-2 text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">
+        <p className="mb-2 text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text)]">
           Market Preview
         </p>
         <div className="border border-[var(--accent)]/20 bg-[var(--accent)]/[0.02] backdrop-blur">
@@ -150,20 +150,20 @@ export const StepReview: FC<StepReviewProps> = ({
                 >
                   {tokenSymbol}-PERP
                 </h3>
-                <p className="text-[10px] text-[var(--text-dim)]">
+                <p className="text-[10px] text-[var(--text-secondary)]">
                   Oracle: {oracleTypeLabel} · {oracleLabel}
                 </p>
-                <p className="text-[9px] text-[var(--text-dim)] font-mono mt-0.5">
+                <p className="text-[9px] text-[var(--text-secondary)] font-mono mt-0.5">
                   Mint: {mintAddress.slice(0, 8)}...{mintAddress.slice(-6)}
                 </p>
               </div>
             </div>
             <div className="text-right">
               <div className="flex items-center gap-1.5 justify-end">
-                <span className="border border-[var(--border)] bg-[var(--bg-surface)] px-1.5 py-0.5 text-[9px] font-medium text-[var(--text-muted)]">
+                <span className="border border-[var(--border)] bg-[var(--bg-surface)] px-1.5 py-0.5 text-[9px] font-medium text-[var(--text-secondary)]">
                   {tradingFeeBps} bps
                 </span>
-                <span className="border border-[var(--border)] bg-[var(--bg-surface)] px-1.5 py-0.5 text-[9px] font-medium text-[var(--text-muted)]">
+                <span className="border border-[var(--border)] bg-[var(--bg-surface)] px-1.5 py-0.5 text-[9px] font-medium text-[var(--text-secondary)]">
                   {maxLeverage}x
                 </span>
                 <span className="border border-[var(--accent)]/20 bg-[var(--accent)]/[0.06] px-1.5 py-0.5 text-[9px] font-bold uppercase text-[var(--accent)]">
@@ -191,7 +191,7 @@ export const StepReview: FC<StepReviewProps> = ({
           {hasSufficientBalance ? (
             <>
               <span className="text-[var(--long)]">✓</span>
-              <span className="text-[var(--text-muted)]">
+              <span className="text-[var(--text-secondary)]">
                 Your balance: {walletBalanceSol.toFixed(4)} SOL
               </span>
             </>
@@ -213,7 +213,7 @@ export const StepReview: FC<StepReviewProps> = ({
             <span className="text-[var(--long)] font-medium">✓ Devnet mode.</span>{" "}
             Your wallet will receive devnet {tokenSymbol} tokens automatically after the market is created.
           </p>
-          <p className="text-[9px] text-[var(--text-dim)]">
+          <p className="text-[9px] text-[var(--text-secondary)]">
             No tokens needed upfront — tokens are airdropped post-launch for testing.
           </p>
         </div>
@@ -224,7 +224,7 @@ export const StepReview: FC<StepReviewProps> = ({
             <span className="text-[var(--accent)] font-medium">ℹ Custom token.</span>{" "}
             You are the mint authority — tokens will not be auto-airdropped.
           </p>
-          <p className="text-[9px] text-[var(--text-dim)]">
+          <p className="text-[9px] text-[var(--text-secondary)]">
             After launch, mint tokens from your wallet and deposit them into the vault to enable trading.
           </p>
         </div>
@@ -232,23 +232,23 @@ export const StepReview: FC<StepReviewProps> = ({
 
       {/* Transaction Steps */}
       <div>
-        <p className="mb-2 text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">
+        <p className="mb-2 text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text)]">
           Transaction Steps
         </p>
         <div className="border border-[var(--border)] bg-[var(--bg)] px-4 py-3 space-y-2">
           {TX_STEPS.map((step, i) => (
             <div key={i} className="flex items-start gap-2 text-[12px]">
-              <span className="text-[10px] font-mono text-[var(--text-dim)] mt-0.5 flex-shrink-0">{i + 1}.</span>
+              <span className="text-[10px] font-mono text-[var(--text-secondary)] mt-0.5 flex-shrink-0">{i + 1}.</span>
               <div className="min-w-0">
-                <span className="text-[var(--text-dim)]">{step.label}</span>
-                <span className="hidden sm:inline text-[10px] text-[var(--text-dim)]/60 ml-2">
+                <span className="text-[var(--text)]">{step.label}</span>
+                <span className="hidden sm:inline text-[10px] text-[var(--text-secondary)] ml-2">
                   — {step.detail}
                 </span>
               </div>
             </div>
           ))}
         </div>
-        <p className="mt-2 text-[10px] text-[var(--text-dim)]">
+        <p className="mt-2 text-[10px] text-[var(--text-secondary)]">
           {TX_STEPS.length} transactions — each requires a wallet signature.
           {" "}Step 1 is atomic: if it fails, no SOL is lost.
         </p>

--- a/app/components/create/StepTokenSelect.tsx
+++ b/app/components/create/StepTokenSelect.tsx
@@ -370,7 +370,7 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
       <div>
         <label
           htmlFor="token-mint"
-          className="block text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)] mb-2"
+          className="block text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text)] mb-2"
         >
           Token Mint Address
         </label>
@@ -445,7 +445,7 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
                   {effectiveMeta.name}
                 </span>
               </p>
-              <p className="text-[10px] font-mono text-[var(--text-dim)] truncate">
+              <p className="text-[10px] font-mono text-[var(--text-secondary)] truncate">
                 {debounced.slice(0, 6)}...{debounced.slice(-4)}
               </p>
               {mirrorMeta && !isNativeDevnetMint && (
@@ -472,7 +472,7 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
 
       {/* Balance */}
       {mintValid && !balanceLoading && balance !== null && effectiveMeta && (
-        <div className="text-[11px] font-mono text-[var(--text-dim)]">
+        <div className="text-[11px] font-mono text-[var(--text-secondary)]">
           Wallet balance:{" "}
           <span className={balance > 0n ? "text-[var(--text)]" : "text-[var(--short)]"}>
             {formatHumanAmount(balance, effectiveMeta.decimals)} {effectiveMeta.symbol}

--- a/app/components/create/WizardProgress.tsx
+++ b/app/components/create/WizardProgress.tsx
@@ -72,7 +72,7 @@ export const WizardProgress: FC<WizardProgressProps> = ({
                       ? "border border-[var(--accent)]/50 bg-[var(--accent)]/[0.15] text-[var(--accent)]"
                       : isActive
                         ? "border-2 border-[var(--accent)] bg-[var(--accent)]/[0.1] text-[var(--accent)] ring-2 ring-[var(--accent)]/20"
-                        : "border border-[var(--border)] bg-[var(--bg-surface)] text-[var(--text-dim)]"
+                        : "border border-[var(--border)] bg-[var(--bg-surface)] text-[var(--text-secondary)]"
                   }`}
                 >
                   {isCompleted ? "✓" : stepNum}
@@ -84,7 +84,7 @@ export const WizardProgress: FC<WizardProgressProps> = ({
                       ? "text-[var(--accent)] group-hover:text-[var(--accent)]"
                       : isActive
                         ? "text-[var(--text)]"
-                        : "text-[var(--text-dim)]"
+                        : "text-[var(--text-secondary)]"
                   }`}
                 >
                   {label}

--- a/app/components/portfolio/LpPositionsPanel.tsx
+++ b/app/components/portfolio/LpPositionsPanel.tsx
@@ -102,7 +102,7 @@ function LpPositionCard({ position: pos }: LpPositionCardProps) {
               <p className="text-sm font-semibold text-[var(--text)] truncate" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
                 {displaySymbol}-PERP
               </p>
-              <p className="text-[10px] text-[var(--text-dim)] truncate">
+              <p className="text-[10px] text-[var(--text-secondary)] truncate">
                 {pos.poolMode === 0 ? "Insurance LP" : "Trading LP"}
               </p>
             </div>
@@ -119,7 +119,7 @@ function LpPositionCard({ position: pos }: LpPositionCardProps) {
             >
               {formatUsd(pos.redeemable)}
             </p>
-            <p className="text-[10px] text-[var(--text-dim)]">
+            <p className="text-[10px] text-[var(--text-secondary)]">
               redeemable
             </p>
           </div>
@@ -128,7 +128,7 @@ function LpPositionCard({ position: pos }: LpPositionCardProps) {
         {/* Details grid */}
         <div className="mt-3 grid grid-cols-2 gap-x-6 gap-y-1.5 sm:grid-cols-4">
           <div>
-            <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">LP Balance</p>
+            <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text)]">LP Balance</p>
             <p
               className="text-[12px] text-[var(--text-secondary)]"
               style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}
@@ -138,7 +138,7 @@ function LpPositionCard({ position: pos }: LpPositionCardProps) {
           </div>
 
           <div>
-            <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">Pool Share</p>
+            <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text)]">Pool Share</p>
             <p
               className="text-[12px] text-[var(--text-secondary)]"
               style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}
@@ -148,7 +148,7 @@ function LpPositionCard({ position: pos }: LpPositionCardProps) {
           </div>
 
           <div>
-            <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">Pool TVL</p>
+            <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text)]">Pool TVL</p>
             <p
               className="text-[12px] text-[var(--text-secondary)]"
               style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}
@@ -158,7 +158,7 @@ function LpPositionCard({ position: pos }: LpPositionCardProps) {
           </div>
 
           <div>
-            <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">Withdraw</p>
+            <p className="text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text)]">Withdraw</p>
             {pos.cooldownElapsed ? (
               <p className="text-[12px] font-semibold text-[var(--long)]">
                 ✓ Ready
@@ -240,7 +240,7 @@ export function LpPositionsPanel({
           <span className="text-xl leading-none">⚠️</span>
           <div>
             <p className="text-[12px] font-semibold text-[var(--text-secondary)]">Unable to load LP positions</p>
-            <p className="mt-0.5 text-[11px] text-[var(--text-dim)]">Please try refreshing</p>
+            <p className="mt-0.5 text-[11px] text-[var(--text-secondary)]">Please try refreshing</p>
           </div>
           {onRetry && (
             <button
@@ -254,8 +254,8 @@ export function LpPositionsPanel({
       ) : positions.length === 0 ? (
         <div className="border border-[var(--border)] bg-[var(--panel-bg)] p-6 flex items-center justify-between gap-4">
           <div>
-            <p className="text-[12px] font-medium text-[var(--text-secondary)]">No LP positions</p>
-            <p className="mt-0.5 text-[11px] text-[var(--text-dim)]">
+            <p className="text-[12px] font-medium text-[var(--text)]">No LP positions</p>
+            <p className="mt-0.5 text-[11px] text-[var(--text-secondary)]">
               Deposit into insurance pools to earn yield while backing the fund.
             </p>
           </div>

--- a/app/components/trade/AccountsCard.tsx
+++ b/app/components/trade/AccountsCard.tsx
@@ -121,7 +121,7 @@ export const AccountsCard: FC = () => {
   const isOpenLike = tab === "open" || tab === "leaderboard";
 
   const SortHeader: FC<{ label: string; sKey: SortKey; align?: "left" | "right"; className?: string }> = ({ label, sKey, align = "right", className = "" }) => (
-    <th onClick={() => toggleSort(sKey)} className={`cursor-pointer select-none whitespace-nowrap px-2 py-1.5 font-medium ${align === "left" ? "text-left" : "text-right"} hover:text-[var(--text-secondary)] ${className}`}>
+    <th onClick={() => toggleSort(sKey)} className={`cursor-pointer select-none whitespace-nowrap px-2 py-1.5 font-medium transition-colors ${align === "left" ? "text-left" : "text-right"} hover:text-[var(--accent)] ${className}`}>
       {label}
       {sortKey === sKey ? <span className="ml-0.5 text-[var(--long)]">{sortDir === "asc" ? "^" : "v"}</span> : ""}
     </th>
@@ -139,23 +139,23 @@ export const AccountsCard: FC = () => {
         {tabs.map((t) => (
           <button key={t.key} onClick={() => setTab(t.key)}
             className={`rounded-none px-2 py-1 text-[9px] font-medium uppercase tracking-[0.15em] transition-all ${
-              tab === t.key ? "border-b border-[var(--accent)] text-[var(--accent)]" : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+              tab === t.key ? "border-b border-[var(--accent)] text-[var(--accent)]" : "text-[var(--text-secondary)] hover:text-[var(--text)]"
             }`}>
             {t.label} ({t.count})
           </button>
         ))}
-        <span className="ml-auto text-[9px] text-[var(--text-dim)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>{accounts.length} total</span>
+        <span className="ml-auto text-[9px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>{accounts.length} total</span>
       </div>
 
       {sortedRows.length === 0 ? (
-        <p className="py-4 text-center text-[10px] text-[var(--text-muted)]">
+        <p className="py-4 text-center text-[10px] text-[var(--text)]">
           {tab === "open" ? "No open positions" : tab === "idle" ? "No idle accounts" : "No data"}
         </p>
       ) : (
         <div className="max-h-[420px] overflow-y-auto overflow-x-auto">
           <table className="min-w-full text-[10px]">
             <thead className="sticky top-0 z-10 bg-[var(--bg)]/95">
-              <tr className="border-b border-[var(--border)]/30 text-[8px] uppercase tracking-[0.15em] text-[var(--text-dim)]">
+              <tr className="border-b border-[var(--border)]/30 text-[8px] uppercase tracking-[0.15em] text-[var(--text)]">
                 <SortHeader label="#" sKey="idx" align="left" />
                 <SortHeader label="Owner" sKey="owner" align="left" />
                 {isOpenLike && <SortHeader label="Side" sKey="direction" align="left" />}

--- a/app/components/trade/FundingRateCard.tsx
+++ b/app/components/trade/FundingRateCard.tsx
@@ -239,7 +239,7 @@ export const FundingRateCard: FC<{ slabAddress: string }> = ({ slabAddress }) =>
     return (
       <div className="rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 p-3">
         <div className="flex items-center justify-between">
-          <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Funding Rate</span>
+          <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text)]">Funding Rate</span>
           <div className="h-4 w-16 animate-pulse rounded-none bg-[var(--border)]" />
         </div>
       </div>
@@ -266,7 +266,7 @@ export const FundingRateCard: FC<{ slabAddress: string }> = ({ slabAddress }) =>
         {/* Header row: label + rate + APR */}
         <div className="mb-1 flex items-center justify-between">
           <div className="flex items-center gap-1">
-            <span className="text-[9px] font-bold uppercase tracking-[0.15em] text-[var(--text-dim)]">
+            <span className="text-[9px] font-bold uppercase tracking-[0.15em] text-[var(--text)]">
               Funding Rate
             </span>
             <InfoIcon tooltip="Funding rates balance long/short positions. Percolator uses inventory-based funding to protect LPs." />
@@ -284,7 +284,7 @@ export const FundingRateCard: FC<{ slabAddress: string }> = ({ slabAddress }) =>
             >
               {rateDisplay}
             </span>
-            <span className="text-[9px] text-[var(--text-dim)]">/8h</span>
+            <span className="text-[9px] text-[var(--text)]">/8h</span>
           </div>
         </div>
 
@@ -293,7 +293,7 @@ export const FundingRateCard: FC<{ slabAddress: string }> = ({ slabAddress }) =>
           <div className="rounded-none border-l-2 border-l-[var(--border)] bg-[var(--bg-elevated)] px-1.5 py-0.5">
             <span className="text-[10px] text-[var(--text-secondary)]">{directionText}</span>
             {countdown > 0 && (
-              <span className="ml-1.5 text-[9px] text-[var(--text-dim)]">· next {formatCountdown(countdown)}</span>
+              <span className="ml-1.5 text-[9px] text-[var(--text-secondary)]">· next {formatCountdown(countdown)}</span>
             )}
           </div>
           <span className="text-[10px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
@@ -304,7 +304,7 @@ export const FundingRateCard: FC<{ slabAddress: string }> = ({ slabAddress }) =>
         {/* P3-4: Mini bar chart — last 4 periods */}
         {miniChartRates.length > 0 && (
           <div className="mb-1 flex items-center justify-between">
-            <span className="text-[9px] text-[var(--text-dim)] uppercase tracking-[0.1em]">Last {miniChartRates.length} periods</span>
+            <span className="text-[9px] text-[var(--text)] uppercase tracking-[0.1em]">Last {miniChartRates.length} periods</span>
             <FundingMiniChart rates={miniChartRates} />
           </div>
         )}
@@ -313,7 +313,7 @@ export const FundingRateCard: FC<{ slabAddress: string }> = ({ slabAddress }) =>
         {positionDirection && estimatedFunding24h !== null && (
           <div className="rounded-none border border-[var(--border)]/30 bg-[var(--bg)] px-1.5 py-1">
             <div className="flex items-center justify-between">
-              <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">
+              <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text)]">
                 Est. 24h ({positionDirection})
               </span>
               <span className={`text-[11px] font-bold ${fundingColor}`} style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>

--- a/app/components/trade/FundingRateChart.tsx
+++ b/app/components/trade/FundingRateChart.tsx
@@ -250,7 +250,7 @@ export const FundingRateChart: FC<{ slabAddress: string }> = ({ slabAddress }) =
   return (
     <div className="rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 p-3">
       <div className="mb-2 flex items-center justify-between">
-        <h3 className="text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-dim)]">
+        <h3 className="text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text)]">
           Funding Rate (24h)
         </h3>
         <div className={`text-right transition-opacity duration-100 ${hoveredPoint ? "opacity-100" : "opacity-0 pointer-events-none"}`}>
@@ -258,7 +258,7 @@ export const FundingRateChart: FC<{ slabAddress: string }> = ({ slabAddress }) =
             {(hoveredPoint?.hourlyRatePercent ?? 0) >= 0 ? "+" : ""}
             {(hoveredPoint?.hourlyRatePercent ?? 0).toFixed(4)}%/h
           </div>
-          <div className="text-[10px] text-[var(--text-dim)]">
+          <div className="text-[10px] text-[var(--text-secondary)]">
             {hoveredPoint ? new Date(hoveredPoint.timestamp).toLocaleString() : "\u00A0"}
           </div>
         </div>

--- a/app/components/trade/MarketBookCard.tsx
+++ b/app/components/trade/MarketBookCard.tsx
@@ -75,7 +75,7 @@ export const MarketBookCard: FC = () => {
       {/* Header with hide control — lets the user collapse the order book
           when they prefer a cleaner trade view. Persists via localStorage. */}
       <div className="mb-2 flex items-center justify-between">
-        <span className="text-[9px] font-semibold uppercase tracking-[0.15em] text-[var(--text-dim)]">
+        <span className="text-[9px] font-semibold uppercase tracking-[0.15em] text-[var(--text)]">
           Order Book
         </span>
         <button
@@ -83,7 +83,7 @@ export const MarketBookCard: FC = () => {
           onClick={toggleBook}
           aria-label="Hide order book"
           title="Hide order book"
-          className="rounded-none border border-[var(--border)]/40 px-1.5 py-0.5 text-[10px] leading-none text-[var(--text-dim)] hover:border-[var(--accent)]/40 hover:text-[var(--text-secondary)] focus-visible:ring-1 focus-visible:ring-[var(--accent)]/30"
+          className="rounded-none border border-[var(--border)]/40 px-1.5 py-0.5 text-[10px] leading-none text-[var(--text-secondary)] hover:border-[var(--accent)]/40 hover:text-[var(--text)] focus-visible:ring-1 focus-visible:ring-[var(--accent)]/30"
         >
           ×
         </button>
@@ -93,12 +93,12 @@ export const MarketBookCard: FC = () => {
       <div className="mb-2 grid grid-cols-3 gap-px border border-[var(--border)]/30">
         {/* Bid */}
         <div className="bg-[var(--bg)] p-2 text-center">
-          <p className="text-[8px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Bid</p>
+          <p className="text-[8px] uppercase tracking-[0.15em] text-[var(--text)]">Bid</p>
           <p className="text-[11px] font-medium text-[var(--long)]" style={{ fontFamily: "var(--font-mono)" }}>{formatUsdPriceE6(bestBidE6)}</p>
         </div>
         {/* Oracle — subtle accent border + bg */}
         <div className="p-2 text-center border-x border-[var(--accent)]/20 bg-[var(--accent)]/[0.03]">
-          <p className="text-[8px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Oracle</p>
+          <p className="text-[8px] uppercase tracking-[0.15em] text-[var(--text)]">Oracle</p>
           <p
             className="text-[13px] font-medium text-[var(--text)]"
             style={{ fontFamily: "var(--font-mono)" }}
@@ -108,7 +108,7 @@ export const MarketBookCard: FC = () => {
         </div>
         {/* Ask */}
         <div className="bg-[var(--bg)] p-2 text-center">
-          <p className="text-[8px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Ask</p>
+          <p className="text-[8px] uppercase tracking-[0.15em] text-[var(--text)]">Ask</p>
           <p className="text-[11px] font-medium text-[var(--short)]" style={{ fontFamily: "var(--font-mono)" }}>{formatUsdPriceE6(bestAskE6)}</p>
         </div>
       </div>
@@ -116,10 +116,10 @@ export const MarketBookCard: FC = () => {
       {/* 2.2: Spread row */}
       {oraclePrice > 0n && (
         <div className="mb-3 flex items-center justify-between px-0.5">
-          <span className="text-[9px] uppercase tracking-[0.12em] text-[var(--text-dim)] font-mono">Spread</span>
-          <span className="text-[9px] text-[var(--text-dim)] font-mono">
+          <span className="text-[9px] uppercase tracking-[0.12em] text-[var(--text)] font-mono">Spread</span>
+          <span className="text-[9px] text-[var(--text)] font-mono">
             ${spreadUsd.toFixed(spreadUsd < 0.001 ? 6 : 4)}{" "}
-            <span className="text-[var(--text-dim)]/60">({spreadPct.toFixed(3)}%)</span>
+            <span className="text-[var(--text-secondary)]">({spreadPct.toFixed(3)}%)</span>
           </span>
         </div>
       )}
@@ -164,7 +164,7 @@ export const MarketBookCard: FC = () => {
       {lps.length > 0 && (
         <div>
           {/* Header */}
-          <div className="mb-1 flex gap-1 text-[8px] uppercase tracking-[0.1em] text-[var(--text-muted)] font-medium">
+          <div className="mb-1 flex gap-1 text-[8px] uppercase tracking-[0.1em] text-[var(--text)] font-medium">
             <span className="w-5">#</span>
             <span className="flex-1">L.P.</span>
             <span className="w-20 text-right">Capital</span>
@@ -204,7 +204,7 @@ export const MarketBookCard: FC = () => {
             {/* +N more row */}
             {hiddenLpCount > 0 && (
               <div className="py-1 text-center">
-                <span className="text-[9px] text-[var(--text-dim)]">+{hiddenLpCount} more</span>
+                <span className="text-[9px] text-[var(--text-secondary)]">+{hiddenLpCount} more</span>
               </div>
             )}
           </div>

--- a/app/components/trade/MarketStatsCard.tsx
+++ b/app/components/trade/MarketStatsCard.tsx
@@ -241,7 +241,7 @@ export const MarketStatsCard: FC = () => {
               className="min-w-0 overflow-hidden"
             >
               <p
-                className="text-[10px] uppercase tracking-widest text-[var(--text-muted)] font-medium leading-tight mb-0.5"
+                className="text-[10px] uppercase tracking-widest text-[var(--text)] font-medium leading-tight mb-0.5"
                 style={{ wordBreak: "break-word", overflowWrap: "anywhere" }}
                 title={s.label}
               >
@@ -271,10 +271,10 @@ export const MarketStatsCard: FC = () => {
           <div className="rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80">
             <button
               onClick={() => setShowFundingChart(!showFundingChart)}
-              className="flex w-full items-center justify-between px-2 py-1 text-left text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)] transition-colors hover:text-[var(--text-secondary)]"
+              className="flex w-full items-center justify-between px-2 py-1 text-left text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-secondary)] transition-colors hover:text-[var(--text)]"
             >
               <span>Funding History</span>
-              <span className={`text-[9px] text-[var(--text-dim)] transition-transform duration-200 ${showFundingChart ? "rotate-180" : ""}`}>▾</span>
+              <span className={`text-[9px] text-[var(--text-secondary)] transition-transform duration-200 ${showFundingChart ? "rotate-180" : ""}`}>▾</span>
             </button>
             {showFundingChart && (
               <div className="px-2 pb-2">

--- a/app/components/trade/PositionNftPanel.tsx
+++ b/app/components/trade/PositionNftPanel.tsx
@@ -61,7 +61,7 @@ export const PositionNftPanel: FC<{ slabAddress: string }> = ({ slabAddress }) =
     return (
       <div className="relative rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 p-3">
         <div className="flex flex-col items-center py-4 text-center">
-          <p className="text-[11px] font-medium text-[var(--text-muted)]">Position NFT</p>
+          <p className="text-[11px] font-medium text-[var(--text)]">Position NFT</p>
           <p className="mt-1 text-[10px] text-[var(--text-dim)]">Connect wallet to view NFT status.</p>
         </div>
       </div>
@@ -91,7 +91,7 @@ export const PositionNftPanel: FC<{ slabAddress: string }> = ({ slabAddress }) =
       <div className="p-3 space-y-2">
         {/* Status row */}
         <div className="flex items-center justify-between py-1">
-          <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Status</span>
+          <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text)]">Status</span>
           <span
             className={`text-[11px] font-semibold ${
               hasMintedNft ? "text-[var(--long)]" : "text-[var(--text-muted)]"
@@ -105,7 +105,7 @@ export const PositionNftPanel: FC<{ slabAddress: string }> = ({ slabAddress }) =
         {/* Mint address — shown when NFT exists */}
         {hasMintedNft && mintAddress && (
           <div className="flex items-center justify-between py-1 border-t border-[var(--border)]/30">
-            <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Mint</span>
+            <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text)]">Mint</span>
             <a
               href={explorerAccountUrl(mintAddress)}
               target="_blank"

--- a/app/components/trade/PositionPanel.tsx
+++ b/app/components/trade/PositionPanel.tsx
@@ -123,18 +123,18 @@ const AddMarginModal: FC<AddMarginModalProps> = ({ slabAddress, userIdx, symbol,
           <span className="text-[11px] font-bold uppercase tracking-[0.15em] text-[var(--text)]">Add Margin</span>
           <button
             onClick={onClose}
-            className="text-[var(--text-dim)] hover:text-[var(--text)] transition-colors"
+            className="text-[var(--text-secondary)] hover:text-[var(--text)] transition-colors"
           >
             ×
           </button>
         </div>
 
-        <p className="mb-3 text-[10px] text-[var(--text-dim)] leading-relaxed">
+        <p className="mb-3 text-[10px] text-[var(--text-secondary)] leading-relaxed">
           Deposit additional collateral to increase your margin and reduce liquidation risk.
         </p>
 
         <div className="mb-2 flex flex-col gap-1">
-          <label className="text-[9px] uppercase tracking-[0.12em] text-[var(--text-dim)]">
+          <label className="text-[9px] uppercase tracking-[0.12em] text-[var(--text)]">
             Amount ({symbol})
           </label>
           <input
@@ -162,7 +162,7 @@ const AddMarginModal: FC<AddMarginModalProps> = ({ slabAddress, userIdx, symbol,
           <p className="mt-2 text-[10px] text-[var(--short)]">{error}</p>
         )}
         {lastSig && (
-          <p className="mt-2 text-[10px] text-[var(--text-dim)]" style={{ fontFamily: "var(--font-mono)" }}>
+          <p className="mt-2 text-[10px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-mono)" }}>
             Tx: {lastSig.slice(0, 16)}…
           </p>
         )}
@@ -223,8 +223,8 @@ export const PositionPanel: FC<{ slabAddress: string }> = ({ slabAddress }) => {
     return (
       <div className="relative rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 p-3">
         <div className="flex flex-col items-center py-6 text-center">
-          <p className="text-[11px] font-medium text-[var(--text-muted)]">No open position</p>
-          <p className="mt-1.5 text-[10px] text-[var(--text-dim)] leading-relaxed max-w-[240px]">
+          <p className="text-[11px] font-medium text-[var(--text)]">No open position</p>
+          <p className="mt-1.5 text-[10px] text-[var(--text-secondary)] leading-relaxed max-w-[240px]">
             Connect wallet and trade to get started.
           </p>
           {/* 3.5: CTA for no-wallet state */}
@@ -395,8 +395,8 @@ export const PositionPanel: FC<{ slabAddress: string }> = ({ slabAddress }) => {
       {!hasPosition ? (
         /* 3.5: Improved empty state */
         <div className="p-3 flex flex-col items-center py-6 text-center">
-          <p className="text-[11px] font-medium text-[var(--text-muted)]">No open position</p>
-          <p className="mt-1.5 text-[10px] text-[var(--text-dim)] leading-relaxed max-w-[240px]">
+          <p className="text-[11px] font-medium text-[var(--text)]">No open position</p>
+          <p className="mt-1.5 text-[10px] text-[var(--text-secondary)] leading-relaxed max-w-[240px]">
             {account.capital > 0n
               ? "Open a position using the trade form."
               : "Connect wallet and trade to get started."}
@@ -484,58 +484,58 @@ export const PositionPanel: FC<{ slabAddress: string }> = ({ slabAddress }) => {
             <div className="divide-y divide-[var(--border)]/30">
               {/* 5.8: Dual contract+USD size */}
               <div className="flex items-center justify-between py-1.5">
-                <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Size</span>
+                <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text)]">Size</span>
                 <div className="flex flex-col items-end gap-0.5">
                   <span className="text-[11px] text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>
                     {formatTokenAmount(absPosition, decimals)} {symbol}
                   </span>
                   {priceUsd != null && priceUsd > 0 && (
-                    <span className="text-[10px] text-[var(--text-dim)]" style={{ fontFamily: "var(--font-mono)" }}>
+                    <span className="text-[10px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-mono)" }}>
                       ${(Number(absPosition) / 10 ** decimals * priceUsd).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                     </span>
                   )}
                 </div>
               </div>
               <div className="flex items-center justify-between py-1.5">
-                <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Entry Price</span>
+                <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text)]">Entry Price</span>
                 <span className="text-[11px] text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>
                   {formatUsdPriceE6(entryPriceE6)}
                 </span>
               </div>
               {/* 3.4: Funding/8h inline — replaces the entry price row area */}
               <div className="flex items-center justify-between py-1.5">
-                <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Funding/8h</span>
+                <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text)]">Funding/8h</span>
                 <div className="flex items-center gap-2">
                   <span className={`text-[11px] font-medium ${fundingRateColor}`} style={{ fontFamily: "var(--font-mono)" }}>
                     {fundingRate8hDisplay}
                   </span>
                   {fundingCountdown && (
-                    <span className="text-[9px] text-[var(--text-dim)]">
+                    <span className="text-[9px] text-[var(--text-secondary)]">
                       ({fundingCountdown})
                     </span>
                   )}
                 </div>
               </div>
               <div className="flex items-center justify-between py-1.5">
-                <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Market Price</span>
+                <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text)]">Market Price</span>
                 <span className={`text-[11px] ${hasValidMark ? "text-[var(--text)]" : "text-[var(--text-dim)]"}`} style={{ fontFamily: "var(--font-mono)" }}>
                   {hasValidMark ? formatUsdPriceE6(currentPriceE6) : "--"}
                 </span>
               </div>
               <div className="flex items-center justify-between py-1.5">
-                <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Liq. Price</span>
+                <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text)]">Liq. Price</span>
                 <span className={`text-[11px] font-medium ${liqPriceColor}`} style={{ fontFamily: "var(--font-mono)" }}>
                   {formatLiqPrice(liqPriceE6)}
                 </span>
               </div>
               <div className="flex items-center justify-between py-1.5">
-                <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Margin Health</span>
+                <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text)]">Margin Health</span>
                 <span className="text-[11px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-mono)" }}>
                   {marginHealthStr}
                 </span>
               </div>
               <div className="flex items-center justify-between py-1.5">
-                <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]" title={RISK_LEVERAGE_TITLE}>
+                <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text)]" title={RISK_LEVERAGE_TITLE}>
                   {RISK_LEVERAGE_LABEL}
                 </span>
                 <span className="text-[11px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-mono)" }}>
@@ -544,7 +544,7 @@ export const PositionPanel: FC<{ slabAddress: string }> = ({ slabAddress }) => {
               </div>
               {savedOrderLeverage != null && (
                 <div className="flex items-center justify-between py-1.5">
-                  <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]" title={ORDER_LEVERAGE_TITLE}>
+                  <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text)]" title={ORDER_LEVERAGE_TITLE}>
                     Order Lev.
                   </span>
                   <span className="text-[11px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-mono)" }}>
@@ -553,7 +553,7 @@ export const PositionPanel: FC<{ slabAddress: string }> = ({ slabAddress }) => {
                 </div>
               )}
               <div className="flex items-center justify-between py-1.5">
-                <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Est. Funding (24h)</span>
+                <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text)]">Est. Funding (24h)</span>
                 <span className={`text-[11px] font-medium ${estFundingColor}`} style={{ fontFamily: "var(--font-mono)" }}>
                   {estFunding24hDisplay}
                 </span>
@@ -734,7 +734,7 @@ const PnlSection: FC<PnlSectionProps> = ({
       } ${flashClass}`}
     >
       <div className="flex items-start justify-between">
-        <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Unrealized PnL</span>
+        <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text)]">Unrealized PnL</span>
         <div className="text-right">
           {hasValidMark ? (
             <div className="flex items-baseline gap-1.5">
@@ -786,7 +786,7 @@ const PnlSection: FC<PnlSectionProps> = ({
           />
         </div>
       ) : (
-        <div className="mt-1.5 text-[9px] text-[var(--text-dim)]">
+        <div className="mt-1.5 text-[9px] text-[var(--text-secondary)]">
           Waiting for price data…
         </div>
       )}

--- a/app/components/trade/PositionsTable.tsx
+++ b/app/components/trade/PositionsTable.tsx
@@ -69,8 +69,8 @@ export const PositionsTable: FC<{ slabAddress: string }> = ({ slabAddress }) => 
               <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5" />
             </svg>
           </div>
-          <p className="text-[11px] font-medium text-[var(--text-muted)]">No open positions</p>
-          <p className="mt-1 text-[10px] text-[var(--text-dim)] max-w-[220px] mx-auto leading-relaxed">
+          <p className="text-[11px] font-medium text-[var(--text)]">No open positions</p>
+          <p className="mt-1 text-[10px] text-[var(--text-secondary)] max-w-[220px] mx-auto leading-relaxed">
             Connect your wallet and deposit collateral to start trading.
           </p>
         </div>
@@ -90,8 +90,8 @@ export const PositionsTable: FC<{ slabAddress: string }> = ({ slabAddress }) => 
               <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5" />
             </svg>
           </div>
-          <p className="text-[11px] font-medium text-[var(--text-muted)]">No open positions</p>
-          <p className="mt-1 text-[10px] text-[var(--text-dim)] max-w-[220px] mx-auto leading-relaxed">
+          <p className="text-[11px] font-medium text-[var(--text)]">No open positions</p>
+          <p className="mt-1 text-[10px] text-[var(--text-secondary)] max-w-[220px] mx-auto leading-relaxed">
             Use the trade form to open a position.
           </p>
         </div>
@@ -189,7 +189,7 @@ export const PositionsTable: FC<{ slabAddress: string }> = ({ slabAddress }) => 
       <div className="overflow-x-auto">
         <table className="min-w-full text-[10px]">
           <thead>
-            <tr className="border-b border-[var(--border)]/30 text-[8px] uppercase tracking-[0.15em] text-[var(--text-muted)]">
+            <tr className="border-b border-[var(--border)]/30 text-[8px] uppercase tracking-[0.15em] text-[var(--text)]">
               <th className="whitespace-nowrap px-4 py-2 text-left font-medium">Market</th>
               <th className="whitespace-nowrap px-3 py-2 text-left font-medium">Side</th>
               <th className="whitespace-nowrap px-3 py-2 text-right font-medium">Size</th>
@@ -222,7 +222,7 @@ export const PositionsTable: FC<{ slabAddress: string }> = ({ slabAddress }) => 
               {/* Size */}
               <td className="whitespace-nowrap px-3 py-2.5 text-right" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
                 <span className="text-[var(--text)]">{formatTokenAmount(absPosition, decimals)}</span>
-                <span className="ml-1 text-[var(--text-dim)]">{symbol}</span>
+                <span className="ml-1 text-[var(--text-secondary)]">{symbol}</span>
               </td>
 
               {/* Entry */}

--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -540,7 +540,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
               <span className={`text-[10px] font-bold uppercase tracking-[0.1em] ${isOpenLong ? "text-green-400" : "text-red-400"}`}>
                 {isOpenLong ? "LONG" : "SHORT"}
               </span>
-              <span className="text-[10px] text-[var(--text-dim)]">{symbol}/USD</span>
+              <span className="text-[10px] text-[var(--text)]">{symbol}/USD</span>
               <span
                 className="text-[10px] font-bold text-cyan-400"
                 style={{ fontFamily: "var(--font-mono)" }}
@@ -559,13 +559,13 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
           {/* Stats grid */}
           <div className="grid grid-cols-2 gap-x-4 gap-y-1.5 text-[10px]">
             <div>
-              <span className="text-[var(--text-dim)] uppercase tracking-[0.08em]">Entry</span>
+              <span className="text-[var(--text)] uppercase tracking-[0.08em]">Entry</span>
               <span className="ml-2 font-mono font-medium text-[var(--text)]">
                 {openEntryPriceE6 > 0n ? formatUsdPriceE6(openEntryPriceE6) : "—"}
               </span>
             </div>
             <div>
-              <span className={`uppercase tracking-[0.08em] ${openLiqDanger ? "text-orange-400" : "text-[var(--text-dim)]"}`}>
+              <span className={`uppercase tracking-[0.08em] ${openLiqDanger ? "text-orange-400" : "text-[var(--text)]"}`}>
                 Liq {openLiqDanger ? "⚠" : ""}
               </span>
               <span className={`ml-2 font-mono font-medium ${openLiqDanger ? "text-orange-400" : "text-[var(--text)]"}`}>
@@ -573,13 +573,13 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
               </span>
             </div>
             <div>
-              <span className="text-[var(--text-dim)] uppercase tracking-[0.08em]">Size</span>
+              <span className="text-[var(--text)] uppercase tracking-[0.08em]">Size</span>
               <span className="ml-2 font-mono font-medium text-[var(--text)]">
                 {formatTokenAmount(abs(openPositionSize), decimals)} {symbol}
               </span>
             </div>
             <div>
-              <span className="text-[var(--text-dim)] uppercase tracking-[0.08em]">PnL</span>
+              <span className="text-[var(--text)] uppercase tracking-[0.08em]">PnL</span>
               <span className={`ml-2 font-mono font-medium ${openPnlTokens > 0n ? "text-green-400" : openPnlTokens < 0n ? "text-red-400" : "text-[var(--text-muted)]"}`}>
                 {openPnlTokens >= 0n ? "+" : ""}{formatTokenAmount(openPnlTokens, decimals)}
                 <span className="ml-1 text-[9px]">({openPnlPercent >= 0 ? "+" : ""}{openPnlPercent.toFixed(2)}%)</span>
@@ -587,7 +587,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
             </div>
             {savedOpenLeverage != null && (
               <div title={RISK_LEVERAGE_TITLE}>
-                <span className="text-[var(--text-dim)] uppercase tracking-[0.08em]">{RISK_LEVERAGE_LABEL}</span>
+                <span className="text-[var(--text)] uppercase tracking-[0.08em]">{RISK_LEVERAGE_LABEL}</span>
                 <span className="ml-2 font-mono font-medium text-[var(--text)]">
                   {formatLeverage(openAccountLeverage)}
                 </span>
@@ -667,7 +667,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
 
       {/* Order type indicator — market orders only */}
       <div className="mb-3 flex items-center gap-1.5">
-        <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Order Type</span>
+        <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text)]">Order Type</span>
         <span className="rounded-none border border-[var(--accent)]/30 bg-[var(--accent)]/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.1em] text-[var(--accent)]">
           Market
         </span>
@@ -681,7 +681,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
           className={`flex-1 rounded-none py-2.5 text-[11px] font-bold uppercase tracking-[0.1em] transition-all duration-150 ${
             direction === "long"
               ? "bg-green-500 border border-green-500 text-black"
-              : "border border-[var(--border)] bg-[var(--bg-surface)] text-[var(--text-dim)]"
+              : "border border-[var(--border)] bg-[var(--bg-surface)] text-[var(--text-secondary)]"
           }`}
         >
           Long
@@ -702,8 +702,8 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
       {/* ── Dual size input (contracts ↔ USDC) ── */}
       <div className="mb-2">
         <div className="mb-1.5 flex items-center justify-between">
-          <label className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Size<InfoIcon tooltip="Position size — enter in contracts (tokens) or USD. Both fields sync automatically." /></label>
-          <span className="text-[10px] text-[var(--text-dim)] whitespace-nowrap min-w-0 shrink-0" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
+          <label className="text-[10px] uppercase tracking-[0.15em] text-[var(--text)]">Size<InfoIcon tooltip="Position size — enter in contracts (tokens) or USD. Both fields sync automatically." /></label>
+          <span className="text-[10px] text-[var(--text)] whitespace-nowrap min-w-0 shrink-0" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
             Bal: {userAccount ? formatPerc(capital, decimals) : (walletAtaBalance !== null ? formatPerc(walletAtaBalance, decimals) : "—")} {collateralSymbol}
           </span>
         </div>
@@ -725,7 +725,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
                 } ${exceedsMargin ? "border-[var(--short)]/50 bg-[var(--short)]/5" : ""}`}
               />
             </div>
-            <span className="mt-0.5 block text-center text-[10px] text-[var(--text-dim)] uppercase tracking-[0.1em]">{symbol}</span>
+            <span className="mt-0.5 block text-center text-[10px] text-[var(--text)] uppercase tracking-[0.1em]">{symbol}</span>
           </div>
           {/* USDC input */}
           <div>
@@ -744,7 +744,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
                 }`}
               />
             </div>
-            <span className="mt-0.5 block text-center text-[10px] text-[var(--text-dim)] uppercase tracking-[0.1em]">USD</span>
+            <span className="mt-0.5 block text-center text-[10px] text-[var(--text)] uppercase tracking-[0.1em]">USD</span>
           </div>
         </div>
         {exceedsMargin && (
@@ -760,7 +760,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
           <button
             key={pct}
             onClick={() => setMarginPercent(pct)}
-            className="flex-1 rounded-none border border-[var(--border)]/30 py-1 text-[10px] font-medium text-[var(--text-muted)] transition-colors hover:border-[var(--accent)]/30 hover:text-[var(--text-secondary)] focus-visible:ring-1 focus-visible:ring-[var(--accent)]/30"
+            className="flex-1 rounded-none border border-[var(--border)]/30 py-1 text-[10px] font-medium text-[var(--text-secondary)] transition-colors hover:border-[var(--accent)]/30 hover:text-[var(--text)] focus-visible:ring-1 focus-visible:ring-[var(--accent)]/30"
           >
             {pct === 100 ? "MAX" : `${pct}%`}
           </button>
@@ -770,7 +770,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
       {/* Leverage slider + presets */}
       <div className="mb-5">
         <div className="mb-1 flex items-center justify-between">
-          <label className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">
+          <label className="text-[10px] uppercase tracking-[0.15em] text-[var(--text)]">
             Order Leverage
             <InfoIcon tooltip="The slider value used to size this order. Your displayed risk leverage can be lower when this slab account has extra collateral." />
           </label>
@@ -794,7 +794,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
               style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}
               className="w-12 rounded-none border border-[var(--border)]/50 bg-[var(--bg)] px-1.5 py-0.5 text-right text-[11px] text-[var(--text)] focus:border-[var(--accent)]/50 focus:outline-none focus:ring-1 focus:ring-[var(--accent)]/20"
             />
-            <span className="text-[11px] font-medium text-[var(--text-dim)]">x</span>
+            <span className="text-[11px] font-medium text-[var(--text)]">x</span>
           </div>
         </div>
         <input
@@ -820,7 +820,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
               className={`flex-1 basis-0 min-w-[32px] rounded-none py-1.5 min-h-[36px] text-[9px] font-medium transition-all duration-150 focus-visible:ring-1 focus-visible:ring-[var(--accent)]/30 touch-manipulation ${
                 leverage === l
                   ? "bg-[var(--accent)] text-white"
-                  : "border border-[var(--border)] text-[var(--text-muted)] hover:border-[var(--accent)]/50 hover:text-[var(--text-secondary)]"
+                  : "border border-[var(--border)] text-[var(--text-secondary)] hover:border-[var(--accent)]/50 hover:text-[var(--text)]"
               }`}
             >
               {l}x
@@ -833,9 +833,9 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
       {getNetwork() === "mainnet" && (
         <div className="mb-5 border border-[var(--accent)]/30 bg-[var(--accent)]/[0.04] px-4 py-3 text-[11px] space-y-1">
           <p className="text-[var(--accent)] font-medium">⚡ Mainnet Phase 1 Guards Active</p>
-          <p className="text-[var(--text-muted)]">• $10K OI cap per market during beta</p>
-          <p className="text-[var(--text-muted)]">• {maxLeverage}x max leverage enforced on-chain</p>
-          <p className="text-[var(--text-muted)]">• Guards auto-lift when caps are raised by DAO</p>
+          <p className="text-[var(--text)]">• $10K OI cap per market during beta</p>
+          <p className="text-[var(--text)]">• {maxLeverage}x max leverage enforced on-chain</p>
+          <p className="text-[var(--text)]">• Guards auto-lift when caps are raised by DAO</p>
         </div>
       )}
 
@@ -966,7 +966,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
       )}
 
       {lastSig && (
-        <p className="mt-2 text-[10px] text-[var(--text-dim)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
+        <p className="mt-2 text-[10px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
           Tx:{" "}
           <a
             href={`${explorerTxUrl(lastSig)}`}
@@ -983,7 +983,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
       <div className="mt-3 flex items-center gap-1.5">
         <InfoIcon tooltip={`This market is margined in ${collateralSymbol}, not USD. Position value and liq risk are affected by the collateral token's price. Effective USD leverage ≈ ${leverage > 0 ? `${leverage * 2}x` : "—"} (nominal ${leverage}x × 2 for coin exposure).`} />
         <InfoIcon tooltip={`This market is margined in ${symbol}, not USD. Position value and liq risk are affected by the collateral token's price. Selected leverage: ${leverage > 0 ? `${leverage}x` : "—"}.`} />
-        <span className="text-[9px] text-[var(--text-dim)] uppercase tracking-[0.1em]">Coin-margined market</span>
+        <span className="text-[9px] text-[var(--text)] uppercase tracking-[0.1em]">Coin-margined market</span>
       </div>
 
       {/* Close position modal */}

--- a/app/components/trade/TradeHistoryTable.tsx
+++ b/app/components/trade/TradeHistoryTable.tsx
@@ -141,8 +141,8 @@ export function TradeHistoryTable({
   if (!loading && trades.length === 0) {
     return (
       <div className="border border-dashed border-[var(--border)] bg-[var(--panel-bg)]/50 p-8 text-center">
-        <p className="text-[13px] text-[var(--text-dim)]">No trades yet</p>
-        <p className="mt-1 text-[10px] text-[var(--text-dim)]/60">
+        <p className="text-[13px] text-[var(--text)]">No trades yet</p>
+        <p className="mt-1 text-[10px] text-[var(--text-secondary)]">
           Your executed trades will appear here once the trade indexer has processed them.
         </p>
         {(process.env.NEXT_PUBLIC_DEFAULT_NETWORK ?? process.env.NEXT_PUBLIC_SOLANA_NETWORK) === "devnet" && (
@@ -161,7 +161,7 @@ export function TradeHistoryTable({
         {["Market", "Side", "Size", "Price", "Fee", "Time", "Tx"].map((h) => (
           <p
             key={h}
-            className="text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-dim)]"
+            className="text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text)]"
           >
             {h}
           </p>
@@ -240,7 +240,7 @@ export function TradeHistoryTable({
               {/* Time */}
               <div>
                 <p
-                  className="text-[10px] text-[var(--text-dim)]"
+                  className="text-[10px] text-[var(--text-secondary)]"
                   title={new Date(trade.created_at).toLocaleString()}
                 >
                   {timeAgo(trade.created_at)}
@@ -271,7 +271,7 @@ export function TradeHistoryTable({
 
       {/* Footer: total count + load more */}
       <div className="mt-3 flex items-center justify-between">
-        <p className="text-[10px] text-[var(--text-dim)]">
+        <p className="text-[10px] text-[var(--text-secondary)]">
           Showing {trades.length} of {total} trades
         </p>
         {hasMore && (


### PR DESCRIPTION
## Summary

Across the trade page, markets browse page, portfolio page, and the entire create-market flow, the app was systematically using \`--text-dim\` (\`#2A2E3D\`) and \`--text-muted\` (\`#454B5F\`) for static labels, helper text, inactive interactable controls, and informational metadata. Both tokens are intended for placeholder-style content and disabled states; on the dark surface they render below comfortable readability for body text. This PR promotes those occurrences to a consistent two-tier scheme:

- **Labels and primary informational headers** → \`--text\` (\`#E1E2E8\`)
- **Inactive interactable controls + secondary helper / metadata** → \`--text-secondary\` (\`#7A7F96\`)

What stays subdued by design (across every commit in this PR):
- Input placeholders (\`placeholder:text-dim\`) — UX convention
- Loading messages (\"Detecting oracle...\", \"Searching DEX pools...\", \"Checking wallet balance...\", \"Loading more...\", etc.)
- Disabled button text (\`disabled:text-dim\`)
- No-data placeholders (\"—\", \"Price TBD\", \"Connect wallet to view NFT status\", \"Data will appear after cranks\")
- Decorative row indices (\`#1\`, \`#2\`, …) and conditional traffic-light dim states (PnL=0, util-low, etc.)
- Borders — modern dark UIs use low-alpha borders for subtle structure; bumping them to white would create a wireframe effect

## Commits

1. **trade-page contrast** (TradeForm, MarketStatsCard, PositionNftPanel, MarketBookCard, FundingRateCard, FundingRateChart, page Tabs)
2. **positions panel + accounts card** (PositionsTable, PositionPanel, AccountsCard) — includes a SortHeader hover-reversal fix where bumping the parent row to \`--text\` would have made the previous \`hover:text-secondary\` *dim* on hover; switched to \`hover:accent\` (color shift, not brightness shift)
3. **markets browse page** — page heading \"All\" word, FILTER label, search clear button, all sort/filter pills, table column headers, MANUAL pill text, row subtitle, end-of-list footer
4. **portfolio page** — \"Your\" heading word, all 5 stat-card labels, Total Deposited value (was inconsistently dimmer than Portfolio Value), LP Value when \`totalRedeemable === 0\`, per-position detail labels, Liquidation Distance row, plus the LP positions panel + trade history table empty/populated states
5. **create-market flow** — entire 4-step wizard: ModeSelector cards, WizardProgress upcoming-step indicators, CreateMarketWizard step header + cancel button, all step components (Token / Oracle / Parameters / Review), and supporting components (CostEstimate, SlabTierPicker, OracleBadge, FeeSlider, LogoUpload, MarketPreview, RecoverSolBanner, LaunchProgress, LaunchSuccess)

## Stats

- **31 files** touched
- **~370** className token swaps
- **0 logic / structure changes** — diff filter confirms only token swaps + one \`font-normal\` opacity removal in the markets page heading
- **No hover regressions** — every interactable I bumped goes \`secondary → text\` on hover (or \`secondary → accent\` for the SortHeader case where parent inheritance would have inverted)

## Test plan

- [x] Full app test suite: 2277 passing, 0 failures
- [x] Direct test files for affected components (CreateMarketWizard, StepReview, StepTokenSelect, Portfolio, market info bar visibility, trade-component suite) — all green; no test asserts on the specific class strings touched
- [ ] Manual smoke: every page above on devnet — labels should read clearly without bumping monitor brightness
- [ ] Manual smoke: hover any inactive tab / filter / button → smooth brighten transition
- [ ] Manual smoke: light theme — confirm \`--text\` on \`#FAFAFD\` light bg still has adequate contrast (token-based, should work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Markets page displays expanded columns with additional market details and load status indicators
* Portfolio page shows new position metrics, including entry price, mark price, and liquidation distance tracking

**Style & UI**
* Enhanced text contrast and visual hierarchy across the application for improved readability
* Refined trading and market creation flows with clearer labeling and visual feedback
* Updated market information cards with additional statistics and details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->