### PR TITLE
feat(waitlist): admin-only referral leaderboard + personal invite counter

### DIFF
--- a/app/app/admin/page.tsx
+++ b/app/app/admin/page.tsx
@@ -6,6 +6,7 @@ import { createBrowserClient } from "@supabase/ssr";
 import type { User } from "@supabase/supabase-js";
 import { OracleAdminSection } from "@/components/admin/OracleAdminSection";
 import { OracleFreshnessSection } from "@/components/admin/OracleFreshnessSection";
+import { WaitlistLeaderboardSection } from "@/components/admin/WaitlistLeaderboardSection";
 
 function getAuthClient() {
   return createBrowserClient(
@@ -720,6 +721,11 @@ export default function AdminDashboard() {
           )}
         </div>
       </div>
+
+      {/* ══════════════════════════════════════════════════════════════════════
+          WAITLIST REFERRAL LEADERBOARD
+      ══════════════════════════════════════════════════════════════════════ */}
+      <WaitlistLeaderboardSection />
 
       {/* ══════════════════════════════════════════════════════════════════════
           ORACLE FRESHNESS CHECK

--- a/app/app/api/admin/waitlist/leaderboard/route.ts
+++ b/app/app/api/admin/waitlist/leaderboard/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+import { getWaitlistServiceSupabase } from "@/lib/waitlist/supabase";
+import { requireAdminSession } from "@/lib/admin-session";
+
+export const runtime = "nodejs";
+// Admin dashboard: always fresh on each visit, no caching. The leaderboard
+// is the operator's view of viral attribution and needs to reflect the
+// actual current state (e.g. when investigating a sudden spike).
+export const dynamic = "force-dynamic";
+
+interface LeaderboardRow {
+  referral_code: string | null;
+  owner_pubkey: string | null;
+  owner_email: string | null;
+  twitter_handle: string | null;
+  signups_referred: number | string;
+  joined_at: string;
+}
+
+interface AdminLeaderboardEntry {
+  rank: number;
+  referralCode: string;
+  ownerPubkey: string | null;
+  ownerEmail: string | null;
+  twitterHandle: string | null;
+  signupsReferred: number;
+  joinedAt: string;
+}
+
+/**
+ * GET /api/admin/waitlist/leaderboard
+ *
+ * Admin-only. Returns the full referral leaderboard including PII
+ * (email, pubkey) for attribution review. Backed by the SECURITY
+ * DEFINER `waitlist_referral_leaderboard()` RPC which is itself
+ * service-role-only at the DB layer — this route adds the operator-
+ * identity check on top.
+ *
+ * Why this isn't public:
+ *  - emails and full pubkeys are PII
+ *  - even a sanitised public version creates a competitive surface
+ *    (people gaming for visibility) before we want that loop running
+ *  - the leaderboard is an operator tool for now, not a user-facing one
+ */
+export async function GET() {
+  const auth = await requireAdminSession();
+  if (!auth.ok) return auth.response;
+
+  try {
+    const supabase = getWaitlistServiceSupabase();
+    const { data, error } = await supabase.rpc("waitlist_referral_leaderboard");
+    if (error) {
+      console.error("[admin/waitlist/leaderboard] rpc error", error);
+      return NextResponse.json({ error: "Failed to load leaderboard" }, { status: 500 });
+    }
+    if (!Array.isArray(data)) {
+      return NextResponse.json({ leaderboard: [] });
+    }
+    const rows = (data as LeaderboardRow[])
+      .filter((r) => {
+        const n = typeof r.signups_referred === "string"
+          ? Number.parseInt(r.signups_referred, 10)
+          : r.signups_referred;
+        return r.referral_code && Number.isFinite(n) && n > 0;
+      })
+      .map((r, i): AdminLeaderboardEntry => {
+        const n = typeof r.signups_referred === "string"
+          ? Number.parseInt(r.signups_referred, 10)
+          : r.signups_referred;
+        return {
+          rank: i + 1,
+          referralCode: r.referral_code as string,
+          ownerPubkey: r.owner_pubkey,
+          ownerEmail: r.owner_email,
+          twitterHandle: r.twitter_handle,
+          signupsReferred: Number.isFinite(n) ? Number(n) : 0,
+          joinedAt: r.joined_at,
+        };
+      });
+
+    return NextResponse.json({ leaderboard: rows });
+  } catch (err) {
+    console.error("[admin/waitlist/leaderboard] unexpected", err);
+    return NextResponse.json({ error: "Unexpected error" }, { status: 500 });
+  }
+}

--- a/app/app/api/waitlist/my-referrals/route.ts
+++ b/app/app/api/waitlist/my-referrals/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { getWaitlistServiceSupabase } from "@/lib/waitlist/supabase";
+import { isValidReferralCodeShape } from "@/lib/waitlist/referralCode";
+
+export const runtime = "nodejs";
+// Short cache — users will be refreshing this after sharing to watch
+// the count tick up. 15s balances "feels live" with "doesn't melt the
+// DB if a thousand people open the page".
+export const revalidate = 15;
+
+/**
+ * GET /api/waitlist/my-referrals?code=AB23XYZ9
+ *
+ * Returns { count: number } — the number of waitlist signups that listed
+ * this referral_code as their referred_by_code.
+ *
+ * Public by design: referral codes are publicly shared (that's the
+ * entire point), and the only signal exposed here is a count of how
+ * many people used a given code. No PII, no membership oracle on
+ * arbitrary identifiers — just a count keyed on a value the holder
+ * has already broadcast.
+ *
+ * Failure mode is { count: 0 } rather than 500 so the ReferralCard
+ * can degrade silently if the API is briefly unavailable.
+ */
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const raw = url.searchParams.get("code");
+  if (!raw) {
+    return NextResponse.json({ count: 0, reason: "missing" }, { status: 400 });
+  }
+  const code = raw.trim().toUpperCase();
+  if (!isValidReferralCodeShape(code)) {
+    return NextResponse.json({ count: 0, reason: "shape" });
+  }
+  try {
+    const supabase = getWaitlistServiceSupabase();
+    const { count, error } = await supabase
+      .from("waitlist")
+      .select("id", { count: "exact", head: true })
+      .eq("referred_by_code", code);
+    if (error) {
+      console.error("[my-referrals] query error", error);
+      return NextResponse.json({ count: 0, reason: "query" });
+    }
+    return NextResponse.json({ count: count ?? 0 });
+  } catch (err) {
+    console.error("[my-referrals] unexpected", err);
+    return NextResponse.json({ count: 0, reason: "unexpected" });
+  }
+}

--- a/app/app/waitlist/page.tsx
+++ b/app/app/waitlist/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import useSWR from "swr";
 import { usePrivy, useLoginWithEmail } from "@privy-io/react-auth";
 import { useWallets, useSignMessage } from "@privy-io/react-auth/solana";
 import { usePrivyAvailable } from "@/hooks/usePrivySafe";
@@ -1151,6 +1152,17 @@ function ReferralCard({ code, shareUrl }: { code: string; shareUrl: string }) {
       // The values are visible in the UI — user can select-and-copy manually.
     }
   };
