### PR TITLE
fix(ci): correct Dockerfile paths in compose/deploy and skip backend jobs when packages/ absent

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,13 +24,16 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Skip when packages/* workspaces are absent (e.g. waitlist-only forks).
+    # When packages/ is restored from upstream, the guard evaluates true and the job runs.
+    if: hashFiles('packages/shared/package.json') != ''
     permissions:
       contents: read
       packages: write
     strategy:
       fail-fast: false
       matrix:
-        service: [api, keeper, indexer]
+        service: [api, oracle-keeper, indexer]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       
@@ -55,7 +58,7 @@ jobs:
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
-          file: packages/${{ matrix.service }}/Dockerfile
+          file: Dockerfile.${{ matrix.service }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -34,30 +34,40 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Backend build/test steps skip when packages/* workspaces are absent
+      # (e.g. waitlist-only forks). They auto-run when packages/ is restored.
       - name: Build shared package
+        if: hashFiles('packages/shared/package.json') != ''
         run: pnpm --filter @percolator/shared build
-        
+
       - name: Build API
+        if: hashFiles('packages/api/package.json') != ''
         run: pnpm --filter @percolator/api build
-        
+
       - name: Build keeper
+        if: hashFiles('packages/keeper/package.json') != ''
         run: pnpm --filter @percolator/keeper build
-        
+
       - name: Build indexer
+        if: hashFiles('packages/indexer/package.json') != ''
         run: pnpm --filter @percolator/indexer build
-        
+
       - name: Test shared package
+        if: hashFiles('packages/shared/package.json') != ''
         run: pnpm --filter @percolator/shared test
-        
+
       - name: Test API
+        if: hashFiles('packages/api/package.json') != ''
         run: pnpm --filter @percolator/api test
-        
+
       - name: Test keeper
+        if: hashFiles('packages/keeper/package.json') != ''
         run: pnpm --filter @percolator/keeper test
-        
+
       - name: Test indexer
+        if: hashFiles('packages/indexer/package.json') != ''
         run: pnpm --filter @percolator/indexer test
-        
+
       - name: Build frontend
         run: cd app && npx next build
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,9 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Skip when packages/* workspaces are absent (e.g. waitlist-only forks).
+    # When packages/ is restored from upstream, the guard evaluates true and the job runs.
+    if: hashFiles('packages/shared/package.json') != ''
     env:
       HAS_CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN != '' }}
     
@@ -79,7 +82,9 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    
+    # Skip when packages/* workspaces are absent (e.g. waitlist-only forks).
+    if: hashFiles('packages/shared/package.json') != ''
+
     env:
       RPC_URL: ${{ secrets.DEVNET_RPC_URL || 'https://api.devnet.solana.com' }}
       DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
@@ -214,7 +219,9 @@ jobs:
     name: Security Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    
+    # Skip when packages/* workspaces are absent (e.g. waitlist-only forks).
+    if: hashFiles('packages/shared/package.json') != ''
+
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -279,12 +286,14 @@ jobs:
     name: ✅ Merge Gate
     runs-on: ubuntu-latest
     needs: [unit-tests, integration-tests, e2e-tests, security-tests, type-check]
-    if: github.event_name == 'pull_request'
-    
+    # Run even when backend jobs are skipped (e.g. waitlist-only forks where packages/* is absent).
+    # Fail only on actual failure or cancellation of a needed job.
+    if: ${{ always() && github.event_name == 'pull_request' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+
     steps:
       - name: All checks passed
         run: |
-          echo "✅ All test suites passed"
+          echo "✅ All test suites passed (skipped jobs treated as passing)"
           echo "✅ Type checking passed"
           echo "✅ Security checks passed"
           echo "🚀 Ready to merge"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   api:
     build:
       context: .
-      dockerfile: packages/api/Dockerfile
+      dockerfile: Dockerfile.api
     ports:
       - "4000:4000"
     env_file: .env
@@ -15,16 +15,16 @@ services:
   indexer:
     build:
       context: .
-      dockerfile: packages/indexer/Dockerfile
+      dockerfile: Dockerfile.indexer
     env_file: .env
     restart: unless-stopped
     networks:
       - percolator
 
-  keeper:
+  oracle-keeper:
     build:
       context: .
-      dockerfile: packages/keeper/Dockerfile
+      dockerfile: Dockerfile.oracle-keeper
     env_file: .env
     restart: unless-stopped
     networks:


### PR DESCRIPTION
## Summary

- `docker-compose.yml` and `.github/workflows/deploy.yml` reference `packages/<svc>/Dockerfile`, but the actual Dockerfiles live at repo root (`Dockerfile.api`, `Dockerfile.indexer`, `Dockerfile.oracle-keeper`). `docker compose build` and the `deploy.yml` workflow both fail at the first file-resolution step.
- `.github/workflows/{test,pr-check}.yml` run `pnpm --filter @percolator/{shared,api,keeper,indexer}` steps that match nothing in the current `main` tree (no `packages/*` workspaces are present). Every PR check fails.
- This PR fixes both, with `hashFiles()` guards so the backend jobs auto-skip when `packages/*` is absent and auto-re-enable when those workspaces are restored.

## Repro

```bash
git clone https://github.com/dcccrypto/percolator-launch && cd percolator-launch
docker compose build api
# unable to prepare context: path "packages/api/Dockerfile" not found

ls packages/ 2>/dev/null || echo "no packages directory"
# no packages directory
```

The `Dockerfile.api`, `Dockerfile.indexer`, `Dockerfile.oracle-keeper` files at repo root reference `packages/shared`, `packages/core`, `packages/api`, etc. in their COPY steps. None of those directories exist on `main`, so the Dockerfiles themselves also can't build until `packages/*` is restored — but the compose/deploy path bug is independent of that.

## What changed

**Path corrections:**
- `docker-compose.yml`: `dockerfile: packages/<svc>/Dockerfile` → `dockerfile: Dockerfile.<svc>`; renamed `keeper` service → `oracle-keeper` to match the actual filename.
- `.github/workflows/deploy.yml`: matrix is now `[api, oracle-keeper, indexer]`; build step uses `Dockerfile.${{ matrix.service }}`.

**Backend-job guards:**
- Added `if: hashFiles('packages/shared/package.json') != ''` to `deploy.yml::build-and-push` and `test.yml::{unit-tests,integration-tests,security-tests}`.
- Added per-step `hashFiles()` guards to the backend build/test steps in `pr-check.yml`. Frontend build remains unconditional.
- `test.yml::merge-gate` now uses `always() && !contains(needs.*.result, 'failure'|'cancelled')` so it passes when backend jobs are cleanly skipped (otherwise the gate would itself skip, blocking the PR).

When the `packages/*` workspaces are restored, every guarded job/step auto-re-enables.

## What this does NOT change

- No Dockerfile contents
- No `pnpm-workspace.yaml`, `package.json`, or `.gitignore` changes
- No source code, frontend, or documentation
- Only the YAML config files that are currently broken

## Test plan

- [x] All 4 edited YAML files parse cleanly via `js-yaml`
- [x] All three `Dockerfile.<svc>` files referenced by the new paths exist at repo root (verified via `gh api`)
- [x] Diff is +41/-19 across exactly the 4 intended files
- [ ] CI runs green on this PR: `pr-check.yml` builds the frontend, backend steps skip; `test.yml` runs `e2e-tests` + `type-check` + `merge-gate`, skips the three backend jobs
- [ ] When `packages/*` is later restored, all guarded jobs auto-re-enable on the next PR

## Context

This was found during a mainnet-readiness audit of [`6figpsolseeker/percolator-launch`](https://github.com/6figpsolseeker/percolator-launch) (a fork). The fix was first validated on the fork in [#1](https://github.com/6figpsolseeker/percolator-launch/pull/1) and is portable to this upstream repo because the bug is identical (same broken paths, same missing `packages/` tree on `main`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to support conditional builds for specialized repository configurations (e.g., forks with limited packages)
  * Reorganized Docker build system with updated service naming conventions and centralized Dockerfile locations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dcccrypto/percolator-launch/pull/2164)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->