### PR TITLE
feat(waitlist): Privy session unifies returning users with their waitlist row

### DIFF
--- a/app/.env.local.example
+++ b/app/.env.local.example
@@ -16,3 +16,8 @@ INDEXER_API_KEY="your-api-key"
 
 # Privy wallet integration
 NEXT_PUBLIC_PRIVY_APP_ID=
+# Server-side Privy app secret — required for /api/waitlist/whoami and the
+# Privy-DID linkage in /api/waitlist/signup. Generate it in the Privy
+# dashboard (App Settings → API Keys). Without it both routes degrade
+# gracefully (the form still works, just no auto-detection of returning users).
+PRIVY_APP_SECRET=

--- a/app/app/api/waitlist/signup/route.ts
+++ b/app/app/api/waitlist/signup/route.ts
@@ -6,6 +6,7 @@ import { Resend } from "resend";
 import { Redis } from "@upstash/redis";
 import { Ratelimit } from "@upstash/ratelimit";
 import { renderWelcomeEmail } from "@/lib/waitlist/email-template";
+import { verifyPrivyAuth } from "@/lib/privy-auth";
 import {
   getWaitlistSupabase,
   getWaitlistServiceSupabase,
@@ -203,6 +204,15 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "invalid json" }, { status: 400 });
   }
 
+  // Optional Privy attestation. When present and verifiable, we'll:
+  //   • match this signup to an existing waitlist row by DID first,
+  //   • backfill privy_did onto rows we find via pubkey or email,
+  //   • stamp privy_did onto any new row we insert.
+  // The route still accepts unauthenticated signups (just an email or
+  // just a wallet sig) — the DID is purely additive when supplied.
+  const privyAuth = await verifyPrivyAuth(req);
+  const privyDid = privyAuth.ok ? privyAuth.userId : null;
+
   const b = body as Record<string, unknown>;
 
   // Honeypot — silently accept and drop
