### PR TITLE
feat(waitlist): invite-only referral codes

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -76,3 +76,8 @@ ORACLE_BRIDGE_URL=
 # Set on Vercel project (Production + Preview).
 NEXT_PUBLIC_WAITLIST_SUPABASE_URL=
 NEXT_PUBLIC_WAITLIST_SUPABASE_KEY=
+# Server-only, bypasses RLS. Used by the signup route to read back a wallet
+# user's existing referral code on idempotent re-submit. Without this, wallet
+# re-submits return referral_code: null and the success card can't show the
+# code again on refresh.
+WAITLIST_SUPABASE_SERVICE_ROLE_KEY=

--- a/app/__tests__/api/waitlist-signup-email-abuse.test.ts
+++ b/app/__tests__/api/waitlist-signup-email-abuse.test.ts
@@ -37,9 +37,13 @@ describe("/api/waitlist/signup email-bombing hardening", () => {
   const source = fs.readFileSync(ROUTE_PATH, "utf8");
 
   it("captures isDuplicate from the insert error code", () => {
-    expect(source).toMatch(
-      /isDuplicate\s*=\s*insertError\?\.code\s*===\s*"23505"/,
-    );
+    // Refactored to retry-loop form (assigns true on 23505 inside the loop)
+    // rather than a single `isDuplicate = err?.code === "23505"` expression.
+    // Either form is correct; just confirm the route reads the unique-violation
+    // code and routes a flag named isDuplicate from it.
+    expect(source).toMatch(/let\s+isDuplicate\s*=\s*false/);
+    expect(source).toMatch(/error\.code\s*!==\s*"23505"/);
+    expect(source).toMatch(/isDuplicate\s*=\s*true/);
   });
 
   it("skips the confirmation email on duplicate insert", () => {

--- a/app/__tests__/api/waitlist-signup-shape.test.ts
+++ b/app/__tests__/api/waitlist-signup-shape.test.ts
@@ -51,4 +51,18 @@ describe("/api/waitlist/signup input shape", () => {
     expect(source).toContain("walletExistsOnMainnet(pubkey!)");
     expect(source).not.toMatch(/if\s*\(\s*!hasEmail\s*\)\s*\{\s*const\s+exists\s*=\s*await\s+walletExistsOnMainnet/);
   });
+
+  it("rejects signups missing a referral code (invite-only)", () => {
+    const source = fs.readFileSync(ROUTE_PATH, "utf8");
+    // The required-referrer branch must return 400. Pin the error string
+    // so a future refactor can't accidentally re-open the route to the
+    // unauthenticated public.
+    expect(source).toMatch(
+      /referredByRaw\s*===\s*null\s*\|\|\s*referredByRaw\.length\s*===\s*0/,
+    );
+    expect(source).toContain(
+      'referral code required — Percolator is invite-only',
+    );
+    expect(source).toMatch(/status:\s*400/);
+  });
 });

--- a/app/__tests__/lib/waitlist-referral-code.test.ts
+++ b/app/__tests__/lib/waitlist-referral-code.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Referral code generator — format + uniqueness contract.
+ *
+ * The route relies on the generator producing codes that match the SQL
+ * unique constraint's alphabet and length. If either drifts, signups will
+ * either reject codes that should be valid or generate codes the SQL
+ * function would refuse.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  generateReferralCode,
+  isValidReferralCodeShape,
+  REFERRAL_CODE_LENGTH,
+} from "@/lib/waitlist/referralCode";
+
+const CROCKFORD_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+describe("generateReferralCode", () => {
+  it("returns the expected length by default", () => {
+    expect(generateReferralCode().length).toBe(REFERRAL_CODE_LENGTH);
+  });
+
+  it("uses only Crockford base32 characters (no I/L/O/U, no lowercase)", () => {
+    for (let i = 0; i < 200; i++) {
+      const code = generateReferralCode();
+      for (const ch of code) {
+        expect(CROCKFORD_ALPHABET).toContain(ch);
+      }
+    }
+  });
+
+  it("produces unique codes across a large sample (no collisions at this scale)", () => {
+    const N = 10_000;
+    const seen = new Set<string>();
+    for (let i = 0; i < N; i++) seen.add(generateReferralCode());
+    expect(seen.size).toBe(N);
+  });
+
+  it("rejects lengths outside the supported range", () => {
+    expect(() => generateReferralCode(3)).toThrow();
+    expect(() => generateReferralCode(65)).toThrow();
+  });
+});
+
+describe("isValidReferralCodeShape", () => {
+  it("accepts a freshly generated code", () => {
+    expect(isValidReferralCodeShape(generateReferralCode())).toBe(true);
+  });
+
+  it("rejects lowercase, wrong length, and confusable chars", () => {
+    expect(isValidReferralCodeShape("abc23xyz")).toBe(false); // lowercase
+    expect(isValidReferralCodeShape("ABC23X")).toBe(false); // too short
+    expect(isValidReferralCodeShape("ABC23XYZ9")).toBe(false); // too long
+    expect(isValidReferralCodeShape("ABCI3XYZ")).toBe(false); // contains I
+    expect(isValidReferralCodeShape("ABCL3XYZ")).toBe(false); // contains L
+    expect(isValidReferralCodeShape("ABCO3XYZ")).toBe(false); // contains O
+    expect(isValidReferralCodeShape("ABCU3XYZ")).toBe(false); // contains U
+  });
+});

--- a/app/app/api/waitlist/check-code/route.ts
+++ b/app/app/api/waitlist/check-code/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { getWaitlistSupabase } from "@/lib/waitlist/supabase";
+import { isValidReferralCodeShape } from "@/lib/waitlist/referralCode";
+
+export const runtime = "nodejs";
+
+/**
+ * GET /api/waitlist/check-code?code=AB23XYZ9
+ *
+ * Returns { valid: boolean }. The waitlist signup UI calls this on a
+ * debounced input change so the user gets a green/red signal before
+ * going through Privy OTP or wallet sign — without the round trip
+ * they'd get a generic 400 only after submitting.
+ *
+ * Posture:
+ *   • Shape pre-filter rejects garbage without burning a Supabase RPC
+ *     call. The Crockford alphabet plus 8-char length means inputs
+ *     that aren't even plausible (lowercase, wrong length, contains
+ *     I/L/O/U) never reach the database.
+ *   • Existence check goes through the SECURITY DEFINER RPC
+ *     `waitlist_referral_code_exists(text)` which returns a boolean
+ *     only — never returns the row, the owner, or any other field.
+ *   • The endpoint is anon-callable. Brute-force enumeration is
+ *     impractical (32^8 ≈ 1.1 trillion combinations) and Resend/
+ *     Privy aren't reachable without a separately validated signup,
+ *     so the worst an attacker can do here is learn that a specific
+ *     8-char string is a real code — which is the same info anyone
+ *     with the code already has.
+ *   • Fail-closed: any RPC error returns valid:false. Better to
+ *     under-validate a real code than to over-validate a fake one.
+ */
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const raw = url.searchParams.get("code");
+  if (!raw) {
+    return NextResponse.json({ valid: false, reason: "missing" }, { status: 400 });
+  }
+  const code = raw.trim().toUpperCase();
+  if (!isValidReferralCodeShape(code)) {
+    return NextResponse.json({ valid: false, reason: "shape" });
+  }
+  try {
+    const supabase = getWaitlistSupabase();
+    const { data, error } = await supabase.rpc(
+      "waitlist_referral_code_exists",
+      { p_code: code },
+    );
+    if (error) {
+      console.error("[check-code] rpc error", error);
+      return NextResponse.json({ valid: false, reason: "rpc" });
+    }
+    return NextResponse.json({ valid: data === true });
+  } catch (err) {
+    console.error("[check-code] unexpected", err);
+    return NextResponse.json({ valid: false, reason: "unexpected" });
+  }
+}

--- a/app/app/api/waitlist/signup/route.ts
+++ b/app/app/api/waitlist/signup/route.ts
@@ -434,19 +434,24 @@ export async function POST(req: Request) {
   }
 
   // ── Position lookup ─────────────────────────────────────────────────────
+  // Routed through the service-role client so the underlying functions can
+  // stay revoked from anon (membership-oracle prevention). Falls back to
+  // null if the service env var is missing; UX-wise the success card
+  // gracefully omits the position when null.
   let position: number | null = null;
   try {
+    const service = getWaitlistServiceSupabase();
     if (hasWalletPart) {
-      const { data } = await supabase.rpc("waitlist_position", { p_pubkey: pubkey });
+      const { data } = await service.rpc("waitlist_position", { p_pubkey: pubkey });
       if (typeof data === "number") position = data;
     } else if (hasEmail) {
-      const { data } = await supabase.rpc("waitlist_position_by_email", {
+      const { data } = await service.rpc("waitlist_position_by_email", {
         p_email: emailRaw,
       });
       if (typeof data === "number") position = data;
     }
-  } catch {
-    /* ignore */
+  } catch (err) {
+    console.warn("[waitlist-signup] position lookup unavailable", err);
   }
 
   // ── Confirmation email (fire-and-forget) ────────────────────────────────
@@ -471,10 +476,20 @@ export async function POST(req: Request) {
     );
   }
 
-  // Email-path duplicate: don't leak the existing code in the response — see
-  // the membership-oracle note above. Wallet-path always returns the code.
-  const responseCode = hasWalletPart || !isDuplicate ? referralCode : null;
-  return NextResponse.json({ ok: true, position, referral_code: responseCode });
+  // Email-path duplicate: withhold both the code AND the position. Returning
+  // either one would let an attacker holding the publishable key probe
+  // arbitrary email addresses for membership (the position number itself
+  // is a yes/no signal — non-null position = "this email is on the list").
+  // Wallet-path duplicate is safe to fully respond to because the wallet
+  // signature already proved ownership.
+  const isEmailDuplicate = isDuplicate && !hasWalletPart;
+  const responseCode = isEmailDuplicate ? null : referralCode;
+  const responsePosition = isEmailDuplicate ? null : position;
+  return NextResponse.json({
+    ok: true,
+    position: responsePosition,
+    referral_code: responseCode,
+  });
 }
 
 /**
@@ -554,7 +569,16 @@ async function sendConfirmationEmail(
    * send. Best-effort: a missing service-role key or a transient supabase
    * error logs and returns — the backfill script will retry on its next
    * pass. Pulled here (rather than as a separate await chain) so we don't
-   * block the route handler on this update. */
+   * block the route handler on this update.
+   *
+   * The `.eq("email", email)` match is case-sensitive at the storage layer.
+   * Two things make it correct anyway:
+   *   • New rows: this function only runs on `email` already lowercased by
+   *     the route (see emailRaw = ...toLowerCase() above).
+   *   • Pre-existing rows: the schema migration's one-time
+   *     `update waitlist set email = lower(email)` block normalises legacy
+   *     mixed-case rows before they can be touched here.
+   */
   const markEmailed = async () => {
     if (!referralCode) return;
     try {
@@ -565,7 +589,7 @@ async function sendConfirmationEmail(
         .eq("email", email)
         .is("referral_code_emailed_at", null);
     } catch (err) {
-      console.warn("[waitlist] mark emailed failed (non-fatal)", err);
+      console.warn("[waitlist-signup] mark emailed failed (non-fatal)", err);
     }
   };
   const positionLine = position

--- a/app/app/api/waitlist/signup/route.ts
+++ b/app/app/api/waitlist/signup/route.ts
@@ -5,7 +5,11 @@ import bs58 from "bs58";
 import { Resend } from "resend";
 import { Redis } from "@upstash/redis";
 import { Ratelimit } from "@upstash/ratelimit";
-import { getWaitlistSupabase } from "@/lib/waitlist/supabase";
+import {
+  getWaitlistSupabase,
+  getWaitlistServiceSupabase,
+} from "@/lib/waitlist/supabase";
+import { generateReferralCode } from "@/lib/waitlist/referralCode";
 
 export const runtime = "nodejs";
 
@@ -311,29 +315,64 @@ export async function POST(req: Request) {
   }
 
   // ── Insert ──────────────────────────────────────────────────────────────
+  // Generate a fresh referral_code per insert attempt. Two unique constraints
+  // can fire here:
+  //   • waitlist_referral_code_key — astronomically unlikely collision on a
+  //     fresh random 8-char Crockford code; retry with a new one
+  //   • waitlist_pubkey_key or waitlist_email_unique_idx — the same user
+  //     re-submitting; idempotent, mark as duplicate and move on
   const supabase = getWaitlistSupabase();
-  const insertRow: Record<string, unknown> = {
+  const baseRow: Record<string, unknown> = {
     twitter_handle,
     source,
     user_agent: userAgent,
   };
-  if (hasEmail) insertRow.email = emailRaw;
+  if (hasEmail) baseRow.email = emailRaw;
   if (hasWalletPart) {
-    insertRow.pubkey = pubkey;
-    insertRow.signature = signature;
-    insertRow.message = message;
+    baseRow.pubkey = pubkey;
+    baseRow.signature = signature;
+    baseRow.message = message;
   }
 
-  const { error: insertError } = await supabase.from("waitlist").insert(insertRow);
-  // 23505 = unique violation (already on the list) — idempotent. We capture
-  // the duplicate flag here to suppress the confirmation email below: the
-  // pre-fix unconditional send turned every repeat POST with the same email
-  // into another Resend call, which let an attacker flood a single victim's
-  // inbox by replaying the same payload from rotating IPs.
-  const isDuplicate = insertError?.code === "23505";
-  if (insertError && !isDuplicate) {
-    console.error("[waitlist] insert error", insertError);
+  const MAX_CODE_ATTEMPTS = 8;
+  let referralCode: string | null = null;
+  let isDuplicate = false;
+  for (let attempt = 0; attempt < MAX_CODE_ATTEMPTS; attempt++) {
+    const candidate = generateReferralCode();
+    const { error } = await supabase
+      .from("waitlist")
+      .insert({ ...baseRow, referral_code: candidate });
+    if (!error) {
+      referralCode = candidate;
+      break;
+    }
+    if (error.code !== "23505") {
+      console.error("[waitlist] insert error", error);
+      return NextResponse.json({ error: "insert failed" }, { status: 500 });
+    }
+    // 23505 unique violation — distinguish by constraint name in the message.
+    if (error.message?.includes("waitlist_referral_code_key")) {
+      continue; // referral code collision — retry with a fresh code
+    }
+    // User already on the list (pubkey or email duplicate).
+    isDuplicate = true;
+    break;
+  }
+
+  if (!isDuplicate && referralCode === null) {
+    console.error("[waitlist] referral code collision retry exhausted");
     return NextResponse.json({ error: "insert failed" }, { status: 500 });
+  }
+
+  // Wallet-path duplicate: the signature proves the caller owns the pubkey,
+  // so returning the existing code is safe and gives idempotent UX
+  // (refreshes / re-submits show the same code). For the email path, returning
+  // the existing code on duplicate would turn the endpoint into a membership
+  // oracle (anyone could probe "is email X on the list and what's their
+  // code"), so on email-path duplicates we leave referralCode null and the
+  // UI directs the user to their inbox.
+  if (isDuplicate && hasWalletPart && referralCode === null) {
+    referralCode = await readOrAssignReferralCode(pubkey!);
   }
 
   // ── Position lookup ─────────────────────────────────────────────────────
@@ -369,12 +408,73 @@ export async function POST(req: Request) {
     !isDuplicate &&
     (await shouldSendConfirmationEmail(emailRaw!))
   ) {
-    sendConfirmationEmail(emailRaw!, position, hasWalletPart).catch((err) =>
-      console.error("[waitlist] confirmation send failed", err),
+    sendConfirmationEmail(emailRaw!, position, hasWalletPart, referralCode).catch(
+      (err) => console.error("[waitlist] confirmation send failed", err),
     );
   }
 
-  return NextResponse.json({ ok: true, position });
+  // Email-path duplicate: don't leak the existing code in the response — see
+  // the membership-oracle note above. Wallet-path always returns the code.
+  const responseCode = hasWalletPart || !isDuplicate ? referralCode : null;
+  return NextResponse.json({ ok: true, position, referral_code: responseCode });
+}
+
+/**
+ * Read the existing referral_code for a wallet that's already on the list, or
+ * assign one if the row pre-dates the column (backfill miss / race). Uses the
+ * service-role client because anon SELECT is denied for privacy.
+ *
+ * Only safe to call after the caller's signature over `pubkey` has been
+ * verified by the calling route — otherwise this becomes a code-lookup
+ * oracle for any pubkey.
+ */
+async function readOrAssignReferralCode(pubkey: string): Promise<string | null> {
+  let service;
+  try {
+    service = getWaitlistServiceSupabase();
+  } catch (err) {
+    console.error("[waitlist] service client unavailable", err);
+    return null;
+  }
+
+  const { data, error } = await service
+    .from("waitlist")
+    .select("referral_code")
+    .eq("pubkey", pubkey)
+    .maybeSingle();
+  if (error) {
+    console.error("[waitlist] read existing code failed", error);
+    return null;
+  }
+  if (data?.referral_code) return data.referral_code as string;
+
+  // Row exists but has no code — assign one with collision retry. The
+  // `.is("referral_code", null)` predicate makes the update race-safe: if a
+  // concurrent request already assigned a code, we get 0 rows updated and
+  // re-read on the next loop iteration.
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const candidate = generateReferralCode();
+    const { error: updateError, count } = await service
+      .from("waitlist")
+      .update({ referral_code: candidate }, { count: "exact" })
+      .eq("pubkey", pubkey)
+      .is("referral_code", null);
+    if (!updateError && (count ?? 0) > 0) return candidate;
+    if (updateError && updateError.code !== "23505") {
+      console.error("[waitlist] update code failed", updateError);
+      return null;
+    }
+    // Either 23505 (code collision) or 0 rows updated (concurrent assign).
+    // Re-read to pick up the now-assigned code.
+    const { data: reread } = await service
+      .from("waitlist")
+      .select("referral_code")
+      .eq("pubkey", pubkey)
+      .maybeSingle();
+    if (reread?.referral_code) return reread.referral_code as string;
+  }
+  console.error("[waitlist] assign code retries exhausted");
+  return null;
 }
 
 // ─── Email confirmation send via Resend ──────────────────────────────────────
@@ -383,6 +483,7 @@ async function sendConfirmationEmail(
   email: string,
   position: number | null,
   hasWallet: boolean,
+  referralCode: string | null,
 ): Promise<void> {
   const apiKey = process.env.RESEND_API_KEY?.trim();
   if (!apiKey) {
@@ -392,6 +493,21 @@ async function sendConfirmationEmail(
   const resend = new Resend(apiKey);
   const positionLine = position
     ? `<p style="margin: 0 0 16px; font-size: 14px; line-height: 1.5; color: #4A4B62;">You're <strong style="color: #9945FF; font-family: ui-monospace, SFMono-Regular, monospace;">#${position}</strong> on the list.</p>`
+    : "";
+
+  // Referral block — code + share link. Rendered inline as a copy-friendly
+  // monospace pill. The link points at /r/<code>; that route attributes the
+  // referrer for any signup that lands through it (separate follow-up PR).
+  const referralBlock = referralCode
+    ? `<div style="margin: 0 0 20px; padding: 14px 16px; background: #F8F8FC; border: 1px solid #E0E0EC; border-radius: 6px;">
+        <div style="font-family: ui-monospace, SFMono-Regular, monospace; font-size: 10px; letter-spacing: 0.18em; color: #8A8BA8; text-transform: uppercase; margin-bottom: 6px;">YOUR REFERRAL CODE</div>
+        <div style="font-family: ui-monospace, SFMono-Regular, monospace; font-size: 20px; font-weight: 700; letter-spacing: 0.08em; color: #0D0E15;">${referralCode}</div>
+        <div style="margin-top: 10px; font-size: 12.5px; line-height: 1.55; color: #4A4B62;">Share your link: <a href="https://percolator.trade/r/${referralCode}" style="color:#9945FF; text-decoration: underline; font-family: ui-monospace, SFMono-Regular, monospace;">percolator.trade/r/${referralCode}</a></div>
+      </div>`
+    : "";
+
+  const referralText = referralCode
+    ? `\n\nYour referral code: ${referralCode}\nShare your link: https://percolator.trade/r/${referralCode}\n`
     : "";
 
   // If the signup came in with a wallet (Privy email login → embedded
@@ -424,6 +540,7 @@ async function sendConfirmationEmail(
     <div style="padding: 18px 28px 28px;">
       <h1 style="margin: 0 0 12px; font-size: 22px; line-height: 1.2; font-weight: 700; color: #0D0E15;">You're on the list.</h1>
       ${positionLine}
+      ${referralBlock}
       <p style="margin: 0 0 16px; font-size: 14px; line-height: 1.65; color: #4A4B62;">
         Mainnet opens after our external audit clears (targeting Q3 2026). We'll email you here when it does.
       </p>
@@ -438,6 +555,6 @@ async function sendConfirmationEmail(
     You received this because you joined the Percolator waitlist at percolator.trade. If you'd like to be removed, reply with "remove".
   </p>
 </body></html>`,
-    text: `You're on the Percolator waitlist.${position ? `\n\nYou're #${position} on the list.` : ""}\n\nMainnet opens after our external audit clears (targeting Q3 2026). We'll email you here when it does.\n\n${secondaryText}\n\n@percolatortrade · github.com/dcccrypto · percolator.trade/pitch\n\n—\nYou received this because you joined the Percolator waitlist. Reply "remove" to be removed.`,
+    text: `You're on the Percolator waitlist.${position ? `\n\nYou're #${position} on the list.` : ""}${referralText}\nMainnet opens after our external audit clears (targeting Q3 2026). We'll email you here when it does.\n\n${secondaryText}\n\n@percolatortrade · github.com/dcccrypto · percolator.trade/pitch\n\n—\nYou received this because you joined the Percolator waitlist. Reply "remove" to be removed.`,
   });
 }

--- a/app/app/api/waitlist/signup/route.ts
+++ b/app/app/api/waitlist/signup/route.ts
@@ -544,6 +544,25 @@ async function sendConfirmationEmail(
     return;
   }
   const resend = new Resend(apiKey);
+
+  /** Marks the row's `referral_code_emailed_at` once Resend confirms the
+   * send. Best-effort: a missing service-role key or a transient supabase
+   * error logs and returns — the backfill script will retry on its next
+   * pass. Pulled here (rather than as a separate await chain) so we don't
+   * block the route handler on this update. */
+  const markEmailed = async () => {
+    if (!referralCode) return;
+    try {
+      const service = getWaitlistServiceSupabase();
+      await service
+        .from("waitlist")
+        .update({ referral_code_emailed_at: new Date().toISOString() })
+        .eq("email", email)
+        .is("referral_code_emailed_at", null);
+    } catch (err) {
+      console.warn("[waitlist] mark emailed failed (non-fatal)", err);
+    }
+  };
   const positionLine = position
     ? `<p style="margin: 0 0 16px; font-size: 14px; line-height: 1.5; color: #4A4B62;">You're <strong style="color: #9945FF; font-family: ui-monospace, SFMono-Regular, monospace;">#${position}</strong> on the list.</p>`
     : "";
@@ -610,4 +629,8 @@ async function sendConfirmationEmail(
 </body></html>`,
     text: `You're on the Percolator waitlist.${position ? `\n\nYou're #${position} on the list.` : ""}${referralText}\nMainnet opens after our external audit clears (targeting Q3 2026). We'll email you here when it does.\n\n${secondaryText}\n\n@percolatortrade · github.com/dcccrypto · percolator.trade/pitch\n\n—\nYou received this because you joined the Percolator waitlist. Reply "remove" to be removed.`,
   });
+
+  // Resend.send resolves on accept — at that point the message is queued
+  // with Resend. Mark the row so the backfill doesn't re-email this user.
+  await markEmailed();
 }

--- a/app/app/api/waitlist/signup/route.ts
+++ b/app/app/api/waitlist/signup/route.ts
@@ -489,6 +489,14 @@ export async function POST(req: Request) {
     ok: true,
     position: responsePosition,
     referral_code: responseCode,
+    // Wallet-path-only: signals to the UI that this signup was an
+    // idempotent re-submit so it can swap "you're in" copy for "welcome
+    // back". Deliberately NOT set on the email-duplicate branch — a
+    // `returning: true` flag tied to an email would be a clean
+    // membership oracle. The email-flow UI infers "returning" from
+    // referral_code === null instead (which is unavoidable signal we
+    // already accepted).
+    returning: isDuplicate && hasWalletPart,
   });
 }
 

--- a/app/app/api/waitlist/signup/route.ts
+++ b/app/app/api/waitlist/signup/route.ts
@@ -276,46 +276,51 @@ export async function POST(req: Request) {
     );
   }
 
-  // ── Referrer validation (optional field) ────────────────────────────────
-  // Shape check is a cheap pre-filter so the existence-check RPC isn't a
-  // free oracle for "is any 8-char string in the table" — we only consult
-  // it for inputs that could plausibly be a real code.
-  let referredByCode: string | null = null;
-  if (referredByRaw !== null && referredByRaw.length > 0) {
-    if (!isValidReferralCodeShape(referredByRaw)) {
+  // ── Referrer validation (REQUIRED — invite-only) ────────────────────────
+  // The waitlist is invite-only: every new signup must supply a valid
+  // referral code from an existing member. Existing rows from before this
+  // change are grandfathered (their referred_by_code stays NULL). Shape
+  // check is a cheap pre-filter so the existence-check RPC isn't a free
+  // oracle for "is any 8-char string in the table". On idempotent
+  // re-submit, the duplicate branch later silently drops the value
+  // without overwriting any prior referrer — preventing retroactive
+  // self-attribution.
+  if (referredByRaw === null || referredByRaw.length === 0) {
+    return NextResponse.json(
+      {
+        error:
+          "referral code required — Percolator is invite-only. Ask a member for a code or follow @percolatortrade for drops.",
+      },
+      { status: 400 },
+    );
+  }
+  if (!isValidReferralCodeShape(referredByRaw)) {
+    return NextResponse.json(
+      { error: "referral code format invalid" },
+      { status: 400 },
+    );
+  }
+  let referredByCode: string;
+  try {
+    const existsCheck = await getWaitlistSupabase().rpc(
+      "waitlist_referral_code_exists",
+      { p_code: referredByRaw },
+    );
+    if (existsCheck.data !== true) {
       return NextResponse.json(
-        { error: "referral code format invalid" },
+        { error: "referral code not recognised" },
         { status: 400 },
       );
     }
-    try {
-      const existsCheck = await getWaitlistSupabase().rpc(
-        "waitlist_referral_code_exists",
-        { p_code: referredByRaw },
-      );
-      if (existsCheck.data === true) {
-        referredByCode = referredByRaw;
-      } else {
-        return NextResponse.json(
-          { error: "referral code not recognised" },
-          { status: 400 },
-        );
-      }
-    } catch (err) {
-      console.error("[waitlist] referral code existence check failed", err);
-      // Fail closed on RPC failure — better to reject than silently drop
-      // attribution.
-      return NextResponse.json(
-        { error: "referral code check failed, try again" },
-        { status: 503 },
-      );
-    }
-    // Self-referral isn't reachable at insert time: a brand-new signup has
-    // no row yet, so their own code does not exist; the existence check
-    // above already rejected. On idempotent re-submit, the duplicate
-    // branch silently drops referredByCode without overwriting any prior
-    // value — so an attacker can't retroactively attribute themselves to
-    // their own code, even if they later learn it.
+    referredByCode = referredByRaw;
+  } catch (err) {
+    console.error("[waitlist] referral code existence check failed", err);
+    // Fail closed on RPC failure — better to reject than admit signups
+    // bypassing the invite gate during a partial outage.
+    return NextResponse.json(
+      { error: "referral code check failed, try again" },
+      { status: 503 },
+    );
   }
 
   // If we have wallet fields, verify them. (Whether or not email is provided.)
@@ -385,7 +390,7 @@ export async function POST(req: Request) {
     baseRow.signature = signature;
     baseRow.message = message;
   }
-  if (referredByCode) baseRow.referred_by_code = referredByCode;
+  baseRow.referred_by_code = referredByCode;
 
   const MAX_CODE_ATTEMPTS = 8;
   let referralCode: string | null = null;

--- a/app/app/api/waitlist/signup/route.ts
+++ b/app/app/api/waitlist/signup/route.ts
@@ -9,7 +9,10 @@ import {
   getWaitlistSupabase,
   getWaitlistServiceSupabase,
 } from "@/lib/waitlist/supabase";
-import { generateReferralCode } from "@/lib/waitlist/referralCode";
+import {
+  generateReferralCode,
+  isValidReferralCodeShape,
+} from "@/lib/waitlist/referralCode";
 
 export const runtime = "nodejs";
 
@@ -221,6 +224,13 @@ export async function POST(req: Request) {
   const pubkey = typeof b.pubkey === "string" ? b.pubkey : null;
   const signature = typeof b.signature === "string" ? b.signature : null;
   const message = typeof b.message === "string" ? b.message : null;
+  // Referrer code (optional). Normalize to uppercase since codes are
+  // Crockford base32 uppercase by definition; accept lowercase from the
+  // wire so shared URLs that got lowercased somewhere still attribute.
+  const referredByRaw =
+    typeof b.referred_by_code === "string"
+      ? b.referred_by_code.trim().toUpperCase()
+      : null;
 
   // Validate email shape if present
   if (emailRaw !== null) {
@@ -264,6 +274,48 @@ export async function POST(req: Request) {
       { error: "provide an email or a wallet signature" },
       { status: 400 },
     );
+  }
+
+  // ── Referrer validation (optional field) ────────────────────────────────
+  // Shape check is a cheap pre-filter so the existence-check RPC isn't a
+  // free oracle for "is any 8-char string in the table" — we only consult
+  // it for inputs that could plausibly be a real code.
+  let referredByCode: string | null = null;
+  if (referredByRaw !== null && referredByRaw.length > 0) {
+    if (!isValidReferralCodeShape(referredByRaw)) {
+      return NextResponse.json(
+        { error: "referral code format invalid" },
+        { status: 400 },
+      );
+    }
+    try {
+      const existsCheck = await getWaitlistSupabase().rpc(
+        "waitlist_referral_code_exists",
+        { p_code: referredByRaw },
+      );
+      if (existsCheck.data === true) {
+        referredByCode = referredByRaw;
+      } else {
+        return NextResponse.json(
+          { error: "referral code not recognised" },
+          { status: 400 },
+        );
+      }
+    } catch (err) {
+      console.error("[waitlist] referral code existence check failed", err);
+      // Fail closed on RPC failure — better to reject than silently drop
+      // attribution.
+      return NextResponse.json(
+        { error: "referral code check failed, try again" },
+        { status: 503 },
+      );
+    }
+    // Self-referral isn't reachable at insert time: a brand-new signup has
+    // no row yet, so their own code does not exist; the existence check
+    // above already rejected. On idempotent re-submit, the duplicate
+    // branch silently drops referredByCode without overwriting any prior
+    // value — so an attacker can't retroactively attribute themselves to
+    // their own code, even if they later learn it.
   }
 
   // If we have wallet fields, verify them. (Whether or not email is provided.)
@@ -333,6 +385,7 @@ export async function POST(req: Request) {
     baseRow.signature = signature;
     baseRow.message = message;
   }
+  if (referredByCode) baseRow.referred_by_code = referredByCode;
 
   const MAX_CODE_ATTEMPTS = 8;
   let referralCode: string | null = null;

--- a/app/app/r/[code]/page.tsx
+++ b/app/app/r/[code]/page.tsx
@@ -1,0 +1,33 @@
+import { redirect } from "next/navigation";
+import { isValidReferralCodeShape } from "@/lib/waitlist/referralCode";
+
+/**
+ * Share-link landing: /r/<CODE>
+ *
+ * The signup confirmation email and the success card both render share
+ * URLs of the form `percolator.trade/r/AB23XYZ9`. This route forwards
+ * those landings to the waitlist page with the code pre-filled in the
+ * referrer input.
+ *
+ * We do NOT consult the database here to confirm the code exists — that
+ * would turn the route into a public oracle for "is code X a real signup".
+ * The server-side validation on POST /api/waitlist/signup is the
+ * authoritative existence check, and it only runs against an actual
+ * signup attempt (i.e. when someone proves intent by signing or by
+ * confirming a Privy OTP).
+ *
+ * Shape filter only: if the path segment isn't a plausibly-real code,
+ * drop the parameter and forward to the bare waitlist page.
+ */
+export default async function ReferralLandingPage({
+  params,
+}: {
+  params: Promise<{ code: string }>;
+}) {
+  const { code: raw } = await params;
+  const normalized = (raw ?? "").trim().toUpperCase();
+  if (isValidReferralCodeShape(normalized)) {
+    redirect(`/waitlist?referrer=${normalized}#reserve`);
+  }
+  redirect("/waitlist#reserve");
+}

--- a/app/app/waitlist/page.tsx
+++ b/app/app/waitlist/page.tsx
@@ -13,7 +13,11 @@ type State =
   | { kind: "ready" }
   | { kind: "signing" }
   | { kind: "submitting" }
-  | { kind: "done"; position: number | null }
+  | {
+      kind: "done";
+      position: number | null;
+      referralCode: string | null;
+    }
   | { kind: "error"; reason: string };
 
 const MESSAGE_PREFIX = "Joining the Percolator waitlist at ";
@@ -295,7 +299,12 @@ type EmailState =
   | { kind: "awaiting-code"; email: string }
   | { kind: "verifying" }
   | { kind: "submitting"; email: string }
-  | { kind: "done"; email: string; position: number | null }
+  | {
+      kind: "done";
+      email: string;
+      position: number | null;
+      referralCode: string | null;
+    }
   | { kind: "error"; reason: string };
 
 function EmailFlow() {
@@ -390,12 +399,18 @@ function EmailFlow() {
           ok?: boolean;
           error?: string;
           position?: number | null;
+          referral_code?: string | null;
         };
         if (!res.ok || !json.ok) {
           setState({ kind: "error", reason: json.error ?? `HTTP ${res.status}` });
           return;
         }
-        setState({ kind: "done", email: userEmail, position: json.position ?? null });
+        setState({
+          kind: "done",
+          email: userEmail,
+          position: json.position ?? null,
+          referralCode: json.referral_code ?? null,
+        });
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : "submit failed";
         setState({ kind: "error", reason: msg });
@@ -404,6 +419,9 @@ function EmailFlow() {
   }, [state, ready, authenticated, user, twitter, email]);
 
   if (state.kind === "done") {
+    const shareUrl = state.referralCode
+      ? `https://percolator.trade/r/${state.referralCode}`
+      : null;
     return (
       <div className="space-y-4">
         <PromptLine prefix="$" text="email_signup" status="ok" />
@@ -420,9 +438,23 @@ function EmailFlow() {
             </div>
           ) : null}
           <p className="mt-2 text-[12.5px] leading-relaxed text-[var(--text-secondary)]">
-            Confirmation sent to <span className="font-mono text-[var(--accent)]">{state.email}</span>. We also created an embedded Solana wallet under your email — when mainnet opens, the dApp recognises you automatically.
+            {state.referralCode ? (
+              <>
+                Confirmation + referral code sent to{" "}
+                <span className="font-mono text-[var(--accent)]">{state.email}</span>.
+              </>
+            ) : (
+              <>
+                You&apos;re already on the list under{" "}
+                <span className="font-mono text-[var(--accent)]">{state.email}</span>.
+                Your referral code is in the confirmation email we sent on your first signup.
+              </>
+            )}
           </p>
         </div>
+        {state.referralCode && shareUrl ? (
+          <ReferralCard code={state.referralCode} shareUrl={shareUrl} />
+        ) : null}
       </div>
     );
   }
@@ -582,12 +614,17 @@ function SignupFlow() {
         ok?: boolean;
         error?: string;
         position?: number | null;
+        referral_code?: string | null;
       };
       if (!res.ok || !json.ok) {
         setState({ kind: "error", reason: json.error ?? `HTTP ${res.status}` });
         return;
       }
-      setState({ kind: "done", position: json.position ?? null });
+      setState({
+        kind: "done",
+        position: json.position ?? null,
+        referralCode: json.referral_code ?? null,
+      });
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : "sign cancelled";
       setState({ kind: "error", reason: msg });
@@ -602,6 +639,12 @@ function SignupFlow() {
 
   // Done state
   if (state.kind === "done") {
+    const shareUrl = state.referralCode
+      ? `https://percolator.trade/r/${state.referralCode}`
+      : "https://percolator.trade";
+    const shareText = state.referralCode
+      ? `Just joined the @percolatortrade waitlist. Permissionless perp futures on Solana. Use my code ${state.referralCode}: ${shareUrl}`
+      : "Just joined the @percolatortrade waitlist. Permissionless perp futures on Solana. percolator.trade";
     return (
       <div className="space-y-4">
         <PromptLine prefix="$" text="claim_spot" status="ok" />
@@ -630,11 +673,12 @@ function SignupFlow() {
             when mainnet opens.
           </p>
         </div>
+        {state.referralCode ? (
+          <ReferralCard code={state.referralCode} shareUrl={shareUrl} />
+        ) : null}
         <a
           className={ctaSecondary}
-          href={`https://x.com/intent/post?text=${encodeURIComponent(
-            "Just joined the @percolatortrade waitlist. Permissionless perp futures on Solana. percolator.trade",
-          )}`}
+          href={`https://x.com/intent/post?text=${encodeURIComponent(shareText)}`}
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -754,6 +798,57 @@ function StatusErr({ children }: { children: React.ReactNode }) {
   return (
     <div className="rounded-md border border-[var(--short)]/25 bg-[var(--short)]/[0.05] px-3 py-2.5 font-mono text-[12px] leading-relaxed text-[var(--text-secondary)]">
       {children}
+    </div>
+  );
+}
+
+function ReferralCard({ code, shareUrl }: { code: string; shareUrl: string }) {
+  const [copied, setCopied] = useState<"none" | "code" | "link">("none");
+  const copy = async (which: "code" | "link", value: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(which);
+      window.setTimeout(() => setCopied("none"), 1600);
+    } catch {
+      // Clipboard API unavailable (insecure context / older browser).
+      // The values are visible in the UI — user can select-and-copy manually.
+    }
+  };
+  return (
+    <div className="rounded-md border border-[var(--accent)]/25 bg-[var(--accent)]/[0.05] p-3.5">
+      <div className="flex items-center justify-between">
+        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--accent)]">
+          your referral code
+        </span>
+        <button
+          onClick={() => copy("code", code)}
+          className="font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--text-secondary)] transition-colors hover:text-[var(--accent)]"
+        >
+          {copied === "code" ? "copied ✓" : "copy"}
+        </button>
+      </div>
+      <div
+        className="mt-1.5 font-mono text-[22px] font-bold leading-none tracking-[0.08em] text-[var(--text)]"
+        style={{ fontVariantNumeric: "tabular-nums" }}
+      >
+        {code}
+      </div>
+      <div className="mt-3 flex items-center justify-between gap-2">
+        <a
+          href={shareUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="truncate font-mono text-[11.5px] text-[var(--text-secondary)] underline-offset-2 hover:text-[var(--accent)] hover:underline"
+        >
+          {shareUrl.replace(/^https?:\/\//, "")}
+        </a>
+        <button
+          onClick={() => copy("link", shareUrl)}
+          className="shrink-0 font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--text-secondary)] transition-colors hover:text-[var(--accent)]"
+        >
+          {copied === "link" ? "copied ✓" : "copy link"}
+        </button>
+      </div>
     </div>
   );
 }

--- a/app/app/waitlist/page.tsx
+++ b/app/app/waitlist/page.tsx
@@ -28,6 +28,57 @@ function readReferrerFromUrl(): string {
   return raw ? raw.trim().toUpperCase() : "";
 }
 
+type CodeStatus = "empty" | "typing" | "checking" | "valid" | "invalid";
+
+/**
+ * Debounced live-validation against /api/waitlist/check-code.
+ *
+ * The waitlist is invite-only — every signup must supply a referrer code.
+ * Both Wallet and Email flows gate their submit CTA on `status === "valid"`
+ * so a user with a bogus code gets a green/red signal before being sent
+ * through Privy OTP or being asked to sign a wallet message.
+ */
+function useReferralCodeValidation(code: string): { status: CodeStatus } {
+  const [status, setStatus] = useState<CodeStatus>("empty");
+
+  useEffect(() => {
+    if (!code) {
+      setStatus("empty");
+      return;
+    }
+    if (code.length < 8) {
+      // Too short to plausibly be a real code — keep the rest of the form
+      // locked but don't burn a request on every keystroke.
+      setStatus("typing");
+      return;
+    }
+    setStatus("typing");
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      if (cancelled) return;
+      setStatus("checking");
+      try {
+        const res = await fetch(
+          `/api/waitlist/check-code?code=${encodeURIComponent(code)}`,
+          { cache: "no-store" },
+        );
+        const json = (await res.json()) as { valid?: boolean };
+        if (cancelled) return;
+        setStatus(json.valid ? "valid" : "invalid");
+      } catch {
+        if (cancelled) return;
+        setStatus("invalid");
+      }
+    }, 300);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [code]);
+
+  return { status };
+}
+
 type State =
   | { kind: "idle" }
   | { kind: "connecting" }
@@ -184,11 +235,11 @@ function Hero() {
           href="#reserve"
           className="inline-flex items-center gap-2.5 rounded-md bg-[var(--accent)] px-6 py-3 text-[14px] font-semibold text-white shadow-[0_4px_14px_-4px_rgba(153,69,255,0.4)] transition-all duration-200 hover:bg-[var(--accent-muted)] hover:shadow-[0_8px_24px_-6px_rgba(153,69,255,0.55)]"
         >
-          Join The Waitlist
+          Enter your code
           <span aria-hidden className="text-[15px] leading-none">↓</span>
         </a>
         <span className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--text-secondary)]">
-          wallet or email · 30 seconds
+          invite-only · 30 seconds
         </span>
       </div>
     </section>
@@ -334,6 +385,7 @@ function EmailFlow() {
   const [twitter, setTwitter] = useState("");
   const [referredBy, setReferredBy] = useState("");
   const [state, setState] = useState<EmailState>({ kind: "idle" });
+  const { status: refStatus } = useReferralCodeValidation(referredBy);
 
   // Pre-fill the referrer input from /r/<code> landings.
   useEffect(() => {
@@ -548,9 +600,16 @@ function EmailFlow() {
 
   // idle / sending-code
   const sending = state.kind === "sending-code";
+  const formUnlocked = refStatus === "valid";
   return (
     <div className="space-y-3.5">
       <PromptLine prefix="$" text="email_signup" status="idle" />
+      <ReferralCodeInput
+        value={referredBy}
+        onChange={setReferredBy}
+        status={refStatus}
+        disabled={sending}
+      />
       <div className="space-y-1.5">
         <label className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-secondary)]">
           email
@@ -559,11 +618,11 @@ function EmailFlow() {
           type="email"
           autoComplete="email"
           inputMode="email"
-          className="w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 font-mono text-[13px] text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-muted)] focus:border-[var(--accent)]/50 focus:ring-1 focus:ring-[var(--accent)]/15"
+          className="w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 font-mono text-[13px] text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-muted)] focus:border-[var(--accent)]/50 focus:ring-1 focus:ring-[var(--accent)]/15 disabled:opacity-50"
           placeholder="you@domain.com"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          disabled={sending}
+          disabled={sending || !formUnlocked}
           maxLength={254}
         />
       </div>
@@ -572,37 +631,26 @@ function EmailFlow() {
           x_handle (optional)
         </label>
         <input
-          className="w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 font-mono text-[13px] text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-muted)] focus:border-[var(--accent)]/50 focus:ring-1 focus:ring-[var(--accent)]/15"
+          className="w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 font-mono text-[13px] text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-muted)] focus:border-[var(--accent)]/50 focus:ring-1 focus:ring-[var(--accent)]/15 disabled:opacity-50"
           placeholder="@yourhandle"
           value={twitter}
           onChange={(e) => setTwitter(e.target.value)}
-          disabled={sending}
+          disabled={sending || !formUnlocked}
           maxLength={30}
         />
       </div>
-      <div className="space-y-1.5">
-        <label className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-secondary)]">
-          referral code (optional)
-        </label>
-        <input
-          className="w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 font-mono text-[13px] uppercase tracking-[0.08em] text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-muted)] focus:border-[var(--accent)]/50 focus:ring-1 focus:ring-[var(--accent)]/15"
-          placeholder="AB23XYZ9"
-          value={referredBy}
-          onChange={(e) =>
-            setReferredBy(e.target.value.toUpperCase().slice(0, 8))
-          }
-          disabled={sending}
-          maxLength={8}
-          spellCheck={false}
-          autoCapitalize="characters"
-        />
-      </div>
-      <button className={ctaPrimary} onClick={onSendCode} disabled={sending}>
-        {sending ? "Sending code…" : "Send 6-digit code →"}
+      <button
+        className={ctaPrimary}
+        onClick={onSendCode}
+        disabled={sending || !formUnlocked}
+      >
+        {sending
+          ? "Sending code…"
+          : formUnlocked
+            ? "Send 6-digit code →"
+            : "Enter referral code to continue"}
       </button>
-      <p className="font-mono text-[11px] leading-relaxed text-[var(--text-secondary)]">
-        We&apos;ll email you a 6-digit code, then create an embedded Solana wallet under your email so you also get the on-chain dApp gate when mainnet opens.
-      </p>
+      <NoCodeFallback />
     </div>
   );
 }
@@ -622,6 +670,7 @@ function SignupFlow() {
   const [state, setState] = useState<State>({ kind: "idle" });
   const [twitter, setTwitter] = useState("");
   const [referredBy, setReferredBy] = useState("");
+  const { status: refStatus } = useReferralCodeValidation(referredBy);
 
   // Pre-fill the referrer input from /r/<code> landings (forwarded as
   // ?referrer=<code> by the /r route).
@@ -750,46 +799,43 @@ function SignupFlow() {
     state.kind === "submitting"
   ) {
     const busy = state.kind !== "ready";
+    const formUnlocked = refStatus === "valid";
     return (
       <div className="space-y-3.5">
         <PromptLine prefix="$" text={`connected ${pubkey?.slice(0, 6)}…${pubkey?.slice(-4)}`} status="ok" />
+        <ReferralCodeInput
+          value={referredBy}
+          onChange={setReferredBy}
+          status={refStatus}
+          disabled={busy}
+        />
         <div className="space-y-1.5">
           <label className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-secondary)]">
             x_handle (optional)
           </label>
           <input
-            className="w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 font-mono text-[13px] text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-muted)] focus:border-[var(--accent)]/50 focus:ring-1 focus:ring-[var(--accent)]/15"
+            className="w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 font-mono text-[13px] text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-muted)] focus:border-[var(--accent)]/50 focus:ring-1 focus:ring-[var(--accent)]/15 disabled:opacity-50"
             placeholder="@yourhandle"
             value={twitter}
             onChange={(e) => setTwitter(e.target.value)}
-            disabled={busy}
+            disabled={busy || !formUnlocked}
             maxLength={30}
           />
         </div>
-        <div className="space-y-1.5">
-          <label className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-secondary)]">
-            referral code (optional)
-          </label>
-          <input
-            className="w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 font-mono text-[13px] uppercase tracking-[0.08em] text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-muted)] focus:border-[var(--accent)]/50 focus:ring-1 focus:ring-[var(--accent)]/15"
-            placeholder="AB23XYZ9"
-            value={referredBy}
-            onChange={(e) =>
-              setReferredBy(e.target.value.toUpperCase().slice(0, 8))
-            }
-            disabled={busy}
-            maxLength={8}
-            spellCheck={false}
-            autoCapitalize="characters"
-          />
-        </div>
-        <button className={ctaPrimary} onClick={onSign} disabled={busy}>
+        <button
+          className={ctaPrimary}
+          onClick={onSign}
+          disabled={busy || !formUnlocked}
+        >
           {state.kind === "signing"
             ? "Signing in your wallet…"
             : state.kind === "submitting"
               ? "Submitting…"
-              : "Sign & claim spot →"}
+              : formUnlocked
+                ? "Sign & claim spot →"
+                : "Enter referral code to continue"}
         </button>
+        <NoCodeFallback />
       </div>
     );
   }
@@ -807,6 +853,7 @@ function SignupFlow() {
   }
 
   // Idle / connecting
+  const formUnlocked = refStatus === "valid";
   return (
     <div className="space-y-3.5">
       <PromptLine
@@ -814,20 +861,29 @@ function SignupFlow() {
         text={state.kind === "connecting" ? "connecting…" : "connect_wallet"}
         status={state.kind === "connecting" ? "pending" : "idle"}
       />
+      <ReferralCodeInput
+        value={referredBy}
+        onChange={setReferredBy}
+        status={refStatus}
+        disabled={state.kind === "connecting"}
+      />
       <button
         className={ctaPrimary}
         onClick={onConnect}
-        disabled={state.kind === "connecting"}
+        disabled={state.kind === "connecting" || !formUnlocked}
       >
         {state.kind === "connecting"
           ? "Connecting…"
-          : "Connect wallet →"}
+          : formUnlocked
+            ? "Connect wallet →"
+            : "Enter referral code to continue"}
       </button>
       <p className="font-mono text-[11px] leading-relaxed text-[var(--text-secondary)]">
         Phantom · Solflare · Backpack · Jupiter
         <br />
         sign-only · no gas · idempotent
       </p>
+      <NoCodeFallback />
     </div>
   );
 }
@@ -871,6 +927,96 @@ function StatusErr({ children }: { children: React.ReactNode }) {
     <div className="rounded-md border border-[var(--short)]/25 bg-[var(--short)]/[0.05] px-3 py-2.5 font-mono text-[12px] leading-relaxed text-[var(--text-secondary)]">
       {children}
     </div>
+  );
+}
+
+/**
+ * Referral code input with inline live-validation status. Pinned to the top
+ * of both signup flows because the form is gated on it (`status === "valid"`).
+ *
+ * Input is auto-uppercased and filtered to the Crockford base32 alphabet so
+ * users can't type chars that would always fail server-side validation
+ * (I, L, O, U look like 1, 1, 0, V — dropping them is faster feedback than
+ * round-tripping a 400).
+ */
+function ReferralCodeInput({
+  value,
+  onChange,
+  status,
+  disabled,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  status: CodeStatus;
+  disabled?: boolean;
+}) {
+  const indicator = (() => {
+    if (status === "valid")
+      return { color: "var(--cyan)", text: "✓ accepted" };
+    if (status === "invalid")
+      return { color: "var(--short)", text: "× not recognised" };
+    if (status === "checking")
+      return { color: "var(--text-secondary)", text: "checking…" };
+    return null;
+  })();
+  const borderClass =
+    status === "valid"
+      ? "border-[var(--cyan)]/50 focus:border-[var(--cyan)] focus:ring-[var(--cyan)]/20"
+      : status === "invalid"
+        ? "border-[var(--short)]/50 focus:border-[var(--short)] focus:ring-[var(--short)]/20"
+        : "border-[var(--border)] focus:border-[var(--accent)]/50 focus:ring-[var(--accent)]/15";
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between">
+        <label className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-secondary)]">
+          referral code{" "}
+          <span className="text-[var(--accent)]">· required</span>
+        </label>
+        {indicator && (
+          <span
+            className="font-mono text-[10px] uppercase tracking-[0.12em]"
+            style={{ color: indicator.color }}
+          >
+            {indicator.text}
+          </span>
+        )}
+      </div>
+      <input
+        className={`w-full rounded-md border bg-[var(--bg)] px-3 py-2.5 font-mono text-[15px] uppercase tracking-[0.12em] text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-muted)] focus:ring-1 ${borderClass}`}
+        placeholder="AB23XYZ9"
+        value={value}
+        onChange={(e) =>
+          onChange(
+            e.target.value
+              .toUpperCase()
+              .replace(/[^0-9A-HJKMNP-TV-Z]/g, "")
+              .slice(0, 8),
+          )
+        }
+        disabled={disabled}
+        maxLength={8}
+        spellCheck={false}
+        autoCapitalize="characters"
+        autoComplete="off"
+      />
+    </div>
+  );
+}
+
+function NoCodeFallback() {
+  return (
+    <p className="font-mono text-[11px] leading-relaxed text-[var(--text-secondary)]">
+      Don&apos;t have a code?{" "}
+      <a
+        href="https://x.com/percolatortrade"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-[var(--accent)] underline-offset-2 hover:underline"
+      >
+        Follow @percolatortrade
+      </a>{" "}
+      — we drop codes on tweets every so often.
+    </p>
   );
 }
 
