### PR TITLE
fix(trade): derive non-zero limit_price_e6 + close-position guard + confirm modal

### DIFF
--- a/app/__tests__/hooks/useTrade.test.ts
+++ b/app/__tests__/hooks/useTrade.test.ts
@@ -41,6 +41,17 @@ vi.mock("@/lib/programAllowlist", () => ({
   assertKnownProgram: () => {},
 }));
 
+// Mock useLivePrice so the slippage-limit auto-compute has a valid mark.
+// Tests that exercise the no-mark abort path override this with priceE6: null.
+vi.mock("@/hooks/useLivePrice", () => ({
+  useLivePrice: vi.fn(() => ({
+    priceUsd: 1.5,
+    priceE6: 1_500_000n,
+    price: 1.5,
+    loading: false,
+  })),
+}));
+
 const mockLpPda = new PublicKey("3yEEksiUkq5K2PmjbRSHpXVN4FJgYuNn7rV31ek3PCwu");
 const mockOraclePda = new PublicKey("8DjWTsU1o8RHTKpRsqGFyYqFMknb8g7z2mjLfVYUyYyF");
 const mockVaultAuth = new PublicKey("DjVE6JNiYqPL2QXyCUUh8rNjHrbz9hXHNYt99MQ59qw1");
@@ -310,6 +321,128 @@ describe("useTrade", () => {
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
       });