@@ -331,10 +341,26 @@ export async function POST(req: Request) {
       const service = getWaitlistServiceSupabase();
       const { data: existing } = await service
         .from("waitlist")
-        .select("referral_code")
+        .select("id, referral_code, privy_did")
         .eq("pubkey", pubkey)
         .maybeSingle();
       if (existing && existing.referral_code) {
+        // Opportunistic Privy DID backfill — if the caller carries a
+        // valid Privy session and this row has no DID yet, link them
+        // so future /whoami lookups are O(1) on the indexed column.
+        if (privyDid && !existing.privy_did) {
+          try {
+            await service
+              .from("waitlist")
+              .update({ privy_did: privyDid })
+              .eq("id", existing.id)
+              .is("privy_did", null);
+          } catch (err) {
+            // 23505 means another concurrent request claimed the DID;
+            // the row is now linked either way. Non-fatal.
+            console.warn("[waitlist-signup] privy_did backfill non-fatal", err);
+          }
+        }
         let position: number | null = null;
         try {
           const { data } = await service.rpc("waitlist_position", {
@@ -442,6 +468,7 @@ export async function POST(req: Request) {
     baseRow.message = message;
   }
   baseRow.referred_by_code = referredByCode;
+  if (privyDid) baseRow.privy_did = privyDid;
 
   const MAX_CODE_ATTEMPTS = 8;
   let referralCode: string | null = null;

--- a/app/app/api/waitlist/whoami/route.ts
+++ b/app/app/api/waitlist/whoami/route.ts
@@ -1,0 +1,165 @@
+import { NextResponse } from "next/server";
+import { getWaitlistServiceSupabase } from "@/lib/waitlist/supabase";
+import { verifyPrivyAuth } from "@/lib/privy-auth";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/waitlist/whoami
+ *
+ * Identity-aware waitlist lookup.
+ *
+ * Auth: Privy access token in `Authorization: Bearer …`. Optionally
+ * `X-Privy-Id-Token` for the no-rate-limit path that parses linked
+ * accounts directly from the id token.
+ *
+ * Resolution order:
+ *   1. Look up by privy_did   — fastest, indexed, no false matches
+ *   2. Look up by pubkey      — for users who signed up wallet-only
+ *                                 before Privy was wired up to write DIDs
+ *   3. Look up by email       — for users who signed up email-only
+ *
+ * On a (2) or (3) hit, opportunistically backfill `privy_did` so the
+ * next request is a (1) hit. This unifies the 126 pre-Privy-DID rows
+ * over time with no migration script.
+ *
+ * Returns:
+ *   { found: true, referral_code, position, returning, linked: {…} }
+ *   { found: false }                       — Privy user, no waitlist row yet
+ *   401                                    — token missing / invalid
+ *   503                                    — server not configured for Privy
+ *
+ * Never reveals which identifier matched (privy_did vs pubkey vs email)
+ * because the client doesn't need to know and the response would be a
+ * mild side-channel about which channel a user originally signed up
+ * through.
+ */
+export async function POST(req: Request) {
+  const auth = await verifyPrivyAuth(req);
+  if (!auth.ok) {
+    return NextResponse.json(
+      { error: auth.reason },
+      { status: auth.status },
+    );
+  }
+
+  try {
+    const supabase = getWaitlistServiceSupabase();
+
+    // ── Step 1: privy_did exact match ────────────────────────────────
+    {
+      const { data } = await supabase
+        .from("waitlist")
+        .select("id, pubkey, email, referral_code, privy_did, created_at")
+        .eq("privy_did", auth.userId)
+        .maybeSingle();
+      if (data?.referral_code) {
+        const position = await getPosition(supabase, data);
+        return NextResponse.json({
+          found: true,
+          referral_code: data.referral_code,
+          position,
+          returning: true,
+        });
+      }
+    }
+
+    // ── Step 2: pubkey match (legacy wallet-path signups) ────────────
+    for (const pubkey of auth.solanaWallets) {
+      const { data } = await supabase
+        .from("waitlist")
+        .select("id, pubkey, email, referral_code, privy_did, created_at")
+        .eq("pubkey", pubkey)
+        .maybeSingle();
+      if (data?.referral_code) {
+        // Opportunistic backfill — if this row has no DID yet, claim it.
+        if (!data.privy_did) {
+          await backfillPrivyDid(supabase, data.id, auth.userId);
+        }
+        const position = await getPosition(supabase, data);
+        return NextResponse.json({
+          found: true,
+          referral_code: data.referral_code,
+          position,
+          returning: true,
+        });
+      }
+    }
+
+    // ── Step 3: email match (legacy email-path signups) ──────────────
+    if (auth.email) {
+      const { data } = await supabase
+        .from("waitlist")
+        .select("id, pubkey, email, referral_code, privy_did, created_at")
+        .eq("email", auth.email)
+        .maybeSingle();
+      if (data?.referral_code) {
+        if (!data.privy_did) {
+          await backfillPrivyDid(supabase, data.id, auth.userId);
+        }
+        const position = await getPosition(supabase, data);
+        return NextResponse.json({
+          found: true,
+          referral_code: data.referral_code,
+          position,
+          returning: true,
+        });
+      }
+    }
+
+    // No matching row — this Privy user isn't on the waitlist yet.
+    return NextResponse.json({ found: false });
+  } catch (err) {
+    console.error("[whoami] unexpected", err);
+    return NextResponse.json({ error: "unexpected" }, { status: 500 });
+  }
+}
+
+async function backfillPrivyDid(
+  supabase: ReturnType<typeof getWaitlistServiceSupabase>,
+  rowId: string,
+  did: string,
+): Promise<void> {
+  try {
+    // `is_null` guard keeps the update idempotent against concurrent
+    // requests for the same Privy user across multiple identifiers.
+    const { error } = await supabase
+      .from("waitlist")
+      .update({ privy_did: did })
+      .eq("id", rowId)
+      .is("privy_did", null);
+    if (error) {
+      // Unique-violation (23505) means another concurrent call won
+      // the race for this DID — that's fine, the row is now linked.
+      if (error.code !== "23505") {
+        console.warn("[whoami] backfill privy_did failed", error);
+      }
+    }
+  } catch (err) {
+    console.warn("[whoami] backfill threw", err);
+  }
+}
+
+async function getPosition(
+  supabase: ReturnType<typeof getWaitlistServiceSupabase>,
+  row: { pubkey: string | null; email: string | null },
+): Promise<number | null> {
+  try {
+    if (row.pubkey) {
+      const { data } = await supabase.rpc("waitlist_position", {
+        p_pubkey: row.pubkey,
+      });
+      if (typeof data === "number") return data;
+    }
+    if (row.email) {
+      const { data } = await supabase.rpc("waitlist_position_by_email", {
+        p_email: row.email,
+      });
+      if (typeof data === "number") return data;
+    }
+  } catch (err) {
+    console.warn("[whoami] position lookup failed", err);
+  }
+  return null;
+}

--- a/app/app/waitlist/page.tsx
+++ b/app/app/waitlist/page.tsx
@@ -6,6 +6,7 @@ import { usePrivy, useLoginWithEmail } from "@privy-io/react-auth";
 import { useWallets, useSignMessage } from "@privy-io/react-auth/solana";
 import { usePrivyAvailable } from "@/hooks/usePrivySafe";
 import { resolveActiveWallet, usePreferredWallet } from "@/hooks/usePreferredWallet";
+import { useWaitlistWhoami } from "@/hooks/useWaitlistWhoami";
 import bs58 from "bs58";
 
 /**
@@ -297,6 +298,13 @@ function SpecField({
 function SignupCard() {
   const privyAvailable = usePrivyAvailable();
   const [tab, setTab] = useState<"wallet" | "email">("wallet");
+
+  // Auto-detect: if the visitor is already a Privy user *and* already on
+  // the waitlist (by DID / wallet / email), skip the signup form entirely
+  // and surface their existing referral code. Returns "idle" / "checking"
+  // / "not-found" / "found" — we only intercept the rendering on "found".
+  const whoami = useWaitlistWhoami();
+
   return (
     <div className="relative w-full max-w-[460px]">
       {/* Static accent gradient halo behind the card — gives it presence */}
@@ -325,42 +333,115 @@ function SignupCard() {
               waitlist · v1
             </span>
           </div>
-          <span className="inline-flex items-center gap-1.5 rounded-sm border border-[var(--accent)]/50 bg-[var(--accent)]/[0.12] px-2 py-0.5 font-mono text-[9.5px] uppercase tracking-[0.18em] text-[var(--accent)]">
-            <svg
-              aria-hidden
-              viewBox="0 0 12 12"
-              className="h-2.5 w-2.5"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth={1.6}
-            >
-              <rect x="3" y="5.5" width="6" height="5" rx="0.6" />
-              <path d="M4.25 5.5V3.75a1.75 1.75 0 1 1 3.5 0V5.5" />
-            </svg>
-            Invite only
-          </span>
-        </div>
-
-        {/* Tab selector */}
-        <div className="mb-4 grid grid-cols-2 gap-1 rounded-md border border-[var(--border)] bg-[var(--bg)] p-1">
-          <TabButton active={tab === "wallet"} onClick={() => setTab("wallet")}>
-            Wallet
-          </TabButton>
-          <TabButton active={tab === "email"} onClick={() => setTab("email")}>
-            Email
-          </TabButton>
-        </div>
-
-        {tab === "wallet" ? (
-          privyAvailable ? (
-            <SignupFlow />
+          {whoami.status === "found" ? (
+            <span className="inline-flex items-center gap-1.5 rounded-sm border border-[var(--cyan)]/50 bg-[var(--cyan)]/[0.12] px-2 py-0.5 font-mono text-[9.5px] uppercase tracking-[0.18em] text-[var(--cyan)]">
+              ✓ on the list
+            </span>
           ) : (
-            <StatusErr>Wallet provider not configured. Reload the page.</StatusErr>
-          )
+            <span className="inline-flex items-center gap-1.5 rounded-sm border border-[var(--accent)]/50 bg-[var(--accent)]/[0.12] px-2 py-0.5 font-mono text-[9.5px] uppercase tracking-[0.18em] text-[var(--accent)]">
+              <svg
+                aria-hidden
+                viewBox="0 0 12 12"
+                className="h-2.5 w-2.5"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={1.6}
+              >
+                <rect x="3" y="5.5" width="6" height="5" rx="0.6" />
+                <path d="M4.25 5.5V3.75a1.75 1.75 0 1 1 3.5 0V5.5" />
+              </svg>
+              Invite only
+            </span>
+          )}
+        </div>
+
+        {whoami.status === "found" ? (
+          <WelcomeBackPanel
+            referralCode={whoami.referralCode}
+            position={whoami.position}
+          />
         ) : (
-          <EmailFlow />
+          <>
+            {/* Tab selector */}
+            <div className="mb-4 grid grid-cols-2 gap-1 rounded-md border border-[var(--border)] bg-[var(--bg)] p-1">
+              <TabButton active={tab === "wallet"} onClick={() => setTab("wallet")}>
+                Wallet
+              </TabButton>
+              <TabButton active={tab === "email"} onClick={() => setTab("email")}>
+                Email
+              </TabButton>
+            </div>
+
+            {whoami.status === "checking" && (
+              <div className="mb-3 flex items-center gap-2 font-mono text-[10.5px] uppercase tracking-[0.18em] text-[var(--text-dim)]">
+                <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-[var(--accent)]" />
+                checking_session...
+              </div>
+            )}
+
+            {tab === "wallet" ? (
+              privyAvailable ? (
+                <SignupFlow />
+              ) : (
+                <StatusErr>Wallet provider not configured. Reload the page.</StatusErr>
+              )
+            ) : (
+              <EmailFlow />
+            )}
+          </>
         )}
       </div>
+    </div>
+  );
+}
+
+/**
+ * Returning-user UI. Shown when /api/waitlist/whoami resolves to "found"
+ * via Privy session — usually a single fetch after page load, no manual
+ * sign / submit step required from the user.
+ *
+ * Reuses ReferralCard for the code + share link block so the visual
+ * language matches the post-signup state of the existing flows.
+ */
+function WelcomeBackPanel({
+  referralCode,
+  position,
+}: {
+  referralCode: string;
+  position: number | null;
+}) {
+  const shareUrl = `https://percolator.trade/r/${referralCode}`;
+  return (
+    <div className="space-y-3.5">
+      <PromptLine prefix="$" text="welcome_back" status="ok" />
+      <div className="rounded-md border border-[var(--cyan)]/25 bg-[var(--cyan)]/[0.05] p-3.5">
+        <div className="font-mono text-[11px] uppercase tracking-[0.12em] text-[var(--cyan)]">
+          ✓ already on the list
+        </div>
+        {position ? (
+          <div
+            className="mt-1.5 font-mono text-[28px] font-bold leading-none text-[var(--text)]"
+            style={{ fontVariantNumeric: "tabular-nums" }}
+          >
+            #{position.toLocaleString()}
+          </div>
+        ) : null}
+        <p className="mt-2 text-[12.5px] leading-relaxed text-[var(--text-secondary)]">
+          We recognised you from your Privy session — no need to sign again.
+          Your referral code is below.
+        </p>
+      </div>
+      <ReferralCard code={referralCode} shareUrl={shareUrl} />
+      <a
+        className={ctaSecondary}
+        href={`https://x.com/intent/post?text=${encodeURIComponent(
+          `Just got my Percolator waitlist code: ${referralCode}. Permissionless perp futures on Solana. ${shareUrl}`,
+        )}`}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        → Share on X
+      </a>
     </div>
   );
 }

--- a/app/hooks/useWaitlistWhoami.ts
+++ b/app/hooks/useWaitlistWhoami.ts
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePrivy, useIdentityToken } from "@privy-io/react-auth";
+import { usePrivyAvailable } from "@/hooks/usePrivySafe";
+
+export type WhoamiState =
+  | { status: "idle" }
+  | { status: "checking" }
+  | { status: "not-found" }
+  | {
+      status: "found";
+      referralCode: string;
+      position: number | null;
+    }
+  | { status: "error"; reason: string };
+
+/**
+ * Polls /api/waitlist/whoami exactly once when the user becomes
+ * Privy-authenticated. Backed by server-side Privy session verification,
+ * so the result is trustworthy.
+ *
+ * Three terminal states the consumer cares about:
+ *   • idle / checking — render the existing signup form
+ *   • found           — render the welcome-back card (skip signup)
+ *   • not-found       — render the signup form (this Privy user has
+ *                       never joined the waitlist)
+ *
+ * The hook never blocks the rest of the page from rendering. If the
+ * fetch errors (network, server, 5xx), it falls back to "not-found"
+ * so the user can still complete a signup manually.
+ */
+export function useWaitlistWhoami(): WhoamiState {
+  const privyAvailable = usePrivyAvailable();
+  const { ready, authenticated, getAccessToken } = usePrivy();
+  // useIdentityToken only works inside PrivyProvider. The hook itself
+  // is null-safe at runtime, but TypeScript wants us to call it
+  // unconditionally — we guard the *use* of the result instead.
+  const { identityToken } = useIdentityToken();
+  const [state, setState] = useState<WhoamiState>({ status: "idle" });
+
+  useEffect(() => {
+    if (!privyAvailable) {
+      setState({ status: "idle" });
+      return;
+    }
+    if (!ready) return;
+    if (!authenticated) {
+      setState({ status: "idle" });
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      setState({ status: "checking" });
+      try {
+        const accessToken = await getAccessToken();
+        if (!accessToken) {
+          if (!cancelled) setState({ status: "not-found" });
+          return;
+        }
+        const headers: Record<string, string> = {
+          Authorization: `Bearer ${accessToken}`,
+        };
+        if (identityToken) headers["x-privy-id-token"] = identityToken;
+
+        const res = await fetch("/api/waitlist/whoami", {
+          method: "POST",
+          headers,
+        });
+        if (cancelled) return;
+        if (res.status === 503) {
+          // Server isn't configured for Privy (no PRIVY_APP_SECRET).
+          // Falling back to not-found lets the signup form keep working.
+          setState({ status: "not-found" });
+          return;
+        }
+        if (!res.ok) {
+          setState({ status: "not-found" });
+          return;
+        }
+        const json = (await res.json()) as {
+          found?: boolean;
+          referral_code?: string | null;
+          position?: number | null;
+        };
+        if (json.found && json.referral_code) {
+          setState({
+            status: "found",
+            referralCode: json.referral_code,
+            position: typeof json.position === "number" ? json.position : null,
+          });
+        } else {
+          setState({ status: "not-found" });
+        }
+      } catch (err) {
+        if (cancelled) return;
+        console.warn("[whoami] fetch failed", err);
+        setState({
+          status: "error",
+          reason: err instanceof Error ? err.message : "unknown",
+        });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [privyAvailable, ready, authenticated, getAccessToken, identityToken]);
+
+  return state;
+}

--- a/app/lib/privy-auth.ts
+++ b/app/lib/privy-auth.ts
@@ -1,0 +1,141 @@
+import { PrivyClient } from "@privy-io/server-auth";
+
+/**
+ * Server-side Privy auth helper.
+ *
+ * Verifies the access token from the `Authorization: Bearer …` header
+ * (security boundary — proves the request came from a valid Privy
+ * session). If an `X-Privy-Id-Token` header is also present, parses it
+ * locally to extract linked accounts (email, wallets) without making a
+ * Privy API call. Falls back to `getUser(userId)` (rate-limited) when
+ * the id-token isn't supplied.
+ *
+ * Returns a flat shape so route handlers don't need to know about
+ * Privy's LinkedAccount discriminated union — they just want the email
+ * and a list of solana addresses.
+ */
+
+const APP_ID = process.env.NEXT_PUBLIC_PRIVY_APP_ID?.trim();
+const APP_SECRET = process.env.PRIVY_APP_SECRET?.trim();
+
+let _client: PrivyClient | null = null;
+
+function getClient(): PrivyClient | null {
+  if (_client) return _client;
+  if (!APP_ID || !APP_SECRET) return null;
+  _client = new PrivyClient(APP_ID, APP_SECRET);
+  return _client;
+}
+
+export interface PrivyAuthResult {
+  userId: string; // Privy DID, e.g. "did:privy:cl…"
+  email: string | null; // lowercased
+  solanaWallets: string[]; // base58 pubkeys
+}
+
+export type PrivyAuthError =
+  | { ok: false; status: 401; reason: "missing-token" | "invalid-token" }
+  | { ok: false; status: 503; reason: "not-configured" };
+
+export type PrivyAuthOk = { ok: true } & PrivyAuthResult;
+
+/**
+ * Verify a Privy session from the request headers.
+ *
+ *  Authorization: Bearer <accessToken>     (required — security boundary)
+ *  X-Privy-Id-Token: <idToken>              (optional — avoids rate-limited API call)
+ *
+ * Returns the verified DID plus best-effort linked email + Solana wallets.
+ * Both lookup branches (id-token parse vs server-side getUser) yield
+ * the same shape; callers shouldn't have to care which path served.
+ */
+export async function verifyPrivyAuth(
+  req: Request,
+): Promise<PrivyAuthOk | PrivyAuthError> {
+  const client = getClient();
+  if (!client) {
+    return { ok: false, status: 503, reason: "not-configured" };
+  }
+
+  const auth = req.headers.get("authorization") ?? "";
+  const token = auth.startsWith("Bearer ") ? auth.slice("Bearer ".length).trim() : "";
+  if (!token) {
+    return { ok: false, status: 401, reason: "missing-token" };
+  }
+
+  let userId: string;
+  try {
+    const claims = await client.verifyAuthToken(token);
+    userId = claims.userId;
+  } catch (err) {
+    console.warn("[privy-auth] verify failed", err);
+    return { ok: false, status: 401, reason: "invalid-token" };
+  }
+
+  // Try the id-token fast path first; fall back to the deprecated
+  // getUser(userId) only if the client didn't supply one. Both yield
+  // the same User shape.
+  const idToken = req.headers.get("x-privy-id-token")?.trim() ?? "";
+  let user: Awaited<ReturnType<typeof client.getUser>> | null = null;
+  try {
+    if (idToken) {
+      user = await client.getUser({ idToken });
+    } else {
+      user = await client.getUser(userId);
+    }
+  } catch (err) {
+    // If id-token parse fails, retry against the API one time so we
+    // still return useful claims rather than refusing the request.
+    console.warn("[privy-auth] getUser failed, retrying via userId", err);
+    try {
+      user = await client.getUser(userId);
+    } catch (err2) {
+      console.warn("[privy-auth] getUser retry also failed — returning DID only", err2);
+    }
+  }
+
+  const email = extractEmail(user);
+  const solanaWallets = extractSolanaWallets(user);
+
+  return { ok: true, userId, email, solanaWallets };
+}
+
+function extractEmail(user: Awaited<ReturnType<PrivyClient["getUser"]>> | null): string | null {
+  if (!user) return null;
+  // The User object exposes a top-level `email` for the primary email
+  // account, plus linked Email/Google/etc accounts. We want the address
+  // they actually used — prefer the primary, then any linked email,
+  // then any oauth provider that exposes an email.
+  const accounts = user.linkedAccounts ?? [];
+  for (const a of accounts) {
+    if (a.type === "email" && "address" in a && typeof a.address === "string") {
+      return a.address.toLowerCase();
+    }
+  }
+  for (const a of accounts) {
+    if (
+      (a.type === "google_oauth" || a.type === "apple_oauth") &&
+      "email" in a &&
+      typeof a.email === "string"
+    ) {
+      return a.email.toLowerCase();
+    }
+  }
+  return null;
+}
+
+function extractSolanaWallets(
+  user: Awaited<ReturnType<PrivyClient["getUser"]>> | null,
+): string[] {
+  if (!user) return [];
+  const out: string[] = [];
+  for (const a of user.linkedAccounts ?? []) {
+    // Privy types its wallet entries as `wallet` with a `chainType` field.
+    if (a.type === "wallet" && "chainType" in a && a.chainType === "solana") {
+      if ("address" in a && typeof a.address === "string") {
+        out.push(a.address);
+      }
+    }
+  }
+  return out;
+}

--- a/app/package.json
+++ b/app/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@percolatorct/sdk": "2.0.9",
     "@privy-io/react-auth": "^3.14.1",
+    "@privy-io/server-auth": "^1.32.5",
     "@sentry/nextjs": "^10.39.0",
     "@solana-program/memo": "^0.11.0",
     "@solana/kit": "^6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       '@privy-io/react-auth':
         specifier: ^3.14.1
         version: 3.14.1(@solana-program/memo@0.11.0(@solana/kit@6.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/system@0.10.0(@solana/kit@6.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/token@0.9.0(@solana/kit@6.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/kit@6.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@18.3.1))(@types/react@19.2.13)(@upstash/redis@1.36.4)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@privy-io/server-auth':
+        specifier: ^1.32.5
+        version: 1.32.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       '@sentry/nextjs':
         specifier: ^10.39.0
         version: 10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.105.2(esbuild@0.27.3))
@@ -650,6 +653,18 @@ packages:
     resolution: {integrity: sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==}
     peerDependencies:
       react: '>= 16 || ^19.0.0-rc'
+
+  '@hpke/chacha20poly1305@1.8.0':
+    resolution: {integrity: sha512-FcBfAQ+Y99vMNJP2yrZ9wpL8V0GOwp1+zMyzvc6alasrBygfFjFm1yeUtyADJCu/27C3Lm5mJzx6u7pwg+cX5w==}
+    engines: {node: '>=16.0.0'}
+
+  '@hpke/common@1.10.1':
+    resolution: {integrity: sha512-moJwhmtLtuxiUzzNp1jpfBfx8yefKoO9D/RCR9dmwrnc7qjJqId1rEtQz+lSlU5cabX8daToMSx/7HayXOiaFw==}
+    engines: {node: '>=16.0.0'}
+
+  '@hpke/core@1.9.0':
+    resolution: {integrity: sha512-pFxWl1nNJeQCSUFs7+GAblHvXBCjn9EPN65vdKlYQil2aURaRxfGMO6vBKGqm1YHTKwiAxJQNEI70PbSowMP9Q==}
+    engines: {node: '>=16.0.0'}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1378,6 +1393,9 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.8
 
+  '@privy-io/api-base@1.7.0':
+    resolution: {integrity: sha512-ji6ARQAAuW/FzRTgft9NCjRuouWX9t+J7JMmvLPsnXQJDFEV9mqh4sWXZhQ8ddTq/iDZ4z/yz1ORJqN8bYAi4Q==}
+
   '@privy-io/api-base@1.8.2':
     resolution: {integrity: sha512-pEvZ73GnC2OB/w35MGCPhqZ8mnApXgUpXxM0t9qZmNzvDNoMKBLPgysUXouAx7E4jO8REJPuwX70Y1AqJ/51kg==}
 
@@ -1409,6 +1427,9 @@ packages:
   '@privy-io/popup@0.0.2':
     resolution: {integrity: sha512-kkxzZ5TFseqnZRDVhBR1Si9mTHc1jW+hLSbYviauK80enJOGsOGmxeeC/U0t0kLZGLpn0Jj5v5lNS2bmQ4as/Q==}
 
+  '@privy-io/public-api@2.45.2':
+    resolution: {integrity: sha512-TSuaFq65PPInb0CBJ9dO/vLh4u4oWXVpv5KxShbVsuaArZ8lig+Orl/HUR1Hri6643zXoBqWlWx9wDt4MQvz9A==}
+
   '@privy-io/react-auth@3.14.1':
     resolution: {integrity: sha512-1lBzoG8kXgsEhUedhsLnV7iZajMQ6R4R3nw7rEgBGFaXx+37tVQlvBV6mV368T1SqRDSAeFpyp1Ujh7Obx/GQg==}
     peerDependencies:
@@ -1436,6 +1457,18 @@ packages:
 
   '@privy-io/routes@0.0.7':
     resolution: {integrity: sha512-87tiO1u3icR/vB/fv0SS9YkfeiDDTx/2GS2EUlC3BN7cU3O/ngAGutuX6977z5x1ps59l85AjekZCPOHMWin6w==}
+
+  '@privy-io/server-auth@1.32.5':
+    resolution: {integrity: sha512-e087vImrFHP4yAMx8alyCeCm6gk2JG/q7eSklFoST5mPTUV9TGKx7XNIyKOQQHxwKMpk5SBVIlkyJcqg3CuxSw==}
+    deprecated: This package is deprecated. If you are looking for the latest features and support, use @privy-io/node instead.
+    peerDependencies:
+      ethers: ^6
+      viem: ^2.24.1
+    peerDependenciesMeta:
+      ethers:
+        optional: true
+      viem:
+        optional: true
 
   '@privy-io/urls@0.0.3':
     resolution: {integrity: sha512-cococ82ycPJc+wSCHUG0TrVJXF2PIkmDH8TLV+oGqBr14Q7ziRI63aCFIp6FpSRhdDDo9jmB0VR9NjCak4ptMA==}
@@ -3857,6 +3890,9 @@ packages:
   base-x@3.0.11:
     resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
 
+  base-x@4.0.1:
+    resolution: {integrity: sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==}
+
   base-x@5.0.1:
     resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
 
@@ -3924,6 +3960,9 @@ packages:
 
   bs58@4.0.1:
     resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
+
+  bs58@5.0.0:
+    resolution: {integrity: sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==}
 
   bs58@6.0.0:
     resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
@@ -6065,6 +6104,9 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  redaxios@0.5.1:
+    resolution: {integrity: sha512-FSD2AmfdbkYwl7KDExYQlVvIrFz6Yd83pGfaGjBzM9F6rpq8g652Q4Yq5QD4c+nf4g2AgeElv1y+8ajUPiOYMg==}
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
@@ -6594,6 +6636,9 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-case-convert@2.1.0:
+    resolution: {integrity: sha512-Ye79el/pHYXfoew6kqhMwCoxp4NWjKNcm2kBzpmEMIU9dd9aBmHNNFtZ+WTm0rz1ngyDmfqDXDlyUnBXayiD0w==}
+
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
@@ -6622,6 +6667,10 @@ packages:
   type-fest@0.7.1:
     resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
     engines: {node: '>=8'}
+
+  type-fest@3.13.1:
+    resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
+    engines: {node: '>=14.16'}
 
   type-fest@5.6.0:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
@@ -7381,7 +7430,7 @@ snapshots:
       idb-keyval: 6.2.1
       ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
       preact: 10.24.2
-      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zustand: 5.0.3(@types/react@19.2.13)(immer@11.1.4)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
     transitivePeerDependencies:
       - '@types/react'
@@ -7449,7 +7498,7 @@ snapshots:
       idb-keyval: 6.2.1
       ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
       preact: 10.24.2
-      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zustand: 5.0.3(@types/react@19.2.13)(immer@11.1.4)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
     transitivePeerDependencies:
       - '@types/react'
@@ -7735,6 +7784,16 @@ snapshots:
   '@heroicons/react@2.2.0(react@18.3.1)':
     dependencies:
       react: 18.3.1
+
+  '@hpke/chacha20poly1305@1.8.0':
+    dependencies:
+      '@hpke/common': 1.10.1
+
+  '@hpke/common@1.10.1': {}
+
+  '@hpke/core@1.9.0':
+    dependencies:
+      '@hpke/common': 1.10.1
 
   '@humanfs/core@0.19.1': {}
 
@@ -8550,6 +8609,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@privy-io/api-base@1.7.0':
+    dependencies:
+      zod: 3.25.76
+
   '@privy-io/api-base@1.8.2':
     dependencies:
       zod: 3.25.76
@@ -8590,6 +8653,18 @@ snapshots:
       viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
 
   '@privy-io/popup@0.0.2': {}
+
+  '@privy-io/public-api@2.45.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@privy-io/api-base': 1.7.0
+      bs58: 5.0.0
+      libphonenumber-js: 1.12.37
+      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
 
   '@privy-io/react-auth@3.14.1(@solana-program/memo@0.11.0(@solana/kit@6.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/system@0.10.0(@solana/kit@6.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/token@0.9.0(@solana/kit@6.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/kit@6.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@18.3.1))(@types/react@19.2.13)(@upstash/redis@1.36.4)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
@@ -8683,6 +8758,31 @@ snapshots:
     dependencies:
       '@privy-io/api-types': 0.5.0
 
+  '@privy-io/server-auth@1.32.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
+    dependencies:
+      '@hpke/chacha20poly1305': 1.8.0
+      '@hpke/core': 1.9.0
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@privy-io/public-api': 2.45.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@scure/base': 1.2.6
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      canonicalize: 2.1.0
+      dotenv: 16.6.1
+      jose: 4.15.9
+      node-fetch-native: 1.6.7
+      redaxios: 0.5.1
+      svix: 1.92.2
+      ts-case-convert: 2.1.0
+      type-fest: 3.13.1
+    optionalDependencies:
+      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+
   '@privy-io/urls@0.0.3': {}
 
   '@react-aria/focus@3.21.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -8749,7 +8849,7 @@ snapshots:
     dependencies:
       big.js: 6.2.2
       dayjs: 1.11.13
-      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -8784,7 +8884,7 @@ snapshots:
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@walletconnect/universal-provider': 2.21.0(@upstash/redis@1.36.4)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       valtio: 1.13.2(@types/react@19.2.13)(react@18.3.1)
-      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -9082,7 +9182,7 @@ snapshots:
       '@walletconnect/logger': 2.1.2
       '@walletconnect/universal-provider': 2.21.0(@upstash/redis@1.36.4)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       valtio: 1.13.2(@types/react@19.2.13)(react@18.3.1)
-      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -9186,7 +9286,7 @@ snapshots:
       '@walletconnect/universal-provider': 2.21.0(@upstash/redis@1.36.4)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       bs58: 6.0.0
       valtio: 1.13.2(@types/react@19.2.13)(react@18.3.1)
-      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -9424,7 +9524,7 @@ snapshots:
   '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.23.1
-      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -12745,6 +12845,8 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  base-x@4.0.1: {}
+
   base-x@5.0.1: {}
 
   base64-js@1.5.1: {}
@@ -12810,6 +12912,10 @@ snapshots:
   bs58@4.0.1:
     dependencies:
       base-x: 3.0.11
+
+  bs58@5.0.0:
+    dependencies:
+      base-x: 4.0.1
 
   bs58@6.0.0:
     dependencies:
@@ -15196,6 +15302,8 @@ snapshots:
 
   real-require@0.2.0: {}
 
+  redaxios@0.5.1: {}
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
@@ -15831,6 +15939,8 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  ts-case-convert@2.1.0: {}
+
   tsconfig-paths@3.15.0:
     dependencies:
       '@types/json5': 0.0.29
@@ -15858,6 +15968,8 @@ snapshots:
   type-fest@0.20.2: {}
 
   type-fest@0.7.1: {}
+
+  type-fest@3.13.1: {}
 
   type-fest@5.6.0:
     dependencies:

--- a/supabase-waitlist-privy-migration.sql
+++ b/supabase-waitlist-privy-migration.sql
@@ -1,0 +1,18 @@
+-- Privy DID integration for the waitlist.
+--
+-- Adds a single nullable column + an index so existing rows stay valid
+-- (the 126 grandfathered signups have no privy_did yet — they'll get
+-- backfilled opportunistically when the user next logs in via Privy).
+--
+-- Run this on the waitlist Supabase project (ref: pqivhfxyyswivraymlfu)
+-- BEFORE deploying the code that references this column. Idempotent —
+-- safe to re-run.
+
+alter table public.waitlist
+  add column if not exists privy_did text;
+
+-- Each Privy user gets one waitlist row at most. Partial index lets the
+-- 126 legacy rows (privy_did IS NULL) coexist without violating uniqueness.
+create unique index if not exists waitlist_privy_did_unique_idx
+  on public.waitlist (privy_did)
+  where privy_did is not null;


### PR DESCRIPTION
Closes the design gap on the waitlist: returning Privy users (whether they originally signed up via email or wallet) now land on a welcome-back state with their referral code automatically, no form re-submit. Existing 126 rows get backfilled with their Privy DID opportunistically on next sign-in.

## Server side

\`app/lib/privy-auth.ts\` — \`verifyPrivyAuth(req)\` verifies the Privy access token from \`Authorization: Bearer …\`, optionally parses linked email + Solana wallets from \`X-Privy-Id-Token\` (no rate-limited API call when present). Returns flat shape \`{ ok, userId, email, solanaWallets }\`.

\`app/app/api/waitlist/whoami/route.ts\` — POST. Resolves a waitlist row in priority order:
1. \`waitlist.privy_did = userId\` — fast path, indexed
2. \`waitlist.pubkey = anyLinkedSolanaWallet\` — for legacy wallet signups
3. \`waitlist.email = linkedEmail\` — for legacy email signups

On a (2) or (3) hit, **opportunistically backfills privy_did** so subsequent calls hit the fast path. Returns \`{ found, referral_code, position, returning }\` or \`{ found: false }\`. Never leaks which channel matched — response shape is identical.

\`app/app/api/waitlist/signup/route.ts\` — when a Privy token is present:
- Stamps \`privy_did\` into the new row on insert
- On the wallet-fast-path duplicate branch, backfills \`privy_did\` onto the existing row if missing

\`supabase-waitlist-privy-migration.sql\` — adds nullable \`privy_did\` column + partial unique index (\`where privy_did is not null\`) so the 126 legacy rows stay valid.

## Frontend

\`app/hooks/useWaitlistWhoami.ts\` — fires once when Privy authenticates, calls \`/api/waitlist/whoami\`, returns \`idle | checking | found | not-found | error\`. Falls back to \`not-found\` on any error.

\`app/app/waitlist/page.tsx\` — \`SignupCard\` intercepts on \`status: \"found\"\` and renders \`<WelcomeBackPanel>\` in place of the tabbed signup flows. The card header switches from \"Invite only\" to a cyan \"✓ on the list\" badge. A \"\$ checking_session…\" prompt line shows above the tabs while resolving.

\`<WelcomeBackPanel>\` reuses \`ReferralCard\` so the visual language matches the post-signup state of the existing flows. Includes position pill + X share-intent CTA.

## Required operator actions BEFORE merging

1. **Apply the SQL migration** to the waitlist Supabase project (\`pqivhfxyyswivraymlfu\`):
   \`\`\`
   supabase-waitlist-privy-migration.sql
   \`\`\`
   Idempotent. Run in the dashboard SQL Editor.

2. **Set \`PRIVY_APP_SECRET\` on Vercel** (Production + Preview). Generate it in the Privy dashboard → App Settings → API Keys.

Without these, the new routes degrade gracefully (503 on \`/whoami\`, signup still works without DID stamping) — so even if the deploy lands before the env is set, nothing breaks.

## Tests
\`pnpm tsc --noEmit\` — clean.
\`pnpm vitest run __tests__/api/waitlist-signup-shape.test.ts __tests__/api/waitlist-signup-email-abuse.test.ts __tests__/lib/waitlist-referral-code.test.ts\` — 17 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Returning waitlist users are now automatically detected and greeted with a personalized welcome-back experience
  * Returning users can view their referral code, current position, and share directly via X
  * Enhanced identity verification using Privy authentication for seamless web3 integration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dcccrypto/percolator-launch/pull/2181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->