### PR TITLE
fix(waitlist): cap confirmation-email send rate per address and globally

### DIFF
--- a/app/__tests__/api/waitlist-signup-email-abuse.test.ts
+++ b/app/__tests__/api/waitlist-signup-email-abuse.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Waitlist signup — email-bombing hardening.
+ *
+ * The route used to fire a Resend confirmation email on every POST that
+ * carried an email field, regardless of whether the insert actually
+ * created a new row. Combined with the route's own 23505 swallow (treating
+ * unique-violation as "already on the list, idempotent"), that meant
+ * resubmitting the same {email} payload from rotating IPs caused the
+ * same victim's inbox to be flooded — once per request. The middleware's
+ * 120 req/min/IP rate limit was trivially bypassed with residential
+ * proxies, and there was no per-email or global ceiling on the Resend
+ * send rate.
+ *
+ * The fix is three-layered:
+ *   (1) capture isDuplicate from the insert error and skip the send when
+ *       set — Resend send count == new-row count.
+ *   (2) per-email Upstash limiter (1/24h) backstops a future regression
+ *       of the unique-on-lower(email) index.
+ *   (3) global hourly Upstash cap (default 500/h, tunable via
+ *       WAITLIST_EMAIL_HOURLY_CAP) bounds Resend quota burn under the
+ *       fresh-victims-mass-signup variant where layer 1 and 2 don't help.
+ *
+ * This test guards the route source so a future "let's just fire the
+ * mail unconditionally again" refactor trips the suite.
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const ROUTE_PATH = path.resolve(
+  __dirname,
+  "../../app/api/waitlist/signup/route.ts",
+);
+
+describe("/api/waitlist/signup email-bombing hardening", () => {
+  const source = fs.readFileSync(ROUTE_PATH, "utf8");
+
+  it("captures isDuplicate from the insert error code", () => {
+    expect(source).toMatch(
+      /isDuplicate\s*=\s*insertError\?\.code\s*===\s*"23505"/,
+    );
+  });
+
+  it("skips the confirmation email on duplicate insert", () => {
+    // The single Resend-send call site must sit inside an `if (...)`
+    // whose condition includes both `hasEmail` and `!isDuplicate`.
+    const beforeSend = source.split("sendConfirmationEmail(emailRaw!")[0];
+    expect(beforeSend).toBeDefined();
+    // Walk back from the call site to the nearest `if (` and confirm the
+    // gate. The pre-fix gate was `if (hasEmail) { sendConfirmationEmail(...) }`.
+    const lastIfIdx = beforeSend.lastIndexOf("if (");
+    expect(lastIfIdx).toBeGreaterThan(-1);
+    const gate = beforeSend.slice(lastIfIdx);
+    expect(gate).toContain("hasEmail");
+    expect(gate).toContain("!isDuplicate");
+  });
+
+  it("gates the send through a per-email budget (1 per 24 h)", () => {
+    expect(source).toContain("shouldSendConfirmationEmail");
+    expect(source).toMatch(/Ratelimit\.slidingWindow\(\s*1\s*,\s*"24 h"/);
+  });
+
+  it("enforces a global hourly cap, env-tunable via WAITLIST_EMAIL_HOURLY_CAP", () => {
+    expect(source).toContain("WAITLIST_EMAIL_HOURLY_CAP");
+    // Global limiter is keyed at "1 h" with a numeric cap (not the literal
+    // 1 of the per-email limiter).
+    expect(source).toMatch(/Ratelimit\.slidingWindow\([^,]+,\s*"1 h"/);
+  });
+
+  it("hashes the email before using it as a Redis key", () => {
+    // Privacy hygiene — Redis logs / dashboards must never see cleartext
+    // emails as rate-limit keys.
+    expect(source).toContain("emailRateKey");
+    expect(source).toMatch(
+      /createHash\("sha256"\)\.update\(email\)\.digest\("hex"\)/,
+    );
+  });
+
+  it("fails open when Upstash is unconfigured (local dev / Redis outage)", () => {
+    // Matches the in-memory fallback posture in middleware.ts. Without
+    // this, /api/waitlist/signup would 500 in CI/dev where UPSTASH_*
+    // env vars are unset.
+    expect(source).toMatch(
+      /if\s*\(\s*!perEmail\s*\|\|\s*!global\s*\)\s*return\s+true/,
+    );
+  });
+
+  it("does not reach the Resend send call from the wallet-only path", () => {
+    // The send guard must require hasEmail. There must be exactly one
+    // call site to sendConfirmationEmail (the function definition isn't
+    // counted by this regex because the param is `email`, not `emailRaw`).
+    const callSites = source.match(/sendConfirmationEmail\(emailRaw!/g) ?? [];
+    expect(callSites.length).toBe(1);
+  });
+});

--- a/app/app/api/waitlist/signup/route.ts
+++ b/app/app/api/waitlist/signup/route.ts
@@ -1,7 +1,10 @@
 import { NextResponse } from "next/server";
+import { createHash } from "crypto";
 import nacl from "tweetnacl";
 import bs58 from "bs58";
 import { Resend } from "resend";
+import { Redis } from "@upstash/redis";
+import { Ratelimit } from "@upstash/ratelimit";
 import { getWaitlistSupabase } from "@/lib/waitlist/supabase";
 
 export const runtime = "nodejs";
@@ -10,6 +13,84 @@ export const runtime = "nodejs";
 // to reject corner-case-valid addresses.
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
 const FROM = "Percolator <waitlist@percolator.trade>";
+
+// ── Email-send abuse limits ──────────────────────────────────────────────
+// Two distributed Upstash limiters bound the Resend send rate:
+//   • per-email: at most one confirmation per address per 24h. Belt-and-
+//     suspenders on top of the duplicate-insert short-circuit below — if
+//     the unique constraint on lower(email) ever regresses, this still
+//     caps inbox flooding from rotating IPs to one mail/day per victim.
+//   • global hourly: at most WAITLIST_EMAIL_HOURLY_CAP confirmations across
+//     all addresses per hour (default 500). Bounds Resend quota burn when
+//     an attacker rotates through many fresh victim emails (the per-email
+//     limiter can't help in that case because each is a first hit).
+// Both fail open when Upstash isn't configured, matching the in-memory
+// fallback posture in app/middleware.ts so local dev / CI keep working.
+let _emailLimiter: Ratelimit | null = null;
+let _globalEmailLimiter: Ratelimit | null = null;
+let _emailLimitersInitialized = false;
+
+function getEmailLimiters(): {
+  perEmail: Ratelimit | null;
+  global: Ratelimit | null;
+} {
+  if (_emailLimitersInitialized) {
+    return { perEmail: _emailLimiter, global: _globalEmailLimiter };
+  }
+  _emailLimitersInitialized = true;
+
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return { perEmail: null, global: null };
+
+  try {
+    const redis = new Redis({ url, token });
+    _emailLimiter = new Ratelimit({
+      redis,
+      limiter: Ratelimit.slidingWindow(1, "24 h"),
+      prefix: "rl:wl-em",
+      analytics: false,
+    });
+    const globalCap = Math.max(
+      1,
+      Number(process.env.WAITLIST_EMAIL_HOURLY_CAP ?? 500),
+    );
+    _globalEmailLimiter = new Ratelimit({
+      redis,
+      limiter: Ratelimit.slidingWindow(globalCap, "1 h"),
+      prefix: "rl:wl-em-global",
+      analytics: false,
+    });
+  } catch {
+    // Init failure (bad credentials, network) — fail open.
+    _emailLimiter = null;
+    _globalEmailLimiter = null;
+  }
+  return { perEmail: _emailLimiter, global: _globalEmailLimiter };
+}
+
+/** sha256 hex of the lowercased email so the email cleartext doesn't end
+ *  up in Redis logs / dashboards. */
+function emailRateKey(email: string): string {
+  return createHash("sha256").update(email).digest("hex");
+}
+
+/** Returns true iff a confirmation email may be sent to this address now.
+ *  Consumes one slot from BOTH limiters on success — order matters: the
+ *  global cap is checked first so a system-wide overflow doesn't burn a
+ *  per-email budget that won't be used. Fail-open when Upstash is
+ *  unconfigured (local dev / Redis outage). */
+async function shouldSendConfirmationEmail(email: string): Promise<boolean> {
+  const { perEmail, global } = getEmailLimiters();
+  if (!perEmail || !global) return true; // fail-open
+  const g = await global.limit("global");
+  if (!g.success) {
+    console.warn("[waitlist] global email cap reached this hour");
+    return false;
+  }
+  const e = await perEmail.limit(emailRateKey(email));
+  return e.success;
+}
 
 /**
  * High-intent waitlist signup.
@@ -229,8 +310,13 @@ export async function POST(req: Request) {
   }
 
   const { error: insertError } = await supabase.from("waitlist").insert(insertRow);
-  // 23505 = unique violation (already on the list) — idempotent
-  if (insertError && insertError.code !== "23505") {
+  // 23505 = unique violation (already on the list) — idempotent. We capture
+  // the duplicate flag here to suppress the confirmation email below: the
+  // pre-fix unconditional send turned every repeat POST with the same email
+  // into another Resend call, which let an attacker flood a single victim's
+  // inbox by replaying the same payload from rotating IPs.
+  const isDuplicate = insertError?.code === "23505";
+  if (insertError && !isDuplicate) {
     console.error("[waitlist] insert error", insertError);
     return NextResponse.json({ error: "insert failed" }, { status: 500 });
   }
@@ -252,7 +338,22 @@ export async function POST(req: Request) {
   }
 
   // ── Confirmation email (fire-and-forget) ────────────────────────────────
-  if (hasEmail) {
+  // Three layers protect the Resend send from abuse:
+  //   (1) skip on duplicate insert — Resend send count == new-row count,
+  //       so the same email replayed from rotating IPs sends one mail, not N.
+  //   (2) per-email budget (1/24h) — backstops layer 1 if the unique
+  //       constraint on lower(email) ever regresses or a row gets deleted.
+  //   (3) global hourly cap — bounds Resend quota burn during the
+  //       many-fresh-victim-emails attack, where layer 1 and 2 don't help
+  //       because every signup is genuinely new.
+  // The response stays {ok:true, position} regardless of whether the mail
+  // actually went out — leaking "we suppressed your mail" would tell an
+  // attacker their target was already on the list (membership oracle).
+  if (
+    hasEmail &&
+    !isDuplicate &&
+    (await shouldSendConfirmationEmail(emailRaw!))
+  ) {
     sendConfirmationEmail(emailRaw!, position, hasWalletPart).catch((err) =>
       console.error("[waitlist] confirmation send failed", err),
     );


### PR DESCRIPTION
## Summary

\`/api/waitlist/signup\` fired a Resend confirmation on every POST that carried an email field, regardless of whether the insert actually created a new row. Combined with the route's existing treatment of the \`23505\` unique-violation as \"idempotent, ignore,\" repeating the same \`{email}\` payload from rotating IPs flooded the same victim's inbox — once per request. The middleware's 120 req/min/IP rate limit was the only ceiling, and ~\$50/mo of residential proxies trivially defeats it (100 IPs × 120/min = 12K sends/min; the free Resend tier dies in 0.5s, the paid tier in minutes; overages then bill per email).

## Fix

Three layers now bound the send rate, all on the email path only — the wallet-only path is untouched:

1. **Skip the send when the insert was a duplicate.** Resend send count == new-row count, so replaying the same email from rotating IPs produces one mail, not N.
2. **Per-email Upstash limiter** (1 send / 24h, keyed on \`sha256(email)\` so cleartext addresses don't land in Redis logs). Backstops layer 1 if the \`lower(email)\` unique constraint ever regresses or a row is admin-deleted.
3. **Global hourly Upstash cap** (default 500/h, env-tunable via \`WAITLIST_EMAIL_HOURLY_CAP\`). Bounds Resend quota burn during the mass-fresh-victim-emails variant where layers 1 and 2 don't help because each signup is genuinely new.

Both Upstash limiters fail open when \`UPSTASH_REDIS_REST_URL\` is unset, matching the in-memory fallback posture in [middleware.ts](app/middleware.ts) so local dev / CI keep working. The response stays \`{ok:true, position}\` regardless of whether the mail actually went out — leaking \"we suppressed your mail\" would tell an attacker their target was already on the list (membership oracle).

Regression test in \`__tests__/api/waitlist-signup-email-abuse.test.ts\` pins the new contract (7 cases).

## Test plan

- [x] \`npx vitest run\` — 2284 passed (+7 new), 0 failures
- [x] \`npx tsc --noEmit\` — no new errors (8 pre-existing on \`main\` are unrelated)
- [ ] Manual: first signup with email → row created, confirmation sent
- [ ] Manual: same email submitted again → row not duplicated, no second confirmation, response still \`{ok:true, position}\`
- [ ] Manual: \`WAITLIST_EMAIL_HOURLY_CAP=2\` env, three rapid fresh-email signups → third gets \`{ok:true}\` but no Resend send (warning logged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)