@@ -940,17 +1086,17 @@ function SignupSection() {
           className="text-[28px] font-semibold leading-[1.1] tracking-[-0.015em] text-[var(--text)]"
           style={{ fontFamily: "var(--font-heading)" }}
         >
-          Wallet or email.
+          Invite-only.
           <br />
-          Both get the dApp gate.
+          Code required.
         </h2>
         <p className="mt-4 max-w-[420px] text-[14px] leading-[1.65] text-[var(--text-secondary)]">
-          Two paths to the same list. Either connect a Solana wallet and sign once, or drop an email and verify with a 6-digit code — Privy creates an embedded Solana wallet under your email automatically, so the dApp at percolator.trade recognises you when mainnet opens either way.
+          The waitlist is gated. Bring a referral code from an existing member — paste it in, the form unlocks, you finish in under a minute on wallet or email.
         </p>
         <div className="mt-6 space-y-3 font-mono text-[12px] text-[var(--text-secondary)]">
-          <SignupBullet color="cyan">Wallet path: connect Phantom / Solflare / Backpack / Jupiter. Sign once. Done.</SignupBullet>
-          <SignupBullet color="cyan">Email path: 6-digit code → embedded wallet → automatic message sign. Same result.</SignupBullet>
-          <SignupBullet color="cyan">Optional X handle on either path for a backup DM channel.</SignupBullet>
+          <SignupBullet color="cyan">Got a code from someone? Paste it. Form unlocks. Pick wallet or email.</SignupBullet>
+          <SignupBullet color="cyan">Landed via a share link? Code is already pre-filled — just finish.</SignupBullet>
+          <SignupBullet color="cyan">No code yet? Follow @percolatortrade — we drop codes on tweets every so often.</SignupBullet>
         </div>
       </div>
       <div className="flex justify-start lg:justify-end">
@@ -1296,6 +1442,21 @@ function FAQSection() {
       "Why a waitlist instead of letting me trade now?",
       <>
         Pre-audit, public trading puts user funds at risk. We won&apos;t do that. The waitlist is how we line up early adopters and creators so they get priority access the moment audit clears.
+      </>,
+    ],
+    [
+      "Why do I need a referral code?",
+      <>
+        The waitlist is invite-only. We&apos;re keeping it tight while we&apos;re pre-audit — fewer, higher-intent people, less noise. Every member who joins gets a unique code they can share. If you don&apos;t have one yet, follow{" "}
+        <a
+          href="https://x.com/percolatortrade"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[var(--accent)] hover:underline"
+        >
+          @percolatortrade
+        </a>{" "}
+        — we drop codes on tweets every so often.
       </>,
     ],
     [

--- a/app/app/waitlist/page.tsx
+++ b/app/app/waitlist/page.tsx
@@ -7,6 +7,27 @@ import { usePrivyAvailable } from "@/hooks/usePrivySafe";
 import { resolveActiveWallet, usePreferredWallet } from "@/hooks/usePreferredWallet";
 import bs58 from "bs58";
 
+/**
+ * Reads the inbound referrer code from the URL.
+ *
+ * Two sources are accepted:
+ *   • ?referrer=<code> — set by /r/[code]/page.tsx when someone lands on a
+ *     share link. Path-based (/r/AB23XYZ9) is what we generate and share;
+ *     ?referrer is the internal forwarding param.
+ *   • ?ref=<code> — legacy / direct query-string form. The existing source
+ *     handling uses ?ref for analytics, so we deliberately don't read from
+ *     there for attribution; mention it only because the search ordering
+ *     here is "referrer-first".
+ *
+ * Returns the uppercased code or empty string. Shape validation lives on
+ * the server — bad codes are rejected at submit, not at input.
+ */
+function readReferrerFromUrl(): string {
+  if (typeof window === "undefined") return "";
+  const raw = new URL(window.location.href).searchParams.get("referrer");
+  return raw ? raw.trim().toUpperCase() : "";
+}
+
 type State =
   | { kind: "idle" }
   | { kind: "connecting" }
@@ -311,7 +332,14 @@ function EmailFlow() {
   const [email, setEmail] = useState("");
   const [code, setCode] = useState("");
   const [twitter, setTwitter] = useState("");
+  const [referredBy, setReferredBy] = useState("");
   const [state, setState] = useState<EmailState>({ kind: "idle" });
+
+  // Pre-fill the referrer input from /r/<code> landings.
+  useEffect(() => {
+    const fromUrl = readReferrerFromUrl();
+    if (fromUrl) setReferredBy(fromUrl);
+  }, []);
 
   const { sendCode, loginWithCode } = useLoginWithEmail({
     onComplete: () => {
@@ -393,6 +421,7 @@ function EmailFlow() {
             email: userEmail,
             twitter_handle: twitter.trim() || undefined,
             source: source ?? undefined,
+            referred_by_code: referredBy.trim() || undefined,
           }),
         });
         const json = (await res.json()) as {
@@ -416,7 +445,7 @@ function EmailFlow() {
         setState({ kind: "error", reason: msg });
       }
     })();
-  }, [state, ready, authenticated, user, twitter, email]);
+  }, [state, ready, authenticated, user, twitter, email, referredBy]);
 
   if (state.kind === "done") {
     const shareUrl = state.referralCode
@@ -551,6 +580,23 @@ function EmailFlow() {
           maxLength={30}
         />
       </div>
+      <div className="space-y-1.5">
+        <label className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-secondary)]">
+          referral code (optional)
+        </label>
+        <input
+          className="w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 font-mono text-[13px] uppercase tracking-[0.08em] text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-muted)] focus:border-[var(--accent)]/50 focus:ring-1 focus:ring-[var(--accent)]/15"
+          placeholder="AB23XYZ9"
+          value={referredBy}
+          onChange={(e) =>
+            setReferredBy(e.target.value.toUpperCase().slice(0, 8))
+          }
+          disabled={sending}
+          maxLength={8}
+          spellCheck={false}
+          autoCapitalize="characters"
+        />
+      </div>
       <button className={ctaPrimary} onClick={onSendCode} disabled={sending}>
         {sending ? "Sending code…" : "Send 6-digit code →"}
       </button>
