### PR TITLE
fix(modals): stop blinking modals + apply same pattern to OracleDetailsPanel

### DIFF
--- a/app/components/market/InsuranceExplainerModal.tsx
+++ b/app/components/market/InsuranceExplainerModal.tsx
@@ -18,6 +18,15 @@ export const InsuranceExplainerModal: FC<InsuranceExplainerModalProps> = ({
   const modalRef = useRef<HTMLDivElement>(null);
   const prefersReduced = usePrefersReducedMotion();
 
+  // Keep the onClose callback in a ref so the mount effect never re-runs on parent
+  // re-renders. Insurance-dashboard parents re-render whenever LP / vault / live-price
+  // data ticks and pass freshly-allocated inline `onClose` closures each time; with
+  // `onClose` in the effect deps, every parent re-render re-fired the gsap fade-in
+  // (opacity 0 → 1) and made the modal blink continuously while open. Same canonical
+  // pattern as TradeConfirmationModal.tsx.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
   useEffect(() => {
     const overlay = overlayRef.current;
     const modal = modalRef.current;
@@ -41,11 +50,12 @@ export const InsuranceExplainerModal: FC<InsuranceExplainerModalProps> = ({
     }
 
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") onCloseRef.current();
     };
     document.addEventListener("keydown", handleEscape);
     return () => document.removeEventListener("keydown", handleEscape);
-  }, [onClose, prefersReduced]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prefersReduced]);
 
   const handleOverlayClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget) onClose();

--- a/app/components/market/InsuranceTopUpModal.tsx
+++ b/app/components/market/InsuranceTopUpModal.tsx
@@ -37,6 +37,15 @@ export const InsuranceTopUpModal: FC<InsuranceTopUpModalProps> = ({
   const prefersReduced = usePrefersReducedMotion();
   const mockMode = isMockMode() && isMockSlab(slabAddress);
 
+  // Keep the onClose callback in a ref so the mount effect never re-runs on parent
+  // re-renders. Insurance-dashboard parents re-render whenever LP / vault / live-price
+  // data ticks and pass freshly-allocated inline `onClose` closures each time; with
+  // `onClose` in the effect deps, every parent re-render re-fired the gsap fade-in
+  // (opacity 0 → 1) and made the modal blink continuously while open. Same canonical
+  // pattern as TradeConfirmationModal.tsx.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
   const wallet = useWalletCompat();
   const { deposit, state: lpState, loading: lpLoading, error: lpError } = useInsuranceLP();
   const { config } = useSlabState();
@@ -72,11 +81,12 @@ export const InsuranceTopUpModal: FC<InsuranceTopUpModalProps> = ({
     }
 
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") onCloseRef.current();
     };
     document.addEventListener("keydown", handleEscape);
     return () => document.removeEventListener("keydown", handleEscape);
-  }, [onClose, prefersReduced]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prefersReduced]);
 
   const handleOverlayClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget && !loading) onClose();

--- a/app/components/oracle/OracleDetailsPanel.tsx
+++ b/app/components/oracle/OracleDetailsPanel.tsx
@@ -43,6 +43,17 @@ export const OracleDetailsPanel: FC<OracleDetailsPanelProps> = ({ onClose }) => 
   const overlayRef = useRef<HTMLDivElement>(null);
   const [isClosing, setIsClosing] = useState(false);
 
+  // Same pattern as TradeConfirmationModal — keep onClose accessible via ref
+  // so the mount-time Escape listener always invokes the latest closure
+  // without the effect needing to resubscribe on every parent render.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  const handleClose = useCallback(() => {
+    setIsClosing(true);
+    setTimeout(() => onCloseRef.current(), 200);
+  }, []);
+
   // Close on Escape
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
@@ -50,12 +61,7 @@ export const OracleDetailsPanel: FC<OracleDetailsPanelProps> = ({ onClose }) => 
     };
     document.addEventListener("keydown", handleKey);
     return () => document.removeEventListener("keydown", handleKey);
