### PR TITLE
fix(trade): stop FundingExplainerModal blinking while open

### DIFF
--- a/app/components/trade/FundingExplainerModal.tsx
+++ b/app/components/trade/FundingExplainerModal.tsx
@@ -14,6 +14,12 @@ export const FundingExplainerModal: FC<FundingExplainerModalProps> = ({ onClose 
   const modalRef = useRef<HTMLDivElement>(null);
   const prefersReduced = usePrefersReducedMotion();
 
+  // Entry animation must run exactly once per mount. The previous combined effect listed
+  // `onClose` in its deps, so every parent re-render — FundingRateCard re-renders every
+  // second from its countdown setInterval, passing a fresh `() => setShowExplainer(false)`
+  // each time — re-fired the animation. gsap.fromTo({opacity:0},{opacity:1}) reset opacity
+  // to 0 then animated to 1 once a second, producing a continuous blink for as long as
+  // the modal stayed open.
   useEffect(() => {
     const overlay = overlayRef.current;
     const modal = modalRef.current;
@@ -31,13 +37,16 @@ export const FundingExplainerModal: FC<FundingExplainerModalProps> = ({ onClose 
         { opacity: 1, scale: 1, duration: 0.25, ease: "power2.out" }
       );
     }
+  }, [prefersReduced]);
 
+  // Escape handler is cheap to re-bind and needs the latest `onClose` reference.
+  useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
     };
     document.addEventListener("keydown", handleEscape);
     return () => document.removeEventListener("keydown", handleEscape);
-  }, [onClose, prefersReduced]);
+  }, [onClose]);
 
   const handleOverlayClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget) onClose();


### PR DESCRIPTION
## Summary

- The funding-rate **\"more\"** modal on `/trade/[slab]` flickered ~1Hz for as long as it stayed open.
- Caused by `FundingExplainerModal`'s entry-animation effect listing `onClose` in its deps. The parent `FundingRateCard` re-renders every second (countdown `setInterval`), passing a fresh inline closure each time, which re-fired the gsap animation and reset opacity to 0 → 1 once per second.
- Fix: split the modal's `useEffect` so the gsap entry animation depends only on \`prefersReduced\` (runs once per mount), while the Escape-key handler keeps depending on \`onClose\` so it always closes the current instance. Modal owns its own animation lifecycle; no parent change needed.

## Test plan

- [ ] Open `/trade/[any slab]` in dev or production
- [ ] Click the **more** link in the Funding Rate section
- [ ] Modal fades in once and stays still — no blinking
- [ ] Wait at least 5 seconds with the modal open — still no flicker
- [ ] Press **Escape** — modal closes
- [ ] Reopen, click outside the modal content — modal closes (overlay click)
- [ ] Reopen, click **Got it** — modal closes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed funding explainer modal animations from re-triggering unnecessarily when parent components update.
  * Improved escape key handling for modal dismissal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->