### PR TITLE
feat(admin): waitlist health panel — integrity checks + breakdown

### DIFF
--- a/app/app/api/admin/waitlist/stats/route.ts
+++ b/app/app/api/admin/waitlist/stats/route.ts
@@ -1,0 +1,201 @@
+import { NextResponse } from "next/server";
+import { getWaitlistServiceSupabase } from "@/lib/waitlist/supabase";
+import { requireAdminSession } from "@/lib/admin-session";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/admin/waitlist/stats
+ *
+ * Comprehensive integrity report for the waitlist + referral system.
+ * Designed to answer:
+ *   - did the SQL backfill assign a code to every row?
+ *   - are codes unique?
+ *   - how many signups have / haven't been notified yet?
+ *   - what does the wallet/email breakdown look like?
+ *   - how many signups arrived via someone's invite link?
+ *
+ * Service-role reads only — anon path stays revoked. Admin session
+ * required.
+ */
+export async function GET() {
+  const auth = await requireAdminSession();
+  if (!auth.ok) return auth.response;
+
+  try {
+    const supabase = getWaitlistServiceSupabase();
+
+    // Pull the whole table once. The waitlist is small (low thousands
+    // at the upper bound for this product stage) and a single read is
+    // far simpler than orchestrating six counts with `head: true` —
+    // and lets us derive all the cross-cutting checks from one view.
+    const { data: rows, error } = await supabase
+      .from("waitlist")
+      .select(
+        "id, pubkey, email, referral_code, referred_by_code, referral_code_emailed_at, twitter_handle, created_at",
+      );
+    if (error) {
+      console.error("[admin/waitlist/stats] select error", error);
+      return NextResponse.json(
+        { error: "Failed to read waitlist" },
+        { status: 500 },
+      );
+    }
+
+    type Row = {
+      id: string;
+      pubkey: string | null;
+      email: string | null;
+      referral_code: string | null;
+      referred_by_code: string | null;
+      referral_code_emailed_at: string | null;
+      twitter_handle: string | null;
+      created_at: string;
+    };
+    const all = (rows ?? []) as Row[];
+
+    // ── Totals + breakdown by signup method ────────────────────────────
+    const totalSignups = all.length;
+    let walletOnly = 0;
+    let emailOnly = 0;
+    let walletAndEmail = 0;
+    let withTwitter = 0;
+    for (const r of all) {
+      const hasW = !!r.pubkey;
+      const hasE = !!r.email;
+      if (hasW && hasE) walletAndEmail++;
+      else if (hasW) walletOnly++;
+      else if (hasE) emailOnly++;
+      if (r.twitter_handle && r.twitter_handle.trim() !== "") withTwitter++;
+    }
+
+    // ── Referral code assignment (was the backfill complete?) ──────────
+    let withCode = 0;
+    let withoutCode = 0;
+    const codeSeen = new Map<string, number>();
+    const malformedCodes: string[] = [];
+    for (const r of all) {
+      if (r.referral_code) {
+        withCode++;
+        codeSeen.set(r.referral_code, (codeSeen.get(r.referral_code) ?? 0) + 1);
+        // Crockford base32, 8 chars, uppercase. Catches any drift.
+        if (!/^[0-9A-HJKMNP-TV-Z]{8}$/.test(r.referral_code)) {
+          malformedCodes.push(r.referral_code);
+        }
+      } else {
+        withoutCode++;
+      }
+    }
+    const distinctCodes = codeSeen.size;
+    const duplicateCodes: { code: string; count: number }[] = [];
+    for (const [code, count] of codeSeen) {
+      if (count > 1) duplicateCodes.push({ code, count });
+    }
+
+    // ── Attribution: did this row come in via someone's invite? ───────
+    let withReferrer = 0;
+    let withoutReferrer = 0;
+    const referredByCount = new Map<string, number>();
+    const orphanedReferrers: string[] = []; // referred_by_code that isn't anyone's referral_code
+    const validCodes = new Set(codeSeen.keys());
+    for (const r of all) {
+      if (r.referred_by_code) {
+        withReferrer++;
+        referredByCount.set(
+          r.referred_by_code,
+          (referredByCount.get(r.referred_by_code) ?? 0) + 1,
+        );
+        if (!validCodes.has(r.referred_by_code)) {
+          orphanedReferrers.push(r.referred_by_code);
+        }
+      } else {
+        withoutReferrer++;
+      }
+    }
+    // Top referrer
+    let topReferrer: { code: string; count: number } | null = null;
+    for (const [code, count] of referredByCount) {
+      if (!topReferrer || count > topReferrer.count) {
+        topReferrer = { code, count };
+      }
+    }
+
+    // ── Email-notification state ───────────────────────────────────────
+    let notifiedTotal = 0; // referral_code_emailed_at IS NOT NULL
+    let pendingEmailable = 0; // has email AND code AND not yet emailed
+    let walletOnlyNoEmail = 0; // no email column — nothing to send to
+    for (const r of all) {
+      if (r.referral_code_emailed_at) {
+        notifiedTotal++;
+        continue;
+      }
+      if (!r.email) {
+        walletOnlyNoEmail++;
+      } else if (r.referral_code) {
+        pendingEmailable++;
+      }
+    }
+
+    // ── Recency ───────────────────────────────────────────────────────
+    const now = Date.now();
+    const ms24h = 24 * 60 * 60 * 1000;
+    const ms7d = 7 * 24 * 60 * 60 * 1000;
+    let last24h = 0;
+    let last7d = 0;
+    for (const r of all) {
+      const t = new Date(r.created_at).getTime();
+      if (Number.isFinite(t)) {
+        if (now - t <= ms24h) last24h++;
+        if (now - t <= ms7d) last7d++;
+      }
+    }
+
+    // ── Self-referral check (defense-in-depth, app prevents it but
+    //    a DB-level CHECK constraint isn't in place yet). ─────────────
+    let selfReferrals = 0;
+    for (const r of all) {
+      if (
+        r.referral_code &&
+        r.referred_by_code &&
+        r.referral_code === r.referred_by_code
+      ) {
+        selfReferrals++;
+      }
+    }
+
+    return NextResponse.json({
+      totalSignups,
+      byMethod: { walletOnly, emailOnly, walletAndEmail, withTwitter },
+      codeAssignment: {
+        withCode,
+        withoutCode,
+        distinctCodes,
+        duplicateCodes,
+        malformedCodes,
+      },
+      attribution: {
+        withReferrer,
+        withoutReferrer,
+        topReferrer,
+        orphanedReferrers,
+      },
+      emailNotification: {
+        notifiedTotal,
+        pendingEmailable,
+        walletOnlyNoEmail,
+      },
+      recency: { last24h, last7d },
+      integrity: {
+        selfReferrals,
+        backfillComplete: withoutCode === 0,
+        codesUnique: duplicateCodes.length === 0,
+        allCodesValidShape: malformedCodes.length === 0,
+        noOrphanedReferrers: orphanedReferrers.length === 0,
+      },
+    });
+  } catch (err) {
+    console.error("[admin/waitlist/stats] unexpected", err);
+    return NextResponse.json({ error: "Unexpected error" }, { status: 500 });
+  }
+}

