### PR TITLE
feat(waitlist): strengthen invite-only lockout + admin email backfill

### DIFF
--- a/app/app/api/admin/waitlist/backfill-emails/route.ts
+++ b/app/app/api/admin/waitlist/backfill-emails/route.ts
@@ -1,0 +1,199 @@
+import { NextResponse } from "next/server";
+import { Resend } from "resend";
+import { getWaitlistServiceSupabase } from "@/lib/waitlist/supabase";
+import { requireAdminSession } from "@/lib/admin-session";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+// Each request sends a bounded batch so a single click can't trip the
+// function timeout. The UI loops on `remaining > 0`.
+export const maxDuration = 60;
+
+const FROM = "Percolator <waitlist@percolator.trade>";
+const BATCH_SIZE = 80;
+const SEND_DELAY_MS = 250;
+
+interface Row {
+  id: string;
+  email: string;
+  referral_code: string;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function renderText(code: string): string {
+  return `Your Percolator referral code is ready.
+
+You're already on the waitlist — we just shipped referral codes and here's yours:
+
+  ${code}
+
+Share your link: https://percolator.trade/r/${code}
+
+When someone joins through your link, you get attribution. Mainnet opens after our external audit clears (targeting Q3 2026).
+
+@percolatortrade · github.com/dcccrypto
+
+—
+You received this because you joined the Percolator waitlist. Reply "remove" to be removed.`;
+}
+
+function renderHtml(code: string): string {
+  return `<!doctype html>
+<html><head><meta charset="utf-8"><title>Your referral code</title></head>
+<body style="margin:0; padding:32px 16px; background:#F8F8FC; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #0D0E15;">
+  <div style="max-width:560px; margin:0 auto; background:#FFFFFF; border:1px solid #E0E0EC; border-radius:8px; overflow:hidden;">
+    <div style="padding: 28px 28px 0;">
+      <div style="font-family: ui-monospace, SFMono-Regular, monospace; font-size: 11px; letter-spacing: 0.18em; color: #8A8BA8; text-transform: uppercase;">PERCOLATOR · WAITLIST</div>
+    </div>
+    <div style="padding: 18px 28px 28px;">
+      <h1 style="margin: 0 0 12px; font-size: 22px; line-height: 1.2; font-weight: 700; color: #0D0E15;">Your referral code is ready.</h1>
+      <p style="margin: 0 0 16px; font-size: 14px; line-height: 1.65; color: #4A4B62;">
+        You're already on the Percolator waitlist. We just shipped referral codes &mdash; here's yours:
+      </p>
+      <div style="margin: 0 0 20px; padding: 14px 16px; background: #F8F8FC; border: 1px solid #E0E0EC; border-radius: 6px;">
+        <div style="font-family: ui-monospace, SFMono-Regular, monospace; font-size: 10px; letter-spacing: 0.18em; color: #8A8BA8; text-transform: uppercase; margin-bottom: 6px;">YOUR REFERRAL CODE</div>
+        <div style="font-family: ui-monospace, SFMono-Regular, monospace; font-size: 20px; font-weight: 700; letter-spacing: 0.08em; color: #0D0E15;">${code}</div>
+        <div style="margin-top: 10px; font-size: 12.5px; line-height: 1.55; color: #4A4B62;">Share your link: <a href="https://percolator.trade/r/${code}" style="color:#9945FF; text-decoration: underline; font-family: ui-monospace, SFMono-Regular, monospace;">percolator.trade/r/${code}</a></div>
+      </div>
+      <p style="margin: 0 0 16px; font-size: 14px; line-height: 1.65; color: #4A4B62;">
+        When someone joins through your link, you get attribution. Mainnet opens after our external audit clears (targeting Q3 2026).
+      </p>
+      <hr style="margin: 22px 0; border:0; border-top: 1px solid #E0E0EC;">
+      <p style="margin: 0; font-family: ui-monospace, SFMono-Regular, monospace; font-size: 12px; line-height: 1.7; color: #8A8BA8;">
+        <a href="https://x.com/percolatortrade" style="color:#8A8BA8; text-decoration:none;">@percolatortrade</a> &middot; <a href="https://github.com/dcccrypto" style="color:#8A8BA8; text-decoration:none;">github.com/dcccrypto</a>
+      </p>
+    </div>
+  </div>
+  <p style="max-width:560px; margin: 14px auto 0; font-size: 11px; line-height: 1.5; color: #B8B9CC; text-align: center;">
+    You received this because you joined the Percolator waitlist. Reply "remove" to be removed.
+  </p>
+</body></html>`;
+}
+
+/**
+ * GET — return the pending count without sending anything.
+ * The admin UI uses this to decide whether to show the "Send emails" button.
+ */
+export async function GET() {
+  const auth = await requireAdminSession();
+  if (!auth.ok) return auth.response;
+  try {
+    const supabase = getWaitlistServiceSupabase();
+    const { count, error } = await supabase
+      .from("waitlist")
+      .select("id", { count: "exact", head: true })
+      .not("email", "is", null)
+      .not("referral_code", "is", null)
+      .is("referral_code_emailed_at", null);
+    if (error) {
+      console.error("[backfill-emails GET] count error", error);
+      return NextResponse.json({ pending: 0 });
+    }
+    return NextResponse.json({ pending: count ?? 0 });
+  } catch (err) {
+    console.error("[backfill-emails GET] unexpected", err);
+    return NextResponse.json({ pending: 0 });
+  }
+}
+
+/**
+ * POST — send one batch (up to BATCH_SIZE rows) of referral-code emails.
+ *
+ * Returns:
+ *   { processed, sent, failed, updateFailed, remaining }
+ *
+ * The UI loops on `remaining > 0` and stops on `updateFailed > 0`
+ * (mirroring the CLI script's "DO NOT RE-RUN until flags are
+ * reconciled" guard — a row that was sent but couldn't be flagged
+ * as sent would get a second email on the next batch).
+ *
+ * Idempotent at the row level: the SELECT filters out
+ * `referral_code_emailed_at IS NOT NULL` so already-emailed users
+ * are never re-sent.
+ */
+export async function POST() {
+  const auth = await requireAdminSession();
+  if (!auth.ok) return auth.response;
+
+  const resendKey = process.env.RESEND_API_KEY?.trim();
+  if (!resendKey) {
+    return NextResponse.json(
+      { error: "RESEND_API_KEY not configured" },
+      { status: 503 },
+    );
+  }
+  const resend = new Resend(resendKey);
+
+  try {
+    const supabase = getWaitlistServiceSupabase();
+    const { data, error } = await supabase
+      .from("waitlist")
+      .select("id, email, referral_code")
+      .not("email", "is", null)
+      .not("referral_code", "is", null)
+      .is("referral_code_emailed_at", null)
+      .limit(BATCH_SIZE);
+
+    if (error) {
+      console.error("[backfill-emails POST] select error", error);
+      return NextResponse.json({ error: "select failed" }, { status: 500 });
+    }
+
+    const rows = (data ?? []) as Row[];
+    let sent = 0;
+    let failed = 0;
+    let updateFailed = 0;
+
+    for (const row of rows) {
+      try {
+        await resend.emails.send({
+          from: FROM,
+          to: row.email,
+          subject: "Your Percolator referral code",
+          html: renderHtml(row.referral_code),
+          text: renderText(row.referral_code),
+        });
+        sent++;
+        const { error: updateError } = await supabase
+          .from("waitlist")
+          .update({ referral_code_emailed_at: new Date().toISOString() })
+          .eq("id", row.id);
+        if (updateError) {
+          updateFailed++;
+          console.error(
+            `[backfill-emails] update flag FAILED for ${row.email}`,
+            updateError,
+          );
+          // Stop early — re-running would email this user a second time.
+          break;
+        }
+        await sleep(SEND_DELAY_MS);
+      } catch (err) {
+        failed++;
+        console.error(`[backfill-emails] send failed for ${row.email}`, err);
+      }
+    }
+
+    // Re-count remaining so the UI can decide to call again.
+    const { count: remainingCount } = await supabase
+      .from("waitlist")
+      .select("id", { count: "exact", head: true })
+      .not("email", "is", null)
+      .not("referral_code", "is", null)
+      .is("referral_code_emailed_at", null);
+
+    return NextResponse.json({
+      processed: rows.length,
+      sent,
+      failed,
+      updateFailed,
+      remaining: remainingCount ?? 0,
+    });
+  } catch (err) {
+    console.error("[backfill-emails POST] unexpected", err);
+    return NextResponse.json({ error: "unexpected" }, { status: 500 });
+  }
+}

--- a/app/app/waitlist/page.tsx
+++ b/app/app/waitlist/page.tsx
@@ -325,8 +325,19 @@ function SignupCard() {
               waitlist · v1
             </span>
           </div>
-          <span className="font-mono text-[10.5px] text-[var(--text-secondary)]">
-            {tab === "wallet" ? "ed25519" : "smtp"}
+          <span className="inline-flex items-center gap-1.5 rounded-sm border border-[var(--accent)]/50 bg-[var(--accent)]/[0.12] px-2 py-0.5 font-mono text-[9.5px] uppercase tracking-[0.18em] text-[var(--accent)]">
+            <svg
+              aria-hidden
+              viewBox="0 0 12 12"
+              className="h-2.5 w-2.5"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={1.6}
+            >
+              <rect x="3" y="5.5" width="6" height="5" rx="0.6" />
+              <path d="M4.25 5.5V3.75a1.75 1.75 0 1 1 3.5 0V5.5" />
+            </svg>
+            Invite only
           </span>
         </div>
 
@@ -641,54 +652,64 @@ function EmailFlow() {
         disabled={sending}
       />
       <FormGateDivider unlocked={formUnlocked} />
-      <div className="space-y-1.5">
-        <label
-          htmlFor="signup-email"
-          className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-secondary)]"
-        >
-          email
-        </label>
-        <input
-          id="signup-email"
-          type="email"
-          autoComplete="email"
-          inputMode="email"
-          className="w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 font-mono text-[13px] text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-muted)] focus:border-[var(--accent)]/50 focus:ring-1 focus:ring-[var(--accent)]/15 disabled:opacity-50"
-          placeholder="you@domain.com"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          disabled={sending || !formUnlocked}
-          maxLength={254}
-        />
-      </div>
-      <div className="space-y-1.5">
-        <label
-          htmlFor="x-handle"
-          className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-secondary)]"
-        >
-          x_handle (optional)
-        </label>
-        <input
-          id="x-handle"
-          className="w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 font-mono text-[13px] text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-muted)] focus:border-[var(--accent)]/50 focus:ring-1 focus:ring-[var(--accent)]/15 disabled:opacity-50"
-          placeholder="@yourhandle"
-          value={twitter}
-          onChange={(e) => setTwitter(e.target.value)}
-          disabled={sending || !formUnlocked}
-          maxLength={30}
-        />
-      </div>
-      <button
-        className={ctaPrimary}
-        onClick={onSendCode}
-        disabled={sending || !formUnlocked}
+      <div
+        className={`space-y-3.5 transition-opacity duration-200 ${
+          formUnlocked ? "" : "pointer-events-none select-none opacity-40"
+        }`}
+        aria-hidden={!formUnlocked}
       >
