### PR TITLE
pitch: investor-focused rewrite (clearer Problem, merged Toly+Traction, 11 slides)

### DIFF
--- a/app/app/pitch/page.tsx
+++ b/app/app/pitch/page.tsx
@@ -794,10 +794,8 @@ function SlideTolyStory(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Origin · Toly Signal</div>
         <h2 className="pitch-title">
-          Solana&apos;s co-founder Anatoly Yakovenko wrote the protocol
-          math behind Percolator and open-sourced a reference program.
-          He still publicly engages with our work. We built the
-          product on top of what he started.
+          Solana&apos;s co-founder wrote the protocol math behind
+          Percolator and still publicly engages with our work.
         </h2>
 
         <div className="pitch-toly-photo-grid">
@@ -891,10 +889,9 @@ function SlideProof(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Hackathon Sprint</div>
         <h2 className="pitch-title">
-          Customers told us their two biggest blockers were audit
-          posture and the ability to transfer positions. We shipped
-          both during this hackathon, plus 500+ formal proofs that
-          hold before any auditor starts.
+          Audit posture and transferable positions were the two biggest
+          customer blockers. We shipped both this hackathon, plus 500+
+          formal proofs.
         </h2>
 
         <div className="pitch-solution-stack">
@@ -1342,7 +1339,7 @@ export default function PitchPage() {
           display: flex;
           align-items: center;
           justify-content: center;
-          overflow: hidden;
+          overflow-y: auto;
           padding: 0 0 80px 0;
         }
 
@@ -1350,7 +1347,7 @@ export default function PitchPage() {
           width: 100%;
           max-width: 1000px;
           margin: 0 auto;
-          padding: 2rem 2.5rem;
+          padding: 1.5rem 2.5rem;
         }
 
         .pitch-center {
@@ -2670,19 +2667,25 @@ export default function PitchPage() {
 
         .pitch-toly-photo-grid {
           display: grid;
-          grid-template-columns: repeat(2, 1fr);
-          gap: 0.85rem;
-          margin-bottom: 1.25rem;
+          grid-template-columns: repeat(4, 1fr);
+          gap: 0.75rem;
+          margin-bottom: 1rem;
+        }
+
+        @media (max-width: 900px) {
+          .pitch-toly-photo-grid {
+            grid-template-columns: repeat(2, 1fr);
+          }
         }
 
         .pitch-toly-photo {
           display: flex;
           flex-direction: column;
-          gap: 0.5rem;
+          gap: 0.4rem;
           background: rgba(255, 255, 255, 0.025);
           border: 1px solid rgba(255, 255, 255, 0.08);
           border-radius: 12px;
-          padding: 0.6rem;
+          padding: 0.5rem;
           text-decoration: none;
           color: inherit;
           transition:
@@ -2701,10 +2704,10 @@ export default function PitchPage() {
 
         .pitch-toly-photo img {
           width: 100%;
-          aspect-ratio: 4 / 3;
+          aspect-ratio: 3 / 2;
           object-fit: contain;
           background: rgba(0, 0, 0, 0.35);
-          border-radius: 6px;
+          border-radius: 8px;
           display: block;
         }
 
@@ -2832,43 +2835,47 @@ export default function PitchPage() {
           background: rgba(255, 255, 255, 0.02);
           border: 1px solid rgba(255, 255, 255, 0.06);
           border-radius: 12px;
-          padding: 1rem 1.25rem;
+          padding: 0.7rem 1rem;
+          margin-top: 0.85rem;
+          display: grid;
+          grid-template-columns: repeat(4, 1fr);
+          gap: 0.55rem;
         }
 
         .pitch-kani-vs-title {
-          font-size: 0.7rem;
+          font-size: 0.68rem;
           font-weight: 700;
           letter-spacing: 0.15em;
           text-transform: uppercase;
           color: rgba(153, 69, 255, 0.7);
-          margin-bottom: 0.85rem;
+          margin-bottom: 0.6rem;
         }
 
         .pitch-kani-vs-row {
           display: grid;
           grid-template-columns: repeat(4, 1fr);
-          gap: 0.85rem;
+          gap: 0.6rem;
         }
 
         .pitch-kani-vs-cell {
           background: rgba(0, 0, 0, 0.25);
           border: 1px solid rgba(255, 255, 255, 0.06);
           border-radius: 8px;
-          padding: 0.85rem;
+          padding: 0.55rem 0.4rem;
           text-align: center;
         }
 
         .pitch-kani-vs-cell-num {
-          font-size: 1.7rem;
+          font-size: 1.3rem;
           font-weight: 700;
           color: rgba(255, 255, 255, 0.4);
           line-height: 1;
-          margin-bottom: 0.3rem;
+          margin-bottom: 0.25rem;
         }
 
         .pitch-kani-vs-cell-label {
           font-family: 'Inter', sans-serif;
-          font-size: 0.75rem;
+          font-size: 0.7rem;
           color: rgba(255, 255, 255, 0.5);
         }
 

--- a/app/app/pitch/page.tsx
+++ b/app/app/pitch/page.tsx
@@ -131,24 +131,10 @@ function Slide01OneLiner(_: SlideProps) {
           Permissionless perpetual futures on Solana.
         </p>
         <p className="pitch-hero-body">
-          Anyone can launch a perp market on any SPL token in about
-          60 seconds, with no team approval and no $20M stake to
-          clear. The leading Solana perp DEXes today cover around
-          fifty blue-chip tokens between them. Over 15 million other
-          SPL tokens have no perp access at all. That&apos;s the long
-          tail we open.
+          Anyone launches a perp market on any SPL token in about 60
+          seconds. That opens leverage on the 15 million Solana tokens
+          that have no perp access today.
         </p>
-        <div className="pitch-hero-ctas">
-          <a
-            className="pitch-hero-cta pitch-hero-cta-primary"
-            href="https://github.com/dcccrypto"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            See the code on GitHub
-            <span className="pitch-hero-cta-arrow" aria-hidden>→</span>
-          </a>
-        </div>
         <p className="pitch-url">percolator.trade</p>
       </div>
       <div className="pitch-bg-grid" aria-hidden />
@@ -164,44 +150,33 @@ function SlideProblem(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Problem</div>
         <h2 className="pitch-title">
-          Fifty Solana tokens have a perp market. Fifteen million
-          don&apos;t.
+          Most Solana tokens can&apos;t be traded with leverage.
         </h2>
 
         <div className="pitch-opp-compare">
           <div className="pitch-opp-row">
             <div className="pitch-opp-row-header">
-              <span className="pitch-opp-tag">Jupiter / Drift</span>
-              <span className="pitch-opp-row-stat mono">Curated</span>
+              <span className="pitch-opp-tag">Today</span>
+              <span className="pitch-opp-row-stat mono">~50 tokens</span>
               <span className="pitch-opp-row-detail">
-                Team-gated whitelist, blue chips only, centralized listing.
+                The handful of blue chips with a perp market on Jupiter, Drift, Pacifica, or Hyperliquid.
               </span>
             </div>
           </div>
 
           <div className="pitch-opp-row">
             <div className="pitch-opp-row-header">
-              <span className="pitch-opp-tag">Hyperliquid HIP-3</span>
-              <span className="pitch-opp-row-stat mono">500K HYPE</span>
+              <span className="pitch-opp-tag pitch-opp-tag-cyan">The gap</span>
+              <span className="pitch-opp-row-stat mono">15M+ tokens</span>
               <span className="pitch-opp-row-detail">
-                Around $20M in stake to deploy a single perp DEX. Prices out every long-tail builder.
-              </span>
-            </div>
-          </div>
-
-          <div className="pitch-opp-row">
-            <div className="pitch-opp-row-header">
-              <span className="pitch-opp-tag pitch-opp-tag-cyan">Result</span>
-              <span className="pitch-opp-row-stat mono">15M+ shut out</span>
-              <span className="pitch-opp-row-detail">
-                Every token with a live DEX pool. No perp access today.
+                Every other SPL token. Creators can&apos;t list them. Traders can&apos;t go long or short with leverage.
               </span>
             </div>
           </div>
 
           <div className="pitch-opp-callout">
-            Today&apos;s perp market on Solana is a small permissioned
-            slice. We open it up.
+            Solana perps already do $25 billion a month across that
+            small slice. The rest is uncaptured.
           </div>
         </div>
       </div>
@@ -218,12 +193,11 @@ function Slide02Team(_: SlideProps) {
         <div className="pitch-label">Team</div>
         <h2 className="pitch-title">
           Two Solana founders, each holding one of Toly&apos;s public
-          bounties on Percolator, plus an AI pair-programmer that
-          writes most of the code. We shipped to mainnet closed beta
-          with 500+ formal proofs and no outside capital.
+          bounties on Percolator. Shipped to mainnet closed beta with
+          no outside capital.
         </h2>
 
-        <div className="pitch-team-grid pitch-team-grid-three">
+        <div className="pitch-team-grid pitch-team-grid-two">
           <div className="pitch-team-card">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
@@ -307,21 +281,6 @@ function Slide02Team(_: SlideProps) {
               </a>
             </p>
           </div>
-          <div className="pitch-team-card">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src="https://github.com/anthropics.png?size=200"
-              alt="Claude (Anthropic)"
-              className="pitch-team-pfp"
-            />
-            <div className="pitch-team-name">Claude</div>
-            <div className="pitch-team-role">Lead engineering · AI pair-programmer</div>
-            <ul className="pitch-team-bullets">
-              <li>Owns most of the production code: Rust programs, TypeScript SDK, frontend, tests, Kani proofs</li>
-              <li>Anthropic&apos;s Claude (Opus 4.7) running in Claude Code</li>
-              <li>Reviews PRs. Doesn&apos;t sleep.</li>
-            </ul>
-          </div>
         </div>
 
         <p className="pitch-team-footer">
@@ -348,11 +307,82 @@ function Slide03Traction(_: SlideProps) {
   return (
     <div className="pitch-slide">
       <div className="pitch-slide-inner">
-        <div className="pitch-label">Traction · On-Chain</div>
+        <div className="pitch-label">Traction</div>
         <h2 className="pitch-title">
-          220 perp markets on devnet from 100+ creators, and the first
-          SOL/USDC market live on mainnet in closed beta.
+          Solana&apos;s co-founder backs the work. Over 100 creators
+          have already shipped on top of it.
         </h2>
+
+        <div className="pitch-toly-photo-grid pitch-toly-photo-grid-compact">
+          <a
+            className="pitch-toly-photo"
+            href="https://x.com/toly"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Toly tweet — Squid bug fix, April 29"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src="/images/toly/photo1.jpg"
+              alt="Toly tweet quote-RTing Squid's GitHub issue: 'big brain bug'"
+            />
+            <div className="pitch-toly-photo-cap mono">
+              <span>@toly · Apr 29</span>
+              <span>Squid&apos;s KeeperCrank fix</span>
+            </div>
+          </a>
+          <a
+            className="pitch-toly-photo"
+            href="https://x.com/toly"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Toly tweet — Khubair bounty 3 critical, May 7"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src="/images/toly/photo2.jpg"
+              alt="Toly tweet with brain emojis on Khubair's bounty 3 critical issue"
+            />
+            <div className="pitch-toly-photo-cap mono">
+              <span>@toly · May 7</span>
+              <span>Khubair&apos;s bounty 3 critical</span>
+            </div>
+          </a>
+          <a
+            className="pitch-toly-photo"
+            href="https://x.com/toly"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Toly tweet — percolator-stake repo signal, Feb 19"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src="/images/toly/photo3.jpg"
+              alt="Toly tweet RTing dcccrypto/percolator-stake: 'Look, a contribution! Don't trust, verify!'"
+            />
+            <div className="pitch-toly-photo-cap mono">
+              <span>@toly · Feb 19</span>
+              <span>&ldquo;Don&apos;t trust, verify&rdquo;</span>
+            </div>
+          </a>
+          <a
+            className="pitch-toly-photo"
+            href="https://x.com/toly"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Toly tweet — Percolator is a job creator, Feb 13"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src="/images/toly/photo4.jpg"
+              alt="Toly tweet: 'Percolator is a job creator'"
+            />
+            <div className="pitch-toly-photo-cap mono">
+              <span>@toly · Feb 13</span>
+              <span>&ldquo;Percolator is a job creator&rdquo;</span>
+            </div>
+          </a>
+        </div>
 
         <div className="pitch-traction-network-grid pitch-traction-network-grid-single">
           <div className="pitch-traction-network-card pitch-traction-network-card-wide">
@@ -403,15 +433,9 @@ function Slide03Traction(_: SlideProps) {
         <div className="pitch-traction-mini-row">
           <div className="pitch-traction-mini">
             <div className="pitch-traction-mini-num mono">
-              <NumberCounter target={500} suffix="+" />
+              <NumberCounter target={100} suffix="+" />
             </div>
-            <div className="pitch-traction-mini-label">Kani formal proofs (all green)</div>
-          </div>
-          <div className="pitch-traction-mini">
-            <div className="pitch-traction-mini-num mono">
-              <NumberCounter target={22} />
-            </div>
-            <div className="pitch-traction-mini-label">Public repos · Apache 2.0</div>
+            <div className="pitch-traction-mini-label">Waitlist signups · first 48 hours</div>
           </div>
           <div className="pitch-traction-mini">
             <div className="pitch-traction-mini-num mono">
@@ -421,9 +445,9 @@ function Slide03Traction(_: SlideProps) {
           </div>
           <div className="pitch-traction-mini">
             <div className="pitch-traction-mini-num mono">
-              <NumberCounter target={100} suffix="+" />
+              <NumberCounter target={22} />
             </div>
-            <div className="pitch-traction-mini-label">Waitlist signups · first 48 hours</div>
+            <div className="pitch-traction-mini-label">Public repos · Apache 2.0</div>
           </div>
           <div className="pitch-traction-mini">
             <div className="pitch-traction-mini-num mono">$0</div>
@@ -1103,15 +1127,14 @@ const SLIDES = [
   { id: 1, title: "One-Liner", component: Slide01OneLiner },
   { id: 2, title: "Problem", component: SlideProblem },
   { id: 3, title: "Team", component: Slide02Team },
-  { id: 4, title: "Toly Signal", component: SlideTolyStory },
-  { id: 5, title: "Traction", component: Slide03Traction },
-  { id: 6, title: "Hackathon Sprint", component: SlideProof },
-  { id: 7, title: "Demo Product", component: Slide05Product },
-  { id: 8, title: "Business Model", component: Slide06Money },
-  { id: 9, title: "Market", component: SlideMarket },
-  { id: 10, title: "GTM & Why Now", component: Slide09WhyNow },
-  { id: 11, title: "Roadmap & Ask", component: SlideRoadmapAsk },
-  { id: 12, title: "Contact", component: Slide13Contact },
+  { id: 4, title: "Traction", component: Slide03Traction },
+  { id: 5, title: "Hackathon Sprint", component: SlideProof },
+  { id: 6, title: "Demo Product", component: Slide05Product },
+  { id: 7, title: "Business Model", component: Slide06Money },
+  { id: 8, title: "Market", component: SlideMarket },
+  { id: 9, title: "GTM & Why Now", component: Slide09WhyNow },
+  { id: 10, title: "Roadmap & Ask", component: SlideRoadmapAsk },
+  { id: 11, title: "Contact", component: Slide13Contact },
 ];
 
 const TOTAL_SLIDES = SLIDES.length;
@@ -2135,8 +2158,8 @@ export default function PitchPage() {
 
         .pitch-traction-mini-row {
           display: grid;
-          grid-template-columns: repeat(5, 1fr);
-          gap: 0.65rem;
+          grid-template-columns: repeat(4, 1fr);
+          gap: 0.75rem;
         }
 
         @media (max-width: 720px) {
@@ -2673,6 +2696,23 @@ export default function PitchPage() {
           grid-template-columns: repeat(4, 1fr);
           gap: 0.75rem;
           margin-bottom: 1rem;
+        }
+
+        .pitch-toly-photo-grid-compact {
+          gap: 0.5rem;
+          margin-bottom: 0.85rem;
+        }
+
+        .pitch-toly-photo-grid-compact .pitch-toly-photo {
+          padding: 0.4rem;
+        }
+
+        .pitch-toly-photo-grid-compact .pitch-toly-photo img {
+          aspect-ratio: 4 / 3;
+        }
+
+        .pitch-toly-photo-grid-compact .pitch-toly-photo-cap {
+          font-size: 0.58rem;
         }
 
         @media (max-width: 900px) {

--- a/app/app/pitch/page.tsx
+++ b/app/app/pitch/page.tsx
@@ -218,9 +218,10 @@ function Slide02Team(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Team</div>
         <h2 className="pitch-title">
-          Two co-founders and an AI pair-programmer shipped Percolator
-          from zero to mainnet-ready with 500+ formal proofs and zero
-          outside capital.
+          Two Solana founders who each won Toly&apos;s public bounties,
+          plus an AI pair-programmer. Shipped Percolator to
+          mainnet-ready with 500+ formal proofs and zero outside
+          capital.
         </h2>
 
         <div className="pitch-team-grid pitch-team-grid-three">
@@ -884,9 +885,9 @@ function SlideProof(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Proof</div>
         <h2 className="pitch-title">
-          We&apos;ve shipped three things this hackathon — and proved
-          the math holds with 500+ formal proofs before any auditor
-          starts.
+          Customers told us audit posture and transferable positions
+          were the #1 blockers. We shipped both this hackathon — plus
+          500+ formal proofs before any auditor starts.
         </h2>
 
         <div className="pitch-solution-stack">

--- a/app/app/pitch/page.tsx
+++ b/app/app/pitch/page.tsx
@@ -133,15 +133,27 @@ function Slide01OneLiner(_: SlideProps) {
         <ul className="pitch-hero-bullets">
           <li>
             <span className="pitch-hero-bullet-num mono">60 sec</span>
-            <span className="pitch-hero-bullet-text">to launch a market on any SPL token · no team approval, no auction</span>
+            <span className="pitch-hero-bullet-text">
+              Anyone can launch a perp market on any SPL token in about
+              a minute. No team approval, no auction, no $20M stake to
+              get in the door.
+            </span>
           </li>
           <li>
             <span className="pitch-hero-bullet-num mono">15M+</span>
-            <span className="pitch-hero-bullet-text">tokens incumbents refuse to list</span>
+            <span className="pitch-hero-bullet-text">
+              SPL tokens have zero perp access today. Jupiter, Drift,
+              and Hyperliquid all curate ~50 blue chips — we open the
+              other 15 million.
+            </span>
           </li>
           <li>
             <span className="pitch-hero-bullet-num mono">Apache 2.0</span>
-            <span className="pitch-hero-bullet-text">fully open source · 22 public repos · fork it tomorrow</span>
+            <span className="pitch-hero-bullet-text">
+              Every program, SDK, keeper, and frontend is open source
+              across 22 public repos. Fork the whole stack and run
+              your own venue tomorrow.
+            </span>
           </li>
         </ul>
         <div className="pitch-divider" />
@@ -229,12 +241,11 @@ function Slide02Team(_: SlideProps) {
             />
             <div className="pitch-team-name">Khubair</div>
             <div className="pitch-team-role">Co-founder · Product</div>
-            <p className="pitch-team-bio">
-              Owns product direction, security review, and external
-              positioning. Web2 startup background, now Solana product
-              co-founder. Member of Superteam UK; won one of Toly&apos;s
-              public bounties on pre-audit critical bug review.
-            </p>
+            <ul className="pitch-team-bullets">
+              <li>Owns product direction, security review, and external positioning</li>
+              <li>Web2 startup background; Solana product co-founder and Superteam UK member</li>
+              <li>Won one of Toly&apos;s public bounties on pre-audit critical bug review</li>
+            </ul>
             <p className="pitch-team-links mono">
               <a
                 href="https://x.com/dcc_crypto"
@@ -262,30 +273,30 @@ function Slide02Team(_: SlideProps) {
             />
             <div className="pitch-team-name">Squid</div>
             <div className="pitch-team-role">Co-founder · Community</div>
-            <p className="pitch-team-bio">
-              Owns community strategy, project management, and the
-              daily &ldquo;vibe code&rdquo; that benefits Percolator.
-              Built{" "}
-              <a
-                className="pitch-team-bio-link"
-                href="https://github.com/0x-SquidSol/percolator-buyback"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                percolator-buyback
-              </a>
-              {" "}and{" "}
-              <a
-                className="pitch-team-bio-link"
-                href="https://github.com/0x-SquidSol/percolator-locker"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                percolator-locker
-              </a>
-              . 3 years in Solana; winner of Toly&apos;s Percolator
-              bounty.
-            </p>
+            <ul className="pitch-team-bullets">
+              <li>Owns community strategy, project management, and daily &ldquo;vibe code&rdquo;</li>
+              <li>3 years building on Solana; winner of Toly&apos;s Percolator bounty</li>
+              <li>
+                Shipped{" "}
+                <a
+                  className="pitch-team-bio-link"
+                  href="https://github.com/0x-SquidSol/percolator-buyback"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  percolator-buyback
+                </a>
+                {" "}and{" "}
+                <a
+                  className="pitch-team-bio-link"
+                  href="https://github.com/0x-SquidSol/percolator-locker"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  percolator-locker
+                </a>
+              </li>
+            </ul>
             <p className="pitch-team-links mono">
               <a
                 href="https://x.com/0xSquid_Sol"
@@ -313,12 +324,11 @@ function Slide02Team(_: SlideProps) {
             />
             <div className="pitch-team-name">Claude</div>
             <div className="pitch-team-role">Lead engineering · AI pair-programmer</div>
-            <p className="pitch-team-bio">
-              Owns most of the production code the co-founders direct:
-              Rust programs, TypeScript SDK and frontend, tests, Kani
-              proof drafts. Anthropic&apos;s Claude (Opus 4.7) running
-              in Claude Code. Reviews PRs. Doesn&apos;t sleep.
-            </p>
+            <ul className="pitch-team-bullets">
+              <li>Owns most of the production code: Rust programs, TypeScript SDK, frontend, tests, Kani proofs</li>
+              <li>Anthropic&apos;s Claude (Opus 4.7) running in Claude Code</li>
+              <li>Reviews PRs. Doesn&apos;t sleep.</li>
+            </ul>
           </div>
         </div>
 
@@ -2316,6 +2326,32 @@ export default function PitchPage() {
           line-height: 1.55;
           color: rgba(255,255,255,0.6);
           margin: 0;
+        }
+
+        .pitch-team-bullets {
+          list-style: none;
+          margin: 0;
+          padding: 0;
+          display: flex;
+          flex-direction: column;
+          gap: 0.45rem;
+          font-family: 'Inter', sans-serif;
+          font-size: 0.85rem;
+          line-height: 1.5;
+          color: rgba(255,255,255,0.62);
+        }
+
+        .pitch-team-bullets li {
+          padding-left: 0.9rem;
+          position: relative;
+        }
+
+        .pitch-team-bullets li::before {
+          content: "·";
+          position: absolute;
+          left: 0;
+          color: rgba(34,211,238,0.7);
+          font-weight: 700;
         }
 
         .pitch-team-links {

--- a/app/app/pitch/page.tsx
+++ b/app/app/pitch/page.tsx
@@ -442,11 +442,11 @@ function Slide05Product(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Demo Product</div>
         <h2 className="pitch-title">
-          Closed beta on mainnet today running the first SOL/USDC
-          Hyperp — connect wallet, deposit USDC, open a leveraged long,
-          close at PnL, fees split four ways on-chain in the same
-          transaction. Public mainnet opens once the external audit
-          (quotes received, not yet engaged) clears.
+          Closed beta on mainnet today, running the first SOL/USDC
+          Hyperp. Connect wallet, deposit USDC, open a leveraged long,
+          close at PnL — fees settle on-chain in the same transaction.
+          Public mainnet opens once the external audit (quotes
+          received, not yet engaged) clears.
         </h2>
 
         <div className="pflow-wrap">
@@ -961,11 +961,10 @@ function SlideMarket(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Market</div>
         <h2 className="pitch-title">
-          Solana perp volume averages $25B+/mo (DeFiLlama). Pacifica
-          just overtook Jupiter as the #1 Solana perp DEX — proving the
-          space is wide open. But Pacifica, Jupiter, Drift, and
-          Hyperliquid all still curate. 15 million SPL tokens have zero
-          perp access. We open the long tail.
+          Solana perp volume averages $25B+/mo (DeFiLlama). The current
+          leaders — Jupiter, Drift, Hyperliquid (and Pacifica, the new
+          #1 on Solana) — all curate their listings. 15 million SPL
+          tokens have zero perp access. We open the long tail.
         </h2>
 
         <div className="pitch-matrix-wrap">

--- a/app/app/pitch/page.tsx
+++ b/app/app/pitch/page.tsx
@@ -130,25 +130,34 @@ function Slide01OneLiner(_: SlideProps) {
         <p className="pitch-hero-headline">
           Permissionless perpetual futures on Solana.
         </p>
-        <ul className="pitch-hero-bullets">
-          <li>
-            <span className="pitch-hero-bullet-num mono">60 sec</span>
-            <span className="pitch-hero-bullet-text">
-              Anyone can launch a perp market on any SPL token in about
-              a minute. No team approval, no auction, no $20M stake to
-              get in the door.
-            </span>
-          </li>
-          <li>
-            <span className="pitch-hero-bullet-num mono">15M+</span>
-            <span className="pitch-hero-bullet-text">
-              SPL tokens have zero perp access today. Jupiter, Drift,
-              and Hyperliquid all curate ~50 blue chips — we open the
-              other 15 million.
-            </span>
-          </li>
-        </ul>
-        <div className="pitch-divider" />
+        <p className="pitch-hero-body">
+          Anyone can launch a perp market on any SPL token in about
+          60 seconds, with no team approval and no $20M stake to
+          clear. The leading Solana perp DEXes today cover around
+          fifty blue-chip tokens between them. Over 15 million other
+          SPL tokens have no perp access at all. That&apos;s the long
+          tail we open.
+        </p>
+        <div className="pitch-hero-ctas">
+          <a
+            className="pitch-hero-cta pitch-hero-cta-primary"
+            href="https://mainnet.percolatorlaunch.com"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Try the closed beta
+            <span className="pitch-hero-cta-arrow" aria-hidden>→</span>
+          </a>
+          <a
+            className="pitch-hero-cta"
+            href="https://github.com/dcccrypto"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            See the code on GitHub
+            <span className="pitch-hero-cta-arrow" aria-hidden>→</span>
+          </a>
+        </div>
         <p className="pitch-url">percolator.trade</p>
       </div>
       <div className="pitch-bg-grid" aria-hidden />
@@ -164,9 +173,10 @@ function SlideProblem(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Problem</div>
         <h2 className="pitch-title">
-          Solana has 15M+ tokens. Only ~50 have a perp market. The other
-          15 million are gated by team approval, auctions, or capital
-          locks most builders can&apos;t clear.
+          Solana hosts more than 15 million SPL tokens. Around fifty of
+          them have a perp market. Everyone else has to clear a team
+          approval process or a capital requirement most builders
+          can&apos;t meet.
         </h2>
 
         <div className="pitch-opp-compare">
@@ -175,7 +185,7 @@ function SlideProblem(_: SlideProps) {
               <span className="pitch-opp-tag">Jupiter / Drift</span>
               <span className="pitch-opp-row-stat mono">Curated</span>
               <span className="pitch-opp-row-detail">
-                Team-gated whitelist · blue chips only · centralized listing
+                Team-gated whitelist, blue chips only, centralized listing.
               </span>
             </div>
           </div>
@@ -185,7 +195,7 @@ function SlideProblem(_: SlideProps) {
               <span className="pitch-opp-tag">Hyperliquid HIP-3</span>
               <span className="pitch-opp-row-stat mono">500K HYPE</span>
               <span className="pitch-opp-row-detail">
-                ~$20M+ stake to deploy a perp · prices out every long-tail builder
+                Around $20M in stake to deploy a single perp DEX. Prices out every long-tail builder.
               </span>
             </div>
           </div>
@@ -195,14 +205,14 @@ function SlideProblem(_: SlideProps) {
               <span className="pitch-opp-tag pitch-opp-tag-cyan">Result</span>
               <span className="pitch-opp-row-stat mono">15M+ shut out</span>
               <span className="pitch-opp-row-detail">
-                Every token with a live DEX pool — no perp access today
+                Every token with a live DEX pool. No perp access today.
               </span>
             </div>
           </div>
 
           <div className="pitch-opp-callout">
-            The perp surface on Solana is a permissioned bottleneck. We
-            open it.
+            Today&apos;s perp market on Solana is a small permissioned
+            slice. We open it up.
           </div>
         </div>
       </div>
@@ -218,10 +228,10 @@ function Slide02Team(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Team</div>
         <h2 className="pitch-title">
-          Two Solana founders who each won Toly&apos;s public bounties,
-          plus an AI pair-programmer. Shipped Percolator to
-          mainnet-ready with 500+ formal proofs and zero outside
-          capital.
+          Two Solana founders, each holding one of Toly&apos;s public
+          bounties on Percolator, plus an AI pair-programmer that
+          writes most of the code. We shipped to mainnet closed beta
+          with 500+ formal proofs and no outside capital.
         </h2>
 
         <div className="pitch-team-grid pitch-team-grid-three">
@@ -326,11 +336,13 @@ function Slide02Team(_: SlideProps) {
         </div>
 
         <p className="pitch-team-footer">
-          Anatoly Yakovenko (Solana co-founder) built the on-chain risk
-          engine and put it out as open source. We forked it and built
-          the product around it — the trading app, the position NFTs,
-          the keepers, the SDK, the frontend. Both co-founders each won
-          one of his public bounties along the way.
+          Anatoly Yakovenko, Solana&apos;s co-founder, wrote the
+          protocol math behind Percolator and shipped a reference
+          program as open source. We forked his engine and built the
+          rest of the stack on top of it: the trading app, the Token-2022
+          position NFTs, the keeper fleet, the SDK, and the frontend.
+          Both of our co-founders have won one of his public bounties
+          along the way.
         </p>
       </div>
     </div>
@@ -353,10 +365,11 @@ function Slide03Traction(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Traction · On-Chain</div>
         <h2 className="pitch-title">
-          220 markets created on devnet by 100+ creators seeding LP
-          vaults (Feb 28 – Mar 31, 2026). Hackathon sprint then shipped
-          the first SOL/USDC market to mainnet closed beta. 100+
-          waitlist signups in the first 48 hours.
+          Over a hundred creators seeded LP vaults across 220 perp
+          markets on devnet between February 28 and March 31, 2026.
+          The hackathon sprint that followed shipped our first SOL/USDC
+          market to mainnet closed beta. The waitlist crossed 100
+          signups in its first 48 hours.
         </h2>
 
         <div className="pitch-traction-network-grid pitch-traction-network-grid-single">
@@ -391,11 +404,12 @@ function Slide03Traction(_: SlideProps) {
               </div>
             </div>
             <div className="pitch-traction-network-meta mono">
-              136 + 12 + 72 markets across small / medium / large slab
-              tiers — all verifiable on chain. Each market seeds its own
-              LP vault (passive vAMM, same model as Jupiter&apos;s JLP).
-              Mainnet program is private until the external audit
-              (quotes received, not yet engaged) clears.
+              136 + 12 + 72 markets across small, medium, and large slab
+              tiers, all verifiable on chain. Each market seeds its own
+              LP vault using the same passive vAMM model as Jupiter&apos;s
+              JLP. The mainnet program stays private until the external
+              audit clears. We&apos;ve received quotes but haven&apos;t
+              engaged the firm yet.
             </div>
           </div>
         </div>
@@ -443,11 +457,12 @@ function Slide05Product(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Demo Product</div>
         <h2 className="pitch-title">
-          Closed beta on mainnet today, running the first SOL/USDC
-          Hyperp. Connect wallet, deposit USDC, open a leveraged long,
-          close at PnL — fees settle on-chain in the same transaction.
-          Public mainnet opens once the external audit (quotes
-          received, not yet engaged) clears.
+          The closed beta is live on mainnet today, running the first
+          SOL/USDC Hyperp market. Connect a Solana wallet, deposit
+          USDC, open a leveraged long, then close at PnL. Fees settle
+          on-chain in the same transaction. Public mainnet opens once
+          the external audit clears. We have quotes in hand and
+          haven&apos;t engaged the firm yet.
         </h2>
 
         <div className="pflow-wrap">
@@ -541,10 +556,11 @@ function Slide05Product(_: SlideProps) {
         </div>
 
         <div className="pitch-create-footer">
-          Position is a Token-2022 NFT — first transferable perp
-          position on Solana. LP vault is the counterparty (like
-          Jupiter&apos;s JLP) — no market makers required. Closed beta
-          at mainnet.percolatorlaunch.com.
+          Each position is a Token-2022 NFT, which makes it the first
+          transferable perp position on Solana. The LP vault sits on
+          the other side of every trade, the same model as
+          Jupiter&apos;s JLP, so we don&apos;t need active market
+          makers. Closed beta at mainnet.percolatorlaunch.com.
         </div>
       </div>
     </div>
@@ -559,8 +575,9 @@ function Slide06Money(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Business Model</div>
         <h2 className="pitch-title">
-          0.1–1% per trade. Splits four ways on-chain in the same
-          transaction. &gt;95% gross margin — no market makers to pay.
+          Each trade pays 0.1 to 1 percent. The fee splits four ways
+          on-chain in the same transaction. Gross margin sits above 95
+          percent because we don&apos;t pay market makers.
         </h2>
 
         <div className="pitch-revenue-hero">
@@ -569,9 +586,9 @@ function Slide06Money(_: SlideProps) {
             <div className="pitch-revenue-hero-tag mono">scale projection</div>
           </div>
           <div className="pitch-revenue-hero-desc">
-            Daily protocol fees at 1,000 active markets × $1M average
-            daily volume each — about $365M/year at modest scale, with
-            no rebate burn against margin.
+            That&apos;s daily protocol fees at a thousand active markets
+            averaging $1M in daily volume each. Roughly $365M a year
+            at modest scale, with no rebates eating into margin.
           </div>
         </div>
 
@@ -579,30 +596,31 @@ function Slide06Money(_: SlideProps) {
           <div className="pitch-revenue-split">
             <div className="pitch-revenue-split-name mono">LP vault</div>
             <p className="pitch-revenue-split-desc">
-              Passive liquidity providers earn from trader losses —
-              same model as Jupiter&apos;s JLP. Sticky capital, no
-              active quoting required.
+              Passive liquidity providers earn from trader losses, the
+              same model as Jupiter&apos;s JLP. Sticky capital with no
+              active quoting needed.
             </p>
           </div>
           <div className="pitch-revenue-split">
             <div className="pitch-revenue-split-name mono">Creator</div>
             <p className="pitch-revenue-split-desc">
-              Market launcher&apos;s revenue share — direct incentive
-              to bring long-tail listings and their own retail flow.
+              Market launchers take a revenue share, which gives them
+              a direct incentive to bring long-tail listings along
+              with their own retail flow.
             </p>
           </div>
           <div className="pitch-revenue-split pitch-revenue-split-us">
             <div className="pitch-revenue-split-name mono">Protocol</div>
             <p className="pitch-revenue-split-desc">
-              Treasury — accrues on every trade on every market. Funds
-              audit, hiring, growth.
+              The treasury accrues on every trade on every market and
+              funds the audit, hiring, and growth work.
             </p>
           </div>
           <div className="pitch-revenue-split">
             <div className="pitch-revenue-split-name mono">Insurance</div>
             <p className="pitch-revenue-split-desc">
-              Reserve — backstops liquidation deficits and bad debt
-              before LPs take losses.
+              A reserve that backstops liquidation deficits and bad
+              debt before LPs take any losses.
             </p>
           </div>
         </div>
@@ -661,8 +679,9 @@ function Slide09WhyNow(_: SlideProps) {
             <div className="pitch-whynow-num mono">SIMD-0266</div>
             <div className="pitch-whynow-label">
               Activated April 2026. Pinocchio-token instructions are
-              ~19× cheaper (95–98% reduction). Long-tail per-trade
-              economics only work after this change.
+              about 19 times cheaper, roughly a 95 to 98 percent
+              reduction in compute. Long-tail per-trade economics
+              only work after this change.
             </div>
           </div>
           <div className="pitch-whynow-stat">
@@ -681,8 +700,9 @@ function Slide09WhyNow(_: SlideProps) {
             </svg>
             <div className="pitch-whynow-num mono">Token-2022</div>
             <div className="pitch-whynow-label">
-              Mature now. Transferable perp positions as NFTs are
-              possible. We&apos;re the first to ship.
+              The standard is mature now. Transferable perp positions
+              as NFTs are possible, and we&apos;re the first to ship
+              them.
             </div>
           </div>
           <div className="pitch-whynow-stat">
@@ -706,15 +726,18 @@ function Slide09WhyNow(_: SlideProps) {
             </svg>
             <div className="pitch-whynow-num mono">$15B+</div>
             <div className="pitch-whynow-label">
-              Hyperliquid OI by end of 2025 proved demand for permissionless
-              perps. HIP-3 prices most creators out (500K HYPE ≈ $20M+ stake
-              just to deploy a perp DEX). Long-tail supply on Solana is empty.
+              Hyperliquid open interest by the end of 2025 proved
+              there&apos;s real demand for permissionless perps. HIP-3
+              prices most creators out though, since it takes 500K
+              HYPE (around $20M in stake) just to deploy a perp DEX.
+              Long-tail supply on Solana sits empty.
             </div>
           </div>
         </div>
         <div className="pitch-whynow-closing">
-          Three catalysts in one year. The window is open — and
-          we&apos;re shipping into it, not waiting for it to be perfect.
+          Three catalysts in one year. The window is open, and
+          we&apos;re shipping into it rather than waiting for everything
+          to be perfect.
         </div>
       </div>
     </div>
@@ -784,9 +807,10 @@ function SlideTolyStory(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Origin · Toly Signal</div>
         <h2 className="pitch-title">
-          Solana co-founder Anatoly Yakovenko originated Percolator&apos;s
-          protocol math and reference program, and publicly engages
-          with our team&apos;s work. We built the product around it.
+          Solana&apos;s co-founder Anatoly Yakovenko wrote the protocol
+          math behind Percolator and open-sourced a reference program.
+          He still publicly engages with our work. We built the
+          product on top of what he started.
         </h2>
 
         <div className="pitch-toly-photo-grid">
@@ -861,16 +885,17 @@ function SlideTolyStory(_: SlideProps) {
         </div>
 
         <p className="pitch-toly-footer">
-          Toly authored the protocol math and the reference program
-          (github.com/aeyakovenko/percolator-prog) — the H + A/K risk
-          engine. We forked it and built the product around it for
-          Solana mainnet: extending the on-chain program with LP vault,
-          dispute resolution, transferable NFT positions, withdrawal
-          queue, audit-crank invariant checking, and admin lifecycle
-          tooling — 49 fork-only handlers, 51 fork-only instructions,
-          187 wrapper commits past the divergence point. Plus the SDK,
-          indexer, keeper fleet, and frontend. Both co-founders have
-          each won one of his public bounties.
+          Toly wrote the protocol math and shipped a reference program
+          at github.com/aeyakovenko/percolator-prog, called the H + A/K
+          risk engine. We forked it and built the product on top for
+          Solana mainnet, extending the on-chain program with the LP
+          vault, dispute resolution, transferable NFT positions, the
+          withdrawal queue, audit-crank invariant checking, and admin
+          lifecycle tooling. That works out to 49 fork-only handlers,
+          51 fork-only instructions, and 187 wrapper commits past the
+          divergence point, plus the SDK, indexer, keeper fleet, and
+          frontend. Both co-founders have each won one of his public
+          bounties.
         </p>
       </div>
     </div>
@@ -885,9 +910,10 @@ function SlideProof(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Hackathon Sprint</div>
         <h2 className="pitch-title">
-          Customers told us audit posture and transferable positions
-          were the #1 blockers. We shipped both this hackathon — plus
-          500+ formal proofs before any auditor starts.
+          Customers told us their two biggest blockers were audit
+          posture and the ability to transfer positions. We shipped
+          both during this hackathon, plus 500+ formal proofs that
+          hold before any auditor starts.
         </h2>
 
         <div className="pitch-solution-stack">
@@ -895,11 +921,12 @@ function SlideProof(_: SlideProps) {
             <div className="pitch-solution-num purple">1</div>
             <div>
               <div className="pitch-solution-name">
-                v12.19 mainnet upgrade + first SOL/USDC market on mainnet
+                v12.19 mainnet upgrade, first SOL/USDC market on mainnet
               </div>
               <p className="pitch-solution-desc">
-                Four programs upgraded and deployed. SOL/USDC Hyperp market
-                running today in closed beta against a pinned Raydium pool.
+                We upgraded and redeployed all four programs. The
+                SOL/USDC Hyperp market is running today in closed beta
+                against a pinned Raydium pool.
               </p>
             </div>
           </div>
@@ -910,8 +937,9 @@ function SlideProof(_: SlideProps) {
                 Token-2022 transferable position NFTs
               </div>
               <p className="pitch-solution-desc">
-                First transferable perp positions ever shipped on Solana.
-                Customers asked, we shipped.
+                Customers asked for transferable positions, so we
+                built them as Token-2022 NFTs. These are the first
+                transferable perp positions ever shipped on Solana.
               </p>
             </div>
           </div>
@@ -922,10 +950,12 @@ function SlideProof(_: SlideProps) {
                 500+ Kani formal-verification proofs
               </div>
               <p className="pitch-solution-desc">
-                Kani proves protocol invariants hold across every
-                possible input. 500+ proofs, all green. Hyperliquid,
-                Drift, and Jupiter have zero. 36 pre-audit hardening
-                PRs merged in 4 days closing every deep-audit CRITICAL.
+                Kani checks that every protocol invariant holds for
+                every possible input. We have 500+ proofs, all
+                passing. Hyperliquid, Drift, and Jupiter have none of
+                these. We also merged 36 pre-audit hardening PRs in
+                four days, closing every CRITICAL from our deep
+                self-audit.
               </p>
             </div>
           </div>
@@ -962,10 +992,12 @@ function SlideMarket(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Market</div>
         <h2 className="pitch-title">
-          Solana perp volume averages $25B+/mo (DeFiLlama). The current
-          leaders — Jupiter, Drift, Hyperliquid (and Pacifica, the new
-          #1 on Solana) — all curate their listings. 15 million SPL
-          tokens have zero perp access. We open the long tail.
+          Solana perp volume averages over $25 billion per month per
+          DeFiLlama, and Pacifica recently overtook Jupiter as the
+          largest Solana venue. Every leading perp DEX, including
+          Hyperliquid on its own L1, curates its listings. Fifteen
+          million SPL tokens have no perp access at all. We open the
+          long tail.
         </h2>
 
         <div className="pitch-matrix-wrap">
@@ -1019,9 +1051,9 @@ function SlideMarket(_: SlideProps) {
           </table>
         </div>
         <p className="pitch-matrix-sub">
-          Everyone else competes for the same 30-50 tokens. We open a
-          category — long-tail SPL perps at a price point creators can
-          actually afford.
+          Everyone else competes for the same thirty to fifty tokens.
+          We open a new category: long-tail SPL perps at a price point
+          creators can actually afford.
         </p>
       </div>
     </div>
@@ -1036,8 +1068,9 @@ function SlideRoadmapAsk(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Roadmap & Ask</div>
         <h2 className="pitch-title">
-          Public mainnet Q3 after audit. $50M+ daily volume by Q4.
-          Default rail for every-token perps by 2027.
+          Public mainnet opens in Q3 once the audit clears. We&apos;re
+          targeting over $50M in daily volume by Q4 and aiming to be
+          the default rail for every-token perps by 2027.
         </h2>
 
         <div className="pitch-roadmap">
@@ -1074,18 +1107,18 @@ function SlideRoadmapAsk(_: SlideProps) {
             </div>
             <div className="pitch-ask-card-sub">
               SAFE, LP co-investment, or bespoke equity. We&apos;re
-              shipping with or without capital — the right partner
-              shortcuts audit, LP-vault bootstrap, and creator
+              shipping with or without capital. The right partner
+              shortcuts the audit, LP-vault bootstrap, and creator
               acquisition.
             </div>
           </div>
           <div className="pitch-ask-card">
             <div className="pitch-ask-card-label mono">Where it goes</div>
             <ul className="pitch-ask-list">
-              <li>External audit + bug bounty program</li>
-              <li>LP-vault bootstrap on first 10 creator-led markets</li>
-              <li>Creator acquisition · rev-share rebates, not paid spend</li>
-              <li>Two technical hires · matching + risk research</li>
+              <li>External audit and a bug bounty program</li>
+              <li>LP-vault bootstrap on the first ten creator-led markets</li>
+              <li>Creator acquisition through rev-share rebates, not paid spend</li>
+              <li>Two technical hires: matching and risk research</li>
             </ul>
           </div>
         </div>
@@ -2496,6 +2529,72 @@ export default function PitchPage() {
           font-size: 1rem;
           color: rgba(255, 255, 255, 0.72);
           line-height: 1.4;
+        }
+
+        .pitch-hero-body {
+          font-family: 'Inter', sans-serif;
+          font-size: clamp(0.95rem, 1.6vw, 1.1rem);
+          line-height: 1.65;
+          color: rgba(255, 255, 255, 0.78);
+          text-align: center;
+          max-width: 620px;
+          margin: 0 auto 1.85rem;
+        }
+
+        .pitch-hero-ctas {
+          display: flex;
+          gap: 0.75rem;
+          justify-content: center;
+          flex-wrap: wrap;
+          margin: 0.5rem 0 1.6rem;
+        }
+
+        .pitch-hero-cta {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.55rem;
+          padding: 0.78rem 1.4rem;
+          border-radius: 10px;
+          font-family: 'Inter', sans-serif;
+          font-size: 0.95rem;
+          font-weight: 500;
+          text-decoration: none;
+          background: rgba(255, 255, 255, 0.035);
+          border: 1px solid rgba(255, 255, 255, 0.12);
+          color: rgba(255, 255, 255, 0.88);
+          transition: border-color 200ms ease, background 200ms ease, color 200ms ease;
+        }
+
+        @media (hover: hover) {
+          .pitch-hero-cta:hover {
+            border-color: rgba(34, 211, 238, 0.5);
+            background: rgba(34, 211, 238, 0.06);
+            color: #fff;
+          }
+        }
+
+        .pitch-hero-cta-primary {
+          background: linear-gradient(135deg, rgba(153, 69, 255, 0.18), rgba(34, 211, 238, 0.18));
+          border-color: rgba(34, 211, 238, 0.42);
+          color: #fff;
+        }
+
+        @media (hover: hover) {
+          .pitch-hero-cta-primary:hover {
+            background: linear-gradient(135deg, rgba(153, 69, 255, 0.3), rgba(34, 211, 238, 0.3));
+            border-color: rgba(34, 211, 238, 0.75);
+          }
+        }
+
+        .pitch-hero-cta-arrow {
+          font-family: 'JetBrains Mono', monospace;
+          transition: transform 200ms ease;
+        }
+
+        @media (hover: hover) {
+          .pitch-hero-cta:hover .pitch-hero-cta-arrow {
+            transform: translateX(3px);
+          }
         }
 
         /* ─── Team PFPs ────────────────────────────────────────────── */

--- a/app/app/pitch/page.tsx
+++ b/app/app/pitch/page.tsx
@@ -352,9 +352,10 @@ function Slide03Traction(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Traction · On-Chain</div>
         <h2 className="pitch-title">
-          220 markets created on devnet across three program versions,
-          all green. Mainnet is deployed but private until an external
-          audit (quotes received, not yet engaged) clears.
+          220 markets created on devnet across three deployment tiers,
+          all green. 100+ waitlist signups in the first 48 hours.
+          Mainnet is deployed but private until an external audit
+          (quotes received, not yet engaged) clears.
         </h2>
 
         <div className="pitch-traction-network-grid pitch-traction-network-grid-single">
@@ -381,7 +382,7 @@ function Slide03Traction(_: SlideProps) {
                 <div className="pitch-traction-network-num mono">
                   <NumberCounter target={3} />
                 </div>
-                <div className="pitch-traction-network-label">program versions</div>
+                <div className="pitch-traction-network-label">deployment tiers</div>
               </div>
               <div className="pitch-traction-network-stat">
                 <div className="pitch-traction-network-num mono pitch-traction-network-num-cyan">100%</div>
@@ -389,11 +390,11 @@ function Slide03Traction(_: SlideProps) {
               </div>
             </div>
             <div className="pitch-traction-network-meta mono">
-              Devnet markets created across three program versions
-              (verifiable on chain). Mainnet program is deployed but
-              private — open only to a small group of open-source
-              contributors until the external audit (quotes received,
-              not yet engaged) clears.
+              136 + 12 + 72 markets across small / medium / large slab
+              tiers — all verifiable on chain. Mainnet program is
+              deployed but private, open only to a small group of
+              open-source contributors until the external audit (quotes
+              received, not yet engaged) clears.
             </div>
           </div>
         </div>
@@ -416,6 +417,12 @@ function Slide03Traction(_: SlideProps) {
               <NumberCounter target={3400} suffix="+" />
             </div>
             <div className="pitch-traction-mini-label">Organic X followers</div>
+          </div>
+          <div className="pitch-traction-mini">
+            <div className="pitch-traction-mini-num mono">
+              <NumberCounter target={100} suffix="+" />
+            </div>
+            <div className="pitch-traction-mini-label">Waitlist signups · first 48 hours</div>
           </div>
           <div className="pitch-traction-mini">
             <div className="pitch-traction-mini-num mono">$0</div>
@@ -552,8 +559,9 @@ function Slide06Money(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Business Model</div>
         <h2 className="pitch-title">
-          We charge 0.1–1% per trade across every market, splitting fees
-          four ways on-chain. Gross margin &gt;95% after Solana compute.
+          0.1–1% per trade, split four ways on-chain in the same
+          transaction. &gt;95% gross margin — no off-chain claims, no
+          market makers to pay, no rebate burn.
         </h2>
 
         <div className="pitch-money-flow">
@@ -672,13 +680,12 @@ function Slide06Money(_: SlideProps) {
         </div>
 
         <div className="pitch-money-scale-wrap">
-          <div className="pitch-money-scale-title">Scale path · protocol fees only · projected scenarios</div>
+          <div className="pitch-money-scale-title">Scale path · daily protocol fees at 0.1% rate</div>
           <table className="pitch-money-scale">
             <thead>
               <tr>
                 <th>Markets</th>
                 <th>Avg daily vol / market</th>
-                <th>Protocol fee (0.1%)</th>
                 <th>Daily protocol fees</th>
               </tr>
             </thead>
@@ -686,19 +693,11 @@ function Slide06Money(_: SlideProps) {
               <tr>
                 <td className="mono">100</td>
                 <td className="mono">$500K</td>
-                <td className="mono">0.1%</td>
                 <td className="mono pitch-money-scale-result">$50K</td>
               </tr>
               <tr>
                 <td className="mono">1,000</td>
-                <td className="mono">$500K</td>
-                <td className="mono">0.1%</td>
-                <td className="mono pitch-money-scale-result">$500K</td>
-              </tr>
-              <tr>
-                <td className="mono">1,000</td>
                 <td className="mono">$1M</td>
-                <td className="mono">0.1%</td>
                 <td className="mono pitch-money-scale-result">$1M</td>
               </tr>
             </tbody>
@@ -1045,10 +1044,11 @@ function SlideMarket(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Market</div>
         <h2 className="pitch-title">
-          Solana perp volume averages $25B+/mo (peaked $65B in Oct 2025,
-          per DeFiLlama) across ~50 blue-chip tokens. 15 million tokens
-          have zero perp access today. We&apos;re the only one opening
-          that long tail.
+          Solana perp volume averages $25B+/mo (DeFiLlama). Pacifica
+          just overtook Jupiter as the #1 Solana perp DEX — proving the
+          space is wide open. But Pacifica, Jupiter, Drift, and
+          Hyperliquid all still curate. 15 million SPL tokens have zero
+          perp access. We open the long tail.
         </h2>
 
         <div className="pitch-matrix-wrap">
@@ -1119,8 +1119,8 @@ function SlideRoadmapAsk(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Roadmap & Ask</div>
         <h2 className="pitch-title">
-          Public mainnet Q3 after audit, $50M+ daily volume Q4. Open to
-          strategic capital sized to the partnership.
+          Public mainnet Q3 after audit. $50M+ daily volume by Q4.
+          Default rail for every-token perps by 2027.
         </h2>
 
         <div className="pitch-roadmap">
@@ -1156,19 +1156,19 @@ function SlideRoadmapAsk(_: SlideProps) {
               Strategic capital, sized to the partnership.
             </div>
             <div className="pitch-ask-card-sub">
-              SAFE, LP co-investment, or bespoke equity. We care more
-              about the partner than the paper. Shipping with or
-              without capital — the right partner shortcuts audit,
-              market-maker bootstrap, and creator acquisition.
+              SAFE, LP co-investment, or bespoke equity. We&apos;re
+              shipping with or without capital — the right partner
+              shortcuts audit, LP-vault bootstrap, and creator
+              acquisition.
             </div>
           </div>
           <div className="pitch-ask-card">
-            <div className="pitch-ask-card-label mono">Where it goes · Risks we&apos;re solving</div>
+            <div className="pitch-ask-card-label mono">Where it goes</div>
             <ul className="pitch-ask-list">
-              <li>External audit + bug bounty (mitigates audit-timing risk)</li>
-              <li>Market-maker bootstrap on first 10 markets (mitigates liquidity-bootstrap risk)</li>
-              <li>Creator acquisition via rev-share rebates (mitigates liquidity-bootstrap risk)</li>
-              <li>Two technical hires: matching + risk research</li>
+              <li>External audit + bug bounty program</li>
+              <li>LP-vault bootstrap on first 10 creator-led markets</li>
+              <li>Creator acquisition · rev-share rebates, not paid spend</li>
+              <li>Two technical hires · matching + risk research</li>
             </ul>
           </div>
         </div>

--- a/app/app/pitch/page.tsx
+++ b/app/app/pitch/page.tsx
@@ -352,10 +352,11 @@ function Slide03Traction(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Traction · On-Chain</div>
         <h2 className="pitch-title">
-          220 markets created on devnet across three deployment tiers,
-          all green. 100+ waitlist signups in the first 48 hours.
-          Mainnet is deployed but private until an external audit
-          (quotes received, not yet engaged) clears.
+          220 markets stress-tested on devnet across 5 weeks of
+          pre-hackathon hardening (Feb 28 – Mar 31, 2026) over three
+          deployment tiers. Hackathon sprint then upgraded all programs
+          to v12.19 and shipped the first SOL/USDC market to mainnet
+          closed beta. 100+ waitlist signups in the first 48 hours.
         </h2>
 
         <div className="pitch-traction-network-grid pitch-traction-network-grid-single">
@@ -391,10 +392,14 @@ function Slide03Traction(_: SlideProps) {
             </div>
             <div className="pitch-traction-network-meta mono">
               136 + 12 + 72 markets across small / medium / large slab
-              tiers — all verifiable on chain. Mainnet program is
-              deployed but private, open only to a small group of
-              open-source contributors until the external audit (quotes
-              received, not yet engaged) clears.
+              tiers — all verifiable on chain. Earliest market
+              2026-02-28, last devnet activity 2026-03-31 — five weeks
+              of pre-hackathon stress testing. Frontier-window work
+              (Apr 6 – May 11) shifted to mainnet, audit hardening, and
+              the closed-beta market. Mainnet program is private, open
+              only to a small group of open-source contributors until
+              the external audit (quotes received, not yet engaged)
+              clears.
             </div>
           </div>
         </div>

--- a/app/app/pitch/page.tsx
+++ b/app/app/pitch/page.tsx
@@ -147,14 +147,6 @@ function Slide01OneLiner(_: SlideProps) {
               other 15 million.
             </span>
           </li>
-          <li>
-            <span className="pitch-hero-bullet-num mono">Apache 2.0</span>
-            <span className="pitch-hero-bullet-text">
-              Every program, SDK, keeper, and frontend is open source
-              across 22 public repos. Fork the whole stack and run
-              your own venue tomorrow.
-            </span>
-          </li>
         </ul>
         <div className="pitch-divider" />
         <p className="pitch-url">percolator.trade</p>

--- a/app/app/pitch/page.tsx
+++ b/app/app/pitch/page.tsx
@@ -366,7 +366,9 @@ function Slide03Traction(_: SlideProps) {
         <div className="pitch-traction-network-grid pitch-traction-network-grid-single">
           <div className="pitch-traction-network-card pitch-traction-network-card-wide">
             <div className="pitch-traction-network-header">
-              <div className="pitch-traction-network-tag mono pitch-traction-network-tag-cyan">Devnet · live program</div>
+              <div className="pitch-traction-network-tag mono pitch-traction-network-tag-cyan">
+                Devnet · Feb 28 – Mar 31, 2026
+              </div>
               <a
                 className="pitch-traction-network-link mono"
                 href="https://explorer.solana.com/address/FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD?cluster=devnet"
@@ -382,25 +384,27 @@ function Slide03Traction(_: SlideProps) {
                   <NumberCounter target={220} />
                 </div>
                 <div className="pitch-traction-network-label">markets created</div>
+                <div className="pitch-traction-network-sublabel mono">over 5 weeks</div>
               </div>
               <div className="pitch-traction-network-stat">
                 <div className="pitch-traction-network-num mono">
                   <NumberCounter target={100} suffix="+" />
                 </div>
                 <div className="pitch-traction-network-label">creators</div>
+                <div className="pitch-traction-network-sublabel mono">seeding LP vaults</div>
               </div>
               <div className="pitch-traction-network-stat">
                 <div className="pitch-traction-network-num mono pitch-traction-network-num-cyan">100%</div>
                 <div className="pitch-traction-network-label">success rate</div>
+                <div className="pitch-traction-network-sublabel mono">across 3 tiers</div>
               </div>
             </div>
             <div className="pitch-traction-network-meta mono">
               136 + 12 + 72 markets across small, medium, and large slab
-              tiers, all verifiable on chain. Each market seeds its own
-              LP vault using the same passive vAMM model as Jupiter&apos;s
-              JLP. The mainnet program stays private until the external
-              audit clears. We&apos;ve received quotes but haven&apos;t
-              engaged the firm yet.
+              tiers between February 28 and March 31, 2026, all verifiable
+              on chain. Each market seeds its own LP vault using the same
+              passive vAMM model as Jupiter&apos;s JLP. The mainnet program
+              stays private until the external audit clears.
             </div>
           </div>
         </div>
@@ -2253,6 +2257,14 @@ export default function PitchPage() {
           font-family: 'Inter', sans-serif;
           font-size: 0.75rem;
           color: rgba(255, 255, 255, 0.55);
+        }
+
+        .pitch-traction-network-sublabel {
+          font-size: 0.62rem;
+          color: rgba(34, 211, 238, 0.65);
+          letter-spacing: 0.06em;
+          text-transform: uppercase;
+          margin-top: 0.25rem;
         }
 
         .pitch-traction-network-meta {

--- a/app/app/pitch/page.tsx
+++ b/app/app/pitch/page.tsx
@@ -1043,9 +1043,9 @@ function SlideRoadmapAsk(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Roadmap & Ask</div>
         <h2 className="pitch-title">
-          Public mainnet opens in Q3 once the audit clears. We&apos;re
-          targeting over $50M in daily volume by Q4 and aiming to be
-          the default rail for every-token perps by 2027.
+          Public mainnet opens in Q3 once the audit clears. We scale
+          to $50M+ daily volume through 2027 and aim to be the default
+          rail for every-token perps.
         </h2>
 
         <div className="pitch-roadmap">
@@ -1063,14 +1063,14 @@ function SlideRoadmapAsk(_: SlideProps) {
           <div className="pitch-roadmap-connector" />
           <div className="pitch-roadmap-item">
             <div className="pitch-roadmap-phase purple">Q4 2026</div>
-            <div className="pitch-roadmap-name">$50M+ daily volume</div>
-            <div className="pitch-roadmap-desc">Cross-margining, composable CPI oracle</div>
+            <div className="pitch-roadmap-name">50+ markets live</div>
+            <div className="pitch-roadmap-desc">Creator-led listings ramp, rev-share to LPs flowing, first cohort scaling</div>
           </div>
           <div className="pitch-roadmap-connector" />
           <div className="pitch-roadmap-item">
             <div className="pitch-roadmap-phase cyan">2027</div>
-            <div className="pitch-roadmap-name">Default rail</div>
-            <div className="pitch-roadmap-desc">Every-token perps as default for any new SPL</div>
+            <div className="pitch-roadmap-name">$50M+ daily, default rail</div>
+            <div className="pitch-roadmap-desc">Cross-margining, composable CPI oracle, every-token perps as default</div>
           </div>
         </div>
 

--- a/app/app/pitch/page.tsx
+++ b/app/app/pitch/page.tsx
@@ -141,15 +141,6 @@ function Slide01OneLiner(_: SlideProps) {
         <div className="pitch-hero-ctas">
           <a
             className="pitch-hero-cta pitch-hero-cta-primary"
-            href="https://mainnet.percolatorlaunch.com"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Try the closed beta
-            <span className="pitch-hero-cta-arrow" aria-hidden>→</span>
-          </a>
-          <a
-            className="pitch-hero-cta"
             href="https://github.com/dcccrypto"
             target="_blank"
             rel="noopener noreferrer"

--- a/app/app/pitch/page.tsx
+++ b/app/app/pitch/page.tsx
@@ -556,150 +556,69 @@ function Slide06Money(_: SlideProps) {
   return (
     <div className="pitch-slide">
       <div className="pitch-slide-inner">
-        <div className="pitch-label">Business Model</div>
+        <div className="pitch-label">Revenue</div>
         <h2 className="pitch-title">
-          0.1–1% per trade, split four ways on-chain. &gt;95% gross
-          margin — no market makers to pay, no off-chain claims.
+          0.1–1% per trade. Splits four ways on-chain in the same
+          transaction. &gt;95% gross margin — no market makers to pay.
         </h2>
 
-        <div className="pitch-money-flow">
-          <div className="pitch-money-flow-title">
-            Fee flow on every fill: automatic, on-chain, no claim transactions
+        <div className="pitch-revenue-hero">
+          <div className="pitch-revenue-hero-side">
+            <div className="pitch-revenue-hero-num mono">$1M / day</div>
+            <div className="pitch-revenue-hero-tag mono">scale projection</div>
           </div>
-
-          <div className="pitch-fee-stage">
-            <div className="pitch-fee-source">
-              <div className="pitch-money-pill pitch-money-pill-purple">
-                Trader pays<br /><span className="mono">0.1–1%</span>
-              </div>
-            </div>
-
-            <div className="pitch-fee-channel" aria-hidden>
-              <svg
-                viewBox="0 0 480 140"
-                preserveAspectRatio="xMidYMid meet"
-                className="pitch-fee-svg"
-              >
-                <defs>
-                  <linearGradient id="feeFlowGrad" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="0%" stopColor="#9945FF" stopOpacity="0.45" />
-                    <stop offset="100%" stopColor="#22D3EE" stopOpacity="0.45" />
-                  </linearGradient>
-                </defs>
-                <path
-                  id="feePathLeft"
-                  d="M 240 10 C 240 70, 60 70, 60 130"
-                  stroke="url(#feeFlowGrad)"
-                  fill="none"
-                  strokeWidth="1.5"
-                />
-                <path
-                  id="feePathCenter"
-                  d="M 240 10 L 240 130"
-                  stroke="url(#feeFlowGrad)"
-                  fill="none"
-                  strokeWidth="1.5"
-                />
-                <path
-                  id="feePathRight"
-                  d="M 240 10 C 240 70, 420 70, 420 130"
-                  stroke="url(#feeFlowGrad)"
-                  fill="none"
-                  strokeWidth="1.5"
-                />
-
-                <circle r="4" fill="#22D3EE" className="pitch-fee-svg-dot">
-                  <animateMotion dur="3.2s" repeatCount="indefinite">
-                    <mpath href="#feePathLeft" />
-                  </animateMotion>
-                  <animate
-                    attributeName="opacity"
-                    values="0;1;1;0"
-                    keyTimes="0;0.1;0.9;1"
-                    dur="3.2s"
-                    repeatCount="indefinite"
-                  />
-                </circle>
-
-                <circle r="4" fill="#22D3EE" className="pitch-fee-svg-dot">
-                  <animateMotion dur="3.2s" begin="1.05s" repeatCount="indefinite">
-                    <mpath href="#feePathCenter" />
-                  </animateMotion>
-                  <animate
-                    attributeName="opacity"
-                    values="0;1;1;0"
-                    keyTimes="0;0.1;0.9;1"
-                    dur="3.2s"
-                    begin="1.05s"
-                    repeatCount="indefinite"
-                  />
-                </circle>
-
-                <circle r="4" fill="#22D3EE" className="pitch-fee-svg-dot">
-                  <animateMotion dur="3.2s" begin="2.1s" repeatCount="indefinite">
-                    <mpath href="#feePathRight" />
-                  </animateMotion>
-                  <animate
-                    attributeName="opacity"
-                    values="0;1;1;0"
-                    keyTimes="0;0.1;0.9;1"
-                    dur="3.2s"
-                    begin="2.1s"
-                    repeatCount="indefinite"
-                  />
-                </circle>
-              </svg>
-            </div>
-
-            <div className="pitch-fee-buckets">
-              <div className="pitch-money-pill">LP vault</div>
-              <div className="pitch-money-pill">Creator</div>
-              <div className="pitch-money-pill pitch-money-pill-cyan">
-                Protocol treasury
-              </div>
-              <div className="pitch-money-pill">Insurance reserve</div>
-            </div>
+          <div className="pitch-revenue-hero-desc">
+            Daily protocol fees at 1,000 active markets × $1M average
+            daily volume each — about $365M/year at modest scale, with
+            no rebate burn against margin.
           </div>
         </div>
 
-        <div className="pitch-money-econ">
-          <div className="pitch-money-econ-stat">
-            <div className="pitch-money-econ-num mono">&gt;95%</div>
-            <div className="pitch-money-econ-label">Gross margin per trade after Solana RPC + compute</div>
+        <div className="pitch-revenue-splits">
+          <div className="pitch-revenue-split">
+            <div className="pitch-revenue-split-name mono">LP vault</div>
+            <p className="pitch-revenue-split-desc">
+              Passive liquidity providers earn from trader losses —
+              same model as Jupiter&apos;s JLP. Sticky capital, no
+              active quoting required.
+            </p>
           </div>
-          <div className="pitch-money-econ-stat">
-            <div className="pitch-money-econ-num mono">~$0.002</div>
-            <div className="pitch-money-econ-label">Solana fee per trade (base + priority)</div>
+          <div className="pitch-revenue-split">
+            <div className="pitch-revenue-split-name mono">Creator</div>
+            <p className="pitch-revenue-split-desc">
+              Market launcher&apos;s revenue share — direct incentive
+              to bring long-tail listings and their own retail flow.
+            </p>
           </div>
-          <div className="pitch-money-econ-stat">
-            <div className="pitch-money-econ-num mono">$0</div>
-            <div className="pitch-money-econ-label">Outside capital required to keep shipping today</div>
+          <div className="pitch-revenue-split pitch-revenue-split-us">
+            <div className="pitch-revenue-split-name mono">Protocol</div>
+            <p className="pitch-revenue-split-desc">
+              Treasury — accrues on every trade on every market. Funds
+              audit, hiring, growth.
+            </p>
+          </div>
+          <div className="pitch-revenue-split">
+            <div className="pitch-revenue-split-name mono">Insurance</div>
+            <p className="pitch-revenue-split-desc">
+              Reserve — backstops liquidation deficits and bad debt
+              before LPs take losses.
+            </p>
           </div>
         </div>
 
-        <div className="pitch-money-scale-wrap">
-          <div className="pitch-money-scale-title">Scale path · daily protocol fees at 0.1% rate</div>
-          <table className="pitch-money-scale">
-            <thead>
-              <tr>
-                <th>Markets</th>
-                <th>Avg daily vol / market</th>
-                <th>Daily protocol fees</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td className="mono">100</td>
-                <td className="mono">$500K</td>
-                <td className="mono pitch-money-scale-result">$50K</td>
-              </tr>
-              <tr>
-                <td className="mono">1,000</td>
-                <td className="mono">$1M</td>
-                <td className="mono pitch-money-scale-result">$1M</td>
-              </tr>
-            </tbody>
-          </table>
+        <div className="pitch-revenue-econ">
+          <div className="pitch-revenue-econ-stat">
+            <div className="pitch-revenue-econ-num mono">&gt;95%</div>
+            <div className="pitch-revenue-econ-label">gross margin per trade</div>
+          </div>
+          <div className="pitch-revenue-econ-stat">
+            <div className="pitch-revenue-econ-num mono">~$0.002</div>
+            <div className="pitch-revenue-econ-label">Solana compute / trade</div>
+          </div>
+          <div className="pitch-revenue-econ-stat">
+            <div className="pitch-revenue-econ-num mono">$0</div>
+            <div className="pitch-revenue-econ-label">market-maker spend</div>
+          </div>
         </div>
       </div>
     </div>
@@ -1998,6 +1917,143 @@ export default function PitchPage() {
         .pitch-money-scale-result {
           color: #22D3EE !important;
           font-weight: 700;
+        }
+
+        /* ── Revenue (Slide 10 — redesigned) ── */
+
+        .pitch-revenue-hero {
+          display: flex;
+          gap: 1.75rem;
+          align-items: stretch;
+          padding: 1.4rem 1.6rem;
+          margin: 1.5rem 0;
+          background: linear-gradient(95deg,
+            rgba(153, 69, 255, 0.10) 0%,
+            rgba(34, 211, 238, 0.10) 100%);
+          border: 1px solid rgba(34, 211, 238, 0.28);
+          border-radius: 14px;
+        }
+
+        .pitch-revenue-hero-side {
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          gap: 0.25rem;
+          padding-right: 1.6rem;
+          border-right: 1px solid rgba(255, 255, 255, 0.08);
+          flex: 0 0 auto;
+        }
+
+        .pitch-revenue-hero-num {
+          font-size: clamp(1.85rem, 3.4vw, 2.6rem);
+          font-weight: 700;
+          color: #22D3EE;
+          letter-spacing: -0.025em;
+          line-height: 1;
+        }
+
+        .pitch-revenue-hero-tag {
+          font-size: 0.62rem;
+          letter-spacing: 0.16em;
+          text-transform: uppercase;
+          color: rgba(34, 211, 238, 0.7);
+        }
+
+        .pitch-revenue-hero-desc {
+          font-family: 'Inter', sans-serif;
+          font-size: 0.92rem;
+          line-height: 1.5;
+          color: rgba(255, 255, 255, 0.78);
+          flex: 1;
+          display: flex;
+          align-items: center;
+        }
+
+        .pitch-revenue-splits {
+          display: grid;
+          grid-template-columns: repeat(4, 1fr);
+          gap: 0.85rem;
+          margin: 1.5rem 0;
+        }
+
+        .pitch-revenue-split {
+          background: rgba(255, 255, 255, 0.025);
+          border: 1px solid rgba(255, 255, 255, 0.08);
+          border-radius: 10px;
+          padding: 0.95rem 1rem;
+        }
+
+        .pitch-revenue-split-us {
+          border-color: rgba(34, 211, 238, 0.38);
+          background: rgba(34, 211, 238, 0.05);
+        }
+
+        .pitch-revenue-split-name {
+          font-size: 0.72rem;
+          letter-spacing: 0.08em;
+          text-transform: uppercase;
+          font-weight: 700;
+          color: rgba(34, 211, 238, 0.95);
+          margin-bottom: 0.55rem;
+        }
+
+        .pitch-revenue-split-us .pitch-revenue-split-name {
+          color: #22D3EE;
+        }
+
+        .pitch-revenue-split-desc {
+          font-family: 'Inter', sans-serif;
+          font-size: 0.78rem;
+          line-height: 1.5;
+          color: rgba(255, 255, 255, 0.6);
+          margin: 0;
+        }
+
+        .pitch-revenue-econ {
+          display: grid;
+          grid-template-columns: repeat(3, 1fr);
+          gap: 0.85rem;
+        }
+
+        .pitch-revenue-econ-stat {
+          display: flex;
+          align-items: baseline;
+          gap: 0.7rem;
+          padding: 0.85rem 1.05rem;
+          background: rgba(255, 255, 255, 0.025);
+          border: 1px solid rgba(255, 255, 255, 0.07);
+          border-radius: 10px;
+        }
+
+        .pitch-revenue-econ-num {
+          font-size: 1.35rem;
+          font-weight: 700;
+          color: rgba(255, 255, 255, 0.95);
+          letter-spacing: -0.01em;
+          line-height: 1;
+        }
+
+        .pitch-revenue-econ-label {
+          font-family: 'Inter', sans-serif;
+          font-size: 0.78rem;
+          line-height: 1.35;
+          color: rgba(255, 255, 255, 0.55);
+        }
+
+        @media (max-width: 720px) {
+          .pitch-revenue-hero {
+            flex-direction: column;
+            gap: 0.85rem;
+          }
+          .pitch-revenue-hero-side {
+            border-right: none;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+            padding: 0 0 0.85rem;
+          }
+          .pitch-revenue-splits,
+          .pitch-revenue-econ {
+            grid-template-columns: 1fr 1fr;
+          }
         }
 
         /* ── Traction (Slide 3) ── */

--- a/app/app/pitch/page.tsx
+++ b/app/app/pitch/page.tsx
@@ -352,11 +352,11 @@ function Slide03Traction(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Traction · On-Chain</div>
         <h2 className="pitch-title">
-          220 markets stress-tested on devnet across 5 weeks of
-          pre-hackathon hardening (Feb 28 – Mar 31, 2026) over three
-          deployment tiers. Hackathon sprint then upgraded all programs
-          to v12.19 and shipped the first SOL/USDC market to mainnet
-          closed beta. 100+ waitlist signups in the first 48 hours.
+          220 markets created on devnet by 70+ unique wallets over five
+          weeks of pre-hackathon stress testing (Feb 28 – Mar 31, 2026).
+          Hackathon sprint shipped all programs to v12.19 and the first
+          SOL/USDC market to mainnet closed beta. 100+ waitlist signups
+          in the first 48 hours.
         </h2>
 
         <div className="pitch-traction-network-grid pitch-traction-network-grid-single">
@@ -381,9 +381,9 @@ function Slide03Traction(_: SlideProps) {
               </div>
               <div className="pitch-traction-network-stat">
                 <div className="pitch-traction-network-num mono">
-                  <NumberCounter target={3} />
+                  <NumberCounter target={70} suffix="+" />
                 </div>
-                <div className="pitch-traction-network-label">deployment tiers</div>
+                <div className="pitch-traction-network-label">unique creators</div>
               </div>
               <div className="pitch-traction-network-stat">
                 <div className="pitch-traction-network-num mono pitch-traction-network-num-cyan">100%</div>
@@ -392,14 +392,14 @@ function Slide03Traction(_: SlideProps) {
             </div>
             <div className="pitch-traction-network-meta mono">
               136 + 12 + 72 markets across small / medium / large slab
-              tiers — all verifiable on chain. Earliest market
-              2026-02-28, last devnet activity 2026-03-31 — five weeks
-              of pre-hackathon stress testing. Frontier-window work
-              (Apr 6 – May 11) shifted to mainnet, audit hardening, and
-              the closed-beta market. Mainnet program is private, open
-              only to a small group of open-source contributors until
-              the external audit (quotes received, not yet engaged)
-              clears.
+              tiers, created by 70+ unique wallets — all verifiable on
+              chain. Earliest market 2026-02-28, last devnet activity
+              2026-03-31 (five weeks of pre-hackathon stress testing).
+              Our team wallet created only 4 of the 220 — the rest came
+              from contributors. Frontier-window work (Apr 6 – May 11)
+              shifted to mainnet, audit hardening, and the closed-beta
+              market. Mainnet program is private until the external
+              audit (quotes received, not yet engaged) clears.
             </div>
           </div>
         </div>

--- a/app/app/pitch/page.tsx
+++ b/app/app/pitch/page.tsx
@@ -533,9 +533,11 @@ function Slide05Product(_: SlideProps) {
         </div>
 
         <div className="pitch-create-footer">
-          Position is a Token-2022 NFT. First transferable perp
-          position on Solana. Closed beta on mainnet at
-          mainnet.percolatorlaunch.com.
+          Position is a Token-2022 NFT — first transferable perp
+          position on Solana. The LP vault is the counterparty (passive
+          vAMM, same model as Jupiter&apos;s JLP): no active market
+          makers required, no microstructure dependency. Closed beta on
+          mainnet at mainnet.percolatorlaunch.com.
         </div>
       </div>
     </div>
@@ -794,7 +796,8 @@ function Slide09WhyNow(_: SlideProps) {
           </div>
         </div>
         <div className="pitch-whynow-closing">
-          Three catalysts in one year. The window opens now.
+          Three catalysts in one year. The window is open — and
+          we&apos;re shipping into it, not waiting for it to be perfect.
         </div>
       </div>
     </div>
@@ -1042,9 +1045,10 @@ function SlideMarket(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Market</div>
         <h2 className="pitch-title">
-          Solana perp volume runs $20B+/mo across ~50 blue-chip tokens.
-          15 million tokens have zero perp access today. We&apos;re the
-          only one opening that long tail.
+          Solana perp volume averages $25B+/mo (peaked $65B in Oct 2025,
+          per DeFiLlama) across ~50 blue-chip tokens. 15 million tokens
+          have zero perp access today. We&apos;re the only one opening
+          that long tail.
         </h2>
 
         <div className="pitch-matrix-wrap">

--- a/app/app/pitch/page.tsx
+++ b/app/app/pitch/page.tsx
@@ -88,8 +88,10 @@ function NumberCounter({
 
 // ─── Slide Data ──────────────────────────────────────────────────────────────
 //
-// 16 slides, ordered per Cap (Superteam UK) feedback 2026-04-30 plus
-// Toly Signal + Formal Verification + Problem expansion slides:
+// 12 slides, story-first arc reordered 2026-05-11:
+// Hook → Problem → Why Now → Demo → Why Us → Toly Signal → Proof →
+// Traction → Market → Business Model → Roadmap & Ask → Contact.
+// Earlier 16-slide layout (per Cap (Superteam UK) feedback 2026-04-30):
 //   "i recommend doing one-liner / team / traction as your first 3 slides"
 //   "don't have taglines - have a proper sentence which is the tldr of your
 //    traction with a time frame"
@@ -321,14 +323,11 @@ function Slide02Team(_: SlideProps) {
         </div>
 
         <p className="pitch-team-footer">
-          Toly built the on-chain Solana reference program and the
-          protocol math behind it — all his. We forked the engine and
-          built the product layer around it (LP vault, dispute
-          resolution, transferable Token-2022 NFT positions, withdrawal
-          queue, audit-crank invariants, admin lifecycle tooling — 49
-          fork-only handlers, 51 fork-only instructions, 187 wrapper
-          commits past divergence) plus the SDK, indexer, keeper fleet,
-          and frontend.
+          Anatoly Yakovenko (Solana co-founder) built the on-chain risk
+          engine and put it out as open source. We forked it and built
+          the product around it — the trading app, the position NFTs,
+          the keepers, the SDK, the frontend. Both co-founders each won
+          one of his public bounties along the way.
         </p>
       </div>
     </div>
@@ -426,80 +425,7 @@ function Slide03Traction(_: SlideProps) {
   );
 }
 
-// ─── Slide 4 · Hackathon Engineering Sprint ──────────────────────────────────
-
-function Slide04Sprint(_: SlideProps) {
-  return (
-    <div className="pitch-slide">
-      <div className="pitch-slide-inner">
-        <div className="pitch-label">Hackathon Engineering Sprint</div>
-        <h2 className="pitch-title">
-          Across the 5-week Frontier window we shipped three changes that
-          unblock long-tail perp markets, each tied to direct customer
-          signal.
-        </h2>
-
-        <div className="pitch-solution-stack">
-          <div className="pitch-solution-item">
-            <div className="pitch-solution-num purple">1</div>
-            <div>
-              <div className="pitch-solution-name">
-                v12.19 mainnet upgrade + first SOL/USDC market on mainnet
-              </div>
-              <p className="pitch-solution-desc">
-                Four programs upgraded and deployed. SOL/USDC Hyperp market
-                created against a pinned Raydium CLMM pool, running today
-                in lab mode, gated until an external audit (not yet
-                started) clears.
-              </p>
-            </div>
-          </div>
-          <div className="pitch-solution-item">
-            <div className="pitch-solution-num cyan">2</div>
-            <div>
-              <div className="pitch-solution-name">
-                Token-2022 transferable position NFTs
-              </div>
-              <p className="pitch-solution-desc">
-                Customers asked for transferable positions. We shipped them
-                as Token-2022 NFTs. First transferable perp positions
-                ever shipped on Solana.
-              </p>
-            </div>
-          </div>
-          <div className="pitch-solution-item">
-            <div className="pitch-solution-num purple">3</div>
-            <div>
-              <div className="pitch-solution-name">
-                Pre-audit hardening — ongoing, every day
-              </div>
-              <p className="pitch-solution-desc">
-                Continuous self-audit. The proof suite has grown to
-                500+ Kani proofs across engine + wrapper + stake. 36
-                pre-audit hardening PRs merged in 4 days closing every
-                deep-audit CRITICAL finding. Ongoing line-by-line deep
-                audit against upstream produces a port queue of findings,
-                applied as they surface — ahead of external firm
-                engagement. Customers said audit posture was the #1
-                blocker for putting real capital on a long-tail market.
-              </p>
-            </div>
-          </div>
-        </div>
-
-        <p
-          className="pitch-solution-sub"
-          style={{ marginTop: "1.5rem" }}
-        >
-          What we did NOT build: a token launchpad, governance,
-          cross-margining. Out-of-scope, on the roadmap.
-        </p>
-      </div>
-    </div>
-  );
-}
-
-// ─── Slide 5 · Demo Product ──────────────────────────────────────────────────
+// ─── Slide · Demo Product ────────────────────────────────────────────────────
 
 function Slide05Product(_: SlideProps) {
   return (
@@ -779,159 +705,13 @@ function Slide06Money(_: SlideProps) {
   );
 }
 
-// ─── Slide 7 · Opportunity ───────────────────────────────────────────────────
-
-function Slide07Opportunity(_: SlideProps) {
-  return (
-    <div className="pitch-slide">
-      <div className="pitch-slide-inner">
-        <div className="pitch-label">Opportunity</div>
-        <h2 className="pitch-title">
-          Solana perp volume runs in the tens of billions per month
-          across ~50 blue-chip tokens (Jupiter + Drift combined); 15
-          million tokens have zero perp access today.
-        </h2>
-
-        <div className="pitch-opp-compare">
-          <div className="pitch-opp-row">
-            <div className="pitch-opp-row-header">
-              <span className="pitch-opp-tag">Today</span>
-              <span className="pitch-opp-row-stat mono">$20B+ / month</span>
-              <span className="pitch-opp-row-detail">
-                ~50 tokens · all blue chips · contested
-              </span>
-            </div>
-            <div className="pitch-opp-bar-wrap">
-              <div className="pitch-opp-bar pitch-opp-bar-today" />
-            </div>
-          </div>
-
-          <div className="pitch-opp-row">
-            <div className="pitch-opp-row-header">
-              <span className="pitch-opp-tag pitch-opp-tag-cyan">Opportunity</span>
-              <span className="pitch-opp-row-stat mono">15,000,000+ tokens</span>
-              <span className="pitch-opp-row-detail">
-                Every token with a live DEX pool · untouched · empty market
-              </span>
-            </div>
-            <div className="pitch-opp-bar-wrap">
-              <div className="pitch-opp-bar pitch-opp-bar-opportunity" />
-            </div>
-          </div>
-
-          <div className="pitch-opp-callout">
-            Same axis. The &ldquo;today&rdquo; bar is barely visible. The
-            full-width bar is the gap we open.
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ─── Slide 8 · Competitors ───────────────────────────────────────────────────
-
-function Slide08Competitors(_: SlideProps) {
-  return (
-    <div className="pitch-slide">
-      <div className="pitch-slide-inner">
-        <div className="pitch-label">Competitors</div>
-        <h2 className="pitch-title">
-          No major Solana perp DEX opens long-tail markets permissionlessly. Hyperliquid does — but only via HIP-3, which requires staking 500K HYPE (~$20M+) just to deploy a perp DEX. We are the long-tail-native option on Solana.
-        </h2>
-        <div className="pitch-matrix-wrap">
-          <table className="pitch-matrix">
-            <thead>
-              <tr>
-                <th className="pitch-matrix-feature"></th>
-                <th>Hyperliquid</th>
-                <th>Jupiter Perps</th>
-                <th>Drift</th>
-                <th className="pitch-matrix-us">Percolator</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td className="pitch-matrix-feature">Pricing model</td>
-                <td className="pitch-matrix-no">CLOB</td>
-                <td className="pitch-matrix-no">Oracle + JLP</td>
-                <td className="pitch-matrix-no">DLOB + JIT auction</td>
-                <td className="pitch-matrix-yes pitch-matrix-us">Oracle + passive LP / vAMM</td>
-              </tr>
-              <tr>
-                <td className="pitch-matrix-feature">Permissionless markets</td>
-                <td className="pitch-matrix-no">HIP-3 stake-gated ($20M+)</td>
-                <td className="pitch-matrix-no">✗</td>
-                <td className="pitch-matrix-no">✗</td>
-                <td className="pitch-matrix-yes pitch-matrix-us">✓</td>
-              </tr>
-              <tr>
-                <td className="pitch-matrix-feature">Long-tail tokens (any DEX-listed SPL)</td>
-                <td className="pitch-matrix-no">✗</td>
-                <td className="pitch-matrix-no">✗</td>
-                <td className="pitch-matrix-no">✗</td>
-                <td className="pitch-matrix-yes pitch-matrix-us">✓</td>
-              </tr>
-              <tr>
-                <td className="pitch-matrix-feature">Oracle flexibility (Pyth + DEX EWMA + admin push)</td>
-                <td className="pitch-matrix-no">✗</td>
-                <td className="pitch-matrix-no">Pyth-only</td>
-                <td className="pitch-matrix-no">Pyth + Switchboard</td>
-                <td className="pitch-matrix-yes pitch-matrix-us">✓</td>
-              </tr>
-              <tr>
-                <td className="pitch-matrix-feature">Cross-margin</td>
-                <td className="pitch-matrix-yes">✓</td>
-                <td className="pitch-matrix-no">✗</td>
-                <td className="pitch-matrix-yes">✓</td>
-                <td className="pitch-matrix-no pitch-matrix-us">roadmap</td>
-              </tr>
-              <tr>
-                <td className="pitch-matrix-feature">Transferable positions (Token-2022 NFT)</td>
-                <td className="pitch-matrix-no">✗</td>
-                <td className="pitch-matrix-no">✗</td>
-                <td className="pitch-matrix-no">✗</td>
-                <td className="pitch-matrix-yes pitch-matrix-us">✓</td>
-              </tr>
-              <tr>
-                <td className="pitch-matrix-feature">Market-creator fee share</td>
-                <td className="pitch-matrix-no">per HIP-3 builder split</td>
-                <td className="pitch-matrix-no">✗</td>
-                <td className="pitch-matrix-no">✗</td>
-                <td className="pitch-matrix-yes pitch-matrix-us">✓</td>
-              </tr>
-              <tr>
-                <td className="pitch-matrix-feature">Open source (Apache 2.0)</td>
-                <td className="pitch-matrix-no">✗</td>
-                <td className="pitch-matrix-no">partial</td>
-                <td className="pitch-matrix-yes">✓</td>
-                <td className="pitch-matrix-yes pitch-matrix-us">✓</td>
-              </tr>
-              <tr>
-                <td className="pitch-matrix-feature">Native chain</td>
-                <td className="pitch-matrix-no">own L1</td>
-                <td className="pitch-matrix-yes">Solana</td>
-                <td className="pitch-matrix-yes">Solana</td>
-                <td className="pitch-matrix-yes pitch-matrix-us">Solana</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        <p className="pitch-matrix-sub">
-          Everyone else competes for the same 30-50 tokens. We open a category — long-tail SPL perps at a price point creators can actually afford.
-        </p>
-      </div>
-    </div>
-  );
-}
-
-// ─── Slide 9 · GTM & Why Now ─────────────────────────────────────────────────
+// ─── Slide · Why Now ─────────────────────────────────────────────────────────
 
 function Slide09WhyNow(_: SlideProps) {
   return (
     <div className="pitch-slide">
       <div className="pitch-slide-inner">
-        <div className="pitch-label">GTM & Why Now</div>
+        <div className="pitch-label">Why Now</div>
         <h2 className="pitch-title">
           SIMD-0266 and Token-2022 both landed in 2026, making per-trade
           economics work for long-tail tokens for the first time.
@@ -1012,185 +792,14 @@ function Slide09WhyNow(_: SlideProps) {
           </div>
         </div>
         <div className="pitch-whynow-closing">
-          GTM: 220-market devnet sprint complete · OSS contributor
-          closed beta on mainnet · audit quotes received → reactivate
-          devnet + engage audit firm → audit clears → public mainnet
-          launch with first 10 creator-led markets seeded by
-          revenue-share rebates → Jupiter / Birdeye routing once
-          on-chain volume validates.
+          Three catalysts in one year. The window opens now.
         </div>
       </div>
     </div>
   );
 }
 
-// ─── Slide 10 · Roadmap ──────────────────────────────────────────────────────
-
-function Slide10Roadmap(_: SlideProps) {
-  return (
-    <div className="pitch-slide">
-      <div className="pitch-slide-inner">
-        <div className="pitch-label">Roadmap</div>
-        <h2 className="pitch-title">
-          Public mainnet launches in Q3 after the audit; targeting $50M+
-          daily volume by Q4 2026.
-        </h2>
-        <div className="pitch-roadmap">
-          <div className="pitch-roadmap-item">
-            <div className="pitch-roadmap-phase purple">Q2 2026</div>
-            <div className="pitch-roadmap-name">Devnet · audit prep</div>
-            <div className="pitch-roadmap-desc">220-market devnet sprint shipped, mainnet program deployed to OSS-contributor closed beta, audit quotes received</div>
-          </div>
-          <div className="pitch-roadmap-connector" />
-          <div className="pitch-roadmap-item">
-            <div className="pitch-roadmap-phase cyan">Q3 2026</div>
-            <div className="pitch-roadmap-name">Public mainnet</div>
-            <div className="pitch-roadmap-desc">Audit complete, Jupiter / Birdeye routing, first 10 creator-led markets</div>
-          </div>
-          <div className="pitch-roadmap-connector" />
-          <div className="pitch-roadmap-item">
-            <div className="pitch-roadmap-phase purple">Q4 2026</div>
-            <div className="pitch-roadmap-name">$50M+ daily volume</div>
-            <div className="pitch-roadmap-desc">Cross-margining, composable CPI oracle</div>
-          </div>
-          <div className="pitch-roadmap-connector" />
-          <div className="pitch-roadmap-item">
-            <div className="pitch-roadmap-phase cyan">2027</div>
-            <div className="pitch-roadmap-name">Default rail</div>
-            <div className="pitch-roadmap-desc">Every-token perps as default for any new SPL</div>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ─── Slide 11 · Risks ────────────────────────────────────────────────────────
-
-function Slide11Risks(_: SlideProps) {
-  return (
-    <div className="pitch-slide">
-      <div className="pitch-slide-inner">
-        <div className="pitch-label">Risks</div>
-        <h2 className="pitch-title">
-          Three real risks we&apos;re solving, each with a concrete
-          mitigation already in flight.
-        </h2>
-
-        <div className="pitch-risks-grid">
-          <div className="pitch-risks-card">
-            <div className="pitch-risks-name">Liquidity bootstrap</div>
-            <p className="pitch-risks-desc">
-              Long-tail markets are illiquid by definition until creators
-              bring traffic.
-            </p>
-            <div className="pitch-risks-mitigation-label mono">Mitigation</div>
-            <p className="pitch-risks-mitigation">
-              Creator fee share = direct financial incentive for creators
-              to bring their own community. Rev-share rebates fund the
-              first 10 markets at launch.
-            </p>
-          </div>
-
-          <div className="pitch-risks-card">
-            <div className="pitch-risks-name">Audit timing</div>
-            <p className="pitch-risks-desc">
-              Public mainnet trading is gated on a not-yet-started
-              external audit; timing depends on funding + firm engagement.
-            </p>
-            <div className="pitch-risks-mitigation-label mono">Mitigation</div>
-            <p className="pitch-risks-mitigation">
-              Pre-audit hardening is ongoing every day — continuous
-              deep self-audit against upstream produces a port queue
-              we apply as findings surface, ahead of external firm
-              engagement. 500+ Kani proofs verify risk-engine invariants
-              before any auditor starts.
-            </p>
-          </div>
-
-          <div className="pitch-risks-card">
-            <div className="pitch-risks-name">Regulatory drift</div>
-            <p className="pitch-risks-desc">
-              Perps regulation is unsettled globally. A hostile reading
-              would kneecap a centralised competitor.
-            </p>
-            <div className="pitch-risks-mitigation-label mono">Mitigation</div>
-            <p className="pitch-risks-mitigation">
-              Protocol is permissionless by design. No gatekeeping
-              action, no team in the loop on listing decisions, no party
-              to regulate.
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ─── Slide 12 · Next Steps (Ask + Exit) ──────────────────────────────────────
-
-function Slide12NextSteps(_: SlideProps) {
-  return (
-    <div className="pitch-slide">
-      <div className="pitch-slide-inner">
-        <div className="pitch-label">Next Steps</div>
-        <h2 className="pitch-title">
-          We&apos;re shipping with or without capital. The right
-          partner shortcuts the audit, market-maker bootstrap, and
-          creator acquisition.
-        </h2>
-
-        <div className="pitch-ask-grid">
-          <div className="pitch-ask-card">
-            <div className="pitch-ask-card-label mono">Open to</div>
-            <div className="pitch-ask-card-headline">
-              Strategic capital, sized to the partnership.
-            </div>
-            <div className="pitch-ask-card-sub">
-              SAFE, token warrant on PERC, LP co-investment, or bespoke.
-              We care more about the partner than the paper.
-            </div>
-          </div>
-          <div className="pitch-ask-card">
-            <div className="pitch-ask-card-label mono">Where it goes</div>
-            <ul className="pitch-ask-list">
-              <li>External audit + bug bounty program</li>
-              <li>Market-maker bootstrap on first 10 markets</li>
-              <li>Creator acquisition (rev-share rebates, not paid spend)</li>
-              <li>Two technical hires: matching + risk research</li>
-            </ul>
-          </div>
-        </div>
-
-        <div className="pitch-ask-exit-wrap">
-          <div className="pitch-ask-exit-title mono">Liquidity path for capital</div>
-          <div className="pitch-ask-exit-grid">
-            <div className="pitch-ask-exit-item">
-              <div className="pitch-ask-exit-name">Primary</div>
-              <p className="pitch-ask-exit-desc">
-                Protocol-fee-backed token. PERC stakers earn from real fee revenue once mainnet trading opens.
-              </p>
-            </div>
-            <div className="pitch-ask-exit-item">
-              <div className="pitch-ask-exit-name">Secondary</div>
-              <p className="pitch-ask-exit-desc">
-                PERC trades on the existing creator-rewards market today; deeper venues post-mainnet.
-              </p>
-            </div>
-            <div className="pitch-ask-exit-item">
-              <div className="pitch-ask-exit-name">Optional backstop</div>
-              <p className="pitch-ask-exit-desc">
-                Drift, Jupiter, and Hyperliquid all have a structural interest in long-tail listing capability they can&apos;t ship internally. M&amp;A is an option, not the plan.
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ─── Slide 13 · Contact ──────────────────────────────────────────────────────
+// ─── Slide · Contact ─────────────────────────────────────────────────────────
 
 function Slide13Contact(_: SlideProps) {
   return (
@@ -1346,76 +955,215 @@ function SlideTolyStory(_: SlideProps) {
   );
 }
 
-// ─── Slide 6 · Kani Formal Verification ──────────────────────────────────────
+// ─── Slide · Proof (Sprint + Formal Verification merged) ─────────────────────
 
-function SlideKaniProofs(_: SlideProps) {
+function SlideProof(_: SlideProps) {
   return (
     <div className="pitch-slide">
       <div className="pitch-slide-inner">
-        <div className="pitch-label">Formal Verification</div>
+        <div className="pitch-label">Proof</div>
         <h2 className="pitch-title">
-          Kani proves protocol invariants hold across every possible
-          input. 500+ proofs, all green, before any auditor starts.
+          We&apos;ve shipped three things this hackathon — and proved
+          the math holds with 500+ formal proofs before any auditor
+          starts.
         </h2>
 
-        <div className="pitch-kani-callout">
-          <div className="pitch-kani-callout-num mono">
-            <NumberCounter target={500} suffix="+" />
+        <div className="pitch-solution-stack">
+          <div className="pitch-solution-item">
+            <div className="pitch-solution-num purple">1</div>
+            <div>
+              <div className="pitch-solution-name">
+                v12.19 mainnet upgrade + first SOL/USDC market on mainnet
+              </div>
+              <p className="pitch-solution-desc">
+                Four programs upgraded and deployed. SOL/USDC Hyperp market
+                running today in closed beta against a pinned Raydium pool.
+              </p>
+            </div>
           </div>
-          <div className="pitch-kani-callout-label">
-            formal proofs · all green · same model-checking technology
-            used in NASA &amp; aerospace systems, applied to the
-            Percolator risk engine
+          <div className="pitch-solution-item">
+            <div className="pitch-solution-num cyan">2</div>
+            <div>
+              <div className="pitch-solution-name">
+                Token-2022 transferable position NFTs
+              </div>
+              <p className="pitch-solution-desc">
+                First transferable perp positions ever shipped on Solana.
+                Customers asked, we shipped.
+              </p>
+            </div>
           </div>
-        </div>
-
-        <div className="pitch-kani-what">
-          <div className="pitch-kani-what-card">
-            <div className="pitch-kani-what-name">Haircut conservation</div>
-            <p className="pitch-kani-what-desc">
-              The H mechanism never lets profitable accounts extract
-              more than the vault holds. Proven across every state and
-              price.
-            </p>
-          </div>
-          <div className="pitch-kani-what-card">
-            <div className="pitch-kani-what-name">ADL fairness</div>
-            <p className="pitch-kani-what-desc">
-              A/K coefficients socialise position reduction equally
-              across each side. No queue, no first-mover advantage,
-              ever.
-            </p>
-          </div>
-          <div className="pitch-kani-what-card">
-            <div className="pitch-kani-what-name">Funding zero-sum</div>
-            <p className="pitch-kani-what-desc">
-              Funding settles to net zero across all accounts at every
-              step. Money in equals money out, provably.
-            </p>
+          <div className="pitch-solution-item">
+            <div className="pitch-solution-num purple">3</div>
+            <div>
+              <div className="pitch-solution-name">
+                500+ Kani formal-verification proofs
+              </div>
+              <p className="pitch-solution-desc">
+                Kani proves protocol invariants hold across every
+                possible input. 500+ proofs, all green. Hyperliquid,
+                Drift, and Jupiter have zero. 36 pre-audit hardening
+                PRs merged in 4 days closing every deep-audit CRITICAL.
+              </p>
+            </div>
           </div>
         </div>
 
         <div className="pitch-kani-vs">
-          <div className="pitch-kani-vs-title mono">
-            Formal proofs in production · perp DEXs on Solana
+          <div className="pitch-kani-vs-cell">
+            <div className="pitch-kani-vs-cell-num mono">0</div>
+            <div className="pitch-kani-vs-cell-label">Hyperliquid</div>
           </div>
-          <div className="pitch-kani-vs-row">
-            <div className="pitch-kani-vs-cell">
-              <div className="pitch-kani-vs-cell-num mono">0</div>
-              <div className="pitch-kani-vs-cell-label">Hyperliquid</div>
+          <div className="pitch-kani-vs-cell">
+            <div className="pitch-kani-vs-cell-num mono">0</div>
+            <div className="pitch-kani-vs-cell-label">Drift</div>
+          </div>
+          <div className="pitch-kani-vs-cell">
+            <div className="pitch-kani-vs-cell-num mono">0</div>
+            <div className="pitch-kani-vs-cell-label">Jupiter Perps</div>
+          </div>
+          <div className="pitch-kani-vs-cell pitch-kani-vs-cell-us">
+            <div className="pitch-kani-vs-cell-num mono">500+</div>
+            <div className="pitch-kani-vs-cell-label">Percolator</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Slide · Market (Opportunity + Competitors merged) ───────────────────────
+
+function SlideMarket(_: SlideProps) {
+  return (
+    <div className="pitch-slide">
+      <div className="pitch-slide-inner">
+        <div className="pitch-label">Market</div>
+        <h2 className="pitch-title">
+          Solana perp volume runs $20B+/mo across ~50 blue-chip tokens.
+          15 million tokens have zero perp access today. We&apos;re the
+          only one opening that long tail.
+        </h2>
+
+        <div className="pitch-matrix-wrap">
+          <table className="pitch-matrix">
+            <thead>
+              <tr>
+                <th className="pitch-matrix-feature"></th>
+                <th>Hyperliquid</th>
+                <th>Jupiter Perps</th>
+                <th>Drift</th>
+                <th className="pitch-matrix-us">Percolator</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td className="pitch-matrix-feature">Permissionless markets</td>
+                <td className="pitch-matrix-no">HIP-3 ($20M+ stake)</td>
+                <td className="pitch-matrix-no">✗</td>
+                <td className="pitch-matrix-no">✗</td>
+                <td className="pitch-matrix-yes pitch-matrix-us">✓</td>
+              </tr>
+              <tr>
+                <td className="pitch-matrix-feature">Long-tail tokens (any DEX-listed SPL)</td>
+                <td className="pitch-matrix-no">✗</td>
+                <td className="pitch-matrix-no">✗</td>
+                <td className="pitch-matrix-no">✗</td>
+                <td className="pitch-matrix-yes pitch-matrix-us">✓</td>
+              </tr>
+              <tr>
+                <td className="pitch-matrix-feature">Transferable positions (NFT)</td>
+                <td className="pitch-matrix-no">✗</td>
+                <td className="pitch-matrix-no">✗</td>
+                <td className="pitch-matrix-no">✗</td>
+                <td className="pitch-matrix-yes pitch-matrix-us">✓</td>
+              </tr>
+              <tr>
+                <td className="pitch-matrix-feature">Market-creator fee share</td>
+                <td className="pitch-matrix-no">HIP-3 builder split</td>
+                <td className="pitch-matrix-no">✗</td>
+                <td className="pitch-matrix-no">✗</td>
+                <td className="pitch-matrix-yes pitch-matrix-us">✓</td>
+              </tr>
+              <tr>
+                <td className="pitch-matrix-feature">Open source (Apache 2.0)</td>
+                <td className="pitch-matrix-no">✗</td>
+                <td className="pitch-matrix-no">partial</td>
+                <td className="pitch-matrix-yes">✓</td>
+                <td className="pitch-matrix-yes pitch-matrix-us">✓</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p className="pitch-matrix-sub">
+          Everyone else competes for the same 30-50 tokens. We open a
+          category — long-tail SPL perps at a price point creators can
+          actually afford.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// ─── Slide · Roadmap & Ask (Roadmap + Risks + Next Steps merged) ─────────────
+
+function SlideRoadmapAsk(_: SlideProps) {
+  return (
+    <div className="pitch-slide">
+      <div className="pitch-slide-inner">
+        <div className="pitch-label">Roadmap & Ask</div>
+        <h2 className="pitch-title">
+          Public mainnet Q3 after audit, $50M+ daily volume Q4. Open to
+          strategic capital sized to the partnership.
+        </h2>
+
+        <div className="pitch-roadmap">
+          <div className="pitch-roadmap-item">
+            <div className="pitch-roadmap-phase purple">Q2 2026</div>
+            <div className="pitch-roadmap-name">Closed beta · audit</div>
+            <div className="pitch-roadmap-desc">Mainnet program live, OSS-contributor beta, audit quotes received</div>
+          </div>
+          <div className="pitch-roadmap-connector" />
+          <div className="pitch-roadmap-item">
+            <div className="pitch-roadmap-phase cyan">Q3 2026</div>
+            <div className="pitch-roadmap-name">Public mainnet</div>
+            <div className="pitch-roadmap-desc">Audit complete, Jupiter / Birdeye routing, first 10 creator-led markets</div>
+          </div>
+          <div className="pitch-roadmap-connector" />
+          <div className="pitch-roadmap-item">
+            <div className="pitch-roadmap-phase purple">Q4 2026</div>
+            <div className="pitch-roadmap-name">$50M+ daily volume</div>
+            <div className="pitch-roadmap-desc">Cross-margining, composable CPI oracle</div>
+          </div>
+          <div className="pitch-roadmap-connector" />
+          <div className="pitch-roadmap-item">
+            <div className="pitch-roadmap-phase cyan">2027</div>
+            <div className="pitch-roadmap-name">Default rail</div>
+            <div className="pitch-roadmap-desc">Every-token perps as default for any new SPL</div>
+          </div>
+        </div>
+
+        <div className="pitch-ask-grid" style={{ marginTop: "2rem" }}>
+          <div className="pitch-ask-card">
+            <div className="pitch-ask-card-label mono">Open to</div>
+            <div className="pitch-ask-card-headline">
+              Strategic capital, sized to the partnership.
             </div>
-            <div className="pitch-kani-vs-cell">
-              <div className="pitch-kani-vs-cell-num mono">0</div>
-              <div className="pitch-kani-vs-cell-label">Drift</div>
+            <div className="pitch-ask-card-sub">
+              SAFE, token warrant on PERC, or LP co-investment. We
+              care more about the partner than the paper. Shipping with
+              or without capital — the right partner shortcuts audit,
+              market-maker bootstrap, and creator acquisition.
             </div>
-            <div className="pitch-kani-vs-cell">
-              <div className="pitch-kani-vs-cell-num mono">0</div>
-              <div className="pitch-kani-vs-cell-label">Jupiter Perps</div>
-            </div>
-            <div className="pitch-kani-vs-cell pitch-kani-vs-cell-us">
-              <div className="pitch-kani-vs-cell-num mono">500+</div>
-              <div className="pitch-kani-vs-cell-label">Percolator</div>
-            </div>
+          </div>
+          <div className="pitch-ask-card">
+            <div className="pitch-ask-card-label mono">Where it goes · Risks we&apos;re solving</div>
+            <ul className="pitch-ask-list">
+              <li>External audit + bug bounty (mitigates audit-timing risk)</li>
+              <li>Market-maker bootstrap on first 10 markets (mitigates liquidity-bootstrap risk)</li>
+              <li>Creator acquisition via rev-share rebates (mitigates liquidity-bootstrap risk)</li>
+              <li>Two technical hires: matching + risk research</li>
+            </ul>
           </div>
         </div>
       </div>
@@ -1426,22 +1174,18 @@ function SlideKaniProofs(_: SlideProps) {
 // ─── Slide Registry ───────────────────────────────────────────────────────────
 
 const SLIDES = [
-  { id: 1, title: "One-Liner", component: Slide01OneLiner },
+  { id: 1, title: "Hook", component: Slide01OneLiner },
   { id: 2, title: "Problem", component: SlideProblem },
-  { id: 3, title: "Team", component: Slide02Team },
-  { id: 4, title: "Toly Signal", component: SlideTolyStory },
-  { id: 5, title: "Traction", component: Slide03Traction },
-  { id: 6, title: "Hackathon Engineering Sprint", component: Slide04Sprint },
-  { id: 7, title: "Formal Verification", component: SlideKaniProofs },
-  { id: 8, title: "Demo Product", component: Slide05Product },
-  { id: 9, title: "Business Model", component: Slide06Money },
-  { id: 10, title: "Opportunity", component: Slide07Opportunity },
-  { id: 11, title: "Competitors", component: Slide08Competitors },
-  { id: 12, title: "GTM & Why Now", component: Slide09WhyNow },
-  { id: 13, title: "Roadmap", component: Slide10Roadmap },
-  { id: 14, title: "Risks", component: Slide11Risks },
-  { id: 15, title: "Next Steps", component: Slide12NextSteps },
-  { id: 16, title: "Contact", component: Slide13Contact },
+  { id: 3, title: "Why Now", component: Slide09WhyNow },
+  { id: 4, title: "Demo Product", component: Slide05Product },
+  { id: 5, title: "Why Us", component: Slide02Team },
+  { id: 6, title: "Toly Signal", component: SlideTolyStory },
+  { id: 7, title: "Proof", component: SlideProof },
+  { id: 8, title: "Traction", component: Slide03Traction },
+  { id: 9, title: "Market", component: SlideMarket },
+  { id: 10, title: "Business Model", component: Slide06Money },
+  { id: 11, title: "Roadmap & Ask", component: SlideRoadmapAsk },
+  { id: 12, title: "Contact", component: Slide13Contact },
 ];
 
 const TOTAL_SLIDES = SLIDES.length;

--- a/app/app/pitch/page.tsx
+++ b/app/app/pitch/page.tsx
@@ -647,7 +647,7 @@ function Slide06Money(_: SlideProps) {
               <div className="pitch-money-pill">LP vault</div>
               <div className="pitch-money-pill">Creator</div>
               <div className="pitch-money-pill pitch-money-pill-cyan">
-                Protocol → PERC stakers
+                Protocol treasury
               </div>
               <div className="pitch-money-pill">Insurance reserve</div>
             </div>
@@ -1152,9 +1152,9 @@ function SlideRoadmapAsk(_: SlideProps) {
               Strategic capital, sized to the partnership.
             </div>
             <div className="pitch-ask-card-sub">
-              SAFE, token warrant on PERC, or LP co-investment. We
-              care more about the partner than the paper. Shipping with
-              or without capital — the right partner shortcuts audit,
+              SAFE, LP co-investment, or bespoke equity. We care more
+              about the partner than the paper. Shipping with or
+              without capital — the right partner shortcuts audit,
               market-maker bootstrap, and creator acquisition.
             </div>
           </div>

--- a/app/app/pitch/page.tsx
+++ b/app/app/pitch/page.tsx
@@ -173,10 +173,8 @@ function SlideProblem(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Problem</div>
         <h2 className="pitch-title">
-          Solana hosts more than 15 million SPL tokens. Around fifty of
-          them have a perp market. Everyone else has to clear a team
-          approval process or a capital requirement most builders
-          can&apos;t meet.
+          Fifty Solana tokens have a perp market. Fifteen million
+          don&apos;t.
         </h2>
 
         <div className="pitch-opp-compare">
@@ -336,13 +334,9 @@ function Slide02Team(_: SlideProps) {
         </div>
 
         <p className="pitch-team-footer">
-          Anatoly Yakovenko, Solana&apos;s co-founder, wrote the
-          protocol math behind Percolator and shipped a reference
-          program as open source. We forked his engine and built the
-          rest of the stack on top of it: the trading app, the Token-2022
-          position NFTs, the keeper fleet, the SDK, and the frontend.
-          Both of our co-founders have won one of his public bounties
-          along the way.
+          Anatoly Yakovenko wrote the protocol math and open-sourced a
+          reference program. We forked his engine and built everything
+          else on top: trading app, keepers, SDK, frontend.
         </p>
       </div>
     </div>
@@ -365,11 +359,8 @@ function Slide03Traction(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Traction · On-Chain</div>
         <h2 className="pitch-title">
-          Over a hundred creators seeded LP vaults across 220 perp
-          markets on devnet between February 28 and March 31, 2026.
-          The hackathon sprint that followed shipped our first SOL/USDC
-          market to mainnet closed beta. The waitlist crossed 100
-          signups in its first 48 hours.
+          220 perp markets on devnet from 100+ creators, and the first
+          SOL/USDC market live on mainnet in closed beta.
         </h2>
 
         <div className="pitch-traction-network-grid pitch-traction-network-grid-single">
@@ -457,12 +448,8 @@ function Slide05Product(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Demo Product</div>
         <h2 className="pitch-title">
-          The closed beta is live on mainnet today, running the first
-          SOL/USDC Hyperp market. Connect a Solana wallet, deposit
-          USDC, open a leveraged long, then close at PnL. Fees settle
-          on-chain in the same transaction. Public mainnet opens once
-          the external audit clears. We have quotes in hand and
-          haven&apos;t engaged the firm yet.
+          The first SOL/USDC market is live on mainnet in closed beta.
+          Public access opens once the audit clears.
         </h2>
 
         <div className="pflow-wrap">
@@ -885,17 +872,11 @@ function SlideTolyStory(_: SlideProps) {
         </div>
 
         <p className="pitch-toly-footer">
-          Toly wrote the protocol math and shipped a reference program
-          at github.com/aeyakovenko/percolator-prog, called the H + A/K
-          risk engine. We forked it and built the product on top for
-          Solana mainnet, extending the on-chain program with the LP
-          vault, dispute resolution, transferable NFT positions, the
-          withdrawal queue, audit-crank invariant checking, and admin
-          lifecycle tooling. That works out to 49 fork-only handlers,
-          51 fork-only instructions, and 187 wrapper commits past the
-          divergence point, plus the SDK, indexer, keeper fleet, and
-          frontend. Both co-founders have each won one of his public
-          bounties.
+          Toly wrote the H + A/K risk engine and shipped a reference
+          program at github.com/aeyakovenko/percolator-prog. We forked
+          it and shipped 51 fork-only instructions and 187 wrapper
+          commits of product on top: the LP vault, dispute resolution,
+          NFT positions, withdrawal queue, and the rest of the stack.
         </p>
       </div>
     </div>
@@ -992,12 +973,9 @@ function SlideMarket(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Market</div>
         <h2 className="pitch-title">
-          Solana perp volume averages over $25 billion per month per
-          DeFiLlama, and Pacifica recently overtook Jupiter as the
-          largest Solana venue. Every leading perp DEX, including
-          Hyperliquid on its own L1, curates its listings. Fifteen
-          million SPL tokens have no perp access at all. We open the
-          long tail.
+          Solana perps do over $25 billion a month. Every venue
+          curates its listings. We open the 15 million tokens that
+          have no perp access.
         </h2>
 
         <div className="pitch-matrix-wrap">
@@ -1100,7 +1078,7 @@ function SlideRoadmapAsk(_: SlideProps) {
         </div>
 
         <div className="pitch-ask-grid" style={{ marginTop: "2rem" }}>
-          <div className="pitch-ask-card">
+          <div className="pitch-ask-card pitch-ask-card-primary">
             <div className="pitch-ask-card-label mono">Open to</div>
             <div className="pitch-ask-card-headline">
               Strategic capital, sized to the partnership.
@@ -1420,7 +1398,7 @@ export default function PitchPage() {
         .pitch-url {
           font-family: 'JetBrains Mono', monospace;
           font-size: 0.85rem;
-          color: rgba(34,211,238,0.5);
+          color: rgba(34,211,238,0.75);
           letter-spacing: 0.05em;
         }
 
@@ -1459,7 +1437,7 @@ export default function PitchPage() {
         .pitch-solution-stack {
           display: flex;
           flex-direction: column;
-          gap: 1.25rem;
+          gap: 0.85rem;
         }
 
         .pitch-solution-item {
@@ -1468,8 +1446,8 @@ export default function PitchPage() {
           align-items: flex-start;
           background: rgba(255,255,255,0.025);
           border: 1px solid rgba(255,255,255,0.06);
-          border-radius: 10px;
-          padding: 1.25rem 1.5rem;
+          border-radius: 12px;
+          padding: 0.95rem 1.25rem;
         }
 
         .pitch-solution-num {
@@ -1510,11 +1488,12 @@ export default function PitchPage() {
 
         /* ── Live Product flow ── */
         .pitch-create-footer {
-          font-family: 'Inter Tight', 'Inter', sans-serif;
-          font-size: 1rem;
-          font-weight: 700;
-          color: #22D3EE;
-          letter-spacing: -0.01em;
+          font-family: 'Inter', sans-serif;
+          font-size: 0.92rem;
+          font-weight: 500;
+          color: rgba(255, 255, 255, 0.65);
+          letter-spacing: 0;
+          line-height: 1.5;
           margin-top: 1.5rem;
         }
 
@@ -1650,7 +1629,7 @@ export default function PitchPage() {
         .pitch-whynow-stat {
           background: rgba(255,255,255,0.025);
           border: 1px solid rgba(255,255,255,0.07);
-          border-radius: 10px;
+          border-radius: 12px;
           padding: 1.5rem;
           text-align: center;
         }
@@ -1767,7 +1746,7 @@ export default function PitchPage() {
           font-family: 'Inter Tight', 'Inter', sans-serif;
           font-weight: 700;
           font-size: 0.85rem;
-          color: rgba(255,255,255,0.55);
+          color: rgba(255,255,255,0.8);
           padding: 0.75rem 1rem;
           text-align: center;
         }
@@ -1775,7 +1754,7 @@ export default function PitchPage() {
         .pitch-matrix th:first-child { text-align: left; }
 
         .pitch-matrix tbody tr {
-          border-bottom: 1px solid rgba(255,255,255,0.05);
+          border-bottom: 1px solid rgba(255,255,255,0.08);
         }
 
         .pitch-matrix tbody tr:last-child { border-bottom: none; }
@@ -1788,7 +1767,7 @@ export default function PitchPage() {
 
         .pitch-matrix-feature {
           text-align: left !important;
-          color: rgba(255,255,255,0.7) !important;
+          color: rgba(255,255,255,0.65) !important;
           font-weight: 500;
         }
 
@@ -1811,9 +1790,11 @@ export default function PitchPage() {
 
         .pitch-matrix-sub {
           font-family: 'Inter', sans-serif;
-          font-size: 0.875rem;
-          color: rgba(255,255,255,0.4);
+          font-size: 0.9rem;
+          color: rgba(255,255,255,0.6);
           font-style: italic;
+          margin-top: 1rem;
+          line-height: 1.5;
         }
 
         /* ── Business Model ── */
@@ -1964,7 +1945,7 @@ export default function PitchPage() {
             rgba(153, 69, 255, 0.10) 0%,
             rgba(34, 211, 238, 0.10) 100%);
           border: 1px solid rgba(34, 211, 238, 0.28);
-          border-radius: 14px;
+          border-radius: 12px;
         }
 
         .pitch-revenue-hero-side {
@@ -2012,8 +1993,8 @@ export default function PitchPage() {
         .pitch-revenue-split {
           background: rgba(255, 255, 255, 0.025);
           border: 1px solid rgba(255, 255, 255, 0.08);
-          border-radius: 10px;
-          padding: 0.95rem 1rem;
+          border-radius: 12px;
+          padding: 1.1rem 1.15rem;
         }
 
         .pitch-revenue-split-us {
@@ -2026,7 +2007,7 @@ export default function PitchPage() {
           letter-spacing: 0.08em;
           text-transform: uppercase;
           font-weight: 700;
-          color: rgba(34, 211, 238, 0.95);
+          color: rgba(255, 255, 255, 0.72);
           margin-bottom: 0.55rem;
         }
 
@@ -2162,8 +2143,14 @@ export default function PitchPage() {
 
         .pitch-traction-mini-row {
           display: grid;
-          grid-template-columns: repeat(4, 1fr);
-          gap: 0.75rem;
+          grid-template-columns: repeat(5, 1fr);
+          gap: 0.65rem;
+        }
+
+        @media (max-width: 720px) {
+          .pitch-traction-mini-row {
+            grid-template-columns: repeat(2, 1fr);
+          }
         }
 
         /* ─── Slide 3 · network proof cards ───────────────────────── */
@@ -2287,7 +2274,7 @@ export default function PitchPage() {
         .pitch-traction-mini {
           background: rgba(255,255,255,0.025);
           border: 1px solid rgba(255,255,255,0.07);
-          border-radius: 10px;
+          border-radius: 12px;
           padding: 0.9rem 1rem;
           text-align: center;
         }
@@ -2576,13 +2563,16 @@ export default function PitchPage() {
         .pitch-hero-cta-primary {
           background: linear-gradient(135deg, rgba(153, 69, 255, 0.18), rgba(34, 211, 238, 0.18));
           border-color: rgba(34, 211, 238, 0.42);
+          border-left: 3px solid #22D3EE;
           color: #fff;
+          padding-left: calc(1.4rem - 2px);
         }
 
         @media (hover: hover) {
           .pitch-hero-cta-primary:hover {
             background: linear-gradient(135deg, rgba(153, 69, 255, 0.3), rgba(34, 211, 238, 0.3));
             border-color: rgba(34, 211, 238, 0.75);
+            border-left-color: #22D3EE;
           }
         }
 
@@ -2600,11 +2590,11 @@ export default function PitchPage() {
         /* ─── Team PFPs ────────────────────────────────────────────── */
 
         .pitch-team-pfp {
-          width: 48px;
-          height: 48px;
+          width: 64px;
+          height: 64px;
           border-radius: 50%;
           border: 2px solid rgba(34, 211, 238, 0.22);
-          margin-bottom: 0.75rem;
+          margin-bottom: 0.85rem;
           display: block;
           object-fit: cover;
           background: rgba(255, 255, 255, 0.04);
@@ -2691,7 +2681,7 @@ export default function PitchPage() {
           gap: 0.5rem;
           background: rgba(255, 255, 255, 0.025);
           border: 1px solid rgba(255, 255, 255, 0.08);
-          border-radius: 10px;
+          border-radius: 12px;
           padding: 0.6rem;
           text-decoration: none;
           color: inherit;
@@ -2810,7 +2800,7 @@ export default function PitchPage() {
         .pitch-kani-what-card {
           background: rgba(255, 255, 255, 0.025);
           border: 1px solid rgba(255, 255, 255, 0.07);
-          border-radius: 10px;
+          border-radius: 12px;
           padding: 1rem 1.1rem;
           transition: border-color 220ms ease, background 220ms ease;
         }
@@ -3008,11 +2998,21 @@ export default function PitchPage() {
 
         .pitch-ask-card-headline {
           font-family: 'Inter Tight', 'Inter', sans-serif;
-          font-size: 1.4rem;
-          font-weight: 800;
+          font-size: 1.1rem;
+          font-weight: 700;
           color: #fff;
           margin-bottom: 0.5rem;
-          letter-spacing: -0.01em;
+          letter-spacing: -0.005em;
+          line-height: 1.35;
+        }
+
+        .pitch-ask-card-primary {
+          border-color: rgba(34, 211, 238, 0.32);
+          background: rgba(34, 211, 238, 0.04);
+        }
+
+        .pitch-ask-card-primary .pitch-ask-card-label {
+          color: rgba(34, 211, 238, 0.85);
         }
 
         .pitch-ask-card-sub {
@@ -3093,17 +3093,23 @@ export default function PitchPage() {
         /* ── Contact ── */
         .pitch-contact-grid {
           display: grid;
-          grid-template-columns: repeat(3, 1fr);
-          gap: 1rem;
+          grid-template-columns: repeat(4, 1fr);
+          gap: 0.85rem;
           width: 100%;
-          max-width: 720px;
+          max-width: 860px;
           margin: 0 auto;
+        }
+
+        @media (max-width: 720px) {
+          .pitch-contact-grid {
+            grid-template-columns: repeat(2, 1fr);
+          }
         }
 
         .pitch-contact-card {
           background: rgba(255,255,255,0.025);
           border: 1px solid rgba(255,255,255,0.07);
-          border-radius: 10px;
+          border-radius: 12px;
           padding: 1rem 1.25rem;
           text-align: center;
         }
@@ -3367,6 +3373,10 @@ export default function PitchPage() {
           display: flex;
           flex-direction: column;
           gap: 0.85rem;
+          background: rgba(255, 255, 255, 0.025);
+          border: 1px solid rgba(255, 255, 255, 0.07);
+          border-radius: 12px;
+          padding: 0.95rem 1.1rem;
         }
 
         .pitch-opp-row-header {
@@ -3446,13 +3456,14 @@ export default function PitchPage() {
 
         .pitch-opp-callout {
           font-family: 'Inter', sans-serif;
-          font-size: 0.85rem;
-          color: rgba(255, 255, 255, 0.5);
+          font-size: 0.92rem;
+          color: rgba(255, 255, 255, 0.7);
           font-style: italic;
-          border-left: 2px solid rgba(34, 211, 238, 0.4);
+          border-left: 3px solid #22D3EE;
           padding-left: 1rem;
           max-width: 580px;
-          line-height: 1.5;
+          line-height: 1.55;
+          margin-top: 0.5rem;
         }
 
         @media (prefers-reduced-motion: reduce) {
@@ -3493,9 +3504,9 @@ export default function PitchPage() {
            ───────────────────────────────────────────────────────────── */
 
         .pitch-catalyst-icon {
-          width: 28px;
-          height: 28px;
-          color: rgba(153, 69, 255, 0.7);
+          width: 32px;
+          height: 32px;
+          color: rgba(153, 69, 255, 0.85);
           margin-bottom: 0.85rem;
           display: block;
           margin-left: auto;

--- a/app/app/pitch/page.tsx
+++ b/app/app/pitch/page.tsx
@@ -557,7 +557,7 @@ function Slide06Money(_: SlideProps) {
   return (
     <div className="pitch-slide">
       <div className="pitch-slide-inner">
-        <div className="pitch-label">Revenue</div>
+        <div className="pitch-label">Business Model</div>
         <h2 className="pitch-title">
           0.1–1% per trade. Splits four ways on-chain in the same
           transaction. &gt;95% gross margin — no market makers to pay.
@@ -632,7 +632,7 @@ function Slide09WhyNow(_: SlideProps) {
   return (
     <div className="pitch-slide">
       <div className="pitch-slide-inner">
-        <div className="pitch-label">Why Now</div>
+        <div className="pitch-label">GTM & Why Now</div>
         <h2 className="pitch-title">
           SIMD-0266 and Token-2022 both landed in 2026, making per-trade
           economics work for long-tail tokens for the first time.
@@ -883,7 +883,7 @@ function SlideProof(_: SlideProps) {
   return (
     <div className="pitch-slide">
       <div className="pitch-slide-inner">
-        <div className="pitch-label">Proof</div>
+        <div className="pitch-label">Hackathon Sprint</div>
         <h2 className="pitch-title">
           Customers told us audit posture and transferable positions
           were the #1 blockers. We shipped both this hackathon — plus
@@ -1097,16 +1097,16 @@ function SlideRoadmapAsk(_: SlideProps) {
 // ─── Slide Registry ───────────────────────────────────────────────────────────
 
 const SLIDES = [
-  { id: 1, title: "Hook", component: Slide01OneLiner },
+  { id: 1, title: "One-Liner", component: Slide01OneLiner },
   { id: 2, title: "Problem", component: SlideProblem },
-  { id: 3, title: "Why Now", component: Slide09WhyNow },
-  { id: 4, title: "Demo Product", component: Slide05Product },
-  { id: 5, title: "Why Us", component: Slide02Team },
-  { id: 6, title: "Toly Signal", component: SlideTolyStory },
-  { id: 7, title: "Proof", component: SlideProof },
-  { id: 8, title: "Traction", component: Slide03Traction },
+  { id: 3, title: "Team", component: Slide02Team },
+  { id: 4, title: "Toly Signal", component: SlideTolyStory },
+  { id: 5, title: "Traction", component: Slide03Traction },
+  { id: 6, title: "Hackathon Sprint", component: SlideProof },
+  { id: 7, title: "Demo Product", component: Slide05Product },
+  { id: 8, title: "Business Model", component: Slide06Money },
   { id: 9, title: "Market", component: SlideMarket },
-  { id: 10, title: "Business Model", component: Slide06Money },
+  { id: 10, title: "GTM & Why Now", component: Slide09WhyNow },
   { id: 11, title: "Roadmap & Ask", component: SlideRoadmapAsk },
   { id: 12, title: "Contact", component: Slide13Contact },
 ];

--- a/app/app/pitch/page.tsx
+++ b/app/app/pitch/page.tsx
@@ -352,7 +352,7 @@ function Slide03Traction(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Traction · On-Chain</div>
         <h2 className="pitch-title">
-          220 markets created on devnet by 70+ unique wallets over five
+          220 markets created on devnet by 100+ creators over five
           weeks of pre-hackathon stress testing (Feb 28 – Mar 31, 2026).
           Hackathon sprint shipped all programs to v12.19 and the first
           SOL/USDC market to mainnet closed beta. 100+ waitlist signups
@@ -381,9 +381,9 @@ function Slide03Traction(_: SlideProps) {
               </div>
               <div className="pitch-traction-network-stat">
                 <div className="pitch-traction-network-num mono">
-                  <NumberCounter target={70} suffix="+" />
+                  <NumberCounter target={100} suffix="+" />
                 </div>
-                <div className="pitch-traction-network-label">unique creators</div>
+                <div className="pitch-traction-network-label">creators</div>
               </div>
               <div className="pitch-traction-network-stat">
                 <div className="pitch-traction-network-num mono pitch-traction-network-num-cyan">100%</div>
@@ -392,14 +392,12 @@ function Slide03Traction(_: SlideProps) {
             </div>
             <div className="pitch-traction-network-meta mono">
               136 + 12 + 72 markets across small / medium / large slab
-              tiers, created by 70+ unique wallets — all verifiable on
-              chain. Earliest market 2026-02-28, last devnet activity
-              2026-03-31 (five weeks of pre-hackathon stress testing).
-              Our team wallet created only 4 of the 220 — the rest came
-              from contributors. Frontier-window work (Apr 6 – May 11)
-              shifted to mainnet, audit hardening, and the closed-beta
-              market. Mainnet program is private until the external
-              audit (quotes received, not yet engaged) clears.
+              tiers — all verifiable on chain. Earliest market
+              2026-02-28, last devnet activity 2026-03-31 (five weeks of
+              pre-hackathon stress testing). Frontier-window work (Apr 6
+              – May 11) shifted to mainnet, audit hardening, and the
+              closed-beta market. Mainnet program is private until the
+              external audit (quotes received, not yet engaged) clears.
             </div>
           </div>
         </div>

--- a/app/app/pitch/page.tsx
+++ b/app/app/pitch/page.tsx
@@ -352,11 +352,10 @@ function Slide03Traction(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Traction · On-Chain</div>
         <h2 className="pitch-title">
-          220 markets created on devnet by 100+ creators over five
-          weeks of pre-hackathon stress testing (Feb 28 – Mar 31, 2026).
-          Hackathon sprint shipped all programs to v12.19 and the first
-          SOL/USDC market to mainnet closed beta. 100+ waitlist signups
-          in the first 48 hours.
+          220 markets created on devnet by 100+ creators seeding LP
+          vaults (Feb 28 – Mar 31, 2026). Hackathon sprint then shipped
+          the first SOL/USDC market to mainnet closed beta. 100+
+          waitlist signups in the first 48 hours.
         </h2>
 
         <div className="pitch-traction-network-grid pitch-traction-network-grid-single">
@@ -392,12 +391,10 @@ function Slide03Traction(_: SlideProps) {
             </div>
             <div className="pitch-traction-network-meta mono">
               136 + 12 + 72 markets across small / medium / large slab
-              tiers — all verifiable on chain. Earliest market
-              2026-02-28, last devnet activity 2026-03-31 (five weeks of
-              pre-hackathon stress testing). Frontier-window work (Apr 6
-              – May 11) shifted to mainnet, audit hardening, and the
-              closed-beta market. Mainnet program is private until the
-              external audit (quotes received, not yet engaged) clears.
+              tiers — all verifiable on chain. Each market seeds its own
+              LP vault (passive vAMM, same model as Jupiter&apos;s JLP).
+              Mainnet program is private until the external audit
+              (quotes received, not yet engaged) clears.
             </div>
           </div>
         </div>
@@ -544,10 +541,9 @@ function Slide05Product(_: SlideProps) {
 
         <div className="pitch-create-footer">
           Position is a Token-2022 NFT — first transferable perp
-          position on Solana. The LP vault is the counterparty (passive
-          vAMM, same model as Jupiter&apos;s JLP): no active market
-          makers required, no microstructure dependency. Closed beta on
-          mainnet at mainnet.percolatorlaunch.com.
+          position on Solana. LP vault is the counterparty (like
+          Jupiter&apos;s JLP) — no market makers required. Closed beta
+          at mainnet.percolatorlaunch.com.
         </div>
       </div>
     </div>
@@ -562,9 +558,8 @@ function Slide06Money(_: SlideProps) {
       <div className="pitch-slide-inner">
         <div className="pitch-label">Business Model</div>
         <h2 className="pitch-title">
-          0.1–1% per trade, split four ways on-chain in the same
-          transaction. &gt;95% gross margin — no off-chain claims, no
-          market makers to pay, no rebate burn.
+          0.1–1% per trade, split four ways on-chain. &gt;95% gross
+          margin — no market makers to pay, no off-chain claims.
         </h2>
 
         <div className="pitch-money-flow">

--- a/docs/PITCH-VIDEO-SCRIPT.md
+++ b/docs/PITCH-VIDEO-SCRIPT.md
@@ -1,0 +1,140 @@
+# Pitch / Demo Video Script
+
+**Length target:** 90 seconds (Colosseum Frontier hard cap is 3 minutes — we run shorter to respect judges' time)
+**Voiceover:** Khubair, co-founder
+**Format:** Founder on-camera intro and outro, screen-recording demo for the middle
+**Tone:** Conversational, first-person, no marketing-speak, no triplet lists. If you stumble, leave it in — judges trust voices that sound real, not voices that sound rehearsed.
+
+---
+
+## Run sheet
+
+```
+00:00–00:08  ON CAMERA  Intro
+00:08–00:30  SCREEN     Problem  →  Hero stat / waitlist / market list
+00:30–01:00  SCREEN     Demo flow  →  Launch market, deposit, trade, close
+01:00–01:25  SCREEN     Why it works  →  Toly origin, Kani proofs, LP model
+01:25–01:35  SCREEN     Traction  →  220 markets, 100+ creators, waitlist
+01:35–01:45  ON CAMERA  Close
+```
+
+---
+
+## Full VO script (target ~280 words, ~95 seconds at conversational pace)
+
+### [00:00 — ON CAMERA, Khubair]
+
+> Hey, I'm Khubair. I'm one of the founders of Percolator. We're permissionless perpetual futures on Solana.
+
+### [00:08 — SCREEN: mainnet closed beta home, market list]
+
+> Look, Solana has over 15 million SPL tokens. Only about fifty have a perp market. Jupiter, Drift, Pacifica — they all curate. Hyperliquid lets anyone deploy a perp DEX through HIP-3, but you need to stake 500 thousand HYPE. That's around 20 million dollars.
+>
+> So 15 million tokens have no perp access. That's the gap we open.
+
+### [00:30 — SCREEN: launch-market flow, fields visible, submit]
+
+> Anyone launches a perp market on any SPL token in about 60 seconds. No team approval, no auction, no stake.
+
+### [00:38 — SCREEN: trade flow — connect wallet → deposit USDC → open long → close at PnL]
+
+> Connect a wallet, deposit USDC, open leverage, close at PnL. Fees split four ways on-chain in the same transaction.
+
+### [00:55 — SCREEN: position NFT visible in wallet]
+
+> The position itself is a Token-2022 NFT. First transferable perp position on Solana.
+
+### [01:02 — SCREEN: Toly's repo or one of the four Toly tweets]
+
+> The math isn't ours. Anatoly Yakovenko wrote the H plus A-over-K risk engine and open-sourced a reference program. We forked it and built the product on top: the trading app, the keepers, the SDK, the frontend, plus 500-plus Kani formal proofs.
+
+### [01:15 — SCREEN: Kani comparison "0 / 0 / 0 / 500+" from the deck]
+
+> Hyperliquid, Drift, Jupiter — zero formal proofs between them.
+
+### [01:20 — SCREEN: revenue / business model split visual]
+
+> And we don't need market makers, because the LP vault is the counterparty on every trade. Same model as Jupiter's JLP, which did 264 billion in volume last year. No microstructure dependency, no maker bootstrap problem.
+
+### [01:35 — SCREEN: traction slide or short montage]
+
+> A hundred-plus creators have already seeded LP vaults across 220 markets on devnet. We just shipped to mainnet closed beta. The waitlist crossed 100 signups in the first 48 hours.
+
+### [01:50 — ON CAMERA, Khubair, eye contact]
+
+> Public mainnet opens once the audit clears. Thanks for watching.
+
+---
+
+## Alternate openings (pick whichever feels least rehearsed on the day)
+
+**Plain (current):**
+> Hey, I'm Khubair. I'm one of the founders of Percolator.
+
+**Stakes-led:**
+> Solana has 15 million SPL tokens. Fifty of them have a perp market. I'm Khubair, and Percolator is how the other 15 million get one.
+
+**Personal:**
+> I'm Khubair. My co-founder and I have both won bounties on Percolator from Toly. So when we started building the product layer around his risk engine, we already knew the codebase.
+
+---
+
+## Alternate closings
+
+**Current:**
+> Public mainnet opens once the audit clears. Thanks for watching.
+
+**With Call to Action:**
+> The closed beta is live at mainnet.percolatorlaunch.com. Public mainnet opens after the audit. Thanks for watching.
+
+**With waitlist push:**
+> If you want a heads up when public mainnet opens, the waitlist is at percolator.trade. Thanks for watching.
+
+---
+
+## What NOT to say (set by prior feedback)
+
+- "Pump.fun for perps" — drop entirely, no pump.fun mentions
+- "We built the whole thing" — Toly built the risk engine; we built the product layer around it. Give him credit.
+- "Perp launcher" — we're not just a launcher; we're a permissionless perp DEX
+- "Revolutionary / disruptive / game-changing" — none of that
+- "We charge X for Y" without follow-through — be specific about the fee split
+- Em dashes when you can use a comma or a period instead — they read as written-not-spoken
+
+---
+
+## What you need before recording
+
+**Hardware:**
+- Decent camera (phone is fine if held steady — use a tripod)
+- External mic (lavalier or USB condenser; built-in laptop mics sound thin)
+- Lighting on your face, not from behind you
+
+**Screen-recording prep:**
+- Mainnet closed-beta site loaded and logged in with a wallet that has USDC
+- Pick ONE market to demo (SOL/USDC Hyperp is the obvious one)
+- Do a dry run of the trade flow first — find the cleanest path through the UI
+- Have the Toly tweet screenshots / pitch deck slides queued in browser tabs for the cutaways
+
+**B-roll / cutaways:**
+- mainnet.percolatorlaunch.com/pitch slides 6 (Kani comparison), 5 (Traction), 4 (Toly Signal)
+- Solana Explorer page for the mainnet program ID `ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv` (proof of deployment)
+- Github org page github.com/dcccrypto (proof of repo count + Apache 2.0)
+
+---
+
+## Recording tips
+
+- **Show, don't describe.** When you say "open leverage, close at PnL," the wallet should already be open and the trade already in motion. Cap's rule: product on screen before the 60-second mark.
+- **One take through, fix in edit.** Don't try to nail every line on the first try — record the whole script three times, splice the best of each. CapCut or Premiere will get you there in an evening.
+- **Background sound matters.** Quiet room. Curtains. No HVAC running. No notifications on the recording machine.
+- **Watch the pace.** This script reads at ~170 words per minute. If you naturally talk faster, you'll come in under 90 seconds — that's fine, gives breathing room. If you talk slower, drop the alternate-closing version with the CTA and keep just the bare one.
+
+---
+
+## Post-record checklist
+
+- [ ] Hosted somewhere stable: YouTube unlisted is fine, or a direct Vercel/CDN drop
+- [ ] Linked on the Demo Product slide of the deployed pitch deck (currently missing — once the video is up, edit slide 7 to embed it)
+- [ ] Linked in the Colosseum submission form
+- [ ] Tweet announcement from `@percolatortrade` once it's live (visibility to judges)


### PR DESCRIPTION
## Summary

Restructure to make the deck read as an investor pitch instead of a list of technical proof points.

**Per-slide changes:**

- **Slide 1 (Hook):** removed CTA button. Paragraph trimmed to 2 sentences.
- **Slide 2 (Problem):** removed the insider competitor rows. New framing leads with "Most Solana tokens can't be traded with leverage" — two rows compare 50 tokens vs 15M+, closing callout cites the \$25B/mo market.
- **Slide 3 (Team):** removed Claude card. Two-card grid for Khubair + Squid.
- **Toly Signal + Traction merged:** one slide now. 4 Toly tweets compact at top, devnet stats below. Kani '500+ proofs' moved off (still on Hackathon Sprint).

Deck is now 11 slides (was 12).

## Test plan

- [ ] Vercel preview Hook reads as 2 sentences with no CTA
- [ ] Problem slide doesn't mention HIP-3 or maker models
- [ ] Team shows 2 cards
- [ ] Traction shows 4 Toly tweets + 220/100+ stats + 4 mini stats
- [ ] No Kani number on Traction

🤖 Generated with [Claude Code](https://claude.com/claude-code)