--- a/app/components/admin/WaitlistLeaderboardSection.tsx
+++ b/app/components/admin/WaitlistLeaderboardSection.tsx
@@ -16,6 +16,37 @@ function SectionHeader({ children }: { children: React.ReactNode }) {
   );
 }
 
+function IntegrityRow({
+  ok,
+  label,
+  detail,
+}: {
+  ok: boolean;
+  label: string;
+  detail: string;
+}) {
+  return (
+    <div className="flex items-start gap-2">
+      <span
+        className="mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center text-[10px] font-bold"
+        style={{
+          color: ok ? "var(--long)" : "var(--short)",
+          background: ok ? "rgba(35,196,124,0.12)" : "rgba(238,80,80,0.12)",
+          border: `1px solid ${ok ? "rgba(35,196,124,0.4)" : "rgba(238,80,80,0.4)"}`,
+        }}
+      >
+        {ok ? "✓" : "!"}
+      </span>
+      <div className="flex-1 min-w-0">
+        <div className="text-[var(--text)]">{label}</div>
+        <div className="text-[11px] text-[var(--text-muted)] mt-0.5 break-words">
+          {detail}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 interface AdminLeaderboardEntry {
   rank: number;
   referralCode: string;
@@ -24,6 +55,42 @@ interface AdminLeaderboardEntry {
   twitterHandle: string | null;
   signupsReferred: number;
   joinedAt: string;
+}
+
+interface WaitlistStats {
+  totalSignups: number;
+  byMethod: {
+    walletOnly: number;
+    emailOnly: number;
+    walletAndEmail: number;
+    withTwitter: number;
+  };
+  codeAssignment: {
+    withCode: number;
+    withoutCode: number;
+    distinctCodes: number;
+    duplicateCodes: { code: string; count: number }[];
+    malformedCodes: string[];
+  };
+  attribution: {
+    withReferrer: number;
+    withoutReferrer: number;
+    topReferrer: { code: string; count: number } | null;
+    orphanedReferrers: string[];
+  };
+  emailNotification: {
+    notifiedTotal: number;
+    pendingEmailable: number;
+    walletOnlyNoEmail: number;
+  };
+  recency: { last24h: number; last7d: number };
+  integrity: {
+    selfReferrals: number;
+    backfillComplete: boolean;
+    codesUnique: boolean;
+    allCodesValidShape: boolean;
+    noOrphanedReferrers: boolean;
+  };
 }
 
 const fetcher = async (url: string) => {
@@ -81,6 +148,15 @@ export function WaitlistLeaderboardSection() {
     refreshInterval: 60_000,
     revalidateOnFocus: true,
   });
+
+  // Full integrity report — verifies the schema backfill assigned codes
+  // to every row, codes are unique, no orphan referred_by_code values,
+  // and shows the wallet/email/twitter breakdown.
+  const { data: stats } = useSWR<WaitlistStats>(
+    "/api/admin/waitlist/stats",
+    fetcher,
+    { refreshInterval: 60_000, revalidateOnFocus: true },
+  );
   const [backfillBusy, setBackfillBusy] = useState(false);
   const [backfillStatus, setBackfillStatus] = useState<string | null>(null);
 
@@ -156,6 +232,154 @@ export function WaitlistLeaderboardSection() {
 
   return (
     <div className="mb-8">
+      <SectionHeader>Waitlist Health</SectionHeader>
+
+      {/* Integrity check — answers "did the SQL backfill run, are
+          codes unique, is anything orphaned?". Hidden until first
+          fetch resolves so we never flash misleading zeroes. */}
+      {stats ? (
+        <>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-3">
+            <div className={`${card} p-4`}>
+              <div className={labelStyle}>Total Signups</div>
+              <div className="text-3xl font-bold mt-1 text-[var(--text)]">
+                {stats.totalSignups.toLocaleString()}
+              </div>
+              <div className="text-[11px] text-[var(--text-muted)] mt-1">
+                +{stats.recency.last24h} in 24h · +{stats.recency.last7d} in 7d
+              </div>
+            </div>
+            <div className={`${card} p-4`}>
+              <div className={labelStyle}>Code Coverage</div>
+              <div
+                className="text-3xl font-bold mt-1"
+                style={{
+                  color: stats.integrity.backfillComplete
+                    ? "var(--cyan)"
+                    : "var(--short)",
+                }}
+              >
+                {stats.codeAssignment.withCode}/{stats.totalSignups}
+              </div>
+              <div className="text-[11px] text-[var(--text-muted)] mt-1">
+                {stats.integrity.backfillComplete
+                  ? "every row has a code ✓"
+                  : `${stats.codeAssignment.withoutCode} missing — backfill incomplete`}
+              </div>
+            </div>
+            <div className={`${card} p-4`}>
+              <div className={labelStyle}>Attributed Signups</div>
+              <div
+                className="text-3xl font-bold mt-1"
+                style={{ color: "var(--accent)" }}
+              >
+                {stats.attribution.withReferrer}
+              </div>
+              <div className="text-[11px] text-[var(--text-muted)] mt-1">
+                {stats.attribution.withoutReferrer.toLocaleString()} pre-invite (grandfathered)
+              </div>
+            </div>
+            <div className={`${card} p-4`}>
+              <div className={labelStyle}>Email Notification</div>
+              <div className="text-3xl font-bold mt-1 text-[var(--text)]">
+                {stats.emailNotification.notifiedTotal}
+              </div>
+              <div className="text-[11px] text-[var(--text-muted)] mt-1">
+                {stats.emailNotification.pendingEmailable > 0
+                  ? `${stats.emailNotification.pendingEmailable} pending · ${stats.emailNotification.walletOnlyNoEmail} wallet-only`
+                  : `${stats.emailNotification.walletOnlyNoEmail} wallet-only (no email)`}
+              </div>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
+            <div className={`${card} p-4`}>
+              <div className={labelStyle}>Wallet Only</div>
+              <div className="text-2xl font-bold mt-1 text-[var(--text)]">
+                {stats.byMethod.walletOnly.toLocaleString()}
+              </div>
+            </div>
+            <div className={`${card} p-4`}>
+              <div className={labelStyle}>Email Only</div>
+              <div className="text-2xl font-bold mt-1 text-[var(--text)]">
+                {stats.byMethod.emailOnly.toLocaleString()}
+              </div>
+            </div>
+            <div className={`${card} p-4`}>
+              <div className={labelStyle}>Wallet + Email</div>
+              <div className="text-2xl font-bold mt-1 text-[var(--text)]">
+                {stats.byMethod.walletAndEmail.toLocaleString()}
+              </div>
+            </div>
+            <div className={`${card} p-4`}>
+              <div className={labelStyle}>With Twitter Handle</div>
+              <div className="text-2xl font-bold mt-1 text-[var(--text)]">
+                {stats.byMethod.withTwitter.toLocaleString()}
+              </div>
+            </div>
+          </div>
+
+          {/* Integrity checks — green tick or red flag for each invariant */}
+          <div className={`${card} p-4 mb-4`}>
+            <div className={`${labelStyle} mb-3`}>Integrity Checks</div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-[12.5px]">
+              <IntegrityRow
+                ok={stats.integrity.backfillComplete}
+                label="Every row has a referral_code"
+                detail={
+                  stats.integrity.backfillComplete
+                    ? `${stats.codeAssignment.withCode} of ${stats.totalSignups}`
+                    : `${stats.codeAssignment.withoutCode} rows missing a code — re-run the SQL backfill`
+                }
+              />
+              <IntegrityRow
+                ok={stats.integrity.codesUnique}
+                label="All referral codes are unique"
+                detail={
+                  stats.integrity.codesUnique
+                    ? `${stats.codeAssignment.distinctCodes} distinct codes`
+                    : `${stats.codeAssignment.duplicateCodes.length} duplicate(s): ${stats.codeAssignment.duplicateCodes
+                        .slice(0, 5)
+                        .map((d) => `${d.code}(×${d.count})`)
+                        .join(", ")}`
+                }
+              />
+              <IntegrityRow
+                ok={stats.integrity.allCodesValidShape}
+                label="All codes match Crockford base32 × 8"
+                detail={
+                  stats.integrity.allCodesValidShape
+                    ? "no malformed codes"
+                    : `${stats.codeAssignment.malformedCodes.length} bad: ${stats.codeAssignment.malformedCodes.slice(0, 5).join(", ")}`
+                }
+              />
+              <IntegrityRow
+                ok={stats.integrity.noOrphanedReferrers}
+                label="Every referred_by_code points at a real code"
+                detail={
+                  stats.integrity.noOrphanedReferrers
+                    ? "no orphans"
+                    : `${stats.attribution.orphanedReferrers.length} orphan(s): ${stats.attribution.orphanedReferrers.slice(0, 5).join(", ")}`
+                }
+              />
+              <IntegrityRow
+                ok={stats.integrity.selfReferrals === 0}
+                label="No self-referrals"
+                detail={
+                  stats.integrity.selfReferrals === 0
+                    ? "clean"
+                    : `${stats.integrity.selfReferrals} row(s) reference their own code`
+                }
+              />
+            </div>
+          </div>
+        </>
+      ) : (
+        <div className={`${card} p-4 mb-4 text-[12px] text-[var(--text-muted)]`}>
+          Loading waitlist health…
+        </div>
+      )}
+
       <SectionHeader>Waitlist Referral Leaderboard</SectionHeader>
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">


### PR DESCRIPTION
Verifies the entire waitlist + referral pipeline at a glance and surfaces over time on /admin.

## New endpoint
\`GET /api/admin/waitlist/stats\` (admin-gated) — service-role reads every waitlist row, computes aggregations in memory.

## What it surfaces

**KPI tiles**
- Total signups + 24h / 7d recency
- Code coverage: \`withCode / total\` (red if backfill didn't run cleanly)
- Attributed signups (came via an invite) vs. pre-invite grandfathered rows
- Email notification state: notified / pending / wallet-only

**Breakdown tiles**
- Wallet only · Email only · Wallet + Email · With Twitter handle

**Integrity checks (✓ / ! markers)**
1. Every row has a \`referral_code\` (proves the SQL backfill ran)
2. All codes unique (no collisions)
3. All codes match Crockford base32 × 8 shape
4. Every \`referred_by_code\` points at a real existing code (no orphans)
5. No self-referrals (\`referral_code === referred_by_code\`)

When a check fails, the detail line surfaces the first 5 offending codes so the operator can drill straight in.

## Why on the admin dashboard
Same pattern as the leaderboard — service-role queries, admin session gate, lives above the leaderboard so the operator sees integrity *before* attribution numbers.

## Type-check
\`pnpm tsc --noEmit\` — clean.