-        {sending
-          ? "Sending code…"
-          : formUnlocked
-            ? "Send 6-digit code →"
-            : "Enter referral code to continue"}
-      </button>
+        <div className="space-y-1.5">
+          <label
+            htmlFor="signup-email"
+            className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-secondary)]"
+          >
+            email
+          </label>
+          <input
+            id="signup-email"
+            type="email"
+            autoComplete="email"
+            inputMode="email"
+            className="w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 font-mono text-[13px] text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-muted)] focus:border-[var(--accent)]/50 focus:ring-1 focus:ring-[var(--accent)]/15 disabled:opacity-50"
+            placeholder="you@domain.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            disabled={sending || !formUnlocked}
+            maxLength={254}
+            tabIndex={formUnlocked ? 0 : -1}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <label
+            htmlFor="x-handle"
+            className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-secondary)]"
+          >
+            x_handle (optional)
+          </label>
+          <input
+            id="x-handle"
+            className="w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 font-mono text-[13px] text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-muted)] focus:border-[var(--accent)]/50 focus:ring-1 focus:ring-[var(--accent)]/15 disabled:opacity-50"
+            placeholder="@yourhandle"
+            value={twitter}
+            onChange={(e) => setTwitter(e.target.value)}
+            disabled={sending || !formUnlocked}
+            maxLength={30}
+            tabIndex={formUnlocked ? 0 : -1}
+          />
+        </div>
+        <button
+          className={ctaPrimary}
+          onClick={onSendCode}
+          disabled={sending || !formUnlocked}
+          tabIndex={formUnlocked ? 0 : -1}
+        >
+          {sending
+            ? "Sending code…"
+            : formUnlocked
+              ? "Send 6-digit code →"
+              : "Enter referral code to continue"}
+        </button>
+      </div>
       <NoCodeFallback />
     </div>
   );
