### PR TITLE
fix(chart): z-index drawing canvas above lightweight-charts' own canvases

### DIFF
--- a/app/components/trade/ChartDrawingOverlay.tsx
+++ b/app/components/trade/ChartDrawingOverlay.tsx
@@ -813,7 +813,18 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
   return (
     <canvas
       ref={canvasRef}
-      className="pointer-events-none absolute inset-0"
+      // z-[1] forces the drawing canvas above lightweight-charts'
+      // own canvases (which paint at z-index auto / 0). The earlier
+      // implementation relied on DOM order alone — that worked in
+      // local dev but in production lightweight-charts' chart
+      // container wins the stacking-order tie-break and paints on
+      // top of the drawing canvas, so committed drawings save
+      // correctly to localStorage and update state but never become
+      // visible. z-[1] sits below the z-10 UI badges (empty-state,
+      // hover-tooltip, position-summary) and above the chart's
+      // canvases. pointer-events stays disabled so chart pan/zoom
+      // still works through this layer.
+      className="pointer-events-none absolute inset-0 z-[1]"
       aria-hidden="true"
     />
   );


### PR DESCRIPTION
## Summary

Drawings on the price chart were saving to state and localStorage correctly (the toolbar's clear-all confirmation reflected the count) but never became visible on screen. Root cause: the overlay canvas was relying on DOM order alone to stack above lightweight-charts' own canvases — both at \`z-index: auto\` (= 0). By spec the drawing canvas (later DOM sibling) should paint on top, and that worked in local dev / Vitest, but in production the chart container's internal stacking context wins the tie-break and lightweight-charts' canvases paint above the drawing canvas instead.

## Fix

One-line change: add explicit \`z-[1]\` to the drawing canvas.

- Drawing canvas at \`z-index: 1\` — above the chart's canvases (z-auto)
- Below the existing z-10 UI badges (empty-state, hover-tooltip, position-summary, drawing toolbar) — preserves the existing visual layering contract
- \`pointer-events: none\` unchanged — chart pan/zoom still works through this layer
- Comment in source explains the tie-break failure mode for future readers

## Test plan

- [x] 64/64 ChartDrawingOverlay tests passing — the existing assertion uses \`className.toContain('pointer-events-none')\` which still matches
- [ ] Manual smoke: open a market → toolbar at top-left → click horizontal-line tool → click on a candle → purple line appears at that price level
- [ ] Manual smoke: drag a rectangle in the candle area → purple shaded box renders + persists across reload
- [ ] Manual smoke: pan the chart → drawings move with the price/time grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)