### PR TITLE
feat(waitlist): wallet sign-in path for pre-invite users to see their code

### DIFF
--- a/app/app/api/waitlist/signup/route.ts
+++ b/app/app/api/waitlist/signup/route.ts
@@ -276,6 +276,87 @@ export async function POST(req: Request) {
     );
   }
 
+  // ── Wallet signature verification (moved up from later in the route) ────
+  // We need to verify the signature BEFORE we can trust the pubkey for
+  // the duplicate-lookup fast path below. Without that, anyone could
+  // probe arbitrary pubkeys for membership. The mainnet spam check
+  // (walletExistsOnMainnet) stays further down so it only fires on
+  // genuinely new signups — pre-invite users who are just looking up
+  // their existing code shouldn't burn a Helius RPC call.
+  if (hasWalletPart) {
+    if (!isValidSolanaPubkey(pubkey!)) {
+      return NextResponse.json({ error: "invalid pubkey" }, { status: 400 });
+    }
+    const ts = parseTimestampFromMessage(message!);
+    if (!ts) {
+      return NextResponse.json({ error: "invalid message format" }, { status: 400 });
+    }
+    if (Math.abs(Date.now() - ts) > MAX_MESSAGE_AGE_MS) {
+      return NextResponse.json({ error: "message expired" }, { status: 400 });
+    }
+    if (!message!.includes(pubkey!)) {
+      return NextResponse.json({ error: "message must include pubkey" }, { status: 400 });
+    }
+    let sigBytes: Uint8Array;
+    let pubBytes: Uint8Array;
+    try {
+      sigBytes = bs58.decode(signature!);
+      pubBytes = bs58.decode(pubkey!);
+    } catch {
+      return NextResponse.json({ error: "decode failed" }, { status: 400 });
+    }
+    if (sigBytes.length !== 64 || pubBytes.length !== 32) {
+      return NextResponse.json({ error: "wrong sig/pubkey length" }, { status: 400 });
+    }
+    const msgBytes = new TextEncoder().encode(message!);
+    const ok = nacl.sign.detached.verify(msgBytes, sigBytes, pubBytes);
+    if (!ok) {
+      return NextResponse.json({ error: "signature invalid" }, { status: 401 });
+    }
+  }
+
+  // ── Sign-in fast path for existing wallet signups ───────────────────────
+  // The waitlist is invite-only NOW, but every row created before that
+  // change is grandfathered (referred_by_code IS NULL). Those users need
+  // to be able to come back and see their backfilled referral code
+  // without supplying an invite of their own — they ARE the invite list.
+  //
+  // Wallet-path only: the signature above proved ownership, so returning
+  // the existing code is safe. Email-path lookup would require an OTP
+  // (membership oracle) and is handled by the separate backfill-emails
+  // operator action.
+  if (hasWalletPart) {
+    try {
+      const service = getWaitlistServiceSupabase();
+      const { data: existing } = await service
+        .from("waitlist")
+        .select("referral_code")
+        .eq("pubkey", pubkey)
+        .maybeSingle();
+      if (existing && existing.referral_code) {
+        let position: number | null = null;
+        try {
+          const { data } = await service.rpc("waitlist_position", {
+            p_pubkey: pubkey,
+          });
+          if (typeof data === "number") position = data;
+        } catch (err) {
+          console.warn("[waitlist-signup] position lookup failed", err);
+        }
+        return NextResponse.json({
+          ok: true,
+          position,
+          referral_code: existing.referral_code,
+          returning: true,
+        });
+      }
+    } catch (err) {
+      console.warn("[waitlist-signup] lookup failed, falling through", err);
+      // Fall through to the normal signup flow — worst case the user
+      // gets the standard "invite required" error if they had no code.
+    }
+  }
+
   // ── Referrer validation (REQUIRED — invite-only) ────────────────────────
   // The waitlist is invite-only: every new signup must supply a valid
   // referral code from an existing member. Existing rows from before this
@@ -323,42 +404,11 @@ export async function POST(req: Request) {
     );
   }
 