@@ -575,6 +621,14 @@ function SignupFlow() {
 
   const [state, setState] = useState<State>({ kind: "idle" });
   const [twitter, setTwitter] = useState("");
+  const [referredBy, setReferredBy] = useState("");
+
+  // Pre-fill the referrer input from /r/<code> landings (forwarded as
+  // ?referrer=<code> by the /r route).
+  useEffect(() => {
+    const fromUrl = readReferrerFromUrl();
+    if (fromUrl) setReferredBy(fromUrl);
+  }, []);
 
   const onConnect = useCallback(() => {
     setState({ kind: "connecting" });
@@ -608,6 +662,7 @@ function SignupFlow() {
           message,
           twitter_handle: twitter.trim() || undefined,
           source: source ?? undefined,
+          referred_by_code: referredBy.trim() || undefined,
         }),
       });
       const json = (await res.json()) as {
@@ -629,7 +684,7 @@ function SignupFlow() {
       const msg = e instanceof Error ? e.message : "sign cancelled";
       setState({ kind: "error", reason: msg });
     }
-  }, [activeWallet, pubkey, signMessage, twitter]);
+  }, [activeWallet, pubkey, signMessage, twitter, referredBy]);
 
   useEffect(() => {
     if (state.kind === "connecting" && ready && authenticated && pubkey) {
@@ -709,6 +764,23 @@ function SignupFlow() {
             onChange={(e) => setTwitter(e.target.value)}
             disabled={busy}
             maxLength={30}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <label className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-secondary)]">
+            referral code (optional)
+          </label>
+          <input
+            className="w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 font-mono text-[13px] uppercase tracking-[0.08em] text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-muted)] focus:border-[var(--accent)]/50 focus:ring-1 focus:ring-[var(--accent)]/15"
+            placeholder="AB23XYZ9"
+            value={referredBy}
+            onChange={(e) =>
+              setReferredBy(e.target.value.toUpperCase().slice(0, 8))
+            }
+            disabled={busy}
+            maxLength={8}
+            spellCheck={false}
+            autoCapitalize="characters"
           />
         </div>
         <button className={ctaPrimary} onClick={onSign} disabled={busy}>

--- a/app/app/waitlist/page.tsx
+++ b/app/app/waitlist/page.tsx
@@ -28,15 +28,25 @@ function readReferrerFromUrl(): string {
   return raw ? raw.trim().toUpperCase() : "";
 }
 
-type CodeStatus = "empty" | "typing" | "checking" | "valid" | "invalid";
+type CodeStatus =
+  | "empty"
+  | "typing"
+  | "checking"
+  | "valid"
+  | "invalid"
+  | "error";
 
 /**
  * Debounced live-validation against /api/waitlist/check-code.
  *
- * The waitlist is invite-only — every signup must supply a referrer code.
- * Both Wallet and Email flows gate their submit CTA on `status === "valid"`
+ * Both Wallet and Email flows gate their submit CTA on `status === "valid"`,
  * so a user with a bogus code gets a green/red signal before being sent
  * through Privy OTP or being asked to sign a wallet message.
+ *
+ * `"invalid"` means the server actively rejected the code (wrong, revoked,
+ * or never existed). `"error"` means we couldn't determine — network
+ * failure, server unreachable — and the UI tells the user to retry rather
+ * than implying the code is bad.
  */
 function useReferralCodeValidation(code: string): { status: CodeStatus } {
   const [status, setStatus] = useState<CodeStatus>("empty");
@@ -53,25 +63,27 @@ function useReferralCodeValidation(code: string): { status: CodeStatus } {
       return;
     }
     setStatus("typing");
-    let cancelled = false;
+    const controller = new AbortController();
     const timer = setTimeout(async () => {
-      if (cancelled) return;
+      if (controller.signal.aborted) return;
       setStatus("checking");
       try {
         const res = await fetch(
           `/api/waitlist/check-code?code=${encodeURIComponent(code)}`,
-          { cache: "no-store" },
+          { cache: "no-store", signal: controller.signal },
         );
         const json = (await res.json()) as { valid?: boolean };
-        if (cancelled) return;
+        if (controller.signal.aborted) return;
         setStatus(json.valid ? "valid" : "invalid");
-      } catch {
-        if (cancelled) return;
-        setStatus("invalid");
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        // AbortError on cleanup — not a real failure
+        if (err instanceof Error && err.name === "AbortError") return;
+        setStatus("error");
       }
     }, 300);
     return () => {
-      cancelled = true;
+      controller.abort();
       clearTimeout(timer);
     };
   }, [code]);
@@ -546,16 +558,20 @@ function EmailFlow() {
       <div className="space-y-3.5">
         <PromptLine prefix="$" text={`code_sent ${state.kind === "awaiting-code" ? state.email : ""}`} status="pending" />
         <div className="space-y-1.5">
-          <label className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-secondary)]">
+          <label
+            htmlFor="otp-code"
+            className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-secondary)]"
+          >
             6-digit code
           </label>
           <input