-  }, []);
-
-  const handleClose = useCallback(() => {
-    setIsClosing(true);
-    setTimeout(onClose, 200);
-  }, [onClose]);
+  }, [handleClose]);
 
   // Close on overlay click
   const handleOverlayClick = useCallback(

--- a/app/components/trade/FundingExplainerModal.tsx
+++ b/app/components/trade/FundingExplainerModal.tsx
@@ -14,6 +14,16 @@ export const FundingExplainerModal: FC<FundingExplainerModalProps> = ({ onClose 
   const modalRef = useRef<HTMLDivElement>(null);
   const prefersReduced = usePrefersReducedMotion();
 
+  // Keep the onClose callback in a ref so the mount effect never re-runs on parent
+  // re-renders. The parent FundingRateCard runs a 1-second `setCountdown` setInterval,
+  // so it re-renders every second and passes a freshly-allocated
+  // `() => setShowExplainer(false)` closure as `onClose` each time. With `onClose` in
+  // the effect deps, every parent tick re-fired the gsap fade-in (opacity 0 → 1),
+  // making the modal blink continuously while open. Same canonical pattern as
+  // TradeConfirmationModal.tsx.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
   useEffect(() => {
     const overlay = overlayRef.current;
     const modal = modalRef.current;
@@ -33,11 +43,12 @@ export const FundingExplainerModal: FC<FundingExplainerModalProps> = ({ onClose 
     }
 
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") onCloseRef.current();
     };
     document.addEventListener("keydown", handleEscape);
     return () => document.removeEventListener("keydown", handleEscape);
-  }, [onClose, prefersReduced]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prefersReduced]);
 
   const handleOverlayClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget) onClose();

--- a/app/components/trade/WarmupExplainerModal.tsx
+++ b/app/components/trade/WarmupExplainerModal.tsx
@@ -16,6 +16,15 @@ export const WarmupExplainerModal: FC<WarmupExplainerModalProps> = ({
   const modalRef = useRef<HTMLDivElement>(null);
   const prefersReduced = usePrefersReducedMotion();
 
+  // Keep the onClose callback in a ref so the mount effect never re-runs on parent
+  // re-renders. Trade-page parents re-render frequently (countdown ticks, WS price
+  // updates, etc.) and pass freshly-allocated inline `onClose` closures each time;
+  // with `onClose` in the effect deps, every parent re-render re-fired the gsap
+  // fade-in (opacity 0 → 1) and made the modal blink continuously while open.
+  // Same canonical pattern as TradeConfirmationModal.tsx.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
   useEffect(() => {
     const overlay = overlayRef.current;
     const modal = modalRef.current;
@@ -39,11 +48,12 @@ export const WarmupExplainerModal: FC<WarmupExplainerModalProps> = ({
     }
 
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") onCloseRef.current();
     };
     document.addEventListener("keydown", handleEscape);
     return () => document.removeEventListener("keydown", handleEscape);
-  }, [onClose, prefersReduced]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prefersReduced]);
 
   const handleOverlayClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget) onClose();


### PR DESCRIPTION
Supersedes #2153.

Ammar's PR fixed four modals where the GSAP fade-in was replaying every parent render because \`onClose\` was in the mount effect's dep array, and parent re-renders produced a new function reference each time.

Adds one extra file the original PR missed: \`OracleDetailsPanel.tsx\` has the same anti-pattern (empty-dep \`useEffect\` closing over \`handleClose\` which depends on \`onClose\`) but doesn't visibly blink because it has no GSAP animation in the effect — just CSS class transitions. Latent staleness bug only.

## Changes on top of #2153
- \`app/components/oracle/OracleDetailsPanel.tsx\` — adds \`onCloseRef\` and routes \`handleClose\`'s deferred \`onClose\` call through the ref so the mount-time Escape handler always invokes the latest closure.

## Tests
\`pnpm tsc --noEmit\` — clean.

## Notes (deferred)
- No automated test added (matches the original PR). An RTL test that renders the modal, waits past initial mount, fires Escape and asserts \`onClose\` was called exactly once would prevent regression.

Closes #2153