### PR TITLE
fix(waitlist): reject combined email+wallet signup shape

### DIFF
--- a/app/__tests__/api/waitlist-signup-shape.test.ts
+++ b/app/__tests__/api/waitlist-signup-shape.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Waitlist signup input-shape rejection.
+ *
+ * The route used to accept three shapes: email-only, wallet-only, and a
+ * combined email+wallet shape that skipped the on-chain mainnet check on
+ * the assumption that Privy's OTP gate proved real intent. The server
+ * never actually verified anything from Privy, so the combined shape let
+ * any caller bind an arbitrary email to a self-controlled keypair, and a
+ * downstream silent 23505 swallow then made a victim's later email-only
+ * signup look successful while their pubkey was never persisted.
+ *
+ * The fix rejects the combined shape outright. This test guards the
+ * route source so a future "let's bring back combined" refactor can't
+ * land without tripping the assertion.
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const ROUTE_PATH = path.resolve(
+  __dirname,
+  "../../app/api/waitlist/signup/route.ts",
+);
+
+describe("/api/waitlist/signup input shape", () => {
+  it("rejects the combined email + wallet shape with 400", () => {
+    const source = fs.readFileSync(ROUTE_PATH, "utf8");
+
+    expect(source).toMatch(/if\s*\(\s*hasEmail\s*&&\s*hasWalletPart\s*\)/);
+    // The 400 status must live inside that branch, not somewhere else.
+    const combinedBranch = source
+      .split("if (hasEmail && hasWalletPart)")[1]
+      ?.split("if (!hasEmail && !hasWalletPart)")[0];
+    expect(combinedBranch).toBeDefined();
+    expect(combinedBranch).toContain("status: 400");
+  });
+
+  it("requires either an email OR a wallet signature, not both", () => {
+    const source = fs.readFileSync(ROUTE_PATH, "utf8");
+    expect(source).toContain('"provide an email or a wallet signature"');
+    // The pre-fix copy ("…or both") must be gone.
+    expect(source).not.toContain('"provide an email, a wallet signature, or both"');
+  });
+
+  it("runs the mainnet existence check unconditionally on the wallet path", () => {
+    const source = fs.readFileSync(ROUTE_PATH, "utf8");
+    // Pre-fix the call sat behind `if (!hasEmail) { … }`. Post-fix the
+    // wrapper is gone. Confirm both: the call still exists and the
+    // wrapper guard does not.
+    expect(source).toContain("walletExistsOnMainnet(pubkey!)");
+    expect(source).not.toMatch(/if\s*\(\s*!hasEmail\s*\)\s*\{\s*const\s+exists\s*=\s*await\s+walletExistsOnMainnet/);
+  });
+});

--- a/app/app/api/waitlist/signup/route.ts
+++ b/app/app/api/waitlist/signup/route.ts
@@ -144,22 +144,39 @@ export async function POST(req: Request) {
     }
   }
 
-  // Three valid input shapes:
+  // Two valid input shapes:
   //   1. email only                       → notify by email only
   //   2. pubkey + signature + message     → notify on chain, no email
-  //   3. email + pubkey + sig + message   → BOTH (Privy email login flow:
-  //                                         email creates an embedded wallet
-  //                                         which signs the join message; we
-  //                                         skip the on-chain existence check
-  //                                         because the embedded wallet is
-  //                                         brand new and Privy's OTP gate
-  //                                         already proved real intent)
+  //
+  // The combined shape (email + wallet fields) was previously accepted for
+  // the Privy embedded-wallet flow, with the on-chain existence check
+  // skipped on the assumption that Privy's OTP gate proved real intent.
+  // The route never actually verified anything from Privy, so the skip
+  // let any caller bind an arbitrary email to a self-controlled keypair —
+  // and the silent 23505 swallow below meant a victim later signing up
+  // with the same email would receive {ok:true} while their pubkey was
+  // never persisted. Rejecting the combined shape closes that vector
+  // without touching the two pure paths. The dApp gate at mainnet open
+  // re-authenticates Privy users via Privy directly, so binding the
+  // embedded wallet into the waitlist row was never load-bearing for
+  // priority-access recovery — it was decorative trust the server
+  // couldn't actually validate.
   const hasWalletPart = pubkey !== null && signature !== null && message !== null;
   const hasEmail = emailRaw !== null;
 
