### PR TITLE
Distinguish wallet balance from in-market account balance in the trade panel

### DIFF
--- a/app/components/trade/DepositTrigger.tsx
+++ b/app/components/trade/DepositTrigger.tsx
@@ -37,8 +37,14 @@ export const DepositTrigger: FC<{ slabAddress: string }> = ({ slabAddress }) => 
   // deposit — NOT what's already deposited into this market. Account
   // balance (capital) is shown alongside the order-form Size row as
   // "Account Bal:" instead.
+  //
+  // Pass `capital` as the refresh trigger so a deposit (which decreases
+  // wallet ATA balance and increases capital) re-fetches the wallet
+  // balance. Without this the bar would keep showing the pre-deposit
+  // number until the user reloaded the page.
   const { balance: walletBalance, decimals: walletDecimals } = useWalletAtaBalance(
     config?.collateralMint ?? null,
+    capital,
   );
   const displayBalance = walletBalance ?? 0n;
   const displayDecimals = walletDecimals ?? decimals;

--- a/app/components/trade/DepositTrigger.tsx
+++ b/app/components/trade/DepositTrigger.tsx
@@ -5,6 +5,7 @@ import { useWalletCompat } from "@/hooks/useWalletCompat";
 import { useUserAccount } from "@/hooks/useUserAccount";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { useTokenMeta } from "@/hooks/useTokenMeta";
+import { useWalletAtaBalance } from "@/hooks/useWalletAtaBalance";
 import { formatTokenAmount } from "@/lib/format";
 import { DepositWithdrawCard } from "./DepositWithdrawCard";
 import { isMockMode } from "@/lib/mock-mode";
@@ -30,6 +31,17 @@ export const DepositTrigger: FC<{ slabAddress: string }> = ({ slabAddress }) => 
 
   const capital = userAccount?.account.capital ?? 0n;
   const prevCapitalRef = useRef(capital);