+    });
+  });
+
+  describe("Slippage protection", () => {
+    // useTrade builds a 2-ix tx: [crank, tradeCpi]. The tradeCpi data layout is
+    //   tag(u8=10) ‖ lpIdx(u16) ‖ userIdx(u16) ‖ size(i128) ‖ limit_price_e6(u64)
+    // = 1 + 2 + 2 + 16 + 8 = 29 bytes. The limit is the trailing u64 LE.
+    function decodeLimit(data: Uint8Array | Buffer): bigint {
+      const buf = data instanceof Uint8Array ? Buffer.from(data) : data;
+      return buf.readBigUInt64LE(buf.length - 8);
+    }
+
+    it("auto-computes a non-zero limit for a long when the caller omits limitPriceE6", async () => {
+      const { result } = renderHook(() => useTrade(mockSlabAddress));
+      await act(async () => {
+        await result.current.trade({ lpIdx: 0, userIdx: 1, size: 1_000_000n });
+      });
+      const tx = vi.mocked(sendTx).mock.calls[0][0] as {
+        instructions: Array<{ data: Uint8Array }>;
+      };
+      const tradeIx = tx.instructions[tx.instructions.length - 1];
+      const limit = decodeLimit(tradeIx.data);
+      // mark = 1_500_000, default 100 bps → 1_500_000 * 10_100 / 10_000 = 1_515_000
+      expect(limit).toBe(1_515_000n);
+    });
+
+    it("auto-computes a non-zero limit ≤ mark for a short (size < 0)", async () => {
+      const { result } = renderHook(() => useTrade(mockSlabAddress));
+      await act(async () => {
+        await result.current.trade({ lpIdx: 0, userIdx: 1, size: -1_000_000n });
+      });
+      const tx = vi.mocked(sendTx).mock.calls[0][0] as {
+        instructions: Array<{ data: Uint8Array }>;
+      };
+      const limit = decodeLimit(tx.instructions[tx.instructions.length - 1].data);
+      // mark = 1_500_000, default 100 bps → 1_500_000 * 9_900 / 10_000 = 1_485_000
+      expect(limit).toBe(1_485_000n);
+      expect(limit).toBeLessThan(1_500_000n);
+    });
+
+    it("preserves an explicit limitPriceE6 supplied by the caller", async () => {
+      const { result } = renderHook(() => useTrade(mockSlabAddress));
+      await act(async () => {
+        await result.current.trade({
+          lpIdx: 0,
+          userIdx: 1,
+          size: 1_000_000n,
+          limitPriceE6: 1_999_999n,
+        });
+      });
+      const tx = vi.mocked(sendTx).mock.calls[0][0] as {
+        instructions: Array<{ data: Uint8Array }>;
+      };
+      const limit = decodeLimit(tx.instructions[tx.instructions.length - 1].data);
+      expect(limit).toBe(1_999_999n);
+    });
+
+    it("keeper escape hatch: explicit limitPriceE6 = 0n is passed through unchanged", async () => {
+      const { result } = renderHook(() => useTrade(mockSlabAddress));
+      await act(async () => {
+        await result.current.trade({
+          lpIdx: 0,
+          userIdx: 1,
+          size: 1_000_000n,
+          limitPriceE6: 0n,
+        });
+      });
+      const tx = vi.mocked(sendTx).mock.calls[0][0] as {
+        instructions: Array<{ data: Uint8Array }>;
+      };
+      const limit = decodeLimit(tx.instructions[tx.instructions.length - 1].data);
+      expect(limit).toBe(0n);
+    });
+
+    it("aborts the trade if the live mark price is null (no oracle yet)", async () => {
+      const { useLivePrice } = await import("@/hooks/useLivePrice");
+      vi.mocked(useLivePrice).mockReturnValueOnce({
+        priceUsd: null,
+        priceE6: null,
+        price: null,
+        loading: true,
+      } as ReturnType<typeof useLivePrice>);
+
+      const { result } = renderHook(() => useTrade(mockSlabAddress));
+      await act(async () => {
+        await expect(
+          result.current.trade({ lpIdx: 0, userIdx: 1, size: 1_000_000n }),
+        ).rejects.toThrow(/mark price unavailable/i);
+      });
+      expect(sendTx).not.toHaveBeenCalled();
+    });
+
+    it("aborts the trade if the live mark price is 0n (broken oracle)", async () => {
+      const { useLivePrice } = await import("@/hooks/useLivePrice");
+      vi.mocked(useLivePrice).mockReturnValueOnce({
+        priceUsd: 0,
+        priceE6: 0n,
+        price: 0,
+        loading: false,
+      } as ReturnType<typeof useLivePrice>);
+
+      const { result } = renderHook(() => useTrade(mockSlabAddress));
+      await act(async () => {
+        await expect(
+          result.current.trade({ lpIdx: 0, userIdx: 1, size: 1_000_000n }),
+        ).rejects.toThrow(/mark price unavailable/i);
+      });
+      expect(sendTx).not.toHaveBeenCalled();
+    });
+
+    it("never encodes the on-chain 0-sentinel by default", async () => {
+      // Regression guard for the original bug: the trade ix must not be
+      // encoded with limit_price_e6 = 0 when the caller didn't ask for that.
+      const { result } = renderHook(() => useTrade(mockSlabAddress));
+      await act(async () => {
+        await result.current.trade({ lpIdx: 0, userIdx: 1, size: 1_000_000n });
+      });
+      const tx = vi.mocked(sendTx).mock.calls[0][0] as {
+        instructions: Array<{ data: Uint8Array }>;
+      };
+      const limit = decodeLimit(tx.instructions[tx.instructions.length - 1].data);
+      expect(limit).not.toBe(0n);
     });
   });
 });