+  if (hasEmail && hasWalletPart) {
+    return NextResponse.json(
+      {
+        error:
+          "email and wallet signups are separate paths — submit one or the other, not both",
+      },
+      { status: 400 },
+    );
+  }
+
   if (!hasEmail && !hasWalletPart) {
     return NextResponse.json(
-      { error: "provide an email, a wallet signature, or both" },
+      { error: "provide an email or a wallet signature" },
       { status: 400 },
     );
   }
@@ -197,20 +214,18 @@ export async function POST(req: Request) {
     }
 
     // Spam filter: wallet must have been seen on Solana mainnet at least once.
-    // EXCEPTION: when email is also present, we trust Privy's OTP gate as proof
-    // of real intent and accept the embedded wallet (which has no on-chain
-    // history yet by design).
-    if (!hasEmail) {
-      const exists = await walletExistsOnMainnet(pubkey!);
-      if (!exists) {
-        return NextResponse.json(
-          {
-            error:
-              "wallet not seen on Solana mainnet — fund this wallet (any amount) and try again",
-          },
-          { status: 400 },
-        );
-      }
+    // The combined-shape rejection above guarantees hasEmail is false here, so
+    // the previous `if (!hasEmail)` guard is now redundant — the check runs
+    // unconditionally on the wallet-only path.
+    const exists = await walletExistsOnMainnet(pubkey!);
+    if (!exists) {
+      return NextResponse.json(
+        {
+          error:
+            "wallet not seen on Solana mainnet — fund this wallet (any amount) and try again",
+        },
+        { status: 400 },
+      );
     }
   }
 

--- a/app/app/waitlist/page.tsx
+++ b/app/app/waitlist/page.tsx
@@ -294,7 +294,6 @@ type EmailState =
   | { kind: "sending-code"; email: string }
   | { kind: "awaiting-code"; email: string }
   | { kind: "verifying" }
-  | { kind: "signing"; email: string }
   | { kind: "submitting"; email: string }
   | { kind: "done"; email: string; position: number | null }
   | { kind: "error"; reason: string };
@@ -316,8 +315,8 @@ function EmailFlow() {
   });
 
   const { user, ready, authenticated } = usePrivy();
-  const { wallets } = useWallets();
-  const { signMessage } = useSignMessage();
+  // The embedded-wallet binding step is gone — see the submit effect below
+  // for why. useWallets / useSignMessage are no longer needed in EmailFlow.
 
   const onSendCode = useCallback(async () => {
     const trimmed = email.trim().toLowerCase();
@@ -351,32 +350,30 @@ function EmailFlow() {
     }
   }, [code, state, loginWithCode]);
 