@@ -868,36 +889,45 @@ function SignupFlow() {
           disabled={busy}
         />
         <FormGateDivider unlocked={formUnlocked} />
-        <div className="space-y-1.5">
-          <label
-            htmlFor="x-handle-wallet"
-            className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-secondary)]"
-          >
-            x_handle (optional)
-          </label>
-          <input
-            id="x-handle-wallet"
-            className="w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 font-mono text-[13px] text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-muted)] focus:border-[var(--accent)]/50 focus:ring-1 focus:ring-[var(--accent)]/15 disabled:opacity-50"
-            placeholder="@yourhandle"
-            value={twitter}
-            onChange={(e) => setTwitter(e.target.value)}
-            disabled={busy || !formUnlocked}
-            maxLength={30}
-          />
-        </div>
-        <button
-          className={ctaPrimary}
-          onClick={onSign}
-          disabled={busy || !formUnlocked}
+        <div
+          className={`space-y-3.5 transition-opacity duration-200 ${
+            formUnlocked ? "" : "pointer-events-none select-none opacity-40"
+          }`}
+          aria-hidden={!formUnlocked}
         >
-          {state.kind === "signing"
-            ? "Signing in your wallet…"
-            : state.kind === "submitting"
-              ? "Submitting…"
-              : formUnlocked
-                ? "Sign & claim spot →"
-                : "Enter referral code to continue"}
-        </button>
+          <div className="space-y-1.5">
+            <label
+              htmlFor="x-handle-wallet"
+              className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-secondary)]"
+            >
+              x_handle (optional)
+            </label>
+            <input
+              id="x-handle-wallet"
+              className="w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 font-mono text-[13px] text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-muted)] focus:border-[var(--accent)]/50 focus:ring-1 focus:ring-[var(--accent)]/15 disabled:opacity-50"
+              placeholder="@yourhandle"
+              value={twitter}
+              onChange={(e) => setTwitter(e.target.value)}
+              disabled={busy || !formUnlocked}
+              maxLength={30}
+              tabIndex={formUnlocked ? 0 : -1}
+            />
+          </div>
+          <button
+            className={ctaPrimary}
+            onClick={onSign}
+            disabled={busy || !formUnlocked}
+            tabIndex={formUnlocked ? 0 : -1}
+          >
+            {state.kind === "signing"
+              ? "Signing in your wallet…"
+              : state.kind === "submitting"
+                ? "Submitting…"
+                : formUnlocked
+                  ? "Sign & claim spot →"
+                  : "Enter referral code to continue"}
+          </button>
+        </div>
         <NoCodeFallback />
       </div>
     );
