### PR TITLE
docs(readme): align mainnet program IDs, instruction tags, and hyperp mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ percolator-launch/
 │   └── simulation/               # @percolator/simulation — price simulation for testing
 │
 ├── program/                      # Solana BPF program (Rust)
-│   ├── src/lib.rs                # All instruction handlers (Tags 0-28)
+│   ├── src/lib.rs                # Instruction handlers — see percolator-prog/src/tags.rs for current tag inventory
 │   └── Cargo.toml                # Feature flags: small, medium, large (default)
 │
 ├── percolator/                   # Risk engine (Rust crate, from aeyakovenko/percolator)
@@ -218,7 +218,9 @@ percolator-launch/
 │   ├── t4-liquidation.ts
 │   ├── t6-risk-gate.ts
 │   ├── t7-market-pause.ts
-│   └── t8-trading-fee-update.ts
+│   ├── t8-trading-fee-update.ts
+│   ├── t10-pricing-engine.ts
+│   └── t10-pricing-edge-cases.ts
 │
 ├── docs/                         # Architecture and planning docs
 ├── supabase/                     # Database migrations
@@ -343,29 +345,34 @@ Bitmap (variable)         — used account slots
 Accounts (N × slot_size) — per-user: kind, owner, position, capital, pnl
 ```
 
-### Key Instructions
+### Pricing Modes
 
-| Tag | Instruction | Who |
-|-----|------------|-----|
-| 0 | `InitSlab` | Creator |
-| 1 | `InitMarket` | Creator |
-| 2 | `InitLP` | Creator |
-| 3 | `InitUser` | Anyone |
-| 4 | `DepositCollateral` | Trader |
-| 5 | `WithdrawCollateral` | Trader |
-| 6 | `TradeNoCpi` | Trader |
-| 7 | `LiquidateAtOracle` | Anyone |
-| 8 | `KeeperCrank` | Anyone |
-| 9 | `PushOraclePrice` | Oracle Auth |
-| 10 | `TradeCpi` | Trader (vAMM) |
-| 14 | `AdminForceClose` | Admin |
-| 15 | `SetRiskThreshold` | Admin |
-| 23 | `RenounceAdmin` | Admin |
-| 24 | `CreateInsuranceMint` | Admin |
-| 25 | `DepositInsuranceLP` | Anyone |
-| 26 | `WithdrawInsuranceLP` | LP holder |
-| 27 | `PauseMarket` | Admin |
-| 28 | `UnpauseMarket` | Admin |
+a market chooses one of two pricing modes at creation:
+
+- **oracle mode** — mark and index prices follow an external oracle (Pyth feed, or admin-pushed price for the special `feed_id = all zeros` case). funding accrues from the spread between oracle and a per-market funding rate.
+- **hyperp mode** — mark and index are computed internally from trade prints (EMA-based), with no external oracle dependency. funding accrues from the premium `(mark - index)`. trades must use `TradeCpi` (the no-CPI path is disabled in hyperp mode). index updates are rate-limited per slot to prevent same-slot price manipulation.
+
+see [`tests/t3-hyperp-lifecycle.ts`](./tests/t3-hyperp-lifecycle.ts) for an end-to-end hyperp lifecycle, [`tests/t10-pricing-engine.ts`](./tests/t10-pricing-engine.ts) for EMA warm-up tests, and [`percolator-prog/README.md`](https://github.com/dcccrypto/percolator-prog) for the protocol-level pricing spec.
+
+### Instruction Tags
+
+the program defines 80 instruction tags. source of truth: [`percolator-prog/src/tags.rs`](https://github.com/dcccrypto/percolator-prog/blob/main/src/tags.rs).
+
+grouped by use case:
+
+| Group | Examples | Caller |
+|---|---|---|
+| Market lifecycle | `InitMarket`, `ResolveMarket`, `PauseMarket`, `UnpauseMarket` | Creator / Admin |
+| User lifecycle | `InitUser`, `DepositCollateral`, `WithdrawCollateral`, `CloseAccount` | Trader |
+| Trading | `TradeNoCpi`, `TradeCpi`, `TradeCpiV2` | Trader |
+| Risk + liquidation | `LiquidateAtOracle`, `ExecuteAdl`, `KeeperCrank` | Permissionless |
+| Oracle | `PushOraclePrice`, `SetPythOracle`, `UpdateMarkPrice`, `UpdateHyperpMark`, `SetOraclePriceCap` | Oracle Auth |
+| LP vault | `CreateLpVault`, `LpVaultDeposit`, `LpVaultWithdraw`, `LpVaultCrankFees` | LP |
+| Insurance | `TopUpInsurance`, `WithdrawInsuranceLimited`, `SetInsuranceWithdrawPolicy`, `FundMarketInsurance` | Admin / LP |
+| Position NFT | `MintPositionNft`, `TransferPositionOwnership`, `BurnPositionNft` | Trader |
+| Admin governance | `UpdateAdmin`, `AcceptAdmin`, `UpdateAuthority`, `UpdateConfig` | Admin |
+
+for the canonical numeric tag (needed when constructing instructions), see [`tags.rs`](https://github.com/dcccrypto/percolator-prog/blob/main/src/tags.rs).
 
 ### Deployed Programs
 
@@ -380,8 +387,13 @@ Accounts (N × slot_size) — per-user: kind, owner, position, capital, pnl
 **Matcher (vAMM):** `4HcGCsyjAqnFua5ccuXyt8KRRQzKFbGTJkVChpS7Yfzy`
 
 **Mainnet:**
-- Program: `GM8zjJ8LTBMv9xEsverh6H6wLyevgMHEJXcEzyY3rY24`
-- Matcher: `DHP6DtwXP1yJsz8YzfoeigRFPB979gzmumkmCxDLSkUX`
+
+| Program | Address |
+|---------|---------|
+| Percolator (small tier only) | `ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv` |
+| Matcher | `DHP6DtwXP1yJsz8YzfoeigRFPB979gzmumkmCxDLSkUX` |
+| Stake | `DC5fovFQD5SZYsetwvEqd4Wi4PFY1Yfnc669VMe6oa7F` |
+| NFT | `FqhKJT9gtScjrmfUuRMjeg7cXNpif1fqsy5Jh65tJmTS` |
 
 ---
 
@@ -407,6 +419,8 @@ npx tsx tests/t4-liquidation.ts
 npx tsx tests/t6-risk-gate.ts
 npx tsx tests/t7-market-pause.ts
 npx tsx tests/t8-trading-fee-update.ts
+npx tsx tests/t10-pricing-engine.ts
+npx tsx tests/t10-pricing-edge-cases.ts
 
 # E2E
 pnpm test:e2e


### PR DESCRIPTION
## what

three things in the top-level README that drifted out of sync with the rest of the ecosystem. all in adjacent sections so I bundled them into one PR.

1. **mainnet program ID is stale.** the README listed `GM8zjJ8LTBMv9xEsverh6H6wLyevgMHEJXcEzyY3rY24`, which has had no transactions since 2026-03-11 and is now frozen (upgrade authority = none). the live mainnet program is `ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv`. that's the one already in `percolator-sdk/README.md` and in the `declare_id!` of squid's #267 in percolator-prog. the launch README also didn't include stake or nft addresses that the SDK README does carry.

2. **instruction tag table is out of sync with `percolator-prog/src/tags.rs`.** the README's "Key Instructions" table had tag numbers that don't match the current program. some examples:
   - README said `Tag 8 = KeeperCrank`. program defines `TAG_KEEPER_CRANK = 5`.
   - README said `Tag 23 = RenounceAdmin`. program has no `RenounceAdmin` constant; tag 23 is `TAG_WITHDRAW_INSURANCE_LIMITED`.
   - README said the program covers "Tags 0-28". program currently defines 80 tags up to `TAG_UPDATE_AUTHORITY = 83` (gaps at 16, 17, 31, 57).

   a contributor or integrator using the README to construct instructions sends to the wrong handler.

3. **hyperp mode is supported and tested but never explained in the README.** `tests/t3-hyperp-lifecycle.ts` and `tests/t10-pricing-engine.ts` both exercise hyperp, but the README only mentions "hyperp" inside test filenames. new integrators have to dig into `percolator-prog` to learn what it is.

## why

mainnet IDs verified onchain via `getSignaturesForAddress` against `api.mainnet-beta.solana.com` on 2026-05-05:

| address | source | latest tx |
|---|---|---|
| `GM8zjJ8LT...` | launch README (mainnet) | 2026-03-11 22:51 UTC |
| `ESa89R5Es...` | sdk README (mainnet) | active today |

tag list cross-referenced from `dcccrypto/percolator-prog/src/tags.rs` (current `main`).

## changes

- `README.md`: replace inline comment `Tags 0-28` with a pointer to `percolator-prog/src/tags.rs` as source of truth.
- `README.md`: add `t10-pricing-engine.ts` and `t10-pricing-edge-cases.ts` to the tests tree.
- `README.md`: replace the misnumbered "Key Instructions" table with a grouped overview by use case, with link to `tags.rs` for canonical numbers.
- `README.md`: rewrite the Deployed Programs section. mainnet now uses `ESa89R5Es...`. add stake (`DC5fovFQD5SZYsetwvEqd4Wi4PFY1Yfnc669VMe6oa7F`) and nft (`FqhKJT9gtScjrmfUuRMjeg7cXNpif1fqsy5Jh65tJmTS`) addresses.
- `README.md`: add t10s to the integration test command list.
- new subsection under "On-Chain Program" (after "Slab Layout"): `### Pricing Modes` — documents oracle mode vs hyperp mode in 6-8 lines, with pointers to t3-hyperp-lifecycle.ts and percolator-prog/README.md.