-  // After Privy login completes: auto-sign with the embedded wallet
-  // (created by Privy because config.embeddedWallets.solana.createOnLogin
-  // = "users-without-wallets") and submit to the waitlist API.
+  // After Privy login completes, submit the email to the waitlist API.
+  //
+  // The earlier flow had the embedded Privy Solana wallet sign the join
+  // message and submitted (email, pubkey, signature). The server skipped
+  // the on-chain existence check on this combined shape on the assumption
+  // that Privy's OTP gate proved real intent — but the server never
+  // actually verified anything from Privy, so any caller could pair a
+  // self-controlled keypair with an arbitrary email and pre-empt that
+  // email's row. The server now rejects the combined shape; here we just
+  // submit the email-only shape and rely on Privy at mainnet open to
+  // re-derive the user's embedded wallet from their verified email.
   useEffect(() => {
     if (state.kind !== "verifying") return;
     if (!ready || !authenticated || !user) return;
-    const wallet = wallets.find((w) => w.address);
-    if (!wallet) return; // wait one tick for embedded wallet to register
-    const userEmail = user.email?.address ?? state.kind === "verifying" ? email.trim().toLowerCase() : null;
+    const userEmail =
+      user.email?.address?.trim().toLowerCase() ?? email.trim().toLowerCase();
     if (!userEmail) {
       setState({ kind: "error", reason: "missing email after login" });
       return;
     }
 
-    setState({ kind: "signing", email: userEmail });
+    setState({ kind: "submitting", email: userEmail });
     (async () => {
       try {
-        const message = buildMessage(wallet.address);
-        const messageBytes = new TextEncoder().encode(message);
-        const { signature } = await signMessage({
-          message: messageBytes,
-          wallet,
-        });
-        const signatureB58 = bs58.encode(signature);
-        setState({ kind: "submitting", email: userEmail });
-
         const url = new URL(window.location.href);
         const source =
           url.searchParams.get("ref") ?? url.searchParams.get("utm_source") ?? null;
@@ -385,9 +382,6 @@ function EmailFlow() {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             email: userEmail,
-            pubkey: wallet.address,
-            signature: signatureB58,
-            message,
             twitter_handle: twitter.trim() || undefined,
             source: source ?? undefined,
           }),
@@ -403,11 +397,11 @@ function EmailFlow() {
         }
         setState({ kind: "done", email: userEmail, position: json.position ?? null });
       } catch (e: unknown) {
-        const msg = e instanceof Error ? e.message : "sign / submit failed";
+        const msg = e instanceof Error ? e.message : "submit failed";
         setState({ kind: "error", reason: msg });
       }
     })();
-  }, [state, ready, authenticated, user, wallets, signMessage, twitter, email]);
+  }, [state, ready, authenticated, user, twitter, email]);
 
   if (state.kind === "done") {
     return (
@@ -469,16 +463,12 @@ function EmailFlow() {
     );
   }
 
-  if (state.kind === "signing" || state.kind === "submitting") {
+  if (state.kind === "submitting") {
     return (
       <div className="space-y-3">
-        <PromptLine
-          prefix="$"
-          text={state.kind === "signing" ? "signing_with_embedded_wallet" : "submitting"}
-          status="pending"
-        />
+        <PromptLine prefix="$" text="submitting" status="pending" />
         <p className="font-mono text-[11px] leading-relaxed text-[var(--text-secondary)]">
-          Privy created an embedded Solana wallet for {state.email}. We&apos;re signing the join message with it now — no prompt, no gas.
+          Verified {state.email}. Adding you to the list now.
         </p>
       </div>
     );


### PR DESCRIPTION
## Summary

The email signup flow had Privy's embedded Solana wallet sign the join message and submitted `(email, pubkey, signature)` to the waitlist API. The route accepted that combined shape and skipped the on-chain mainnet existence check, on the assumption that Privy's OTP gate had already proved real intent — but the route never actually verified anything from Privy (no JWT check, no SDK round-trip), so any caller could pair a self-controlled keypair with an arbitrary email.

Combined with the silent `23505` swallow on insert, that pre-emption was indistinguishable from a successful signup to the victim: a later genuine email-only signup hit the unique-violation branch, returned `ok:true`, and never overwrote the attacker's pubkey row. Priority access at mainnet open would then resolve to the attacker's wallet, not the victim's.

## Fix

- Server: reject the combined shape with a 400 in `app/api/waitlist/signup/route.ts`. Two clean paths remain — email-only and wallet-only.
- Server: the mainnet existence check on the wallet path is now unconditional (the `if (!hasEmail)` exception was the skip the combined shape relied on; it is no longer reachable).
- Frontend `EmailFlow` (`app/waitlist/page.tsx`) drops the sign step entirely and submits email-only after Privy login. Privy still creates an embedded wallet under the user's email on Privy's side, so the dApp gate at mainnet open re-authenticates by email and re-derives the same wallet — binding the embedded pubkey into the waitlist row was never load-bearing for that recovery path, only decorative trust the server couldn't validate.
- Regression test in `__tests__/api/waitlist-signup-shape.test.ts` pins the route source to the new shape contract.

## Test plan

- [x] `npx vitest run` — 2280 passed, 0 failed (3 new tests in `waitlist-signup-shape.test.ts`)
- [x] `npx tsc --noEmit` — no new errors introduced (8 pre-existing errors on `main` unrelated to this change)
- [ ] Manual: email-only signup end-to-end (Privy OTP → email submitted → row created → confirmation email)
- [ ] Manual: wallet-only signup end-to-end (existing path, mainnet check still applies)
- [ ] Manual: combined shape returns 400 with the new error copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Waitlist signup now enforces email-only or wallet-signature-only submission (cannot use both)
  * Updated validation error messaging to clarify separate signup paths
  * Removed wallet signing prompt from email signup flow
  * Enhanced wallet verification for wallet-only signups

<!-- end of auto-generated comment: release notes by coderabbit.ai -->