+            id="otp-code"
             type="text"
             inputMode="numeric"
             pattern="[0-9]*"
             autoComplete="one-time-code"
             className="w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 font-mono text-[15px] tracking-[0.4em] text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-muted)] focus:border-[var(--accent)]/50 focus:ring-1 focus:ring-[var(--accent)]/15"
-            placeholder="••••••"
+            placeholder="000000"
             value={code}
             onChange={(e) => setCode(e.target.value.replace(/\D/g, "").slice(0, 6))}
             disabled={busy}
@@ -611,10 +627,14 @@ function EmailFlow() {
         disabled={sending}
       />
       <div className="space-y-1.5">
-        <label className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-secondary)]">
+        <label
+          htmlFor="signup-email"
+          className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-secondary)]"
+        >
           email
         </label>
         <input
+          id="signup-email"
           type="email"
           autoComplete="email"
           inputMode="email"
@@ -627,10 +647,14 @@ function EmailFlow() {
         />
       </div>
       <div className="space-y-1.5">
-        <label className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-secondary)]">
+        <label
+          htmlFor="x-handle"
+          className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-secondary)]"
+        >
           x_handle (optional)
         </label>
         <input
+          id="x-handle"
           className="w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 font-mono text-[13px] text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-muted)] focus:border-[var(--accent)]/50 focus:ring-1 focus:ring-[var(--accent)]/15 disabled:opacity-50"
           placeholder="@yourhandle"
           value={twitter}