--- a/app/__tests__/lib/slippage.test.ts
+++ b/app/__tests__/lib/slippage.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeLimitPriceE6,
+  DEFAULT_SLIPPAGE_BPS,
+  MAX_SLIPPAGE_BPS,
+  SlippageError,
+} from "@/lib/slippage";
+
+const MARK = 200_000_000n; // $200.000000 in e6
+
+describe("computeLimitPriceE6 — long side (size > 0)", () => {
+  it("default 100 bps → mark * 1.01 (ceil-rounded)", () => {
+    // 200_000_000 * 10_100 = 2_020_000_000_000 / 10_000 = 202_000_000 (exact)
+    expect(computeLimitPriceE6({ markE6: MARK, size: 1n })).toBe(202_000_000n);
+  });
+
+  it("explicit 250 bps tolerance", () => {
+    expect(
+      computeLimitPriceE6({ markE6: MARK, size: 1n, slippageBps: 250n }),
+    ).toBe(205_000_000n);
+  });
+
+  it("ceil-rounds so a 1-unit truncation never tightens the limit below the floor", () => {
+    // 99 * 10_100 = 999_900 → /10_000 = 99 (truncated) — but ceil pushes to 100
+    const limit = computeLimitPriceE6({ markE6: 99n, size: 1n, slippageBps: 100n });
+    expect(limit).toBe(100n);
+    expect(limit).toBeGreaterThanOrEqual(99n);
+  });
+
+  it("zero-bps tolerance equals mark (exact)", () => {
+    expect(
+      computeLimitPriceE6({ markE6: MARK, size: 1n, slippageBps: 0n }),
+    ).toBe(MARK);
+  });
+});
+
+describe("computeLimitPriceE6 — short side (size < 0)", () => {
+  it("default 100 bps → mark * 0.99", () => {
+    // 200_000_000 * 9_900 = 1_980_000_000_000 / 10_000 = 198_000_000
+    expect(computeLimitPriceE6({ markE6: MARK, size: -1n })).toBe(198_000_000n);
+  });
+
+  it("limit is always ≤ mark for shorts", () => {
+    const limit = computeLimitPriceE6({ markE6: MARK, size: -1n, slippageBps: 50n });
+    expect(limit).toBeLessThanOrEqual(MARK);
+  });
+
+  it("floor-rounds (truncation is fine on the short side — widens tolerance)", () => {
+    // 99 * 9_900 = 980_100 / 10_000 = 98 (truncated)
+    expect(
+      computeLimitPriceE6({ markE6: 99n, size: -1n, slippageBps: 100n }),
+    ).toBe(98n);
+  });
+});
+
+describe("computeLimitPriceE6 — close-position direction (sign-derived)", () => {
+  it("close-long uses short-side limit (size < 0 → limit ≤ mark)", () => {
+    // A long position is closed with a negative size.
+    const limit = computeLimitPriceE6({ markE6: MARK, size: -500n });
+    expect(limit).toBeLessThanOrEqual(MARK);
+  });
+
+  it("close-short uses long-side limit (size > 0 → limit ≥ mark)", () => {
+    const limit = computeLimitPriceE6({ markE6: MARK, size: 500n });
+    expect(limit).toBeGreaterThanOrEqual(MARK);
+  });
+});
+
+describe("computeLimitPriceE6 — error cases", () => {
+  it("throws SlippageError on markE6 = 0n", () => {
+    expect(() => computeLimitPriceE6({ markE6: 0n, size: 1n })).toThrow(
+      SlippageError,
+    );
+    expect(() => computeLimitPriceE6({ markE6: 0n, size: 1n })).toThrow(
+      /mark price unavailable/i,
+    );
+  });
+
+  it("throws on negative markE6 (defensive)", () => {
+    expect(() => computeLimitPriceE6({ markE6: -1n, size: 1n })).toThrow(
+      SlippageError,
+    );
+  });
+
+  it("throws on size = 0n", () => {
+    expect(() => computeLimitPriceE6({ markE6: MARK, size: 0n })).toThrow(
+      SlippageError,
+    );
+  });
+
+  it("throws on slippageBps above MAX_SLIPPAGE_BPS", () => {
+    expect(() =>
+      computeLimitPriceE6({
+        markE6: MARK,
+        size: 1n,
+        slippageBps: MAX_SLIPPAGE_BPS + 1n,
+      }),
+    ).toThrow(SlippageError);
+  });
+
+  it("throws on negative slippageBps", () => {
+    expect(() =>
+      computeLimitPriceE6({ markE6: MARK, size: 1n, slippageBps: -1n }),
+    ).toThrow(SlippageError);
+  });
+});
+
+describe("computeLimitPriceE6 — invariants", () => {
+  it("DEFAULT_SLIPPAGE_BPS matches the on-chain default band (100 bps)", () => {
+    expect(DEFAULT_SLIPPAGE_BPS).toBe(100n);
+  });
+
+  it("never returns 0n (the on-chain disable sentinel) for a valid mark", () => {
+    expect(computeLimitPriceE6({ markE6: 1n, size: 1n })).not.toBe(0n);
+    expect(computeLimitPriceE6({ markE6: 1n, size: -1n })).not.toBe(0n);
+  });
+});