+
+  // The bar at the top of the trade panel now shows the user's PHANTOM
+  // (or whichever wallet) USDC balance — what they have available to
+  // deposit — NOT what's already deposited into this market. Account
+  // balance (capital) is shown alongside the order-form Size row as
+  // "Account Bal:" instead.
+  const { balance: walletBalance, decimals: walletDecimals } = useWalletAtaBalance(
+    config?.collateralMint ?? null,
+  );
+  const displayBalance = walletBalance ?? 0n;
+  const displayDecimals = walletDecimals ?? decimals;
 
   // Read localStorage on mount
   useEffect(() => {
@@ -65,9 +77,12 @@ export const DepositTrigger: FC<{ slabAddress: string }> = ({ slabAddress }) => 
         onClick={() => setExpanded(!expanded)}
       >
         <div className="flex items-center gap-2">
-          <span className="text-[9px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Account</span>
+          {/* Label and value share the same brightness so the whole
+              "Wallet Balance: X USDC" line reads as one unit. The
+              earlier "Account" label was at --text-dim, which made
+              users squint to read which balance this was. */}
           <span className="text-[11px] font-medium text-[var(--text)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
-            {formatTokenAmount(capital, decimals)} {symbol}
+            Wallet Balance: {formatTokenAmount(displayBalance, displayDecimals)} {symbol}
           </span>
         </div>
         <div className="flex items-center gap-1.5">

--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -704,7 +704,14 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
         <div className="mb-1.5 flex items-center justify-between">
           <label className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Size<InfoIcon tooltip="Position size — enter in contracts (tokens) or USD. Both fields sync automatically." /></label>
           <span className="text-[10px] text-[var(--text-dim)] whitespace-nowrap min-w-0 shrink-0" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
-            Bal: {userAccount ? formatPerc(capital, decimals) : (walletAtaBalance !== null ? formatPerc(walletAtaBalance, decimals) : "—")} {collateralSymbol}
+            {/* "Account Bal" rather than "Bal" so users can't confuse this
+                with the wallet balance shown at the top of the trade
+                panel. This row is the in-market account capital — what
+                you have available to TRADE on this slab — not the
+                Phantom wallet's USDC balance. Pre-account users see
+                "0" because they haven't deposited yet; the wallet
+                balance row above tells them what they could deposit. */}
+            Account Bal: {userAccount ? formatPerc(capital, decimals) : "0"} {collateralSymbol}
           </span>
         </div>
         <div className="grid grid-cols-2 gap-1.5">

--- a/app/hooks/useWalletAtaBalance.ts
+++ b/app/hooks/useWalletAtaBalance.ts
@@ -15,12 +15,19 @@ export interface WalletAtaBalance {
 
 /** Fetches the user's associated token account balance for a given mint.
  *  Returns `{ balance: null }` when the wallet is disconnected, the mint
- *  is null, or the ATA doesn't exist yet. One-shot fetch on mount /
- *  dependency change — does NOT poll, so callers that want live
- *  updates after a deposit/withdraw should rebuild on the changing
- *  market state (slab capital change, etc.). */
+ *  is null, or the ATA doesn't exist yet.
+ *
+ *  Re-fetch trigger: pass any value as `refreshTrigger` whose identity
+ *  changes when an external event invalidates the cached balance.
+ *  The canonical use is the in-market `capital` value — a deposit
+ *  decreases the wallet ATA balance and increases capital; passing
+ *  capital as the trigger forces a re-read of the ATA so the bar
+ *  reflects the post-deposit state instead of the stale pre-deposit
+ *  number. Without this, only publicKey/mint/connection changes would
+ *  trigger a re-read, none of which fire after a deposit/withdraw. */
 export function useWalletAtaBalance(
   mint: PublicKey | null | undefined,
+  refreshTrigger?: unknown,
 ): WalletAtaBalance {
   const { publicKey } = useWalletCompat();
   const { connection } = useConnectionCompat();
@@ -40,14 +47,20 @@ export function useWalletAtaBalance(
         const ata = getAssociatedTokenAddressSync(mint, publicKey);
         const info = await connection.getTokenAccountBalance(ata);
         if (cancelled) return;
+        // RPC returns amount as a string. The happy-path zero balance
+        // is "0" (truthy in JS). The else branch only fires for the
+        // unusual empty-string / falsy case from a malformed response;
+        // even then we want to preserve any decimals the RPC did
+        // hand back rather than silently drop them.
+        const onChainDecimals =
+          info.value.decimals !== undefined ? info.value.decimals : null;
         if (info.value.amount) {
           setState({
             balance: BigInt(info.value.amount),
-            decimals:
-              info.value.decimals !== undefined ? info.value.decimals : null,
+            decimals: onChainDecimals,
           });
         } else {
-          setState({ balance: null, decimals: null });
+          setState({ balance: null, decimals: onChainDecimals });
         }
       } catch {
         // ATA may not exist yet (user hasn't received this token), keep null.
@@ -57,7 +70,7 @@ export function useWalletAtaBalance(
     return () => {
       cancelled = true;
     };
-  }, [publicKey, mint, connection]);
+  }, [publicKey, mint, connection, refreshTrigger]);
 
   return state;
 }

--- a/app/hooks/useWalletAtaBalance.ts
+++ b/app/hooks/useWalletAtaBalance.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import type { PublicKey } from "@solana/web3.js";
+import { getAssociatedTokenAddressSync } from "@solana/spl-token";
+import { useWalletCompat, useConnectionCompat } from "@/hooks/useWalletCompat";
+
+export interface WalletAtaBalance {
+  /** Raw atomic balance from the user's ATA, or null if no ATA / not connected. */
+  balance: bigint | null;
+  /** On-chain decimals from the ATA, or null if unavailable. Useful for
+   *  tokens where TokenMetadata fails (cross-network, missing). */
+  decimals: number | null;
+}
+
+/** Fetches the user's associated token account balance for a given mint.
+ *  Returns `{ balance: null }` when the wallet is disconnected, the mint
+ *  is null, or the ATA doesn't exist yet. One-shot fetch on mount /
+ *  dependency change — does NOT poll, so callers that want live
+ *  updates after a deposit/withdraw should rebuild on the changing
+ *  market state (slab capital change, etc.). */
+export function useWalletAtaBalance(
+  mint: PublicKey | null | undefined,
+): WalletAtaBalance {
+  const { publicKey } = useWalletCompat();
+  const { connection } = useConnectionCompat();
+  const [state, setState] = useState<WalletAtaBalance>({
+    balance: null,
+    decimals: null,
+  });
+
+  useEffect(() => {
+    if (!publicKey || !mint) {
+      setState({ balance: null, decimals: null });
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const ata = getAssociatedTokenAddressSync(mint, publicKey);
+        const info = await connection.getTokenAccountBalance(ata);
+        if (cancelled) return;
+        if (info.value.amount) {
+          setState({
+            balance: BigInt(info.value.amount),
+            decimals:
+              info.value.decimals !== undefined ? info.value.decimals : null,
+          });
+        } else {
+          setState({ balance: null, decimals: null });
+        }
+      } catch {
+        // ATA may not exist yet (user hasn't received this token), keep null.
+        if (!cancelled) setState({ balance: null, decimals: null });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [publicKey, mint, connection]);
+
+  return state;
+}


### PR DESCRIPTION
## Summary

Two pieces of data were being conflated in the trade panel UI:

1. The user's Phantom (or other wallet) USDC balance — what they have available to deposit
2. The user's deposited capital on this market's slab account — what they can actually trade

Previously the top of the trade panel showed \"ACCOUNT 0 USDC\" and the Size row showed \"Bal: 0 USDC\" — both reading from the same in-market capital figure (with a fallback to wallet balance when no account existed). Users had no way to tell what they had in their wallet vs what was on-chain in the market.

## Changes

| Surface | Before | After |
|---------|--------|-------|
| Top bar (DepositTrigger) | \`ACCOUNT 0 USDC\` (label dim, value bright) — value was account capital | \`Wallet Balance: X USDC\` (label and value same brightness) — value is wallet ATA balance |
| Size row (TradeForm) | \`Bal: 0 USDC\` — value was capital with fallback to wallet balance when no account | \`Account Bal: 0 USDC\` — value is always capital (\"0\" pre-account, truthful) |

New hook \`useWalletAtaBalance\` fetches the user's associated token account balance via \`getTokenAccountBalance\`. One-shot fetch on dependency change — no polling.

## Why

The relabel makes the relationship between the two figures explicit:
- **Wallet Balance** at the top tells the user how much they have available to deposit.
- **Account Bal** in the Size row tells them what's already in the market for trading.

Pre-account users now see \`Account Bal: 0 USDC\` (truthful — they haven't deposited anything yet) instead of the previous fallback to wallet balance, which was misleading because the same number now appears above as Wallet Balance.

## Test plan

- [x] Full app suite: 2277 passing, 0 failures
- [x] TradeForm tests still passing — they don't assert on the specific label text
- [ ] Manual smoke: connect wallet with USDC → top bar shows actual Phantom USDC, Size row shows 0 (no account yet)
- [ ] Manual smoke: deposit some USDC → wallet balance decreases, account balance increases, both visible
- [ ] Manual smoke: pre-account user sees both rows informatively (no \"squint to read\" issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Deposit header now displays the wallet-available balance for clearer funding visibility.
  * Balance label in trade inputs updated to "Account Bal" for clarity.

* **Bug Fixes**
  * Deposit trigger header corrected to reflect wallet-available funds rather than already-deposited capital.
  * Balance fallbacks standardized to show "0" when account data is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->