@@ -1124,18 +1154,35 @@ function NoCodeFallback() {
  * step label so the gate is legible.
  */
 function FormGateDivider({ unlocked }: { unlocked: boolean }) {
+  if (unlocked) {
+    return (
+      <div className="flex items-center gap-2.5 py-0.5">
+        <span className="h-px flex-1 bg-[var(--cyan)]/40" />
+        <span className="font-mono text-[9px] uppercase tracking-[0.18em] text-[var(--cyan)]">
+          ↓ continue
+        </span>
+        <span className="h-px flex-1 bg-[var(--cyan)]/40" />
+      </div>
+    );
+  }
+  // Locked: stronger visual barrier with a lock icon. Pairs with the
+  // dimmed pointer-events-none wrapper around the fields below.
   return (
-    <div className="flex items-center gap-2.5 py-0.5">
-      <span className="h-px flex-1 bg-[var(--border)]" />
-      <span
-        className="font-mono text-[9px] uppercase tracking-[0.18em]"
-        style={{
-          color: unlocked ? "var(--cyan)" : "var(--text-secondary)",
-        }}
+    <div className="flex items-center gap-2.5 rounded-md border border-dashed border-[var(--border)] bg-[var(--bg)]/60 px-3 py-2">
+      <svg
+        aria-hidden
+        viewBox="0 0 14 14"
+        className="h-3 w-3 text-[var(--text-secondary)]"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.4}
       >
-        {unlocked ? "↓ continue" : "↓ unlocks with valid code"}
+        <rect x="3.5" y="6.5" width="7" height="5.5" rx="0.6" />
+        <path d="M5 6.5V4.5a2 2 0 1 1 4 0V6.5" />
+      </svg>
+      <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--text-secondary)]">
+        Locked — referral code required to continue
       </span>