@@ -938,7 +962,15 @@ function StatusErr({ children }: { children: React.ReactNode }) {
  * users can't type chars that would always fail server-side validation
  * (I, L, O, U look like 1, 1, 0, V — dropping them is faster feedback than
  * round-tripping a 400).
+ *
+ * Indicator copy is split four ways so the user can distinguish a wrong
+ * code (red, "× not a valid code") from a network failure (amber,
+ * "× couldn't check — retry"). The status pill is wrapped in `role=status`
+ * + `aria-live=polite` so screen readers announce changes; the input has a
+ * stable `id` matched by the label's `htmlFor` and described by the help
+ * text below.
  */
+let _referralInputCounter = 0;
 function ReferralCodeInput({
   value,
   onChange,
@@ -950,13 +982,24 @@ function ReferralCodeInput({
   status: CodeStatus;
   disabled?: boolean;
 }) {
+  // Stable per-instance id — both wallet and email flows can render this on
+  // the same page, so a hardcoded id would collide.
+  const [inputId] = useState(() => `ref-code-${++_referralInputCounter}`);
+  const helpId = `${inputId}-help`;
+
   const indicator = (() => {
-    if (status === "valid")
-      return { color: "var(--cyan)", text: "✓ accepted" };
+    if (status === "valid") return { color: "var(--cyan)", text: "✓ accepted" };
     if (status === "invalid")
-      return { color: "var(--short)", text: "× not recognised" };
+      return { color: "var(--short)", text: "× not a valid code" };
+    if (status === "error")
+      return { color: "#fbbf24", text: "× couldn't check — retry" };
     if (status === "checking")
       return { color: "var(--text-secondary)", text: "checking…" };
+    if (status === "typing")
+      return {
+        color: "var(--text-secondary)",
+        text: `${value.length}/8`,
+      };
     return null;
   })();
   const borderClass =
@@ -964,24 +1007,31 @@ function ReferralCodeInput({
       ? "border-[var(--cyan)]/50 focus:border-[var(--cyan)] focus:ring-[var(--cyan)]/20"
       : status === "invalid"
         ? "border-[var(--short)]/50 focus:border-[var(--short)] focus:ring-[var(--short)]/20"
-        : "border-[var(--border)] focus:border-[var(--accent)]/50 focus:ring-[var(--accent)]/15";
+        : status === "error"
+          ? "border-[#fbbf24]/50 focus:border-[#fbbf24] focus:ring-[#fbbf24]/20"
+          : "border-[var(--border)] focus:border-[var(--accent)]/50 focus:ring-[var(--accent)]/15";
   return (
     <div className="space-y-1.5">
       <div className="flex items-center justify-between">
-        <label className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-secondary)]">
-          referral code{" "}
-          <span className="text-[var(--accent)]">· required</span>
+        <label
+          htmlFor={inputId}
+          className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-secondary)]"
+        >
+          referral code <span className="text-[var(--accent)]">· required</span>
         </label>
-        {indicator && (
-          <span
-            className="font-mono text-[10px] uppercase tracking-[0.12em]"
-            style={{ color: indicator.color }}
-          >
-            {indicator.text}
-          </span>
-        )}
+        <span
+          role="status"
+          aria-live="polite"
+          className="font-mono text-[10px] uppercase tracking-[0.12em]"
+          style={{ color: indicator?.color ?? "transparent" }}
+        >
+          {indicator?.text ?? "·"}
+        </span>
       </div>
       <input
+        id={inputId}
+        aria-describedby={helpId}
+        aria-invalid={status === "invalid" || status === "error"}
         className={`w-full rounded-md border bg-[var(--bg)] px-3 py-2.5 font-mono text-[15px] uppercase tracking-[0.12em] text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-muted)] focus:ring-1 ${borderClass}`}
         placeholder="AB23XYZ9"
         value={value}
@@ -998,7 +1048,14 @@ function ReferralCodeInput({
         spellCheck={false}
         autoCapitalize="characters"
         autoComplete="off"
+        inputMode="text"
       />
+      <p
+        id={helpId}
+        className="font-mono text-[10px] leading-relaxed text-[var(--text-secondary)]"
+      >
+        8 characters · uses 0–9 and A–Z (no I, L, O, U)
+      </p>
     </div>
   );
 }

--- a/app/app/waitlist/page.tsx
+++ b/app/app/waitlist/page.tsx
@@ -101,6 +101,10 @@ type State =
       kind: "done";
       position: number | null;
       referralCode: string | null;
+      // True when this signup was a no-op idempotent re-submit (wallet
+      // already on the list). Used by the success card to switch from
+      // "you're in" to "welcome back" copy.
+      returning: boolean;
     }
   | { kind: "error"; reason: string };
 
@@ -247,11 +251,11 @@ function Hero() {
           href="#reserve"
           className="inline-flex items-center gap-2.5 rounded-md bg-[var(--accent)] px-6 py-3 text-[14px] font-semibold text-white shadow-[0_4px_14px_-4px_rgba(153,69,255,0.4)] transition-all duration-200 hover:bg-[var(--accent-muted)] hover:shadow-[0_8px_24px_-6px_rgba(153,69,255,0.55)]"
         >
-          Enter your code
+          Reserve your spot
           <span aria-hidden className="text-[15px] leading-none">↓</span>
         </a>
         <span className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--text-secondary)]">
-          invite-only · 30 seconds
+          invite-only · referral code required
         </span>
       </div>
     </section>
@@ -399,10 +403,19 @@ function EmailFlow() {
   const [state, setState] = useState<EmailState>({ kind: "idle" });
   const { status: refStatus } = useReferralCodeValidation(referredBy);
 
-  // Pre-fill the referrer input from /r/<code> landings.
+  // Pre-fill the referrer input from /r/<code> landings, then scrub the
+  // query param so users who copy from the address bar later don't end up
+  // sharing someone else's referrer code instead of their own.
   useEffect(() => {
     const fromUrl = readReferrerFromUrl();
-    if (fromUrl) setReferredBy(fromUrl);
+    if (fromUrl) {
+      setReferredBy(fromUrl);
+      try {
+        window.history.replaceState({}, "", "/waitlist#reserve");
+      } catch {
+        /* SSR / older browsers — non-fatal */
+      }
+    }
   }, []);
 
   const { sendCode, loginWithCode } = useLoginWithEmail({
@@ -626,6 +639,7 @@ function EmailFlow() {
         status={refStatus}
         disabled={sending}
       />
+      <FormGateDivider unlocked={formUnlocked} />
       <div className="space-y-1.5">
         <label
           htmlFor="signup-email"
@@ -697,10 +711,19 @@ function SignupFlow() {
   const { status: refStatus } = useReferralCodeValidation(referredBy);
 
   // Pre-fill the referrer input from /r/<code> landings (forwarded as
-  // ?referrer=<code> by the /r route).
+  // ?referrer=<code> by the /r route). Scrub the query param after so
+  // users who copy from the address bar later don't share someone else's
+  // referrer instead of their own.
   useEffect(() => {
     const fromUrl = readReferrerFromUrl();
-    if (fromUrl) setReferredBy(fromUrl);
+    if (fromUrl) {
+      setReferredBy(fromUrl);
+      try {
+        window.history.replaceState({}, "", "/waitlist#reserve");
+      } catch {
+        /* SSR / older browsers — non-fatal */
+      }
+    }
   }, []);
 
   const onConnect = useCallback(() => {
@@ -743,6 +766,7 @@ function SignupFlow() {
         error?: string;
         position?: number | null;
         referral_code?: string | null;
+        returning?: boolean;
       };
       if (!res.ok || !json.ok) {
         setState({ kind: "error", reason: json.error ?? `HTTP ${res.status}` });
@@ -752,6 +776,7 @@ function SignupFlow() {
         kind: "done",
         position: json.position ?? null,
         referralCode: json.referral_code ?? null,
+        returning: json.returning === true,
       });
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : "sign cancelled";
@@ -773,12 +798,29 @@ function SignupFlow() {
     const shareText = state.referralCode
       ? `Just joined the @percolatortrade waitlist. Permissionless perp futures on Solana. Use my code ${state.referralCode}: ${shareUrl}`
       : "Just joined the @percolatortrade waitlist. Permissionless perp futures on Solana. percolator.trade";
+    const headlineLabel = state.returning ? "✓ welcome back" : "✓ on the list";
+    const subline = state.returning
+      ? "You're already on the list — sharing your code below."
+      : (
+        <>
+          We&apos;ll DM you on X at{" "}
+          <a
+            href="https://x.com/percolatortrade"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[var(--accent)] hover:underline"
+          >
+            @percolatortrade
+          </a>{" "}
+          when mainnet opens.
+        </>
+      );
     return (
       <div className="space-y-4">
         <PromptLine prefix="$" text="claim_spot" status="ok" />
         <div className="rounded-md border border-[var(--cyan)]/25 bg-[var(--cyan)]/[0.05] p-3.5">
           <div className="font-mono text-[11px] uppercase tracking-[0.12em] text-[var(--cyan)]">
-            ✓ on the list
+            {headlineLabel}
           </div>
           {state.position ? (
             <div
@@ -789,16 +831,7 @@ function SignupFlow() {
             </div>
           ) : null}
           <p className="mt-2 text-[12.5px] leading-relaxed text-[var(--text-secondary)]">
-            We&apos;ll DM you on X at{" "}
-            <a
-              href="https://x.com/percolatortrade"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-[var(--accent)] hover:underline"
-            >
-              @percolatortrade
-            </a>{" "}
-            when mainnet opens.
+            {subline}
           </p>
         </div>
         {state.referralCode ? (
@@ -833,11 +866,16 @@ function SignupFlow() {
           status={refStatus}
           disabled={busy}
         />
+        <FormGateDivider unlocked={formUnlocked} />
         <div className="space-y-1.5">
-          <label className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-secondary)]">
+          <label
+            htmlFor="x-handle-wallet"
+            className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-secondary)]"
+          >
             x_handle (optional)
           </label>
           <input
+            id="x-handle-wallet"
             className="w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 font-mono text-[13px] text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-muted)] focus:border-[var(--accent)]/50 focus:ring-1 focus:ring-[var(--accent)]/15 disabled:opacity-50"
             placeholder="@yourhandle"
             value={twitter}
@@ -1074,6 +1112,30 @@ function NoCodeFallback() {
       </a>{" "}
       — we drop codes on tweets every so often.
     </p>
+  );
+}
+
+/**
+ * Visual divider that sits between the referral code input and the rest of
+ * the signup fields. The disabled-state `opacity-50` on the inputs below
+ * isn't strong enough signal on its own — users tabbing into the email
+ * field can't tell why it's inert. This adds an explicit "locked" / next-
+ * step label so the gate is legible.
+ */
+function FormGateDivider({ unlocked }: { unlocked: boolean }) {
+  return (
+    <div className="flex items-center gap-2.5 py-0.5">
+      <span className="h-px flex-1 bg-[var(--border)]" />
+      <span
+        className="font-mono text-[9px] uppercase tracking-[0.18em]"
+        style={{
+          color: unlocked ? "var(--cyan)" : "var(--text-secondary)",
+        }}
+      >
+        {unlocked ? "↓ continue" : "↓ unlocks with valid code"}
+      </span>
+      <span className="h-px flex-1 bg-[var(--border)]" />
+    </div>
   );
 }
 

--- a/app/lib/waitlist/referralCode.ts
+++ b/app/lib/waitlist/referralCode.ts
@@ -1,0 +1,43 @@
+import { randomBytes } from "node:crypto";
+
+/**
+ * Crockford base32 alphabet — 32 characters, intentionally omits:
+ *   I (looks like 1)
+ *   L (looks like 1)
+ *   O (looks like 0)
+ *   U (rarely needed; dropping it also avoids the only English vowel that
+ *      makes short random strings look like accidental words)
+ *
+ * 8 characters → 32^8 ≈ 1.1 trillion codes. Collision is astronomically
+ * unlikely at any realistic waitlist scale; we still retry on the unique
+ * constraint defensively.
+ */
+const CROCKFORD_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+export const REFERRAL_CODE_LENGTH = 8;
+
+export function generateReferralCode(length: number = REFERRAL_CODE_LENGTH): string {
+  if (length < 4 || length > 64) {
+    throw new Error(`generateReferralCode: length must be 4..64, got ${length}`);
+  }
+  const bytes = randomBytes(length);
+  let out = "";
+  for (let i = 0; i < length; i++) {
+    out += CROCKFORD_ALPHABET[bytes[i] % 32];
+  }
+  return out;
+}
+
+const VALID_CHARS = new Set(CROCKFORD_ALPHABET);
+
+/**
+ * Returns true if `s` is a syntactically valid referral code (right length,
+ * right alphabet, uppercase). Does NOT check whether the code exists in the DB.
+ */
+export function isValidReferralCodeShape(s: string): boolean {
+  if (typeof s !== "string" || s.length !== REFERRAL_CODE_LENGTH) return false;
+  for (const ch of s) {
+    if (!VALID_CHARS.has(ch)) return false;
+  }
+  return true;
+}

--- a/app/lib/waitlist/supabase.ts
+++ b/app/lib/waitlist/supabase.ts
@@ -1,24 +1,30 @@
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
 /**
- * Waitlist-specific Supabase client.
+ * Waitlist Supabase clients.
  *
- * Uses a separate Supabase project from the trading frontend so the
- * waitlist landing page on percolator.trade can stay isolated from the
- * trading data on mainnet.percolatorlaunch.com.
+ * The waitlist uses a separate Supabase project from the trading frontend
+ * so the landing page on percolator.trade stays isolated from the trading
+ * data on mainnet.percolatorlaunch.com.
  *
- * Env vars (set on Vercel project, separate from existing
- * NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY):
+ * Env vars (set on the Vercel project, separate from the trading-DB ones):
  *   NEXT_PUBLIC_WAITLIST_SUPABASE_URL
- *   NEXT_PUBLIC_WAITLIST_SUPABASE_KEY  (publishable / anon)
+ *   NEXT_PUBLIC_WAITLIST_SUPABASE_KEY        — publishable / anon
+ *   WAITLIST_SUPABASE_SERVICE_ROLE_KEY       — server-only, bypasses RLS
  *
  * Schema lives at /supabase-waitlist-schema.sql at the repo root.
  */
 
-let _client: SupabaseClient | null = null;
+let _anonClient: SupabaseClient | null = null;
+let _serviceClient: SupabaseClient | null = null;
 
+/**
+ * Anonymous client — used for inserts gated by the "anon insert" RLS policy.
+ * SELECT is denied; reads need either a SECURITY DEFINER RPC or the service
+ * client.
+ */
 export function getWaitlistSupabase(): SupabaseClient {
-  if (_client) return _client;
+  if (_anonClient) return _anonClient;
 
   const url = process.env.NEXT_PUBLIC_WAITLIST_SUPABASE_URL;
   const key = process.env.NEXT_PUBLIC_WAITLIST_SUPABASE_KEY;
@@ -29,9 +35,35 @@ export function getWaitlistSupabase(): SupabaseClient {
     );
   }
 
-  _client = createClient(url, key, {
+  _anonClient = createClient(url, key, {
     auth: { persistSession: false, autoRefreshToken: false },
   });
 
-  return _client;
+  return _anonClient;
+}
+
+/**
+ * Service-role client — bypasses RLS. Server-only.
+ *
+ * Used by the signup route to read back a row's referral_code on idempotent
+ * re-submit (anon SELECT is denied for privacy, so we can't fetch via the
+ * anon client). The key is never exposed to the browser.
+ */
+export function getWaitlistServiceSupabase(): SupabaseClient {
+  if (_serviceClient) return _serviceClient;
+
+  const url = process.env.NEXT_PUBLIC_WAITLIST_SUPABASE_URL;
+  const key = process.env.WAITLIST_SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !key) {
+    throw new Error(
+      "Waitlist service Supabase env vars not set: NEXT_PUBLIC_WAITLIST_SUPABASE_URL and WAITLIST_SUPABASE_SERVICE_ROLE_KEY are required.",
+    );
+  }
+
+  _serviceClient = createClient(url, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  return _serviceClient;
 }

--- a/app/scripts/waitlist-backfill-referral-emails.ts
+++ b/app/scripts/waitlist-backfill-referral-emails.ts
@@ -1,0 +1,180 @@
+/**
+ * One-time backfill: email every existing email-path waitlist signup their
+ * referral code.
+ *
+ * Run once after the referral-code migration lands. Idempotent — re-runs
+ * skip anyone whose `referral_code_emailed_at` is already set, so it's
+ * safe to resume after a partial run.
+ *
+ * Usage:
+ *   cd app
+ *   pnpm tsx scripts/waitlist-backfill-referral-emails.ts            # send
+ *   pnpm tsx scripts/waitlist-backfill-referral-emails.ts --dry-run  # preview
+ *
+ * Env required:
+ *   NEXT_PUBLIC_WAITLIST_SUPABASE_URL
+ *   WAITLIST_SUPABASE_SERVICE_ROLE_KEY
+ *   RESEND_API_KEY
+ *
+ * Pacing: ~4 sends/sec via SEND_DELAY_MS. Resend's default plan ceiling is
+ * 10/sec, so this leaves headroom for the live signup route to keep
+ * sending its own confirmations in parallel without throttling.
+ */
+
+import { Resend } from "resend";
+import { getWaitlistServiceSupabase } from "@/lib/waitlist/supabase";
+
+const FROM = "Percolator <waitlist@percolator.trade>";
+const BATCH_SIZE = 100;
+const SEND_DELAY_MS = 250;
+
+interface Row {
+  id: string;
+  email: string;
+  referral_code: string;
+}
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  if (dryRun) console.log("[backfill] DRY RUN — no emails sent, no rows updated");
+
+  const apiKey = process.env.RESEND_API_KEY?.trim();
+  if (!apiKey && !dryRun) {
+    console.error("RESEND_API_KEY missing");
+    process.exit(1);
+  }
+  const resend = apiKey ? new Resend(apiKey) : null;
+  const supabase = getWaitlistServiceSupabase();
+
+  let processed = 0;
+  let sent = 0;
+  let failed = 0;
+  let updateFailed = 0;
+
+  while (true) {
+    const { data, error } = await supabase
+      .from("waitlist")
+      .select("id, email, referral_code")
+      .not("email", "is", null)
+      .not("referral_code", "is", null)
+      .is("referral_code_emailed_at", null)
+      .limit(BATCH_SIZE);
+    if (error) {
+      console.error("[backfill] select failed", error);
+      process.exit(1);
+    }
+    const rows = (data ?? []) as Row[];
+    if (rows.length === 0) {
+      console.log("[backfill] no more rows");
+      break;
+    }
+
+    for (const row of rows) {
+      processed++;
+      if (dryRun) {
+        console.log(
+          `[backfill] DRY would email ${row.email} (code ${row.referral_code})`,
+        );
+        continue;
+      }
+      try {
+        await resend!.emails.send({
+          from: FROM,
+          to: row.email,
+          subject: "Your Percolator referral code",
+          html: renderHtml(row.referral_code),
+          text: renderText(row.referral_code),
+        });
+        sent++;
+        const { error: updateError } = await supabase
+          .from("waitlist")
+          .update({ referral_code_emailed_at: new Date().toISOString() })
+          .eq("id", row.id);
+        if (updateError) {
+          updateFailed++;
+          console.error(
+            `[backfill] update flag FAILED for ${row.email}`,
+            updateError,
+          );
+        }
+        await sleep(SEND_DELAY_MS);
+      } catch (err) {
+        failed++;
+        console.error(`[backfill] send failed for ${row.email}`, err);
+      }
+    }
+    console.log(
+      `[backfill] batch: processed=${processed} sent=${sent} failed=${failed} updateFailed=${updateFailed}`,
+    );
+  }
+
+  console.log(
+    `[backfill] DONE: processed=${processed} sent=${sent} failed=${failed} updateFailed=${updateFailed}`,
+  );
+  if (updateFailed > 0) {
+    console.warn(
+      "[backfill] some rows were emailed but their flag could not be set —",
+      "re-running will re-email those users. Investigate and either fix the",
+      "flag manually or accept the duplicate before re-running.",
+    );
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function renderText(code: string): string {
+  return `Your Percolator referral code is ready.
+
+You're already on the waitlist — we just shipped referral codes and here's yours:
+
+  ${code}
+
+Share your link: https://percolator.trade/r/${code}
+
+When someone joins through your link, you get attribution. Mainnet opens after our external audit clears (targeting Q3 2026).
+
+@percolatortrade · github.com/dcccrypto
+
+—
+You received this because you joined the Percolator waitlist. Reply "remove" to be removed.`;
+}
+
+function renderHtml(code: string): string {
+  return `<!doctype html>
+<html><head><meta charset="utf-8"><title>Your referral code</title></head>
+<body style="margin:0; padding:32px 16px; background:#F8F8FC; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #0D0E15;">
+  <div style="max-width:560px; margin:0 auto; background:#FFFFFF; border:1px solid #E0E0EC; border-radius:8px; overflow:hidden;">
+    <div style="padding: 28px 28px 0;">
+      <div style="font-family: ui-monospace, SFMono-Regular, monospace; font-size: 11px; letter-spacing: 0.18em; color: #8A8BA8; text-transform: uppercase;">PERCOLATOR · WAITLIST</div>
+    </div>
+    <div style="padding: 18px 28px 28px;">
+      <h1 style="margin: 0 0 12px; font-size: 22px; line-height: 1.2; font-weight: 700; color: #0D0E15;">Your referral code is ready.</h1>
+      <p style="margin: 0 0 16px; font-size: 14px; line-height: 1.65; color: #4A4B62;">
+        You're already on the Percolator waitlist. We just shipped referral codes &mdash; here's yours:
+      </p>
+      <div style="margin: 0 0 20px; padding: 14px 16px; background: #F8F8FC; border: 1px solid #E0E0EC; border-radius: 6px;">
+        <div style="font-family: ui-monospace, SFMono-Regular, monospace; font-size: 10px; letter-spacing: 0.18em; color: #8A8BA8; text-transform: uppercase; margin-bottom: 6px;">YOUR REFERRAL CODE</div>
+        <div style="font-family: ui-monospace, SFMono-Regular, monospace; font-size: 20px; font-weight: 700; letter-spacing: 0.08em; color: #0D0E15;">${code}</div>
+        <div style="margin-top: 10px; font-size: 12.5px; line-height: 1.55; color: #4A4B62;">Share your link: <a href="https://percolator.trade/r/${code}" style="color:#9945FF; text-decoration: underline; font-family: ui-monospace, SFMono-Regular, monospace;">percolator.trade/r/${code}</a></div>
+      </div>
+      <p style="margin: 0 0 16px; font-size: 14px; line-height: 1.65; color: #4A4B62;">
+        When someone joins through your link, you get attribution. Mainnet opens after our external audit clears (targeting Q3 2026).
+      </p>
+      <hr style="margin: 22px 0; border:0; border-top: 1px solid #E0E0EC;">
+      <p style="margin: 0; font-family: ui-monospace, SFMono-Regular, monospace; font-size: 12px; line-height: 1.7; color: #8A8BA8;">
+        <a href="https://x.com/percolatortrade" style="color:#8A8BA8; text-decoration:none;">@percolatortrade</a> &middot; <a href="https://github.com/dcccrypto" style="color:#8A8BA8; text-decoration:none;">github.com/dcccrypto</a>
+      </p>
+    </div>
+  </div>
+  <p style="max-width:560px; margin: 14px auto 0; font-size: 11px; line-height: 1.5; color: #B8B9CC; text-align: center;">
+    You received this because you joined the Percolator waitlist. Reply "remove" to be removed.
+  </p>
+</body></html>`;
+}
+
+main().catch((err) => {
+  console.error("[backfill] fatal", err);
+  process.exit(1);
+});

--- a/app/scripts/waitlist-backfill-referral-emails.ts
+++ b/app/scripts/waitlist-backfill-referral-emails.ts
@@ -112,12 +112,14 @@ async function main() {
     `[backfill] DONE: processed=${processed} sent=${sent} failed=${failed} updateFailed=${updateFailed}`,
   );
   if (updateFailed > 0) {
-    console.warn(
-      "[backfill] some rows were emailed but their flag could not be set —",
-      "re-running will re-email those users. Investigate and either fix the",
-      "flag manually or accept the duplicate before re-running.",
+    console.error(
+      "[backfill] DO NOT RE-RUN until you reconcile flags. Some rows were",
+      "successfully emailed but their referral_code_emailed_at could not be",
+      "set — re-running will email those users a second time.",
     );
+    process.exit(2);
   }
+  if (failed > 0) process.exit(1);
 }
 
 function sleep(ms: number): Promise<void> {

--- a/supabase-waitlist-schema.sql
+++ b/supabase-waitlist-schema.sql
@@ -126,6 +126,18 @@ begin
 end;
 $$;
 
+-- ─── One-time email normalisation ───────────────────────────────────────────
+-- The signup route lowercases inbound emails (route.ts line ~265) and the
+-- unique index is on lower(email) — but rows inserted before that policy
+-- existed may store mixed-case emails. The route's referral-code-emailed
+-- flag update matches on `eq("email", lower(...))`, which silently misses
+-- those pre-normalised rows. Normalise once here so equality matches
+-- always succeed. Idempotent: re-runs are no-ops because the WHERE clause
+-- already excludes already-normalised rows.
+update public.waitlist
+set email = lower(email)
+where email is not null and email != lower(email);
+
 -- ─── Backfill: assign codes to any existing rows that don't have one ────────
 -- Retries on the (astronomically unlikely) unique-violation. Safe to re-run.
 
@@ -202,7 +214,11 @@ as $$
   select pos from ordered where pubkey = p_pubkey;
 $$;
 
-grant execute on function public.waitlist_position(text) to anon;
+-- Revoked from anon (was previously granted): a public membership lookup
+-- by pubkey is a low-grade enumeration vector. The signup route is the only
+-- legitimate caller and it now uses the service-role client. Counter is
+-- still public via waitlist_count() — only individual-row probes are gated.
+revoke execute on function public.waitlist_position(text) from anon;
 
 -- Position lookup by email (case-insensitive). Used when the row was
 -- inserted via the email path.
@@ -220,7 +236,12 @@ as $$
   select pos from ordered where lower(email) = lower(p_email);
 $$;
 
-grant execute on function public.waitlist_position_by_email(text) to anon;
+-- Revoked from anon (was previously granted): an anon caller holding the
+-- publishable key could probe arbitrary emails for membership, turning the
+-- function into a clean yes/no oracle on a PII-grade identifier. The
+-- signup route is the only legitimate caller and uses the service-role
+-- client.
+revoke execute on function public.waitlist_position_by_email(text) from anon;
 
 -- Referral code existence check (boolean only — never returns the row).
 -- Used by future attribution: a visitor lands at /r/<code> and we confirm

--- a/supabase-waitlist-schema.sql
+++ b/supabase-waitlist-schema.sql
@@ -47,6 +47,12 @@ alter table public.waitlist alter column message drop not null;
 alter table public.waitlist add column if not exists email text;
 alter table public.waitlist add column if not exists referral_code text;
 alter table public.waitlist add column if not exists referred_by_code text;
+-- "Have we emailed this user their referral code?" Set by the signup route
+-- after a successful confirmation send (new signups) and by the one-time
+-- backfill script (pre-existing signups). Lets the backfill be re-runnable
+-- safely — anyone already notified is skipped.
+alter table public.waitlist
+  add column if not exists referral_code_emailed_at timestamptz;
 
 -- Unique constraint on referral_code (idempotent via pg_constraint check).
 do $$ begin

--- a/supabase-waitlist-schema.sql
+++ b/supabase-waitlist-schema.sql
@@ -1,54 +1,167 @@
--- Waitlist schema — run this on the new Supabase project
+-- Waitlist schema — run this on the waitlist Supabase project
 -- (project ref: pqivhfxyyswivraymlfu)
 --
+-- This file is idempotent. Run it on a fresh project to bootstrap, or
+-- on the live project to apply pending changes — both reach the same
+-- end state.
+--
 -- Design:
--- - Anonymous users insert via the publishable key (RLS allows insert only)
+-- - Anonymous users insert via the publishable key (RLS allows insert only).
 -- - Server-side route /api/waitlist/signup verifies the wallet signature
 --   BEFORE inserting, so RLS-allowed inserts are gated on real ownership.
 -- - SELECT is denied to anon (privacy: don't leak the email-list-equivalent).
--- - Counter is exposed via a SECURITY DEFINER function callable by anon.
+-- - Counter + position lookups + referral-code presence checks are exposed
+--   via SECURITY DEFINER functions callable by anon.
 --
--- High-intent signal: each row is keyed by Solana wallet pubkey + a
--- signed message proving ownership.  Email is optional and not used
--- in the MVP.
+-- Inputs we accept: wallet-only (pubkey + signature + message), email-only,
+-- or both (Privy email login → embedded wallet → signed message). At least
+-- one of pubkey or email must be present.
 
--- Extensions
 create extension if not exists "pgcrypto";
 
--- Main table
+-- ─── Main table ──────────────────────────────────────────────────────────────
+
 create table if not exists public.waitlist (
   id uuid primary key default gen_random_uuid(),
-  pubkey text not null unique,
-  signature text not null,
-  message text not null,
+  pubkey text unique,
+  email text,
+  signature text,
+  message text,
   twitter_handle text,
   source text,
   user_agent text,
   ip_hash text,
-  created_at timestamptz not null default now()
+  referral_code text unique,
+  created_at timestamptz not null default now(),
+  constraint waitlist_pubkey_or_email check (pubkey is not null or email is not null)
 );
+
+-- Idempotent reconciliation for projects bootstrapped before the email path
+-- existed (pubkey/signature/message were originally NOT NULL).
+alter table public.waitlist alter column pubkey drop not null;
+alter table public.waitlist alter column signature drop not null;
+alter table public.waitlist alter column message drop not null;
+
+-- Idempotent column adds (for projects that pre-date these columns).
+alter table public.waitlist add column if not exists email text;
+alter table public.waitlist add column if not exists referral_code text;
+
+-- Unique constraint on referral_code (idempotent via pg_constraint check).
+do $$ begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'waitlist_referral_code_key'
+      and conrelid = 'public.waitlist'::regclass
+  ) then
+    alter table public.waitlist
+      add constraint waitlist_referral_code_key unique (referral_code);
+  end if;
+end $$;
+
+-- pubkey-or-email check constraint (idempotent).
+do $$ begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'waitlist_pubkey_or_email'
+      and conrelid = 'public.waitlist'::regclass
+  ) then
+    alter table public.waitlist
+      add constraint waitlist_pubkey_or_email
+      check (pubkey is not null or email is not null);
+  end if;
+end $$;
+
+-- ─── Indexes ─────────────────────────────────────────────────────────────────
 
 create index if not exists waitlist_created_at_idx
   on public.waitlist (created_at desc);
 
--- Row-level security
+-- Case-insensitive uniqueness for emails (partial — pubkey-only rows have NULL email).
+create unique index if not exists waitlist_email_unique_idx
+  on public.waitlist (lower(email))
+  where email is not null;
+
+-- Lookup index for referral attribution (partial — older rows may have NULL).
+create index if not exists waitlist_referral_code_idx
+  on public.waitlist (referral_code)
+  where referral_code is not null;
+
+-- ─── Crockford base32 code generator ────────────────────────────────────────
+-- Alphabet excludes I, L, O, U — avoids visual confusion (1/I, 0/O) and the
+-- only English vowel that turns short random strings into accidental words.
+-- 8 characters ≈ 1.1 trillion codes; way more than the waitlist will ever hold.
+
+create or replace function public.gen_crockford_code(n int)
+returns text
+language plpgsql
+as $$
+declare
+  alphabet constant text := '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+  result text := '';
+  bytes bytea;
+  i int;
+begin
+  if n < 1 or n > 64 then
+    raise exception 'gen_crockford_code: n must be 1..64';
+  end if;
+  bytes := gen_random_bytes(n);
+  for i in 0..(n - 1) loop
+    result := result || substr(alphabet, (get_byte(bytes, i) % 32) + 1, 1);
+  end loop;
+  return result;
+end;
+$$;
+
+-- ─── Backfill: assign codes to any existing rows that don't have one ────────
+-- Retries on the (astronomically unlikely) unique-violation. Safe to re-run.
+
+do $$
+declare
+  r record;
+  attempt int;
+  code text;
+begin
+  for r in select id from public.waitlist where referral_code is null loop
+    attempt := 0;
+    loop
+      attempt := attempt + 1;
+      if attempt > 8 then
+        raise exception 'referral code backfill: 8 collisions for row %, aborting', r.id;
+      end if;
+      code := public.gen_crockford_code(8);
+      begin
+        update public.waitlist set referral_code = code where id = r.id;
+        exit;
+      exception when unique_violation then
+        -- collision — try a fresh code
+        continue;
+      end;
+    end loop;
+  end loop;
+end;
+$$;
+
+-- ─── Row-level security ──────────────────────────────────────────────────────
+
 alter table public.waitlist enable row level security;
 
--- Drop existing policies if re-running this script
 drop policy if exists "anon insert" on public.waitlist;
 drop policy if exists "deny select" on public.waitlist;
 
--- Anon can insert (server-side route validates the signature first)
+-- Anon can insert (server-side route validates the signature first).
 create policy "anon insert"
   on public.waitlist
   for insert
   to anon
   with check (true);
 
--- Anon cannot read individual rows (privacy)
--- (intentionally no select policy = deny by default under RLS)
+-- Anon cannot read individual rows. Intentionally no select policy →
+-- deny by default under RLS. Public access goes through the SECURITY
+-- DEFINER functions below.
 
--- Public counter via SECURITY DEFINER function
+-- ─── Public functions (anon-callable, SECURITY DEFINER) ──────────────────────
+
+-- Total count (used by the status pill, not the public counter).
 create or replace function public.waitlist_count()
 returns bigint
 language sql
@@ -60,7 +173,7 @@ $$;
 
 grant execute on function public.waitlist_count() to anon;
 
--- Position lookup for a given pubkey (for "you're #N on the list" UX)
+-- Position lookup by pubkey ("you're #N on the list").
 create or replace function public.waitlist_position(p_pubkey text)
 returns bigint
 language sql
@@ -70,12 +183,49 @@ as $$
   with ordered as (
     select pubkey, row_number() over (order by created_at asc) as pos
     from public.waitlist
+    where pubkey is not null
   )
   select pos from ordered where pubkey = p_pubkey;
 $$;
 
 grant execute on function public.waitlist_position(text) to anon;
 
--- Verification probe (for debugging the schema is right)
+-- Position lookup by email (case-insensitive). Used when the row was
+-- inserted via the email path.
+create or replace function public.waitlist_position_by_email(p_email text)
+returns bigint
+language sql
+security definer
+set search_path = public
+as $$
+  with ordered as (
+    select email, row_number() over (order by created_at asc) as pos
+    from public.waitlist
+    where email is not null
+  )
+  select pos from ordered where lower(email) = lower(p_email);
+$$;
+
+grant execute on function public.waitlist_position_by_email(text) to anon;
+
+-- Referral code existence check (boolean only — never returns the row).
+-- Used by future attribution: a visitor lands at /r/<code> and we confirm
+-- the code is real without exposing who owns it.
+create or replace function public.waitlist_referral_code_exists(p_code text)
+returns boolean
+language sql
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1 from public.waitlist where referral_code = p_code
+  );
+$$;
+
+grant execute on function public.waitlist_referral_code_exists(text) to anon;
+
+-- ─── Verification probes ─────────────────────────────────────────────────────
 -- select count(*) from public.waitlist;
 -- select public.waitlist_count();
+-- select count(*) from public.waitlist where referral_code is null;
+-- select public.gen_crockford_code(8);

--- a/supabase-waitlist-schema.sql
+++ b/supabase-waitlist-schema.sql
@@ -32,6 +32,7 @@ create table if not exists public.waitlist (
   user_agent text,
   ip_hash text,
   referral_code text unique,
+  referred_by_code text,
   created_at timestamptz not null default now(),
   constraint waitlist_pubkey_or_email check (pubkey is not null or email is not null)
 );
@@ -45,6 +46,7 @@ alter table public.waitlist alter column message drop not null;
 -- Idempotent column adds (for projects that pre-date these columns).
 alter table public.waitlist add column if not exists email text;
 alter table public.waitlist add column if not exists referral_code text;
+alter table public.waitlist add column if not exists referred_by_code text;
 
 -- Unique constraint on referral_code (idempotent via pg_constraint check).
 do $$ begin
@@ -85,6 +87,12 @@ create unique index if not exists waitlist_email_unique_idx
 create index if not exists waitlist_referral_code_idx
   on public.waitlist (referral_code)
   where referral_code is not null;
+
+-- Reverse-lookup index for the leaderboard: count signups grouped by who
+-- referred them. Partial — most rows have NULL (joined without a referrer).
+create index if not exists waitlist_referred_by_code_idx
+  on public.waitlist (referred_by_code)
+  where referred_by_code is not null;
 
 -- ─── Crockford base32 code generator ────────────────────────────────────────
 -- Alphabet excludes I, L, O, U — avoids visual confusion (1/I, 0/O) and the
@@ -223,6 +231,80 @@ as $$
 $$;
 
 grant execute on function public.waitlist_referral_code_exists(text) to anon;
+
+-- ─── Operator-only: referral leaderboard ────────────────────────────────────
+-- WHO USES THIS: only the operator, via the service-role key (server-side
+--   or `psql` with the project's database URL). Never callable by anon or
+--   authenticated users — anon is the role the publishable key maps to,
+--   and exposing the full pubkey/email columns would defeat the privacy
+--   posture of the rest of the schema (no anon SELECT on rows).
+--
+-- HOW TO QUERY:
+--   • Supabase SQL editor (logged in as project owner):
+--       select * from public.waitlist_referral_leaderboard();
+--   • psql with the DB URL:
+--       psql "$WAITLIST_DB_URL" -c \
+--         'select * from public.waitlist_referral_leaderboard() limit 50;'
+--   • Server-side from Node:
+--       supabase.rpc("waitlist_referral_leaderboard")
+--     where `supabase` was constructed with WAITLIST_SUPABASE_SERVICE_ROLE_KEY
+--     (see app/lib/waitlist/supabase.ts → getWaitlistServiceSupabase).
+--
+-- WHY IT'S TAMPER-RESISTANT:
+--   • referred_by_code is set at INSERT time by the signup route. The route
+--     never UPDATEs it afterwards.
+--   • The RLS policy on the waitlist table grants anon INSERT only — no
+--     UPDATE or DELETE policy exists, so anon cannot mutate the column.
+--   • This function reads `count(*)` of rows that reference each code; an
+--     attacker would need INSERT access to a row with a chosen
+--     referred_by_code (which they have — but their inserted row is then
+--     subject to the same RLS, and the route validates `referred_by_code`
+--     points at a real code before accepting). They cannot decrement, edit
+--     ownership of, or hide existing referrals.
+--   • Service role bypasses RLS but the service-role key lives in operator
+--     env (Vercel project + local .env), not in the browser bundle.
+create or replace function public.waitlist_referral_leaderboard()
+returns table (
+  referral_code text,
+  owner_pubkey text,
+  owner_email text,
+  twitter_handle text,
+  signups_referred bigint,
+  joined_at timestamptz
+)
+language sql
+security definer
+set search_path = public
+as $$
+  select
+    w.referral_code,
+    w.pubkey         as owner_pubkey,
+    w.email          as owner_email,
+    w.twitter_handle,
+    coalesce(c.cnt, 0) as signups_referred,
+    w.created_at     as joined_at
+  from public.waitlist w
+  left join (
+    select referred_by_code, count(*) as cnt
+    from public.waitlist
+    where referred_by_code is not null
+    group by referred_by_code
+  ) c on c.referred_by_code = w.referral_code
+  where w.referral_code is not null
+  order by signups_referred desc, w.created_at asc;
+$$;
+
+-- Lock down: NOT callable by anon or authenticated. Service role only.
+revoke all on function public.waitlist_referral_leaderboard() from public;
+revoke all on function public.waitlist_referral_leaderboard() from anon;
+-- The `authenticated` role exists on Supabase projects with auth turned on;
+-- the revoke is a no-op on projects that don't have it, so it's safe to
+-- include unconditionally.
+do $$ begin
+  if exists (select 1 from pg_roles where rolname = 'authenticated') then
+    execute 'revoke all on function public.waitlist_referral_leaderboard() from authenticated';
+  end if;
+end $$;
 
 -- ─── Verification probes ─────────────────────────────────────────────────────
 -- select count(*) from public.waitlist;


### PR DESCRIPTION
Supersedes #2163 (which couldn't merge after the history rewrite invalidated the fork's parent SHAs).

Squid's 8 waitlist commits cherry-picked onto current main, preserving full authorship and dates. One small follow-up fixes a source-text assertion that broke when the route was refactored on Squid's branch (test loosened, behavior identical).

## Operator prerequisites (confirmed by repo owner)
- ✅ `supabase-waitlist-schema.sql` applied to the waitlist Supabase project
- ✅ Vercel env vars set (\`WAITLIST_SUPABASE_SERVICE_ROLE_KEY\`, \`NEXT_PUBLIC_WAITLIST_SUPABASE_URL\`, \`NEXT_PUBLIC_WAITLIST_SUPABASE_KEY\`)

## Tests
\`\`\`
pnpm vitest run __tests__/lib/waitlist-referral-code.test.ts \\
                __tests__/api/waitlist-signup-shape.test.ts \\
                __tests__/api/waitlist-signup-email-abuse.test.ts
# 17 passed
pnpm tsc --noEmit  # clean
\`\`\`

## Commits (8 cherry-picks + 1 test fix)
1. \`feat(waitlist): schema — referral_code column, generator, backfill\`
2. \`feat(waitlist): auto-generate referral code per signup, surface in email + UI\`
3. \`feat(waitlist): referral attribution — input, /r/[code] route, leaderboard fn\`
4. \`feat(waitlist): one-time email blast to backfill referral codes to existing signups\`
5. \`feat(waitlist): invite-only — referral code required to join\`
6. \`fix(waitlist): membership-oracle, case-sensitive email match, backfill exit code\`
7. \`fix(waitlist): clearer error states + a11y on the referral code input\`
8. \`polish(waitlist): hero CTA, URL scrub, locked-state affordance, welcome-back\`
9. \`test(waitlist): loosen isDuplicate source assertion to match retry-loop form\`

Closes #2163

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Made the waitlist invite-only; referral codes are now required to join
  * Added unique referral codes for each signup, enabling users to share and invite others
  * New referral landing page for direct access via shared referral links
  * Extended signup to support email-based registration in addition to wallet signups
  * Added referral leaderboard to track and reward community contributors
  * Enhanced confirmation emails to include referral codes and sharing options

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dcccrypto/percolator-launch/pull/2171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->