+
+  // Personal referral count. Polls every 30s so the user can paste their
+  // link in Discord, refresh, and watch the number climb. Failure is
+  // silent: the row hides rather than showing a confusing zero state.
+  const { data: countData } = useSWR<{ count: number }>(
+    code ? `/api/waitlist/my-referrals?code=${encodeURIComponent(code)}` : null,
+    swrFetcher,
+    { refreshInterval: 30_000, revalidateOnFocus: true, dedupingInterval: 5_000 },
+  );
+  const referralCount = countData?.count ?? null;
+
   return (
     <div className="rounded-md border border-[var(--accent)]/25 bg-[var(--accent)]/[0.05] p-3.5">
       <div className="flex items-center justify-between">
@@ -1186,9 +1198,25 @@ function ReferralCard({ code, shareUrl }: { code: string; shareUrl: string }) {
           {copied === "link" ? "copied ✓" : "copy link"}
         </button>
       </div>
+      {referralCount !== null && (
+        <div className="mt-3 flex items-center justify-between border-t border-[var(--accent)]/15 pt-3">
+          <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-dim)]">
+            joined with your code
+          </span>
+          <span
+            className="font-mono text-[14px] font-bold text-[var(--accent)]"
+            style={{ fontVariantNumeric: "tabular-nums" }}
+          >
+            {referralCount.toLocaleString()}
+          </span>
+        </div>
+      )}
     </div>
   );
 }
+
+const swrFetcher = (url: string) =>
+  fetch(url).then((r) => (r.ok ? r.json() : Promise.reject(r.status)));
 
 // ============================================================================
 // SIGNUP SECTION — anchored card, the actual reservation step

