### PR TITLE
fix(chart): bump dark-theme grid + border contrast one tone

### DIFF
--- a/app/hooks/useChartTheme.ts
+++ b/app/hooks/useChartTheme.ts
@@ -16,8 +16,17 @@ export interface ChartTheme {
 const DARK_THEME: ChartTheme = {
   bg: "#0D0D0F",
   textColor: "rgba(255,255,255,0.45)",
-  gridColor: "rgba(255,255,255,0.04)",
-  borderColor: "rgba(255,255,255,0.06)",
+  // Grid bumped from 0.04 → 0.07 and border from 0.06 → 0.10 — the
+  // earlier alphas sat at the very floor of what professional trading
+  // UIs use (Bloomberg / TradingView / Binance run grids around 0.06–
+  // 0.10) and made the chart blend into the page bg. The new values
+  // give the panel a defined edge without competing with the data.
+  // Indicator reference lines (RSI 30/70, MACD signal) derive from
+  // textColor at ~25% / 75% alpha, which after multiplying through
+  // textColor's own 0.45 lands at ~0.11 / ~0.34 effective — still
+  // clearly above this 0.07 grid, so the hierarchy holds.
+  gridColor: "rgba(255,255,255,0.07)",
+  borderColor: "rgba(255,255,255,0.10)",
   upColor: "#22c55e",
   downColor: "#ef4444",
   volUpColor: "rgba(34,197,94,0.6)",


### PR DESCRIPTION
## Summary

The chart panel's grid and border alphas sat at the floor of what professional trading UIs use (4% / 6% white on the dark bg), which made the chart blend into the surrounding page bg without giving it a defined panel edge. Bumping each up one tone:

| Token | Before | After |
|-------|--------|-------|
| \`gridColor\` | \`rgba(255,255,255,0.04)\` | \`rgba(255,255,255,0.07)\` |
| \`borderColor\` | \`rgba(255,255,255,0.06)\` | \`rgba(255,255,255,0.10)\` |

For reference, peer products run grids around 0.06–0.10 and borders 0.08–0.12 on dark themes. The new values land in the bottom of that range so they read as subtle structure rather than as graph paper.

## Indicator hierarchy preserved

| Layer | Effective alpha after bump |
|-------|---------------------------|
| Candles / data | full color |
| Bollinger bands | per-indicator palette color (independent) |
| MACD signal line | textColor (0.45) × 0.75 = ~0.34 |
| RSI 30 / 70 reference | textColor (0.45) × 0.25 = ~0.11 |
| Grid (new) | 0.07 |
| Border (new) | 0.10 |

Hierarchy candles > indicator lines > grid is intact.

## What stays untouched

- **Light theme** — gridColor at 0.05 / borderColor at 0.10 on light bg already sits in industry-standard contrast; the same +3pp bump on light bg would push into \"graph paper\" territory.
- **Indicator reference lines** — RSI 30/70 and MACD signal both derive from \`textColor\`, not gridColor, so no propagation needed.

## Test plan

- [x] 365 trade + hook tests passing
- [ ] Manual smoke (dark theme): grid lines should be visible without competing with candles. RSI 30/70 dashed lines should still read clearly above the grid.
- [ ] Manual smoke (light theme): no visible regression — values unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)