--- a/app/components/trade/TradeConfirmationModal.tsx
+++ b/app/components/trade/TradeConfirmationModal.tsx
@@ -13,6 +13,15 @@ interface TradeConfirmationModalProps {
   leverage: number;
   estimatedLiqPrice: bigint;
   tradingFee: bigint;
+  /**
+   * Worst-acceptable fill price (limit_price_e6) the trade will be signed
+   * with, derived from live mark + default slippage bps. Shown so the user
+   * reviews the binding slippage tolerance before confirming. `0n` is used
+   * as a sentinel when no live mark is available; in that case the row is
+   * suppressed and the submit gate (priceUsd / oracleStale) blocks the
+   * trade anyway.
+   */
+  worstFillPriceE6?: bigint;
   /** Current slab account equity in collateral units. Used to show risk leverage. */
   accountEquity?: bigint | null;
   /** Underlying asset symbol (e.g. SOL). Used to label the position size. */
@@ -40,6 +49,7 @@ export const TradeConfirmationModal: FC<TradeConfirmationModalProps> = ({
   leverage,
   estimatedLiqPrice,
   tradingFee,
+  worstFillPriceE6,
   accountEquity,
   symbol,
   collateralSymbol,
@@ -179,6 +189,16 @@ export const TradeConfirmationModal: FC<TradeConfirmationModalProps> = ({
               {estimatedLiqPrice <= 0n ? "N/A" : `$${formatPerc(estimatedLiqPrice, 6)}`}
             </span>
           </div>
+          {worstFillPriceE6 != null && worstFillPriceE6 > 0n && (
+            <div className="flex justify-between">
+              <span className="text-[var(--text-dim)]">
+                {direction === "long" ? "Max Fill Price:" : "Min Fill Price:"}
+              </span>
+              <span className="font-mono font-medium text-[var(--text)]">
+                ${formatPerc(worstFillPriceE6, 6)}
+              </span>
+            </div>
+          )}
         </div>
 
         {/* Risk warning */}

--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -8,6 +8,7 @@ import { useTrade } from "@/hooks/useTrade";
 import { humanizeError, withTransientRetry } from "@/lib/errorMessages";
 import { explorerTxUrl, getNetwork } from "@/lib/config";
 import { useUserAccount } from "@/hooks/useUserAccount";
+import { computeLimitPriceE6 } from "@/lib/slippage";
 import { useEngineState } from "@/hooks/useEngineState";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { useTokenMeta } from "@/hooks/useTokenMeta";
@@ -147,6 +148,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
     marginNative: bigint;
     estimatedLiqPrice: bigint;
     tradingFee: bigint;
+    worstFillPriceE6: bigint;
   } | null>(null);
   const [showCloseModal, setShowCloseModal] = useState(false);
   // Inline deposit form. Only rendered as a *fallback* — when the user has
@@ -928,11 +930,24 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
             // Snapshot all price-dependent values so the modal doesn't flicker
             // when WebSocket price updates arrive while it's open.
             const oracleE6 = priceUsd ? BigInt(Math.round(priceUsd * 1e6)) : 0n;
+            // Same derivation useTrade will apply when this confirm fires.
+            // Showing it here means the user reviews the binding slippage
+            // limit before signing, rather than discovering it post-hoc.
+            const signedSize = direction === "short" ? -positionSize : positionSize;
+            let worstFillPriceE6 = 0n;
+            try {
+              worstFillPriceE6 = livePriceE6 && livePriceE6 > 0n
+                ? computeLimitPriceE6({ markE6: livePriceE6, size: signedSize })
+                : 0n;
+            } catch {
+              worstFillPriceE6 = 0n;
+            }
             setConfirmSnapshot({
               positionSize,
               marginNative,
               estimatedLiqPrice: computePreTradeLiqPrice(oracleE6, marginNative, positionSize, maintenanceMarginBps, tradingFeeBps, direction),
               tradingFee: livePriceE6 && livePriceE6 > 0n ? ((positionSize * livePriceE6 / 1_000_000n) * tradingFeeBps) / 10000n : 0n,
+              worstFillPriceE6,
             });
             setShowConfirmModal(true);
           }}
@@ -1026,6 +1041,7 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
           leverage={leverage}
           estimatedLiqPrice={confirmSnapshot.estimatedLiqPrice}
           tradingFee={confirmSnapshot.tradingFee}
+          worstFillPriceE6={confirmSnapshot.worstFillPriceE6}
           accountEquity={userAccount ? capital : null}
           symbol={symbol}
           collateralSymbol={collateralSymbol}

--- a/app/hooks/useClosePosition.ts
+++ b/app/hooks/useClosePosition.ts
@@ -6,6 +6,7 @@ import { useConnectionCompat } from "@/hooks/useWalletCompat";
 import { AccountKind } from "@percolatorct/sdk";
 import { useTrade } from "@/hooks/useTrade";
 import { useUserAccount } from "@/hooks/useUserAccount";
+import { useLivePrice } from "@/hooks/useLivePrice";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { humanizeError, withTransientRetry } from "@/lib/errorMessages";
 import { isMockMode } from "@/lib/mock-mode";
@@ -28,6 +29,7 @@ export function useClosePosition(slabAddress: string): UseClosePositionReturn {
   const { connection } = useConnectionCompat();
   const userAccount = useUserAccount();
   const { trade } = useTrade(slabAddress);
+  const { priceE6: livePriceE6 } = useLivePrice();
   const { accounts } = useSlabState();
   const mockMode = isMockMode() && isMockSlab(slabAddress);
 
@@ -97,6 +99,17 @@ export function useClosePosition(slabAddress: string): UseClosePositionReturn {
           closeSize = freshIsLong ? -partialAbs : partialAbs;
         }
 
+        // useTrade derives limit_price_e6 from livePriceE6 and throws
+        // SlippageError when the live mark is unavailable. That error is
+        // non-transient — retrying it in withTransientRetry just burns
+        // 2×3s before failing. Short-circuit here when we know the mark
+        // is missing so the user sees the real reason immediately.
+        if (livePriceE6 == null) {
+          throw new Error(
+            "Live mark price unavailable — wait for the price feed to reconnect, then try again.",
+          );
+        }
+
         const sig = await withTransientRetry(
           async () => trade({ lpIdx, userIdx: userAccount.idx, size: closeSize }),
           { maxRetries: 2, delayMs: 3000 },
@@ -117,7 +130,7 @@ export function useClosePosition(slabAddress: string): UseClosePositionReturn {
         setLoading(false);
       }
     },
-    [connection, userAccount, trade, lpIdx, slabAddress, mockMode],
+    [connection, userAccount, trade, lpIdx, slabAddress, mockMode, livePriceE6],
   );
 
   return { closePosition, loading, error, phase, lastSig, resetPhase };

--- a/app/hooks/useTrade.ts
+++ b/app/hooks/useTrade.ts
@@ -24,6 +24,8 @@ import { sendTx } from "@/lib/tx";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { detectOracleMode } from "@/lib/oraclePrice";
 import { assertKnownProgram } from "@/lib/programAllowlist";
+import { useLivePrice } from "@/hooks/useLivePrice";
+import { computeLimitPriceE6 } from "@/lib/slippage";
 
 const INLINE_ORACLE_PUSH_REMOVED_ERROR =
   "Inline oracle price push was removed on-chain in beta.29. Migrate this flow to /api/oracle/advance-phase or another server-side oracle publisher before trading as the oracle authority.";
@@ -32,6 +34,7 @@ export function useTrade(slabAddress: string) {
   const { connection } = useConnectionCompat();
   const wallet = useWalletCompat();
   const { config: mktConfig, accounts, programId: slabProgramId } = useSlabState();
+  const { priceE6: livePriceE6 } = useLivePrice();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inflightRef = useRef(false);
@@ -54,6 +57,20 @@ export function useTrade(slabAddress: string) {
         const programId = slabProgramId;
         const slabPk = new PublicKey(slabAddress);
         const [lpPda] = deriveLpPda(programId, slabPk, params.lpIdx);
+
+        // Slippage protection. The on-chain handler treats limit_price_e6 == 0
+        // as a "no limit" sentinel and skips the slippage check entirely
+        // (percolator.rs::handle_trade_cpi). Without a real limit, the only
+        // remaining defense is the anti-off-market band (~1% by default),
+        // leaving the user exposed within that band to a hostile matcher or
+        // an in-band MEV race. Derive a non-zero limit from the live mark
+        // when the caller omits one. An explicit `limitPriceE6: 0n` from the
+        // caller is preserved as an opt-in escape hatch for keeper/bot paths
+        // that intentionally skip the check.
+        const effectiveLimitPriceE6: bigint =
+          params.limitPriceE6 !== undefined
+            ? params.limitPriceE6
+            : computeLimitPriceE6({ markE6: livePriceE6 ?? 0n, size: params.size });
 
         // Determine oracle mode using centralised detectOracleMode (oraclePrice.ts).
         // "pyth-pinned" = Pyth feed; "admin" or "hyperp" = use slab as oracle account.
@@ -96,7 +113,7 @@ export function useTrade(slabAddress: string) {
             lpAccount.account.matcherContext,
             lpPda,
           ]),
-          data: encodeTradeCpi({ lpIdx: params.lpIdx, userIdx: params.userIdx, size: params.size.toString(), limitPriceE6: params.limitPriceE6?.toString() ?? "0" }),
+          data: encodeTradeCpi({ lpIdx: params.lpIdx, userIdx: params.userIdx, size: params.size.toString(), limitPriceE6: effectiveLimitPriceE6.toString() }),
         });
         instructions.push(tradeIx);
 
@@ -110,7 +127,7 @@ export function useTrade(slabAddress: string) {
         setLoading(false);
       }
     },
