### PR TITLE
fix(modals): stop four modals blinking while open (effect-deps + onClose ref)

### DIFF
--- a/app/components/market/InsuranceExplainerModal.tsx
+++ b/app/components/market/InsuranceExplainerModal.tsx
@@ -18,6 +18,15 @@ export const InsuranceExplainerModal: FC<InsuranceExplainerModalProps> = ({
   const modalRef = useRef<HTMLDivElement>(null);
   const prefersReduced = usePrefersReducedMotion();
 
+  // Keep the onClose callback in a ref so the mount effect never re-runs on parent
+  // re-renders. Insurance-dashboard parents re-render whenever LP / vault / live-price
+  // data ticks and pass freshly-allocated inline `onClose` closures each time; with
+  // `onClose` in the effect deps, every parent re-render re-fired the gsap fade-in
+  // (opacity 0 → 1) and made the modal blink continuously while open. Same canonical
+  // pattern as TradeConfirmationModal.tsx.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
   useEffect(() => {
     const overlay = overlayRef.current;
     const modal = modalRef.current;
@@ -41,11 +50,12 @@ export const InsuranceExplainerModal: FC<InsuranceExplainerModalProps> = ({
     }
 
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") onCloseRef.current();
     };
     document.addEventListener("keydown", handleEscape);
     return () => document.removeEventListener("keydown", handleEscape);
-  }, [onClose, prefersReduced]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prefersReduced]);
 
   const handleOverlayClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget) onClose();

--- a/app/components/market/InsuranceTopUpModal.tsx
+++ b/app/components/market/InsuranceTopUpModal.tsx
@@ -37,6 +37,15 @@ export const InsuranceTopUpModal: FC<InsuranceTopUpModalProps> = ({
   const prefersReduced = usePrefersReducedMotion();
   const mockMode = isMockMode() && isMockSlab(slabAddress);
 
+  // Keep the onClose callback in a ref so the mount effect never re-runs on parent
+  // re-renders. Insurance-dashboard parents re-render whenever LP / vault / live-price
+  // data ticks and pass freshly-allocated inline `onClose` closures each time; with
+  // `onClose` in the effect deps, every parent re-render re-fired the gsap fade-in
+  // (opacity 0 → 1) and made the modal blink continuously while open. Same canonical
+  // pattern as TradeConfirmationModal.tsx.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
   const wallet = useWalletCompat();
   const { deposit, state: lpState, loading: lpLoading, error: lpError } = useInsuranceLP();
   const { config } = useSlabState();
@@ -72,11 +81,12 @@ export const InsuranceTopUpModal: FC<InsuranceTopUpModalProps> = ({
     }
 
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") onCloseRef.current();
     };
     document.addEventListener("keydown", handleEscape);
     return () => document.removeEventListener("keydown", handleEscape);
-  }, [onClose, prefersReduced]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prefersReduced]);
 
   const handleOverlayClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget && !loading) onClose();

--- a/app/components/trade/FundingExplainerModal.tsx
+++ b/app/components/trade/FundingExplainerModal.tsx
@@ -14,6 +14,16 @@ export const FundingExplainerModal: FC<FundingExplainerModalProps> = ({ onClose 
   const modalRef = useRef<HTMLDivElement>(null);
   const prefersReduced = usePrefersReducedMotion();
 
+  // Keep the onClose callback in a ref so the mount effect never re-runs on parent
+  // re-renders. The parent FundingRateCard runs a 1-second `setCountdown` setInterval,
+  // so it re-renders every second and passes a freshly-allocated
+  // `() => setShowExplainer(false)` closure as `onClose` each time. With `onClose` in
+  // the effect deps, every parent tick re-fired the gsap fade-in (opacity 0 → 1),
+  // making the modal blink continuously while open. Same canonical pattern as
+  // TradeConfirmationModal.tsx.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
   useEffect(() => {
     const overlay = overlayRef.current;
     const modal = modalRef.current;
@@ -33,11 +43,12 @@ export const FundingExplainerModal: FC<FundingExplainerModalProps> = ({ onClose 
     }
 
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") onCloseRef.current();
     };
     document.addEventListener("keydown", handleEscape);
     return () => document.removeEventListener("keydown", handleEscape);
-  }, [onClose, prefersReduced]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prefersReduced]);
 
   const handleOverlayClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget) onClose();

--- a/app/components/trade/WarmupExplainerModal.tsx
+++ b/app/components/trade/WarmupExplainerModal.tsx
@@ -16,6 +16,15 @@ export const WarmupExplainerModal: FC<WarmupExplainerModalProps> = ({
   const modalRef = useRef<HTMLDivElement>(null);
   const prefersReduced = usePrefersReducedMotion();
 
+  // Keep the onClose callback in a ref so the mount effect never re-runs on parent
+  // re-renders. Trade-page parents re-render frequently (countdown ticks, WS price
+  // updates, etc.) and pass freshly-allocated inline `onClose` closures each time;
+  // with `onClose` in the effect deps, every parent re-render re-fired the gsap
+  // fade-in (opacity 0 → 1) and made the modal blink continuously while open.
+  // Same canonical pattern as TradeConfirmationModal.tsx.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
   useEffect(() => {
     const overlay = overlayRef.current;
     const modal = modalRef.current;
@@ -39,11 +48,12 @@ export const WarmupExplainerModal: FC<WarmupExplainerModalProps> = ({
     }
 
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") onCloseRef.current();
     };
     document.addEventListener("keydown", handleEscape);
     return () => document.removeEventListener("keydown", handleEscape);
-  }, [onClose, prefersReduced]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prefersReduced]);
 
   const handleOverlayClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget) onClose();


### PR DESCRIPTION
## Summary

- Four modals were flickering ~1Hz for as long as they stayed open: **Funding Rate \"more\"**, **Warmup explainer**, **Insurance Top-Up**, **Insurance \"more\"**.
- Same root cause in all four: each one's mount effect listed `onClose` in its dep array and ran a `gsap.fromTo` entry animation inside. Their parents re-render on a sub-second cadence — `FundingRateCard` runs a 1-second countdown `setInterval`, the trade and insurance dashboards tick on WS price / LP updates — and they all pass a freshly-allocated `() => set...(false)` closure as `onClose` on every render. New `onClose` reference → effect re-fired → `gsap.fromTo({opacity: 0}, {opacity: 1})` reset opacity to 0 then animated back to 1, once per parent tick.
- Fix is the canonical pattern already used (and commented) in [`TradeConfirmationModal.tsx:60-95`](https://github.com/dcccrypto/percolator-launch/blob/main/app/components/trade/TradeConfirmationModal.tsx#L60-L95): stash `onClose` in a ref updated during render, drop it from the effect deps, call `onCloseRef.current()` from the Escape handler. The four modals in this PR had simply drifted out of consistency with the canonical fix.
- `ClosePositionModal`, `SendPositionNftModal`, and `TradeConfirmationModal` were checked during the audit and already use the correct pattern — left untouched.

## Test plan

- [ ] `/trade/[any slab]` → click **more** in the Funding Rate section → modal stays still for ≥5s, no flicker
- [ ] Same trade page → trigger the **Warmup** explainer modal → stays still for ≥5s
- [ ] Insurance dashboard on a market with insurance → click **Top Up** → modal stays still for ≥5s
- [ ] Same dashboard → click the insurance **more / explainer** trigger → modal stays still for ≥5s
- [ ] For each modal: pressing **Escape** still closes it
- [ ] For each modal: clicking the dim overlay still closes it
- [ ] Reduced-motion users (`prefers-reduced-motion: reduce`) still see the modal appear instantly with no animation