### PR TITLE
chore: sync pnpm-lock specifier for @percolatorct/sdk to match exact pin

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ importers:
   .:
     dependencies:
       '@percolatorct/sdk':
-        specifier: ^2.0.9
+        specifier: 2.0.9
         version: 2.0.9(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/spl-token':
         specifier: ^0.4.14
@@ -64,7 +64,7 @@ importers:
   app:
     dependencies:
       '@percolatorct/sdk':
-        specifier: ^2.0.9
+        specifier: 2.0.9
         version: 2.0.9(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@privy-io/react-auth':
         specifier: ^3.14.1


### PR DESCRIPTION
Unblocks the Vercel build that started failing tonight:

\`\`\`
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with <ROOT>/package.json
* 1 dependencies are mismatched:
  - @percolatorct/sdk (lockfile: ^2.0.9, manifest: 2.0.9)
\`\`\`

PR #2161 pinned \`@percolatorct/sdk\` to \`"2.0.9"\` (exact) in both \`package.json\` files but the lockfile still recorded \`specifier: ^2.0.9\` for both workspace projects. Vercel CI runs \`pnpm install\` with \`--frozen-lockfile\` by default, so the mismatch was a hard fail.

\`\`\`
importers:
  .:    '@percolatorct/sdk': specifier: ^2.0.9 → 2.0.9
  app:  '@percolatorct/sdk': specifier: ^2.0.9 → 2.0.9
\`\`\`

The resolved version is unchanged (2.0.9 in both cases) — metadata-only sync, no dependency churn.