--- a/app/components/admin/WaitlistLeaderboardSection.tsx
+++ b/app/components/admin/WaitlistLeaderboardSection.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { useState } from "react";
+import useSWR from "swr";
+
+const card = "rounded-none bg-[var(--panel-bg)] border border-[var(--border)]";
+const labelStyle =
+  "text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-muted)]";
+
+function SectionHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-3 mb-3">
+      <div className={labelStyle}>{children}</div>
+      <div className="flex-1 h-px bg-[var(--border)]" />
+    </div>
+  );
+}
+
+interface AdminLeaderboardEntry {
+  rank: number;
+  referralCode: string;
+  ownerPubkey: string | null;
+  ownerEmail: string | null;
+  twitterHandle: string | null;
+  signupsReferred: number;
+  joinedAt: string;
+}
+
+const fetcher = async (url: string) => {
+  const res = await fetch(url, { credentials: "include" });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+};
+
+function truncatePubkey(pubkey: string | null): string {
+  if (!pubkey) return "—";
+  if (pubkey.length <= 12) return pubkey;
+  return `${pubkey.slice(0, 6)}…${pubkey.slice(-4)}`;
+}
+
+function formatDate(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  } catch {
+    return "—";
+  }
+}
+
+/**
+ * Operator view of who's brought in the most waitlist signups.
+ *
+ * Backed by /api/admin/waitlist/leaderboard (requireAdminSession +
+ * service-role read of waitlist_referral_leaderboard()). Returns full
+ * identifiers — referral_code, pubkey, email, twitter_handle — so the
+ * operator can correlate attribution with on-chain or off-chain
+ * activity for that referrer.
+ *
+ * This is NOT a public-facing leaderboard. Adding one of those needs
+ * a sanitisation layer + sign-off on the gamification surface.
+ */
+export function WaitlistLeaderboardSection() {
+  const [limit, setLimit] = useState<10 | 25 | 100>(25);
+  const { data, error, isLoading, mutate } = useSWR<{
+    leaderboard: AdminLeaderboardEntry[];
+  }>("/api/admin/waitlist/leaderboard", fetcher, {
+    refreshInterval: 30_000,
+    revalidateOnFocus: true,
+  });
+
+  const rows = (data?.leaderboard ?? []).slice(0, limit);
+  const totalReferrers = data?.leaderboard.length ?? 0;
+  const totalSignupsAttributed = (data?.leaderboard ?? []).reduce(
+    (sum, r) => sum + r.signupsReferred,
+    0,
+  );
+
+  return (
+    <div className="mb-8">
+      <SectionHeader>Waitlist Referral Leaderboard</SectionHeader>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
+        <div className={`${card} p-4`}>
+          <div className={labelStyle}>Active Referrers</div>
+          <div className="text-3xl font-bold mt-1 text-[var(--cyan)]">
+            {totalReferrers.toLocaleString()}
+          </div>
+          <div className="text-[11px] text-[var(--text-muted)] mt-1">
+            with ≥ 1 invitee
+          </div>
+        </div>
+
+        <div className={`${card} p-4`}>
+          <div className={labelStyle}>Attributed Signups</div>
+          <div
+            className="text-3xl font-bold mt-1"
+            style={{ color: "var(--accent)" }}
+          >
+            {totalSignupsAttributed.toLocaleString()}
+          </div>
+          <div className="text-[11px] text-[var(--text-muted)] mt-1">
+            joined via a code
+          </div>
+        </div>
+
+        <div className={`${card} p-4`}>
+          <div className={labelStyle}>Top Referrer</div>
+          <div className="text-xl font-bold mt-1 text-[var(--text)] truncate">
+            {rows[0]
+              ? rows[0].twitterHandle
+                ? `@${rows[0].twitterHandle.replace(/^@/, "")}`
+                : rows[0].referralCode
+              : "—"}
+          </div>
+          <div className="text-[11px] text-[var(--text-muted)] mt-1">
+            {rows[0]
+              ? `${rows[0].signupsReferred.toLocaleString()} invites`
+              : "no data yet"}
+          </div>
+        </div>
+
+        <div className={`${card} p-4 flex flex-col`}>
+          <div className={labelStyle}>Show</div>
+          <div className="mt-1 flex gap-1.5">
+            {[10, 25, 100].map((n) => (
+              <button
+                key={n}
+                onClick={() => setLimit(n as 10 | 25 | 100)}
+                className={`flex-1 rounded-none border px-2 py-1.5 text-[11px] font-bold uppercase tracking-[0.1em] transition-colors ${
+                  limit === n
+                    ? "border-[var(--accent)] bg-[var(--accent)]/10 text-[var(--text)]"
+                    : "border-[var(--border)] text-[var(--text-secondary)] hover:border-[var(--border-hover)]"
+                }`}
+              >
+                {n}
+              </button>
+            ))}
+          </div>
+          <button
+            onClick={() => mutate()}
+            className="mt-2 rounded-none border border-[var(--border)] px-2 py-1.5 text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-secondary)] hover:text-[var(--text)] hover:border-[var(--border-hover)] transition-colors"
+          >
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      <div className={card}>
+        {error ? (
+          <div className="p-4 text-[12px] text-[var(--short)]">
+            Failed to load leaderboard.
+          </div>
+        ) : isLoading && !data ? (
+          <div className="p-4 text-[12px] text-[var(--text-muted)]">
+            Loading…
+          </div>
+        ) : rows.length === 0 ? (
+          <div className="p-4 text-[12px] text-[var(--text-muted)]">
+            No referrals attributed yet.
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-[12px]">
+              <thead>
+                <tr className="border-b border-[var(--border)] text-[var(--text-muted)]">
+                  <th className="px-3 py-2 text-left text-[10px] font-bold uppercase tracking-[0.12em]">
+                    Rank
+                  </th>
+                  <th className="px-3 py-2 text-left text-[10px] font-bold uppercase tracking-[0.12em]">
+                    Code
+                  </th>
+                  <th className="px-3 py-2 text-left text-[10px] font-bold uppercase tracking-[0.12em]">
+                    Twitter
+                  </th>
+                  <th className="px-3 py-2 text-left text-[10px] font-bold uppercase tracking-[0.12em]">
+                    Pubkey
+                  </th>
+                  <th className="px-3 py-2 text-left text-[10px] font-bold uppercase tracking-[0.12em]">
+                    Email
+                  </th>
+                  <th className="px-3 py-2 text-right text-[10px] font-bold uppercase tracking-[0.12em]">
+                    Invites
+                  </th>
+                  <th className="px-3 py-2 text-left text-[10px] font-bold uppercase tracking-[0.12em]">
+                    Joined
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr
+                    key={row.referralCode}
+                    className="border-b border-[var(--border)]/40 last:border-b-0"
+                  >
+                    <td className="px-3 py-2 font-mono text-[var(--text-muted)]">
+                      #{row.rank}
+                    </td>
+                    <td className="px-3 py-2 font-mono font-bold text-[var(--text)]">
+                      {row.referralCode}
+                    </td>
+                    <td className="px-3 py-2 font-mono text-[var(--text-secondary)]">
+                      {row.twitterHandle ? (
+                        <a
+                          href={`https://x.com/${row.twitterHandle.replace(/^@/, "")}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="hover:text-[var(--accent)] hover:underline"
+                        >
+                          @{row.twitterHandle.replace(/^@/, "")}
+                        </a>
+                      ) : (
+                        <span className="text-[var(--text-muted)]">—</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 font-mono text-[var(--text-secondary)]">
+                      {row.ownerPubkey ? (
+                        <a
+                          href={`https://solscan.io/account/${row.ownerPubkey}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="hover:text-[var(--accent)] hover:underline"
+                          title={row.ownerPubkey}
+                        >
+                          {truncatePubkey(row.ownerPubkey)}
+                        </a>
+                      ) : (
+                        <span className="text-[var(--text-muted)]">—</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 font-mono text-[var(--text-secondary)]">
+                      {row.ownerEmail ?? (
+                        <span className="text-[var(--text-muted)]">—</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono font-bold text-[var(--accent)]">
+                      {row.signupsReferred.toLocaleString()}
+                    </td>
+                    <td className="px-3 py-2 font-mono text-[var(--text-muted)]">
+                      {formatDate(row.joinedAt)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Two pieces on top of the merged referral plumbing (#2171):

## 1. Personal invite counter on \`ReferralCard\`
Public-facing. When a signed-up user looks at their referral card, they now see how many people joined with their code. Polls every 30s.

- **API:** \`GET /api/waitlist/my-referrals?code=XYZ12345\` → \`{ count: 7 }\`
- Counts are not PII (codes are publicly shared by design), so this stays anon-callable on top of the service-role count query.
- Failure mode is silent: row hides rather than showing a confusing zero.

## 2. Admin-only leaderboard
Operator surface, not user-facing. Sitting in the admin dashboard between bug analytics and oracle freshness.

- **API:** \`GET /api/admin/waitlist/leaderboard\` — gated by \`requireAdminSession()\`
- Returns full identifiers (code, twitter handle, pubkey, email, invites, joined date) for attribution review
- New section \`WaitlistLeaderboardSection\` in \`/admin\` — KPI tiles + sortable table + manual refresh + 10/25/100 limit picker
- Backed by the existing \`waitlist_referral_leaderboard()\` RPC (no new SQL migration)

## Why not a public leaderboard
- Emails and full pubkeys are PII
- A public version creates a gamification surface before we want one
- Re-architect later with explicit sanitisation if/when needed

## Type-check
\`pnpm tsc --noEmit\` — clean.