### PR TITLE
fix(trade): reject slabs owned by unrecognized programs

### DIFF
--- a/app/__tests__/hooks/useDeposit.test.ts
+++ b/app/__tests__/hooks/useDeposit.test.ts
@@ -28,6 +28,14 @@ vi.mock("@/lib/tx", () => ({
   sendTx: vi.fn(),
 }));
 
+// Bypass the program-allowlist gate for tests that focus on the deposit flow.
+// The gate is exercised in app/__tests__/lib/programAllowlist.test.ts and
+// app/__tests__/providers/SlabProvider-allowlist.test.tsx.
+vi.mock("@/lib/programAllowlist", () => ({
+  isKnownProgram: () => true,
+  assertKnownProgram: () => {},
+}));
+
 vi.mock("@percolatorct/sdk", async () => {
   const actual = await vi.importActual("@percolatorct/sdk");
   return {

--- a/app/__tests__/hooks/useTrade.test.ts
+++ b/app/__tests__/hooks/useTrade.test.ts
@@ -33,6 +33,14 @@ vi.mock("@/lib/config", () => ({
   getBackendUrl: vi.fn(() => "http://localhost:3001"),
 }));
 
+// Bypass the program-allowlist gate for tests that focus on the trade flow.
+// The gate is exercised in app/__tests__/lib/programAllowlist.test.ts and
+// app/__tests__/providers/SlabProvider-allowlist.test.tsx.
+vi.mock("@/lib/programAllowlist", () => ({
+  isKnownProgram: () => true,
+  assertKnownProgram: () => {},
+}));
+
 const mockLpPda = new PublicKey("3yEEksiUkq5K2PmjbRSHpXVN4FJgYuNn7rV31ek3PCwu");
 const mockOraclePda = new PublicKey("8DjWTsU1o8RHTKpRsqGFyYqFMknb8g7z2mjLfVYUyYyF");
 const mockVaultAuth = new PublicKey("DjVE6JNiYqPL2QXyCUUh8rNjHrbz9hXHNYt99MQ59qw1");

--- a/app/__tests__/hooks/useWithdraw.test.ts
+++ b/app/__tests__/hooks/useWithdraw.test.ts
@@ -33,6 +33,14 @@ vi.mock("@/lib/config", () => ({
   getBackendUrl: vi.fn(() => "http://localhost:3001"),
 }));
 
+// Bypass the program-allowlist gate for tests that focus on the withdraw flow.
+// The gate is exercised in app/__tests__/lib/programAllowlist.test.ts and
+// app/__tests__/providers/SlabProvider-allowlist.test.tsx.
+vi.mock("@/lib/programAllowlist", () => ({
+  isKnownProgram: () => true,
+  assertKnownProgram: () => {},
+}));
+
 const mockVaultAuth = new PublicKey("DjVE6JNiYqPL2QXyCUUh8rNjHrbz9hXHNYt99MQ59qw1");
 const mockOraclePda = new PublicKey("8DjWTsU1o8RHTKpRsqGFyYqFMknb8g7z2mjLfVYUyYyF");
 

--- a/app/__tests__/lib/programAllowlist.test.ts
+++ b/app/__tests__/lib/programAllowlist.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from "vitest";
+import { PublicKey } from "@solana/web3.js";
+import { isKnownProgram, assertKnownProgram } from "@/lib/programAllowlist";
+import { getAllProgramIds } from "@/lib/config";
+
+// vitest.config.ts pins NEXT_PUBLIC_DEFAULT_NETWORK=devnet for tests, so
+// getAllProgramIds() returns the devnet set: default + small/medium/large.
+
+describe("programAllowlist", () => {
+  it("accepts every program ID returned by getAllProgramIds()", () => {
+    const ids = getAllProgramIds();
+    expect(ids.length).toBeGreaterThan(0);
+    for (const id of ids) {
+      expect(isKnownProgram(id)).toBe(true);
+      expect(isKnownProgram(new PublicKey(id))).toBe(true);
+    }
+  });
+
+  it("rejects an attacker-controlled program ID", () => {
+    // Synthetic — must not collide with any real deployed program.
+    const attacker = "11111111111111111111111111111112";
+    expect(isKnownProgram(attacker)).toBe(false);
+    expect(isKnownProgram(new PublicKey(attacker))).toBe(false);
+  });
+
+  it("rejects null and undefined", () => {
+    expect(isKnownProgram(null)).toBe(false);
+    expect(isKnownProgram(undefined)).toBe(false);
+  });
+
+  it("assertKnownProgram throws on a foreign program ID", () => {
+    const attacker = new PublicKey("11111111111111111111111111111112");
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(() => assertKnownProgram(attacker)).toThrow(/not owned by a recognized/i);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("assertKnownProgram throws on null/undefined", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(() => assertKnownProgram(null)).toThrow();
+      expect(() => assertKnownProgram(undefined)).toThrow();
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("assertKnownProgram does NOT echo the bad program ID in the thrown message", () => {
+    const attacker = new PublicKey("11111111111111111111111111111112");
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      try {
+        assertKnownProgram(attacker);
+        throw new Error("expected throw");
+      } catch (e) {
+        expect((e as Error).message).not.toContain(attacker.toBase58());
+      }
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("assertKnownProgram is a no-op for an allowed program", () => {
+    const allowed = getAllProgramIds()[0];
+    expect(() => assertKnownProgram(allowed)).not.toThrow();
+    expect(() => assertKnownProgram(new PublicKey(allowed))).not.toThrow();
+  });
+});

--- a/app/__tests__/providers/SlabProvider-allowlist.test.tsx
+++ b/app/__tests__/providers/SlabProvider-allowlist.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * SlabProvider phishing guard.
+ *
+ * Validates that the provider refuses to publish `programId` to consumers
+ * when the slab account is owned by a program not in `getAllProgramIds()`.
+ * Without this gate, a phishing URL like /trade/<malicious_slab> would let
+ * downstream hooks (useDeposit/useWithdraw/useTrade/useInitUser) build
+ * wallet-signed transactions against an attacker-controlled BPF program
+ * that can CPI spl_token::Transfer to drain the user's ATA.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { FC, ReactNode } from "react";
+import { PublicKey } from "@solana/web3.js";
+
+const ALLOWED_PROGRAM = "FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD"; // devnet default + large tier
+const ATTACKER_PROGRAM = "11111111111111111111111111111112";
+const SLAB_ADDRESS = "So11111111111111111111111111111111111111112";
+
+// Stub the SDK parsers so we don't have to hand-craft 992_560-byte buffers.
+// The gate runs BEFORE parseHeader, so legitimate parses succeed and
+// attacker slabs are rejected on the owner check regardless of bytes.
+vi.mock("@percolatorct/sdk", () => ({
+  parseHeader: () => ({ version: 0 }),
+  parseConfig: () => ({
+    collateralMint: new PublicKey("11111111111111111111111111111111"),
+    vaultPubkey: new PublicKey("11111111111111111111111111111111"),
+  }),
+  parseEngine: () => ({}),
+  parseParams: () => ({}),
+  parseAllAccounts: () => [],
+}));
+
+vi.mock("@/lib/mock-mode", () => ({ isMockMode: () => false }));
+vi.mock("@/lib/mock-trade-data", () => ({
+  isMockSlab: () => false,
+  getMockSlabState: () => null,
+}));
+
+const getAccountInfo = vi.fn();
+const onAccountChange = vi.fn().mockReturnValue(1);
+const removeAccountChangeListener = vi.fn();
+
+vi.mock("@/hooks/useWalletCompat", () => ({
+  useConnectionCompat: () => ({
+    connection: {
+      rpcEndpoint: "http://test",
+      getAccountInfo,
+      onAccountChange,
+      removeAccountChangeListener,
+    },
+  }),
+}));
+
+describe("SlabProvider phishing guard", () => {
+  beforeEach(() => {
+    getAccountInfo.mockReset();
+    onAccountChange.mockClear();
+    onAccountChange.mockReturnValue(1);
+  });
+
+  it("ACCEPTS a slab owned by a known program (legitimate path)", async () => {
+    getAccountInfo.mockResolvedValue({
+      data: new Uint8Array(1024),
+      owner: new PublicKey(ALLOWED_PROGRAM),
+    });
+
+    const { SlabProvider, useSlabState } = await import(
+      "@/components/providers/SlabProvider"
+    );
+    const wrapper: FC<{ children: ReactNode }> = ({ children }) => (
+      <SlabProvider slabAddress={SLAB_ADDRESS}>{children}</SlabProvider>
+    );
+
+    const { result } = renderHook(() => useSlabState(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.programId?.toBase58()).toBe(ALLOWED_PROGRAM);
+    expect(result.current.config).not.toBeNull();
+  });
+
+  it("REJECTS a slab owned by an attacker program (exploit case)", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    getAccountInfo.mockResolvedValue({
+      data: new Uint8Array(1024),
+      owner: new PublicKey(ATTACKER_PROGRAM),
+    });
+
+    const { SlabProvider, useSlabState } = await import(
+      "@/components/providers/SlabProvider"
+    );
+    const wrapper: FC<{ children: ReactNode }> = ({ children }) => (
+      <SlabProvider slabAddress={SLAB_ADDRESS}>{children}</SlabProvider>
+    );
+
+    try {
+      const { result } = renderHook(() => useSlabState(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.error).toMatch(/not owned by a recognized/i);
+      // Critical: programId must be null so downstream hooks short-circuit.
+      expect(result.current.programId).toBeNull();
+      // Parsed state must not leak from a rejected account.
+      expect(result.current.config).toBeNull();
+      expect(result.current.engine).toBeNull();
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("does NOT echo the attacker program ID in the user-facing error", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    getAccountInfo.mockResolvedValue({
+      data: new Uint8Array(1024),
+      owner: new PublicKey(ATTACKER_PROGRAM),
+    });
+
+    const { SlabProvider, useSlabState } = await import(
+      "@/components/providers/SlabProvider"
+    );
+    const wrapper: FC<{ children: ReactNode }> = ({ children }) => (
+      <SlabProvider slabAddress={SLAB_ADDRESS}>{children}</SlabProvider>
+    );
+
+    try {
+      const { result } = renderHook(() => useSlabState(), { wrapper });
+      await waitFor(() => expect(result.current.error).toBeTruthy());
+
+      expect(result.current.error).not.toContain(ATTACKER_PROGRAM);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("REJECTS via the WebSocket subscription path (not just polling)", async () => {
+    // Initial poll returns nothing; the WS callback delivers the attacker payload.
+    getAccountInfo.mockResolvedValue(null);
+    let wsCb: ((info: { data: Buffer; owner: PublicKey }) => void) | null =
+      null;
+    onAccountChange.mockImplementation((_pk: PublicKey, cb: typeof wsCb) => {
+      wsCb = cb;
+      return 1;
+    });
+
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { SlabProvider, useSlabState } = await import(
+      "@/components/providers/SlabProvider"
+    );
+    const wrapper: FC<{ children: ReactNode }> = ({ children }) => (
+      <SlabProvider slabAddress={SLAB_ADDRESS}>{children}</SlabProvider>
+    );
+
+    try {
+      const { result } = renderHook(() => useSlabState(), { wrapper });
+      await waitFor(() => expect(onAccountChange).toHaveBeenCalled());
+
+      // Push an attacker-owned payload via the WS callback.
+      wsCb!({
+        data: Buffer.alloc(1024),
+        owner: new PublicKey(ATTACKER_PROGRAM),
+      });
+
+      await waitFor(() => expect(result.current.error).toBeTruthy());
+      expect(result.current.programId).toBeNull();
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("does not flap during initial load when owner is undefined", async () => {
+    // Hang the RPC so we observe the loading window.
+    getAccountInfo.mockImplementation(() => new Promise(() => {}));
+
+    const { SlabProvider, useSlabState } = await import(
+      "@/components/providers/SlabProvider"
+    );
+    const wrapper: FC<{ children: ReactNode }> = ({ children }) => (
+      <SlabProvider slabAddress={SLAB_ADDRESS}>{children}</SlabProvider>
+    );
+
+    const { result } = renderHook(() => useSlabState(), { wrapper });
+    // Brief await to let the effect register.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(true);
+  });
+});

--- a/app/components/providers/SlabProvider.tsx
+++ b/app/components/providers/SlabProvider.tsx
@@ -26,6 +26,7 @@ import {
 } from "@percolatorct/sdk";
 import { isMockSlab, getMockSlabState } from "@/lib/mock-trade-data";
 import { isMockMode } from "@/lib/mock-mode";
+import { isKnownProgram } from "@/lib/programAllowlist";
 
 export interface SlabState {
   /** The slab account address this provider is tracking */
@@ -120,6 +121,35 @@ export const SlabProvider: FC<{ children: ReactNode; slabAddress: string }> = ({
 
     function parseSlab(data: Uint8Array, owner?: PublicKey) {
       if (cancelled) return;
+      // Refuse to surface programId for slabs owned by a program we did not
+      // deploy. The slab address in the URL is user-controlled, and Solana
+      // lets anyone create an account owned by any BPF program — so without
+      // this gate a phishing URL like /trade/<malicious_slab> would render
+      // a full trade UI whose Deposit/Trade/Withdraw flows build instructions
+      // against an attacker-controlled program. The downstream signing hooks
+      // (useDeposit/useWithdraw/useTrade/useInitUser) consume `programId`
+      // from useSlabState() and pass it straight into buildIx; keeping
+      // programId null here causes those hooks to short-circuit on their
+      // existing "Wallet not connected or market not loaded" guard.
+      // Source of truth: getAllProgramIds() (config.programId plus every
+      // entry in programsBySlabTier). New program deploys roll out via
+      // config, not by editing this gate.
+      if (owner && !isKnownProgram(owner)) {
+        if (process.env.NODE_ENV !== "production") {
+          console.error(
+            `[SlabProvider] Refusing to render slab owned by unknown program: ${owner.toBase58()}`,
+          );
+        }
+        setState((s) => ({
+          ...s,
+          loading: false,
+          error:
+            "This market is not owned by a recognized Percolator program. " +
+            "If you reached this page from a link, treat it as untrusted — only trade markets listed on the official Markets page.",
+          programId: null,
+        }));
+        return;
+      }
       try {
         const header = parseHeader(data);
 

--- a/app/hooks/useDeposit.ts
+++ b/app/hooks/useDeposit.ts
@@ -21,6 +21,7 @@ import {
 } from "@percolatorct/sdk";
 import { sendTx } from "@/lib/tx";
 import { useSlabState } from "@/components/providers/SlabProvider";
+import { assertKnownProgram } from "@/lib/programAllowlist";
 
 export function useDeposit(slabAddress: string) {
   const { connection } = useConnectionCompat();
@@ -39,6 +40,11 @@ export function useDeposit(slabAddress: string) {
       try {
         if (!wallet.publicKey || !mktConfig || !slabProgramId)
           throw new Error("Wallet not connected or market not loaded");
+        // Defense-in-depth: refuse to build a tx whose programId is not in
+        // our deployed allowlist, even if SlabProvider somehow surfaced one
+        // (e.g. a future code path mutates programId post-load, or a future
+        // page mounts this hook without going through SlabProvider's gate).
+        assertKnownProgram(slabProgramId);
 
         const programId = slabProgramId;
         const slabPk = new PublicKey(slabAddress);

--- a/app/hooks/useInitUser.ts
+++ b/app/hooks/useInitUser.ts
@@ -19,6 +19,7 @@ import {
 } from "@percolatorct/sdk";
 import { sendTx } from "@/lib/tx";
 import { useSlabState } from "@/components/providers/SlabProvider";
+import { assertKnownProgram } from "@/lib/programAllowlist";
 
 
 export function useInitUser(slabAddress: string) {
@@ -34,6 +35,10 @@ export function useInitUser(slabAddress: string) {
       setError(null);
       try {
         if (!wallet.publicKey || !mktConfig || !slabProgramId) throw new Error("Wallet not connected or market not loaded");
+        // Defense-in-depth: refuse to build a tx whose programId is not in
+        // our deployed allowlist. See SlabProvider.parseSlab for the primary
+        // gate.
+        assertKnownProgram(slabProgramId);
 
         // The on-chain InitUser handler requires:
         //   1. fee_payment >= new_account_fee (account registration fee)

--- a/app/hooks/useTrade.ts
+++ b/app/hooks/useTrade.ts
@@ -23,6 +23,7 @@ import {
 import { sendTx } from "@/lib/tx";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { detectOracleMode } from "@/lib/oraclePrice";
+import { assertKnownProgram } from "@/lib/programAllowlist";
 
 const INLINE_ORACLE_PUSH_REMOVED_ERROR =
   "Inline oracle price push was removed on-chain in beta.29. Migrate this flow to /api/oracle/advance-phase or another server-side oracle publisher before trading as the oracle authority.";
@@ -43,6 +44,10 @@ export function useTrade(slabAddress: string) {
       setError(null);
       try {
         if (!wallet.publicKey || !mktConfig || !slabProgramId) throw new Error("Wallet not connected or market not loaded");
+        // Defense-in-depth: refuse to build a tx whose programId is not in
+        // our deployed allowlist. See SlabProvider.parseSlab for the primary
+        // gate.
+        assertKnownProgram(slabProgramId);
         const lpAccount = accounts.find((a) => a.idx === params.lpIdx);
         if (!lpAccount) throw new Error(`LP at index ${params.lpIdx} not found`);
 

--- a/app/hooks/useWithdraw.ts
+++ b/app/hooks/useWithdraw.ts
@@ -24,6 +24,7 @@ import {
 import { sendTx } from "@/lib/tx";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { detectOracleMode } from "@/lib/oraclePrice";
+import { assertKnownProgram } from "@/lib/programAllowlist";
 
 const INLINE_ORACLE_PUSH_REMOVED_ERROR =
   "Inline oracle price push was removed on-chain in beta.29. Migrate this flow to /api/oracle/advance-phase or another server-side oracle publisher before withdrawing as the oracle authority.";
@@ -44,7 +45,12 @@ export function useWithdraw(slabAddress: string) {
       setError(null);
       try {
         if (!wallet.publicKey || !mktConfig || !slabProgramId) throw new Error("Wallet not connected or market not loaded");
-        
+        // Defense-in-depth: refuse to build a tx whose programId is not in
+        // our deployed allowlist. See SlabProvider.parseSlab for the primary
+        // gate; this hook is a second line so unknown-program slabs cannot
+        // produce a wallet-signed withdrawal CPI under any bypass scenario.
+        assertKnownProgram(slabProgramId);
+
         // P-CRITICAL-3: Validate network before withdrawal
         try {
           const slabInfo = await connection.getAccountInfo(new PublicKey(slabAddress));

--- a/app/lib/programAllowlist.ts
+++ b/app/lib/programAllowlist.ts
@@ -1,0 +1,45 @@
+import type { PublicKey } from "@solana/web3.js";
+import { getAllProgramIds } from "@/lib/config";
+
+/**
+ * Returns true iff `programId` is one of the deployed program IDs for the
+ * currently selected network. Null/undefined returns false — callers should
+ * treat "not yet loaded" as "not safe to sign".
+ *
+ * The set is computed from `getAllProgramIds()` (config.programId plus every
+ * entry in `programsBySlabTier`). Adding a new tier in config automatically
+ * extends the allowlist — no code change here.
+ */
+export function isKnownProgram(programId: PublicKey | string | null | undefined): boolean {
+  if (!programId) return false;
+  const idStr = typeof programId === "string" ? programId : programId.toBase58();
+  return getAllProgramIds().includes(idStr);
+}
+
+/**
+ * Throws if `programId` is not one of the deployed programs. Use at the top
+ * of any hook that builds a transaction whose `programId` is derived from
+ * on-chain state via `useSlabState()`.
+ *
+ * The thrown message is intentionally generic and does NOT echo the bad
+ * program ID — that would confirm to a phishing attacker that their URL
+ * reached a victim's browser. The bad ID is logged to the console in dev.
+ */
+export function assertKnownProgram(programId: PublicKey | string | null | undefined): void {
+  if (isKnownProgram(programId)) return;
+  if (process.env.NODE_ENV !== "production") {
+    const idStr =
+      programId == null
+        ? "<null>"
+        : typeof programId === "string"
+          ? programId
+          : programId.toBase58();
+    console.error(
+      `[assertKnownProgram] Refusing to build tx for unknown program: ${idStr}. ` +
+        `Allowed: ${getAllProgramIds().join(", ")}`,
+    );
+  }
+  throw new Error(
+    "This market is not owned by a recognized Percolator program. Refusing to build a transaction.",
+  );
+}


### PR DESCRIPTION
## Summary

Adds an allowlist gate so the `/trade/<slab>` UI refuses to build wallet-signed transactions against a Solana program we did not deploy. Before this change, `SlabProvider` trusted the slab account's on-chain `owner` field and surfaced it to consumers as `programId`; the signing hooks (`useDeposit`, `useWithdraw`, `useTrade`, `useInitUser`) then passed that `programId` directly into `buildIx`, so an account at any `/trade/<addr>` URL whose owner was an attacker-deployed BPF program would have the user sign a `DepositCollateral` / `Trade` / `Withdraw` instruction targeting that program. The attacker's program can CPI `spl_token::Transfer` from the user's ATA using the user's top-level signature, with `mktConfig.vaultPubkey` and `mktConfig.collateralMint` taken from attacker-controlled account bytes.

## What changed

- **`app/lib/programAllowlist.ts` (new):** `isKnownProgram()` and `assertKnownProgram()` backed by the existing `getAllProgramIds()` helper (config.programId plus every entry in `programsBySlabTier`). New program deploys roll out by editing config, not the gate.
- **`SlabProvider.parseSlab`:** rejects unknown owners before any state write. `programId` stays `null` and a user-facing error is set, so every consumer that depends on `programId` short-circuits on the existing ``Wallet not connected or market not loaded`` guard. The check runs in both the WebSocket subscription path and the `getAccountInfo` polling path, so a live owner-flip via account close/reopen is also caught.
- **Four signing hooks (`useDeposit`, `useWithdraw`, `useTrade`, `useInitUser`):** call `assertKnownProgram(slabProgramId)` immediately after their existing null-guard. Defense-in-depth — if a future code path mounts these hooks without going through SlabProvider's gate, or if `programId` is mutated post-load, the tx still refuses to build.

Mock mode is untouched: it returns from the provider before `parseSlab` runs and never invokes the gate.

The user-facing error string does not echo the rejected program ID — an attacker who lands a phishing URL must not be able to use the error as a confirmation oracle. The bad ID is logged to the console in dev only.

## Tests

- **`app/__tests__/lib/programAllowlist.test.ts`** (7 tests) — every deployed program ID is accepted, attacker IDs / null / undefined are rejected, the thrown message does not contain the bad ID, and an allowed program is a no-op.
- **`app/__tests__/providers/SlabProvider-allowlist.test.tsx`** (5 tests) — allowed-owner slab loads normally; attacker-owner slab is rejected via both the polling path and the WebSocket subscription path; the user-facing error does not echo the attacker ID; the initial-load window does not flap to an error state when `owner` is undefined.
- The three existing hook tests (`useDeposit.test.ts`, `useWithdraw.test.ts`, `useTrade.test.ts`) stub `@/lib/programAllowlist` to a no-op so they continue to exercise only the deposit / withdraw / trade flow.

Full vitest suite: **12 new tests passing, 0 new failures**. The two pre-existing failing files on `origin/main` (`tx-legacy-retry-guard.test.ts`, `useStuckSlabs.test.ts`) are unchanged by this PR. `tsc --noEmit` produces the same set of pre-existing errors in unrelated files (`waitlist/signup` `resend` import, `useBestLp`/`useVAMM` `@percolator/sdk` aliases, `scripts/*`); no new type errors.

## Test plan

- [ ] Open `/trade/<unknown_slab>` on a deployment — page renders an error state, no Deposit/Withdraw/Trade buttons can sign a tx
- [ ] Open `/trade/<real_slab>` for a deployed mainnet or devnet program — page renders normally, all flows work
- [ ] Mock mode (`?mock=1` on a MOCK_MAP slab) still renders synthetic data
- [ ] WebSocket-driven owner change to an unknown program mid-session rejects subsequent signing attempts
- [ ] `pnpm --filter=app test` passes
- [ ] `npx tsc --noEmit` shows no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for program allowlist validation across deposit, trade, and withdraw operations.

* **Security Enhancements**
  * Implemented program allowlist validation to prevent unauthorized program interactions during critical operations (deposits, trades, withdrawals).
  * SlabProvider now validates that slab accounts are owned by authorized programs before loading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dcccrypto/percolator-launch/pull/2165)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->