### PR TITLE
fix(trade): reject slabs owned by unrecognized programs + matcher fix

### DIFF
--- a/app/__tests__/hooks/useDeposit.test.ts
+++ b/app/__tests__/hooks/useDeposit.test.ts
@@ -28,6 +28,14 @@ vi.mock("@/lib/tx", () => ({
   sendTx: vi.fn(),
 }));
 
+// Bypass the program-allowlist gate for tests that focus on the deposit flow.
+// The gate is exercised in app/__tests__/lib/programAllowlist.test.ts and
+// app/__tests__/providers/SlabProvider-allowlist.test.tsx.
+vi.mock("@/lib/programAllowlist", () => ({
+  isKnownProgram: () => true,
+  assertKnownProgram: () => {},
+}));
+
 vi.mock("@percolatorct/sdk", async () => {
   const actual = await vi.importActual("@percolatorct/sdk");
   return {

--- a/app/__tests__/hooks/useTrade.test.ts
+++ b/app/__tests__/hooks/useTrade.test.ts
@@ -33,6 +33,14 @@ vi.mock("@/lib/config", () => ({
   getBackendUrl: vi.fn(() => "http://localhost:3001"),
 }));
 
+// Bypass the program-allowlist gate for tests that focus on the trade flow.
+// The gate is exercised in app/__tests__/lib/programAllowlist.test.ts and
+// app/__tests__/providers/SlabProvider-allowlist.test.tsx.
+vi.mock("@/lib/programAllowlist", () => ({
+  isKnownProgram: () => true,
+  assertKnownProgram: () => {},
+}));
+
 const mockLpPda = new PublicKey("3yEEksiUkq5K2PmjbRSHpXVN4FJgYuNn7rV31ek3PCwu");
 const mockOraclePda = new PublicKey("8DjWTsU1o8RHTKpRsqGFyYqFMknb8g7z2mjLfVYUyYyF");
 const mockVaultAuth = new PublicKey("DjVE6JNiYqPL2QXyCUUh8rNjHrbz9hXHNYt99MQ59qw1");

--- a/app/__tests__/hooks/useWithdraw.test.ts
+++ b/app/__tests__/hooks/useWithdraw.test.ts
@@ -33,6 +33,14 @@ vi.mock("@/lib/config", () => ({
   getBackendUrl: vi.fn(() => "http://localhost:3001"),
 }));
 
+// Bypass the program-allowlist gate for tests that focus on the withdraw flow.
+// The gate is exercised in app/__tests__/lib/programAllowlist.test.ts and
+// app/__tests__/providers/SlabProvider-allowlist.test.tsx.
+vi.mock("@/lib/programAllowlist", () => ({
+  isKnownProgram: () => true,
+  assertKnownProgram: () => {},
+}));
+
 const mockVaultAuth = new PublicKey("DjVE6JNiYqPL2QXyCUUh8rNjHrbz9hXHNYt99MQ59qw1");
 const mockOraclePda = new PublicKey("8DjWTsU1o8RHTKpRsqGFyYqFMknb8g7z2mjLfVYUyYyF");
 

--- a/app/__tests__/lib/programAllowlist.test.ts
+++ b/app/__tests__/lib/programAllowlist.test.ts
@@ -68,4 +68,14 @@ describe("programAllowlist", () => {
     expect(() => assertKnownProgram(allowed)).not.toThrow();
     expect(() => assertKnownProgram(new PublicKey(allowed))).not.toThrow();
   });
+
+  it("getAllProgramIds() includes the cluster's matcherProgramId", async () => {
+    // Slabs are owned by the matcher program; without this entry the gate
+    // rejects every legitimate market on mainnet.
+    const { getConfig } = await import("@/lib/config");
+    const cfg = getConfig();
+    const ids = getAllProgramIds();
+    expect(ids).toContain(cfg.matcherProgramId);
+    expect(isKnownProgram(cfg.matcherProgramId)).toBe(true);
+  });
 });

--- a/app/__tests__/lib/programAllowlist.test.ts
+++ b/app/__tests__/lib/programAllowlist.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from "vitest";
+import { PublicKey } from "@solana/web3.js";
+import { isKnownProgram, assertKnownProgram } from "@/lib/programAllowlist";
+import { getAllProgramIds } from "@/lib/config";
+
+// vitest.config.ts pins NEXT_PUBLIC_DEFAULT_NETWORK=devnet for tests, so
+// getAllProgramIds() returns the devnet set: default + small/medium/large.
+
+describe("programAllowlist", () => {
+  it("accepts every program ID returned by getAllProgramIds()", () => {
+    const ids = getAllProgramIds();
+    expect(ids.length).toBeGreaterThan(0);
+    for (const id of ids) {
+      expect(isKnownProgram(id)).toBe(true);
+      expect(isKnownProgram(new PublicKey(id))).toBe(true);
+    }
+  });
+
+  it("rejects an attacker-controlled program ID", () => {
+    // Synthetic — must not collide with any real deployed program.
+    const attacker = "11111111111111111111111111111112";
+    expect(isKnownProgram(attacker)).toBe(false);
+    expect(isKnownProgram(new PublicKey(attacker))).toBe(false);
+  });
+
+  it("rejects null and undefined", () => {
+    expect(isKnownProgram(null)).toBe(false);
+    expect(isKnownProgram(undefined)).toBe(false);
+  });
+
+  it("assertKnownProgram throws on a foreign program ID", () => {
+    const attacker = new PublicKey("11111111111111111111111111111112");
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(() => assertKnownProgram(attacker)).toThrow(/not owned by a recognized/i);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("assertKnownProgram throws on null/undefined", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(() => assertKnownProgram(null)).toThrow();
+      expect(() => assertKnownProgram(undefined)).toThrow();
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("assertKnownProgram does NOT echo the bad program ID in the thrown message", () => {
+    const attacker = new PublicKey("11111111111111111111111111111112");
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      try {
+        assertKnownProgram(attacker);
+        throw new Error("expected throw");
+      } catch (e) {
+        expect((e as Error).message).not.toContain(attacker.toBase58());
+      }
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("assertKnownProgram is a no-op for an allowed program", () => {
+    const allowed = getAllProgramIds()[0];
+    expect(() => assertKnownProgram(allowed)).not.toThrow();
+    expect(() => assertKnownProgram(new PublicKey(allowed))).not.toThrow();
+  });
+});

--- a/app/__tests__/providers/SlabProvider-allowlist.test.tsx
+++ b/app/__tests__/providers/SlabProvider-allowlist.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * SlabProvider phishing guard.
+ *
+ * Validates that the provider refuses to publish `programId` to consumers
+ * when the slab account is owned by a program not in `getAllProgramIds()`.
+ * Without this gate, a phishing URL like /trade/<malicious_slab> would let
+ * downstream hooks (useDeposit/useWithdraw/useTrade/useInitUser) build
+ * wallet-signed transactions against an attacker-controlled BPF program
+ * that can CPI spl_token::Transfer to drain the user's ATA.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { FC, ReactNode } from "react";
+import { PublicKey } from "@solana/web3.js";
+
+const ALLOWED_PROGRAM = "FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD"; // devnet default + large tier
+const ATTACKER_PROGRAM = "11111111111111111111111111111112";
+const SLAB_ADDRESS = "So11111111111111111111111111111111111111112";
+
+// Stub the SDK parsers so we don't have to hand-craft 992_560-byte buffers.
+// The gate runs BEFORE parseHeader, so legitimate parses succeed and
+// attacker slabs are rejected on the owner check regardless of bytes.
+vi.mock("@percolatorct/sdk", () => ({
+  parseHeader: () => ({ version: 0 }),
+  parseConfig: () => ({
+    collateralMint: new PublicKey("11111111111111111111111111111111"),
+    vaultPubkey: new PublicKey("11111111111111111111111111111111"),
+  }),
+  parseEngine: () => ({}),
+  parseParams: () => ({}),
+  parseAllAccounts: () => [],
+}));
+
+vi.mock("@/lib/mock-mode", () => ({ isMockMode: () => false }));
+vi.mock("@/lib/mock-trade-data", () => ({
+  isMockSlab: () => false,
+  getMockSlabState: () => null,
+}));
+
+const getAccountInfo = vi.fn();
+const onAccountChange = vi.fn().mockReturnValue(1);
+const removeAccountChangeListener = vi.fn();
+
+vi.mock("@/hooks/useWalletCompat", () => ({
+  useConnectionCompat: () => ({
+    connection: {
+      rpcEndpoint: "http://test",
+      getAccountInfo,
+      onAccountChange,
+      removeAccountChangeListener,
+    },
+  }),
+}));
+
+describe("SlabProvider phishing guard", () => {
+  beforeEach(() => {
+    getAccountInfo.mockReset();
+    onAccountChange.mockClear();
+    onAccountChange.mockReturnValue(1);
+  });
+
+  it("ACCEPTS a slab owned by a known program (legitimate path)", async () => {
+    getAccountInfo.mockResolvedValue({
+      data: new Uint8Array(1024),
+      owner: new PublicKey(ALLOWED_PROGRAM),
+    });
+
+    const { SlabProvider, useSlabState } = await import(
+      "@/components/providers/SlabProvider"
+    );
+    const wrapper: FC<{ children: ReactNode }> = ({ children }) => (
+      <SlabProvider slabAddress={SLAB_ADDRESS}>{children}</SlabProvider>
+    );
+
+    const { result } = renderHook(() => useSlabState(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.programId?.toBase58()).toBe(ALLOWED_PROGRAM);
+    expect(result.current.config).not.toBeNull();
+  });
+
+  it("REJECTS a slab owned by an attacker program (exploit case)", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    getAccountInfo.mockResolvedValue({
+      data: new Uint8Array(1024),
+      owner: new PublicKey(ATTACKER_PROGRAM),
+    });
+
+    const { SlabProvider, useSlabState } = await import(
+      "@/components/providers/SlabProvider"
+    );
+    const wrapper: FC<{ children: ReactNode }> = ({ children }) => (
+      <SlabProvider slabAddress={SLAB_ADDRESS}>{children}</SlabProvider>
+    );
+
+    try {
+      const { result } = renderHook(() => useSlabState(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.error).toMatch(/not owned by a recognized/i);
+      // Critical: programId must be null so downstream hooks short-circuit.
+      expect(result.current.programId).toBeNull();
+      // Parsed state must not leak from a rejected account.
+      expect(result.current.config).toBeNull();
+      expect(result.current.engine).toBeNull();
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("does NOT echo the attacker program ID in the user-facing error", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    getAccountInfo.mockResolvedValue({
+      data: new Uint8Array(1024),
+      owner: new PublicKey(ATTACKER_PROGRAM),
+    });
+
+    const { SlabProvider, useSlabState } = await import(
+      "@/components/providers/SlabProvider"
+    );
+    const wrapper: FC<{ children: ReactNode }> = ({ children }) => (
+      <SlabProvider slabAddress={SLAB_ADDRESS}>{children}</SlabProvider>
+    );
+
+    try {
+      const { result } = renderHook(() => useSlabState(), { wrapper });
+      await waitFor(() => expect(result.current.error).toBeTruthy());
+
+      expect(result.current.error).not.toContain(ATTACKER_PROGRAM);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("REJECTS via the WebSocket subscription path (not just polling)", async () => {
+    // Initial poll returns nothing; the WS callback delivers the attacker payload.
+    getAccountInfo.mockResolvedValue(null);
+    let wsCb: ((info: { data: Buffer; owner: PublicKey }) => void) | null =
+      null;
+    onAccountChange.mockImplementation((_pk: PublicKey, cb: typeof wsCb) => {
+      wsCb = cb;
+      return 1;
+    });
+
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { SlabProvider, useSlabState } = await import(
+      "@/components/providers/SlabProvider"
+    );
+    const wrapper: FC<{ children: ReactNode }> = ({ children }) => (
+      <SlabProvider slabAddress={SLAB_ADDRESS}>{children}</SlabProvider>
+    );
+
+    try {
+      const { result } = renderHook(() => useSlabState(), { wrapper });
+      await waitFor(() => expect(onAccountChange).toHaveBeenCalled());
+
+      // Push an attacker-owned payload via the WS callback.
+      wsCb!({
+        data: Buffer.alloc(1024),
+        owner: new PublicKey(ATTACKER_PROGRAM),
+      });
+
+      await waitFor(() => expect(result.current.error).toBeTruthy());
+      expect(result.current.programId).toBeNull();
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("does not flap during initial load when owner is undefined", async () => {
+    // Hang the RPC so we observe the loading window.
+    getAccountInfo.mockImplementation(() => new Promise(() => {}));
+
+    const { SlabProvider, useSlabState } = await import(
+      "@/components/providers/SlabProvider"
+    );
+    const wrapper: FC<{ children: ReactNode }> = ({ children }) => (
+      <SlabProvider slabAddress={SLAB_ADDRESS}>{children}</SlabProvider>
+    );
+
+    const { result } = renderHook(() => useSlabState(), { wrapper });
+    // Brief await to let the effect register.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(true);
+  });
+});

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -1165,6 +1165,9 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Slab account does not exist on-chain" }, { status: 400 });
     }
     const validPrograms = new Set<string>([cfg.programId]);
+    // Slabs are owned by the matcher program. Without this, mainnet
+    // markets (no programsBySlabTier yet) get rejected here.
+    if (cfg.matcherProgramId) validPrograms.add(cfg.matcherProgramId);
     const tiers = (cfg as Record<string, unknown>).programsBySlabTier as Record<string, string> | undefined;
     if (tiers) Object.values(tiers).forEach((id) => validPrograms.add(id));
     if (!validPrograms.has(accountInfo.owner.toBase58())) {

--- a/app/components/providers/SlabProvider.tsx
+++ b/app/components/providers/SlabProvider.tsx
@@ -26,6 +26,7 @@ import {
 } from "@percolatorct/sdk";
 import { isMockSlab, getMockSlabState } from "@/lib/mock-trade-data";
 import { isMockMode } from "@/lib/mock-mode";
+import { isKnownProgram } from "@/lib/programAllowlist";
 
 export interface SlabState {
   /** The slab account address this provider is tracking */
@@ -120,6 +121,35 @@ export const SlabProvider: FC<{ children: ReactNode; slabAddress: string }> = ({
 
     function parseSlab(data: Uint8Array, owner?: PublicKey) {
       if (cancelled) return;
+      // Refuse to surface programId for slabs owned by a program we did not
+      // deploy. The slab address in the URL is user-controlled, and Solana
+      // lets anyone create an account owned by any BPF program — so without
+      // this gate a phishing URL like /trade/<malicious_slab> would render
+      // a full trade UI whose Deposit/Trade/Withdraw flows build instructions
+      // against an attacker-controlled program. The downstream signing hooks
+      // (useDeposit/useWithdraw/useTrade/useInitUser) consume `programId`
+      // from useSlabState() and pass it straight into buildIx; keeping
+      // programId null here causes those hooks to short-circuit on their
+      // existing "Wallet not connected or market not loaded" guard.
+      // Source of truth: getAllProgramIds() (config.programId plus every
+      // entry in programsBySlabTier). New program deploys roll out via
+      // config, not by editing this gate.
+      if (owner && !isKnownProgram(owner)) {
+        if (process.env.NODE_ENV !== "production") {
+          console.error(
+            `[SlabProvider] Refusing to render slab owned by unknown program: ${owner.toBase58()}`,
+          );
+        }
+        setState((s) => ({
+          ...s,
+          loading: false,
+          error:
+            "This market is not owned by a recognized Percolator program. " +
+            "If you reached this page from a link, treat it as untrusted — only trade markets listed on the official Markets page.",
+          programId: null,
+        }));
+        return;
+      }
       try {
         const header = parseHeader(data);
 

--- a/app/hooks/useDeposit.ts
+++ b/app/hooks/useDeposit.ts
@@ -21,6 +21,7 @@ import {
 } from "@percolatorct/sdk";
 import { sendTx } from "@/lib/tx";
 import { useSlabState } from "@/components/providers/SlabProvider";
+import { assertKnownProgram } from "@/lib/programAllowlist";
 
 export function useDeposit(slabAddress: string) {
   const { connection } = useConnectionCompat();
@@ -39,6 +40,11 @@ export function useDeposit(slabAddress: string) {
       try {
         if (!wallet.publicKey || !mktConfig || !slabProgramId)
           throw new Error("Wallet not connected or market not loaded");
+        // Defense-in-depth: refuse to build a tx whose programId is not in
+        // our deployed allowlist, even if SlabProvider somehow surfaced one
+        // (e.g. a future code path mutates programId post-load, or a future
+        // page mounts this hook without going through SlabProvider's gate).
+        assertKnownProgram(slabProgramId);
 
         const programId = slabProgramId;
         const slabPk = new PublicKey(slabAddress);

--- a/app/hooks/useInitUser.ts
+++ b/app/hooks/useInitUser.ts
@@ -19,6 +19,7 @@ import {
 } from "@percolatorct/sdk";
 import { sendTx } from "@/lib/tx";
 import { useSlabState } from "@/components/providers/SlabProvider";
+import { assertKnownProgram } from "@/lib/programAllowlist";
 
 
 export function useInitUser(slabAddress: string) {
@@ -34,6 +35,10 @@ export function useInitUser(slabAddress: string) {
       setError(null);
       try {
         if (!wallet.publicKey || !mktConfig || !slabProgramId) throw new Error("Wallet not connected or market not loaded");
+        // Defense-in-depth: refuse to build a tx whose programId is not in
+        // our deployed allowlist. See SlabProvider.parseSlab for the primary
+        // gate.
+        assertKnownProgram(slabProgramId);
 
         // The on-chain InitUser handler requires:
         //   1. fee_payment >= new_account_fee (account registration fee)

--- a/app/hooks/useTrade.ts
+++ b/app/hooks/useTrade.ts
@@ -23,6 +23,7 @@ import {
 import { sendTx } from "@/lib/tx";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { detectOracleMode } from "@/lib/oraclePrice";
+import { assertKnownProgram } from "@/lib/programAllowlist";
 
 const INLINE_ORACLE_PUSH_REMOVED_ERROR =
   "Inline oracle price push was removed on-chain in beta.29. Migrate this flow to /api/oracle/advance-phase or another server-side oracle publisher before trading as the oracle authority.";
@@ -43,6 +44,10 @@ export function useTrade(slabAddress: string) {
       setError(null);
       try {
         if (!wallet.publicKey || !mktConfig || !slabProgramId) throw new Error("Wallet not connected or market not loaded");
+        // Defense-in-depth: refuse to build a tx whose programId is not in
+        // our deployed allowlist. See SlabProvider.parseSlab for the primary
+        // gate.
+        assertKnownProgram(slabProgramId);
         const lpAccount = accounts.find((a) => a.idx === params.lpIdx);
         if (!lpAccount) throw new Error(`LP at index ${params.lpIdx} not found`);
 

--- a/app/hooks/useWithdraw.ts
+++ b/app/hooks/useWithdraw.ts
@@ -24,6 +24,7 @@ import {
 import { sendTx } from "@/lib/tx";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { detectOracleMode } from "@/lib/oraclePrice";
+import { assertKnownProgram } from "@/lib/programAllowlist";
 
 const INLINE_ORACLE_PUSH_REMOVED_ERROR =
   "Inline oracle price push was removed on-chain in beta.29. Migrate this flow to /api/oracle/advance-phase or another server-side oracle publisher before withdrawing as the oracle authority.";
@@ -44,7 +45,12 @@ export function useWithdraw(slabAddress: string) {
       setError(null);
       try {
         if (!wallet.publicKey || !mktConfig || !slabProgramId) throw new Error("Wallet not connected or market not loaded");
-        
+        // Defense-in-depth: refuse to build a tx whose programId is not in
+        // our deployed allowlist. See SlabProvider.parseSlab for the primary
+        // gate; this hook is a second line so unknown-program slabs cannot
+        // produce a wallet-signed withdrawal CPI under any bypass scenario.
+        assertKnownProgram(slabProgramId);
+
         // P-CRITICAL-3: Validate network before withdrawal
         try {
           const slabInfo = await connection.getAccountInfo(new PublicKey(slabAddress));

--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -199,6 +199,11 @@ export function getAllProgramIds(): string[] {
   const cfg = getConfig();
   const ids = new Set<string>();
   if (cfg.programId) ids.add(cfg.programId);
+  // Slabs are owned by the matcher program, not the engine. Mainnet has no
+  // programsBySlabTier yet (single matcher), so without this entry the
+  // mainnet allowlist excludes the canonical matcher and parseSlab rejects
+  // every legitimate market — trade UI dies on deploy.
+  if (cfg.matcherProgramId) ids.add(cfg.matcherProgramId);
   const byTier = cfg.programsBySlabTier;
   if (byTier) {
     Object.values(byTier).forEach((id) => { if (id) ids.add(id); });

--- a/app/lib/programAllowlist.ts
+++ b/app/lib/programAllowlist.ts
@@ -1,0 +1,45 @@
+import type { PublicKey } from "@solana/web3.js";
+import { getAllProgramIds } from "@/lib/config";
+
+/**
+ * Returns true iff `programId` is one of the deployed program IDs for the
+ * currently selected network. Null/undefined returns false — callers should
+ * treat "not yet loaded" as "not safe to sign".
+ *
+ * The set is computed from `getAllProgramIds()` (config.programId plus every
+ * entry in `programsBySlabTier`). Adding a new tier in config automatically
+ * extends the allowlist — no code change here.
+ */
+export function isKnownProgram(programId: PublicKey | string | null | undefined): boolean {
+  if (!programId) return false;
+  const idStr = typeof programId === "string" ? programId : programId.toBase58();
+  return getAllProgramIds().includes(idStr);
+}
+
+/**
+ * Throws if `programId` is not one of the deployed programs. Use at the top
+ * of any hook that builds a transaction whose `programId` is derived from
+ * on-chain state via `useSlabState()`.
+ *
+ * The thrown message is intentionally generic and does NOT echo the bad
+ * program ID — that would confirm to a phishing attacker that their URL
+ * reached a victim's browser. The bad ID is logged to the console in dev.
+ */
+export function assertKnownProgram(programId: PublicKey | string | null | undefined): void {
+  if (isKnownProgram(programId)) return;
+  if (process.env.NODE_ENV !== "production") {
+    const idStr =
+      programId == null
+        ? "<null>"
+        : typeof programId === "string"
+          ? programId
+          : programId.toBase58();
+    console.error(
+      `[assertKnownProgram] Refusing to build tx for unknown program: ${idStr}. ` +
+        `Allowed: ${getAllProgramIds().join(", ")}`,
+    );
+  }
+  throw new Error(
+    "This market is not owned by a recognized Percolator program. Refusing to build a transaction.",
+  );
+}


### PR DESCRIPTION
Supersedes #2165.

Squid's PR introduced a client + server allowlist gate so slabs owned by foreign programs are rejected before parsing. The gate is correct in shape, but the helper `getAllProgramIds()` (and the parallel `validPrograms` set in `/api/markets`) omitted `cfg.matcherProgramId`. Slabs are owned by the matcher program, not the engine, and mainnet has no `programsBySlabTier` yet, so on mainnet:

- the allowlist resolved to just `ESa89R5…` (engine)
- the canonical matcher `GDK8wx38…` was excluded
- `parseSlab` would have rejected every legitimate market on deploy

This PR keeps the original gate and adds the missing matcher entry, plus a regression test.

## Changes on top of #2165
- `app/lib/config.ts` — `getAllProgramIds()` now also adds `cfg.matcherProgramId`
- `app/app/api/markets/route.ts` — server-side `validPrograms` set now also adds `cfg.matcherProgramId`
- `app/__tests__/lib/programAllowlist.test.ts` — new test asserting the cluster's matcher ID is in the allowlist

## Tests
```
pnpm vitest run __tests__/lib/programAllowlist.test.ts __tests__/lib/config.test.ts
# 25 passed
```

## Notes (deferred to follow-ups)
- F-2 from review: allowlist inherits `getNetwork()`'s `localStorage` override; should read `process.env.NEXT_PUBLIC_DEFAULT_NETWORK` directly for security-critical paths.
- Pre-existing CRITICAL: live `SUPABASE_SERVICE_ROLE_KEY`, `DEVNET_MINT_AUTHORITY_KEYPAIR`, Helius keys on disk in `.env.production.local` and `app/.env.vercel-prod` — rotate independently.

Closes #2165