-      <span className="h-px flex-1 bg-[var(--border)]" />
     </div>
   );
 }

--- a/app/components/admin/WaitlistLeaderboardSection.tsx
+++ b/app/components/admin/WaitlistLeaderboardSection.tsx
@@ -72,12 +72,87 @@ export function WaitlistLeaderboardSection() {
     revalidateOnFocus: true,
   });
 
+  // Pending referral-code email backfill for legacy email-path signups
+  // who never received their code (the security review intentionally
+  // prevents the duplicate-email signup path from echoing the code).
+  const { data: backfill, mutate: refreshBackfill } = useSWR<{
+    pending: number;
+  }>("/api/admin/waitlist/backfill-emails", fetcher, {
+    refreshInterval: 60_000,
+    revalidateOnFocus: true,
+  });
+  const [backfillBusy, setBackfillBusy] = useState(false);
+  const [backfillStatus, setBackfillStatus] = useState<string | null>(null);
+
   const rows = (data?.leaderboard ?? []).slice(0, limit);
   const totalReferrers = data?.leaderboard.length ?? 0;
   const totalSignupsAttributed = (data?.leaderboard ?? []).reduce(
     (sum, r) => sum + r.signupsReferred,
     0,
   );
+
+  const runBackfill = async () => {
+    if (backfillBusy) return;
+    const pending = backfill?.pending ?? 0;
+    if (pending === 0) return;
+    const ok = window.confirm(
+      `Send referral-code emails to ${pending} pending recipient${
+        pending === 1 ? "" : "s"
+      }? This is rate-limited at ~4/sec and may take multiple clicks if there are more than 80 pending.`,
+    );
+    if (!ok) return;
+
+    setBackfillBusy(true);
+    setBackfillStatus("Sending…");
+    try {
+      let totalSent = 0;
+      let totalFailed = 0;
+      // Loop until no pending rows remain or an update-flag failure halts
+      // the run (which the server mirrors from the CLI script — re-running
+      // after a flag-failure would double-email those users).
+      while (true) {
+        const res = await fetch("/api/admin/waitlist/backfill-emails", {
+          method: "POST",
+          credentials: "include",
+        });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(
+            body.error || `Backfill failed with HTTP ${res.status}`,
+          );
+        }
+        const json = (await res.json()) as {
+          processed: number;
+          sent: number;
+          failed: number;
+          updateFailed: number;
+          remaining: number;
+        };
+        totalSent += json.sent;
+        totalFailed += json.failed;
+        if (json.updateFailed > 0) {
+          throw new Error(
+            "A row was emailed but its flag could not be updated — manual reconciliation required before retrying.",
+          );
+        }
+        setBackfillStatus(
+          `Sent ${totalSent} so far · ${json.remaining} remaining`,
+        );
+        if (json.remaining === 0 || json.processed === 0) break;
+      }
+      setBackfillStatus(
+        `Done. Sent ${totalSent}${
+          totalFailed > 0 ? `, ${totalFailed} failed` : ""
+        }.`,
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setBackfillStatus(`Failed: ${msg}`);
+    } finally {
+      setBackfillBusy(false);
+      refreshBackfill();
+    }
+  };
 
   return (
     <div className="mb-8">
@@ -148,6 +223,35 @@ export function WaitlistLeaderboardSection() {
           </button>
         </div>
       </div>
+
+      {/* Pending email backfill — legacy email signups who haven't been
+          notified of their code. Hidden when the queue is empty. */}
+      {(backfill?.pending ?? 0) > 0 || backfillStatus ? (
+        <div className={`${card} p-4 mb-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between`}>
+          <div className="flex-1">
+            <div className={labelStyle}>Email backfill pending</div>
+            <div className="mt-1 text-[13px] text-[var(--text-secondary)]">
+              {(backfill?.pending ?? 0) > 0
+                ? `${backfill?.pending.toLocaleString()} email-path signup${
+                    backfill?.pending === 1 ? "" : "s"
+                  } never received their referral code.`
+                : "All caught up — no pending backfill."}
+              {backfillStatus ? (
+                <span className="ml-2 font-mono text-[11px] text-[var(--text-muted)]">
+                  · {backfillStatus}
+                </span>
+              ) : null}
+            </div>
+          </div>
+          <button
+            onClick={runBackfill}
+            disabled={backfillBusy || (backfill?.pending ?? 0) === 0}
+            className="shrink-0 rounded-none border border-[var(--accent)]/60 bg-[var(--accent)]/[0.12] px-4 py-2 text-[11px] font-bold uppercase tracking-[0.14em] text-[var(--text)] transition-colors hover:bg-[var(--accent)]/20 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {backfillBusy ? "Sending…" : "Send referral emails"}
+          </button>
+        </div>
+      ) : null}
 
       <div className={card}>
         {error ? (


### PR DESCRIPTION
Two related improvements:

## 1. Lockout — make invite-only legible
- **\`Invite only\` badge** with lock icon in SignupCard header (replaces the decorative ed25519/smtp label on the right)
- **\`FormGateDivider\` upgraded** when locked: dashed border + lock icon + \"Locked — referral code required to continue\" copy (unlocked state unchanged)
- **Fields below divider locked harder**: opacity-40 + \`pointer-events-none\` + \`tabIndex={-1}\` + \`aria-hidden\` when no valid code. Screen-reader users hear the locked state, keyboard users can't tab into inert inputs

Server already rejected codeless signups (route.ts line 288) — this is the UX that backs it up.

## 2. Backfill emails for legacy signups
**Wallet duplicates** already see their code on re-sign — signature proves ownership, route returns it. **Email duplicates** intentionally don't (membership-oracle prevention), so legacy email signups need the code mailed to them. The CLI script existed; this adds an admin UI trigger.

- \`GET  /api/admin/waitlist/backfill-emails\` → \`{ pending: N }\` (just a count)
- \`POST /api/admin/waitlist/backfill-emails\` → process up to 80 rows per request, return \`{ processed, sent, failed, updateFailed, remaining }\`
- New section in admin's WaitlistLeaderboardSection: \"Email backfill pending\" tile + confirm-then-send button + live progress
- Client loops on \`remaining > 0\`; halts immediately on \`updateFailed > 0\` (mirrors CLI safety: a sent-but-not-flagged row would get double-emailed on retry)
- Idempotent at the DB level — \`referral_code_emailed_at IS NULL\` filter means already-emailed rows are never reprocessed

## Tests
\`pnpm tsc --noEmit\` — clean.

## Operator note
Set \`RESEND_API_KEY\` on the Vercel project if not already set. Endpoint returns 503 with a clear message if missing.