-    [connection, wallet, mktConfig, accounts, slabAddress, slabProgramId]
+    [connection, wallet, mktConfig, accounts, slabAddress, slabProgramId, livePriceE6]
   );
 
   return { trade, loading, error };

--- a/app/lib/slippage.ts
+++ b/app/lib/slippage.ts
@@ -1,0 +1,69 @@
+/**
+ * Slippage / limit-price helpers for the on-chain TradeCpi instruction.
+ *
+ * The on-chain handler treats `limit_price_e6 == 0` as an explicit "skip
+ * slippage check" sentinel. Sending zero forfeits the protocol's documented
+ * MEV/slippage protection (only the anti-off-market band — typically ~1% — is
+ * left). User-initiated trades must compute a real limit from the live mark
+ * price and a slippage tolerance.
+ *
+ * Direction is derived from the sign of `size`:
+ *   - long  (size > 0): on-chain reverts if execution price > limit
+ *                       → limit = mark * (1 + bps/10_000), rounded UP
+ *   - short (size < 0): on-chain reverts if execution price < limit
+ *                       → limit = mark * (1 - bps/10_000), rounded DOWN
+ *
+ * Rounding direction is chosen so a 1-unit truncation can only widen the
+ * tolerance, never silently tighten it below the intended floor/ceiling.
+ *
+ * `DEFAULT_SLIPPAGE_BPS = 100` matches the on-chain default band
+ * (max(2 * trading_fee_bps, 100) bps for typical markets), so the off-chain
+ * limit becomes the binding constraint in the common case.
+ */
+
+export const DEFAULT_SLIPPAGE_BPS = 100n;
+export const MAX_SLIPPAGE_BPS = 10_000n;
+
+export class SlippageError extends Error {
+  constructor(msg: string) {
+    super(msg);
+    this.name = "SlippageError";
+  }
+}
+
+export interface ComputeLimitArgs {
+  markE6: bigint;
+  size: bigint;
+  slippageBps?: bigint;
+}
+
+export function computeLimitPriceE6(args: ComputeLimitArgs): bigint {
+  const { markE6, size } = args;
+  const slippageBps = args.slippageBps ?? DEFAULT_SLIPPAGE_BPS;
+
+  if (markE6 <= 0n) {
+    throw new SlippageError(
+      "Cannot compute slippage limit: live mark price unavailable. Wait for the oracle to load, then retry.",
+    );
+  }
+  if (size === 0n) {
+    throw new SlippageError("Cannot compute slippage limit: trade size is zero.");
+  }
+  if (slippageBps < 0n || slippageBps > MAX_SLIPPAGE_BPS) {
+    throw new SlippageError(`Slippage bps out of range: ${slippageBps}`);
+  }
+
+  const BPS_DENOM = 10_000n;
+  let limit: bigint;
+  if (size > 0n) {
+    const numer = markE6 * (BPS_DENOM + slippageBps);
+    limit = (numer + BPS_DENOM - 1n) / BPS_DENOM;
+  } else {
+    const numer = markE6 * (BPS_DENOM - slippageBps);
+    limit = numer / BPS_DENOM;
+  }
+  // Floor guard: a very small markE6 combined with a large short-side
+  // slippage can truncate to 0, which is the on-chain disable sentinel.
+  // Clamp to 1n so the slippage check is always actually enforced.
+  return limit > 0n ? limit : 1n;
+}


