### PR TITLE
fix(rpc): gate the no-Origin/no-Referer path with INTERNAL_API_SECRET

### DIFF
--- a/app/__tests__/api/rpc-origin-guard.test.ts
+++ b/app/__tests__/api/rpc-origin-guard.test.ts
@@ -48,3 +48,121 @@ describe("/api/rpc origin guard", () => {
     expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("/api/rpc no-Origin server-call gate", () => {
+  const originalFetch = global.fetch;
+  const originalSecret = process.env.INTERNAL_API_SECRET;
+  const SECRET = "test-internal-secret-do-not-use-in-prod";
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = vi.fn().mockResolvedValue({
+      json: async () => ({ jsonrpc: "2.0", id: 1, result: "ok" }),
+    } as Response) as typeof fetch;
+    process.env.INTERNAL_API_SECRET = SECRET;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    if (originalSecret === undefined) {
+      delete process.env.INTERNAL_API_SECRET;
+    } else {
+      process.env.INTERNAL_API_SECRET = originalSecret;
+    }
+  });
+
+  // Cache-busting counter — the route caches getHealth responses for 5s with
+  // a module-level Map keyed on method+params, so reuse across tests would
+  // skip fetch. Each test gets a unique sentinel in params.
+  let nextParam = 1000;
+  function makeReq(headers: Record<string, string> = {}, body?: unknown): NextRequest {
+    nextParam += 1;
+    return new NextRequest("http://localhost/api/rpc", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...headers },
+      body: JSON.stringify(
+        body ?? {
+          jsonrpc: "2.0",
+          id: nextParam,
+          method: "getHealth",
+          params: [`test-${nextParam}`],
+        },
+      ),
+    });
+  }
+
+  it("rejects POST with no Origin AND no Referer AND no token (the original bypass)", async () => {
+    const res = await POST(makeReq());
+    expect(res.status).toBe(403);
+    expect(global.fetch).not.toHaveBeenCalled();
+    const body = await res.json();
+    expect(body.error.message).toBe("Forbidden");
+  });
+
+  it("rejects no-Origin POST with the wrong token", async () => {
+    const res = await POST(makeReq({ "x-internal-token": "wrong" }));
+    expect(res.status).toBe(403);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects no-Origin POST with an empty-string token", async () => {
+    const res = await POST(makeReq({ "x-internal-token": "" }));
+    expect(res.status).toBe(403);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("accepts no-Origin POST with the correct X-Internal-Token", async () => {
+    const res = await POST(makeReq({ "x-internal-token": SECRET }));
+    expect(res.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when INTERNAL_API_SECRET is unset (no token can succeed)", async () => {
+    delete process.env.INTERNAL_API_SECRET;
+    const res = await POST(makeReq({ "x-internal-token": SECRET }));
+    expect(res.status).toBe(403);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when INTERNAL_API_SECRET is an empty string", async () => {
+    process.env.INTERNAL_API_SECRET = "";
+    const res = await POST(makeReq({ "x-internal-token": SECRET }));
+    expect(res.status).toBe(403);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when INTERNAL_API_SECRET is whitespace-only", async () => {
+    process.env.INTERNAL_API_SECRET = "   ";
+    // Whitespace .trim() reduces to empty → fail closed even if a token literally matches the untrimmed value.
+    const res = await POST(makeReq({ "x-internal-token": "   " }));
+    expect(res.status).toBe(403);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("regression: closes the high-impact sendTransaction relay path", async () => {
+    // The original bypass let anonymous callers broadcast arbitrary signed
+    // transactions through the project's paid Helius mainnet key.
+    const res = await POST(
+      makeReq(
+        {},
+        { jsonrpc: "2.0", id: 1, method: "sendTransaction", params: ["<base64-tx>"] },
+      ),
+    );
+    expect(res.status).toBe(403);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("browser path is unaffected: Origin: percolatorlaunch.com still passes without a token", async () => {
+    const res = await POST(makeReq({ origin: "https://percolatorlaunch.com" }));
+    expect(res.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("browser path is unaffected: Referer-only with valid hostname still passes without a token", async () => {
+    const res = await POST(
+      makeReq({ referer: "https://app.percolatorlaunch.com/trade" }),
+    );
+    expect(res.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/app/api/rpc/route.ts
+++ b/app/app/api/rpc/route.ts
@@ -47,6 +47,27 @@ function getDeploymentNetwork(): "mainnet" | "devnet" {
 }
 
 /**
+ * Timing-safe comparison of an inbound token against INTERNAL_API_SECRET.
+ *
+ * Returns true iff INTERNAL_API_SECRET is set, non-empty, and the provided
+ * token matches it exactly. Fails closed when the env var is unset/empty so
+ * misconfig cannot widen access. Both values are SHA-256 hashed before the
+ * compare so buffers have equal length and the comparison time is independent
+ * of the secret length.
+ *
+ * Shared by the no-Origin server-call gate in isAllowedOrigin and the
+ * cross-network override gate in validateNetworkOverride. One canonical
+ * comparison, one place to audit.
+ */
+function checkInternalSecret(token: string | null | undefined): boolean {
+  const secret = process.env.INTERNAL_API_SECRET?.trim();
+  if (!secret) return false;
+  const expected = createHash("sha256").update(secret).digest();
+  const provided = createHash("sha256").update(token ?? "").digest();
+  return timingSafeEqual(expected, provided);
+}
+
+/**
  * Validate that a network override is permitted for this deployment.
  * Returns an error response string, or null if allowed.
  */
@@ -64,18 +85,8 @@ function validateNetworkOverride(
 
   // Rule 2 & 3: any cross-network override requires internal auth secret
   if (requestedNetwork !== deploymentNetwork) {
-    const secret = process.env.INTERNAL_API_SECRET?.trim();
-    if (!secret) {
-      // No secret configured — disallow all network overrides for safety
-      console.warn("[/api/rpc] PERC-8310: network override blocked (INTERNAL_API_SECRET not set)");
-      return { error: "Network override requires authentication", status: 403 };
-    }
-    // Use timing-safe comparison to prevent side-channel brute-force of the secret.
-    // Hash both values to equalise buffer lengths (timingSafeEqual requires same length).
-    const expected = createHash("sha256").update(secret).digest();
-    const provided = createHash("sha256").update(authHeader ?? "").digest();
-    if (!timingSafeEqual(expected, provided)) {
-      console.warn("[/api/rpc] PERC-8310: network override blocked (invalid secret)");
+    if (!checkInternalSecret(authHeader)) {
+      console.warn("[/api/rpc] PERC-8310: network override blocked (missing/invalid INTERNAL_API_SECRET)");
       return { error: "Network override requires authentication", status: 403 };
     }
   }
@@ -318,15 +329,39 @@ async function processSingleRequest(
 }
 
 /**
- * PERC-8308: Enforce same-origin or allowlisted origin for all POST requests.
- * Prevents arbitrary external callers from abusing the Helius API key quota.
+ * Enforce same-origin or authenticated server-call on every POST.
+ *
+ * Two acceptance paths:
+ *   (a) Browser path — request carries Origin or Referer whose hostname is the
+ *       apex domain, an allowed subdomain, or localhost. No token required.
+ *   (b) Server path — request has neither Origin nor Referer (curl, internal
+ *       services, cron jobs) and MUST present X-Internal-Token matching
+ *       INTERNAL_API_SECRET. Fails closed when INTERNAL_API_SECRET is unset
+ *       or empty, so misconfig cannot widen access.
+ *
+ * Anything else (foreign Origin, malformed URL, mismatched token) is rejected
+ * with 403. Previously this gate had an unconditional `if (!origin && !referer)
+ * return true` branch justified as "server-side calls have no Origin header,"
+ * but no in-repo server caller routes through /api/rpc — `getRpcEndpoint()`
+ * returns the direct Helius URL server-side. The bypass allowed any anonymous
+ * external caller (curl, scripts, botnets) to drain paid Helius mainnet quota
+ * and relay arbitrary user-signed transactions via the allowlisted methods.
  */
 function isAllowedOrigin(req: NextRequest): boolean {
   const origin = req.headers.get("origin");
   const referer = req.headers.get("referer");
 
-  // Server-side calls (Railway services, crons) have no Origin header — allow
-  if (!origin && !referer) return true;
+  // Server-side path: no browser-provided origin. Require the shared secret.
+  // Any future internal caller (Railway service, cron, healthcheck) must send
+  // X-Internal-Token: $INTERNAL_API_SECRET. Fails closed if the env var is
+  // unset, so an unconfigured deployment cannot accidentally be open.
+  if (!origin && !referer) {
+    const ok = checkInternalSecret(req.headers.get("x-internal-token"));
+    if (!ok) {
+      console.warn("[/api/rpc] no-Origin request rejected (missing/invalid X-Internal-Token)");
+    }
+    return ok;
+  }
 
   const hostToCheck = origin ?? referer ?? "";
   let hostname: string | null = null;


### PR DESCRIPTION
Supersedes #2173 — Squid's PR was based on a pre-history-rewrite SHA, so GitHub was showing 44K-line divergence as the diff. This is a clean cherry-pick of the actual fix commit (76789be9) onto current main. **Authorship preserved as @0X-SquidSol.**

## What the fix does
The \`/api/rpc\` proxy guards browser callers via Origin/Referer hostname allowlist but had an unconditional bypass for callers that omit both headers:

\`\`\`ts
// Server-side calls (Railway services, crons) have no Origin header — allow
if (!origin && !referer) return true;
\`\`\`

That branch is reached by every non-browser HTTP client (curl, node-fetch, python-requests, bots) since none set those headers by default. The bypass let **anonymous external callers drain our paid Helius mainnet key**, including the broadcast-capable \`sendTransaction\` and \`simulateTransaction\` methods in \`ALLOWED_RPC_METHODS\`.

The "server-side internal caller" justification doesn't hold: \`getRpcEndpoint()\` in \`app/lib/config.ts\` returns the direct Helius URL server-side (verified: \`typeof window === "undefined"\` branch returns \`https://mainnet.helius-rpc.com/?api-key=…\`), so no in-repo code routes through \`/api/rpc\` from the server. Browser-only callers like \`devnet-mint-content.tsx\`, \`tokenMeta.ts\`, \`batchRpc.ts\` all build the URL via \`window.location.origin\` and carry an Origin header — they're unaffected.

## Implementation
- Extracts the existing \`sha256 + timingSafeEqual\` comparison into a private \`checkInternalSecret(token)\` helper, used by both the existing cross-network override gate (\`validateNetworkOverride\`) and the new no-Origin gate (\`isAllowedOrigin\`). One place to audit.
- Replaces the bypass: no-Origin path now requires \`X-Internal-Token === INTERNAL_API_SECRET\`. Fails closed when \`INTERNAL_API_SECRET\` is unset/empty/whitespace.
- Browser path unchanged: requests with Origin/Referer matching \`percolatorlaunch.com\`, \`*.percolatorlaunch.com\`, or localhost continue through with no token.
- No new env var. Reuses \`INTERNAL_API_SECRET\` already documented in \`.env.example\`.

## Tests
\`\`\`
pnpm vitest run __tests__/api/rpc-origin-guard.test.ts
# 12 passed (2 pre-existing + 10 new)
pnpm tsc --noEmit  # clean
\`\`\`

New test coverage (10 cases): rejects no-Origin POST without token / with wrong token / with empty token, accepts with correct token, fails closed across three INTERNAL_API_SECRET misconfig states, regression-guards the \`sendTransaction\` relay path, verifies the Origin-carrying and Referer-only browser paths still pass without a token.

## Required after deploy
Make sure \`INTERNAL_API_SECRET\` is set on Vercel Production (it already gates the cross-network override per PERC-8310, so this is likely already set — verify before merge auto-deploys).

Closes #2173