-  // If we have wallet fields, verify them. (Whether or not email is provided.)
+  // Wallet signature was already verified at the top of this route
+  // (before the sign-in fast-path lookup). Only the mainnet spam check
+  // remains for new wallet signups — it fires here so existing-user
+  // lookups don't burn a Helius RPC call.
   if (hasWalletPart) {
-    if (!isValidSolanaPubkey(pubkey!)) {
-      return NextResponse.json({ error: "invalid pubkey" }, { status: 400 });
-    }
-    const ts = parseTimestampFromMessage(message!);
-    if (!ts) {
-      return NextResponse.json({ error: "invalid message format" }, { status: 400 });
-    }
-    if (Math.abs(Date.now() - ts) > MAX_MESSAGE_AGE_MS) {
-      return NextResponse.json({ error: "message expired" }, { status: 400 });
-    }
-    if (!message!.includes(pubkey!)) {
-      return NextResponse.json({ error: "message must include pubkey" }, { status: 400 });
-    }
-    let sigBytes: Uint8Array;
-    let pubBytes: Uint8Array;
-    try {
-      sigBytes = bs58.decode(signature!);
-      pubBytes = bs58.decode(pubkey!);
-    } catch {
-      return NextResponse.json({ error: "decode failed" }, { status: 400 });
-    }
-    if (sigBytes.length !== 64 || pubBytes.length !== 32) {
-      return NextResponse.json({ error: "wrong sig/pubkey length" }, { status: 400 });
-    }
-    const msgBytes = new TextEncoder().encode(message!);
-    const ok = nacl.sign.detached.verify(msgBytes, sigBytes, pubBytes);
-    if (!ok) {
-      return NextResponse.json({ error: "signature invalid" }, { status: 401 });
-    }
-
-    // Spam filter: wallet must have been seen on Solana mainnet at least once.
-    // The combined-shape rejection above guarantees hasEmail is false here, so
-    // the previous `if (!hasEmail)` guard is now redundant — the check runs
-    // unconditionally on the wallet-only path.
     const exists = await walletExistsOnMainnet(pubkey!);
     if (!exists) {
       return NextResponse.json(

--- a/app/app/waitlist/page.tsx
+++ b/app/app/waitlist/page.tsx
@@ -889,6 +889,13 @@ function SignupFlow() {
           disabled={busy}
         />
         <FormGateDivider unlocked={formUnlocked} />
+        {/* The x_handle is only relevant for NEW signups (it lands on the
+            inserted row). For returning users it's ignored, so we keep
+            it inside the locked container with the gate. The submit
+            button moves OUT of the locked container so pre-invite users
+            can sign in and look up their existing code without supplying
+            an invite — the server returns it once the wallet signature
+            proves ownership. */}
         <div
           className={`space-y-3.5 transition-opacity duration-200 ${
             formUnlocked ? "" : "pointer-events-none select-none opacity-40"
@@ -913,21 +920,27 @@ function SignupFlow() {
               tabIndex={formUnlocked ? 0 : -1}
             />
           </div>
-          <button
-            className={ctaPrimary}
-            onClick={onSign}
-            disabled={busy || !formUnlocked}
-            tabIndex={formUnlocked ? 0 : -1}
-          >
-            {state.kind === "signing"
-              ? "Signing in your wallet…"
-              : state.kind === "submitting"
-                ? "Submitting…"
-                : formUnlocked
-                  ? "Sign & claim spot →"
-                  : "Enter referral code to continue"}
-          </button>
         </div>
+        <button
+          className={ctaPrimary}
+          onClick={onSign}
+          disabled={busy}
+        >
+          {state.kind === "signing"
+            ? "Signing in your wallet…"
+            : state.kind === "submitting"
+              ? "Submitting…"
+              : formUnlocked
+                ? "Sign & claim spot →"
+                : "Sign in to check / look up code →"}
+        </button>
+        {!formUnlocked && (
+          <p className="font-mono text-[10.5px] leading-relaxed text-[var(--text-secondary)]">
+            Already on the waitlist? Sign — we&apos;ll surface your existing
+            referral code. New here? Enter a referral code above to claim
+            your spot.
+          </p>
+        )}
         <NoCodeFallback />
       </div>
     );


### PR DESCRIPTION
The 126 existing waitlist signups predate the invite-only gate. They have no referrer of their own, so #2171's "referral code required" check was blocking them from coming back to see the \`referral_code\` that the SQL backfill assigned to their row. Form locked, lookup never fired.

## Server (\`app/app/api/waitlist/signup/route.ts\`)
1. **Move wallet signature verification to the top** of the route. Pubkey is now trusted earlier, which makes the duplicate-lookup fast path safe.
2. **Insert a sign-in fast path** after sig verification: \`SELECT referral_code FROM waitlist WHERE pubkey = ?\`. If the row exists, return \`{ ok: true, referral_code, position, returning: true }\` and skip the referrer-required check entirely. The signature proved ownership, so returning the existing code is not a membership-oracle leak.
3. **Mainnet spam check moves down** below the fast path — pre-invite users looking up their code don't burn a Helius RPC call.
4. **Email-path unchanged.** Email duplicates still don't reveal the code (no proof of ownership); the operator-run backfill-emails action (#2174) covers them.

## Frontend (\`app/app/waitlist/page.tsx\`, \`SignupFlow\` ready state)
- **Submit button moves out of the locked container** so it stays clickable when no code is entered. The \`x_handle\` input stays inside the locked container (it's only relevant for new signups).
- **Button text adapts**: "Sign in to check / look up code →" when no valid code, "Sign & claim spot →" when a valid code is entered.
- **Helper line** below the locked button explains both paths.
- **\`returning: true\` handling already existed** — the welcome-back state and \`ReferralCard\` render automatically.

## What pre-invite users see now
1. Land on /waitlist, connect wallet (Privy)
2. Click "Sign in to check / look up code →" without entering any code
3. Sign the message
4. See "✓ welcome back" + their assigned \`referral_code\` + share link

## Tests
\`\`\`
pnpm vitest run __tests__/api/waitlist-signup-shape.test.ts \\
                __tests__/api/waitlist-signup-email-abuse.test.ts \\
                __tests__/lib/waitlist-referral-code.test.ts
# 17 passed
pnpm tsc --noEmit  # clean
\`\`\`