### PR TITLE
security(scripts): remove hardcoded Helius mainnet API key

### DIFF
--- a/scripts/admin-resolve-and-close.ts
+++ b/scripts/admin-resolve-and-close.ts
@@ -26,7 +26,8 @@ import { getAssociatedTokenAddressSync, TOKEN_PROGRAM_ID } from "@solana/spl-tok
 import { fetchSlab, parseAllAccounts, parseConfig, parseHeader } from "@percolatorct/sdk";
 import fs from "fs";
 
-const RPC = "https://mainnet.helius-rpc.com/?api-key=2a089bfd-18ae-48b5-abbe-36b0383ecad3";
+const RPC = process.env.RPC_URL || (process.env.HELIUS_API_KEY ? `https://mainnet.helius-rpc.com/?api-key=${process.env.HELIUS_API_KEY}` : "");
+if (!RPC) throw new Error("Set RPC_URL or HELIUS_API_KEY before running this script");
 const SLAB_ADDRESS = process.env.SLAB_ADDRESS || "DSz7UykKuHLWAJjEEREAZAoLeYdoKQ9GL5rhA2BU6irH";
 const PROGRAM_ID = "ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv";
 

--- a/scripts/close-and-recover.ts
+++ b/scripts/close-and-recover.ts
@@ -7,7 +7,8 @@ import { Connection, PublicKey, Keypair, TransactionInstruction, SYSVAR_CLOCK_PU
 import { getAssociatedTokenAddressSync, TOKEN_PROGRAM_ID, createAssociatedTokenAccountInstruction } from "@solana/spl-token";
 import fs from "fs";
 
-const RPC = "https://mainnet.helius-rpc.com/?api-key=2a089bfd-18ae-48b5-abbe-36b0383ecad3";
+const RPC = process.env.RPC_URL || (process.env.HELIUS_API_KEY ? `https://mainnet.helius-rpc.com/?api-key=${process.env.HELIUS_API_KEY}` : "");
+if (!RPC) throw new Error("Set RPC_URL or HELIUS_API_KEY before running this script");
 const SLAB = new PublicKey("DSz7UykKuHLWAJjEEREAZAoLeYdoKQ9GL5rhA2BU6irH");
 const PROGRAM = new PublicKey("ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv");
 

--- a/scripts/close-market-full.ts
+++ b/scripts/close-market-full.ts
@@ -12,7 +12,8 @@ import { Connection, PublicKey, Keypair, TransactionInstruction, Transaction, se
 import { getAssociatedTokenAddressSync, TOKEN_PROGRAM_ID, createAssociatedTokenAccountInstruction } from "@solana/spl-token";
 import fs from "fs";
 
-const RPC = process.env.RPC_URL || "https://mainnet.helius-rpc.com/?api-key=2a089bfd-18ae-48b5-abbe-36b0383ecad3";
+const RPC = process.env.RPC_URL || (process.env.HELIUS_API_KEY ? `https://mainnet.helius-rpc.com/?api-key=${process.env.HELIUS_API_KEY}` : "");
+if (!RPC) throw new Error("Set RPC_URL or HELIUS_API_KEY before running this script");
 const SLAB = new PublicKey("5RfUzS1kpdhVb2CNGvE9UGdthsGbd354LoXSYjCFHv3R");
 const PROGRAM = new PublicKey("ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv");       // wrapper
 const STAKE_PROGRAM = new PublicKey("DC5fovFQD5SZYsetwvEqd4Wi4PFY1Yfnc669VMe6oa7F");  // stake

--- a/scripts/create-stake-pool.ts
+++ b/scripts/create-stake-pool.ts
@@ -27,7 +27,8 @@ import * as path from "path";
 // ── Config ──────────────────────────────────────────────────────
 const STAKE_PROGRAM_ID = new PublicKey("DC5fovFQD5SZYsetwvEqd4Wi4PFY1Yfnc669VMe6oa7F");
 const PERCOLATOR_PROGRAM_ID = new PublicKey("ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv");
-const RPC_URL = "https://mainnet.helius-rpc.com/?api-key=2a089bfd-18ae-48b5-abbe-36b0383ecad3";
+const RPC_URL = process.env.RPC_URL || (process.env.HELIUS_API_KEY ? `https://mainnet.helius-rpc.com/?api-key=${process.env.HELIUS_API_KEY}` : "");
+if (!RPC_URL) throw new Error("Set RPC_URL or HELIUS_API_KEY before running this script");
 const ADMIN_KEYPAIR_PATH = path.join(process.env.HOME!, ".percolator-mainnet/keys/deploy-authority.json");
 
 // ── Parse args ──────────────────────────────────────────────────

--- a/scripts/refund-user.ts
+++ b/scripts/refund-user.ts
@@ -2,7 +2,8 @@ import { Connection, PublicKey, Keypair, TransactionInstruction, Transaction, se
 import { getAssociatedTokenAddressSync, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import fs from "fs";
 
-const RPC = "https://mainnet.helius-rpc.com/?api-key=2a089bfd-18ae-48b5-abbe-36b0383ecad3";
+const RPC = process.env.RPC_URL || (process.env.HELIUS_API_KEY ? `https://mainnet.helius-rpc.com/?api-key=${process.env.HELIUS_API_KEY}` : "");
+if (!RPC) throw new Error("Set RPC_URL or HELIUS_API_KEY before running this script");
 const SLAB = new PublicKey("6akNPYQLyg2nGLDtGAoykB8ZtuoAEwGhxreXaDWncya2");
 const PROGRAM = new PublicKey("ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv");
 const USDC_MINT = new PublicKey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");

--- a/scripts/rescue-and-close-slab.ts
+++ b/scripts/rescue-and-close-slab.ts
@@ -2,7 +2,8 @@ import { Connection, PublicKey, Keypair, TransactionInstruction, Transaction, se
 import { getAssociatedTokenAddressSync, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import fs from "fs";
 
-const RPC = "https://mainnet.helius-rpc.com/?api-key=2a089bfd-18ae-48b5-abbe-36b0383ecad3";
+const RPC = process.env.RPC_URL || (process.env.HELIUS_API_KEY ? `https://mainnet.helius-rpc.com/?api-key=${process.env.HELIUS_API_KEY}` : "");
+if (!RPC) throw new Error("Set RPC_URL or HELIUS_API_KEY before running this script");
 const SLAB = new PublicKey("5RfUzS1kpdhVb2CNGvE9UGdthsGbd354LoXSYjCFHv3R");
 const PROGRAM = new PublicKey("ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv");
 const USDC_MINT = new PublicKey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");

--- a/scripts/swap-usdc-sol.ts
+++ b/scripts/swap-usdc-sol.ts
@@ -1,7 +1,8 @@
 import { Connection, Keypair, VersionedTransaction } from "@solana/web3.js";
 import fs from "fs";
 
-const RPC = "https://mainnet.helius-rpc.com/?api-key=2a089bfd-18ae-48b5-abbe-36b0383ecad3";
+const RPC = process.env.RPC_URL || (process.env.HELIUS_API_KEY ? `https://mainnet.helius-rpc.com/?api-key=${process.env.HELIUS_API_KEY}` : "");
+if (!RPC) throw new Error("Set RPC_URL or HELIUS_API_KEY before running this script");
 const USDC = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 const SOL = "So11111111111111111111111111111111111111112";
 

--- a/scripts/test-force-close.ts
+++ b/scripts/test-force-close.ts
@@ -2,7 +2,8 @@ import { Connection, PublicKey, Keypair, TransactionInstruction, Transaction, Co
 import { getAssociatedTokenAddressSync, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import fs from "fs";
 
-const RPC = "https://mainnet.helius-rpc.com/?api-key=2a089bfd-18ae-48b5-abbe-36b0383ecad3";
+const RPC = process.env.RPC_URL || (process.env.HELIUS_API_KEY ? `https://mainnet.helius-rpc.com/?api-key=${process.env.HELIUS_API_KEY}` : "");
+if (!RPC) throw new Error("Set RPC_URL or HELIUS_API_KEY before running this script");
 const SLAB = new PublicKey("5RfUzS1kpdhVb2CNGvE9UGdthsGbd354LoXSYjCFHv3R");
 const PROGRAM = new PublicKey("ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv");
 const USDC_MINT = new PublicKey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");


### PR DESCRIPTION
The mainnet Helius RPC key \`2a089bfd-18ae-48b5-abbe-36b0383ecad3\` was hardcoded as the \`RPC\` URL in 8 admin/utility scripts and has been in public history since \`dc41af54\`. This repo is public, so anyone with read access (or a clone, or who's read a PR diff) has the key already.

This PR replaces each hardcoded URL with:
\`\`\`ts
const RPC = process.env.RPC_URL || (process.env.HELIUS_API_KEY ? \`https://mainnet.helius-rpc.com/?api-key=\${process.env.HELIUS_API_KEY}\` : "");
if (!RPC) throw new Error("Set RPC_URL or HELIUS_API_KEY before running this script");
\`\`\`

The hard-fail at startup means scripts can never silently fall back to a leaked default again.

## Files
- scripts/admin-resolve-and-close.ts
- scripts/close-and-recover.ts
- scripts/close-market-full.ts
- scripts/create-stake-pool.ts
- scripts/refund-user.ts
- scripts/rescue-and-close-slab.ts
- scripts/swap-usdc-sol.ts
- scripts/test-force-close.ts

## Required operator follow-up (cannot be done by this PR alone)
1. **Rotate the key in Helius dashboard.** Revoke \`2a089bfd-18ae-48b5-abbe-36b0383ecad3\`, issue a fresh one.
2. Set \`HELIUS_API_KEY\` (just the new UUID) in the operator's shell env / .env.production.local — never in tracked code.
3. Optional: \`git filter-repo\` to scrub the leaked UUID from historical commits. Cosmetic since the key is already in the wild; useful only if you also want to avoid leaking it to future cloners. Discussed separately.