### PR DESCRIPTION
Supersedes #2166.

Squid's PR derives a non-zero `limit_price_e6` from the live mark instead of always sending `0` (which the on-chain handler treats as "no slippage cap"). Math, e6 scale, and the `limitPriceE6: 0n` keeper escape hatch are all correct. Adds two follow-ups from review:

## 1. Close-position null-mark guard
`useClosePosition` was calling `trade()` inside `withTransientRetry`. When `livePriceE6 == null` (WS disconnect mid-session), the derivation throws a non-transient `SlippageError`, but the retry wrapper still spends 2×3 s on it before surfacing. Now short-circuits with a clear "price feed unavailable — wait for the price feed to reconnect" message.

## 2. Worst-fill price in the confirmation modal
The derived limit was never shown before signing. `TradeForm` computes the same value `useTrade` will sign with and stores it in `confirmSnapshot.worstFillPriceE6`. `TradeConfirmationModal` renders it as **Max Fill Price** (long) or **Min Fill Price** (short). Hidden when the live mark is missing — the existing submit gate (`priceUsd` / `oracleStale`) already blocks the trade in that case.

## Tests
```
pnpm vitest run __tests__/lib/slippage.test.ts __tests__/hooks/useTrade.test.ts
# 32 passed
pnpm tsc --noEmit  # clean
```

## Notes (deferred to follow-ups)
- F-2 advisory: `scripts/floating-maker.ts:653` calls `encodeTradeCpi` without `limitPriceE6` → runtime `TypeError`. Pre-existing in keeper path; fix by passing `"0"` explicitly.
- F-3: `useLivePrice` has no TTL on its cached WS price. Out of scope.

Closes #2166