## open question

three READMEs (`percolator-launch`, `percolator-sdk`, `percolator-prog`) each carry their own program-ID table. the IDs drift between them, this PR is the third instance of fixing one of those drifts I noticed in a week. worth opening a separate issue to discuss centralizing program IDs in one source (e.g. exporting from `@percolator/sdk` and having every README reference the SDK rather than hardcoding addresses). happy to open that issue if you want.

## caveat

the launch repo no longer contains a `program/` directory locally, per the recent monorepo split documented in `docs/plans/2026-02-24-repo-split-plan.md`. the Project Structure tree at lines 208-210 still references it. this PR keeps the entry but the comment now points to `percolator-prog` as the source of truth. a fuller restructure of "Project Structure" felt out of scope here, flagging for follow-up.

## test plan

- [ ] `pnpm install` succeeds
- [ ] no code changes; README renders correctly on GitHub
- [ ] all three new mainnet program IDs (`ESa89R5Es...`, `DC5fovFQ...`, `FqhKJT9g...`) exist on mainnet via `getAccountInfo`
- [ ] `tags.rs` link resolves


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced Pricing Modes and Instruction Tags sections to the On-Chain Program chapter.
  * Updated mainnet deployment addresses for Percolator small tier, Matcher, Stake, and NFT programs.
  * Added new test references and documentation for pricing engine and edge case testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->