### PR TITLE
chore(privy): migrate from deprecated @privy-io/server-auth to @privy-io/node

### DIFF
--- a/app/lib/privy-auth.ts
+++ b/app/lib/privy-auth.ts
@@ -1,18 +1,19 @@
-import { PrivyClient } from "@privy-io/server-auth";
+import { PrivyClient, type User, type LinkedAccount } from "@privy-io/node";
 
 /**
  * Server-side Privy auth helper.
  *
- * Verifies the access token from the `Authorization: Bearer …` header
- * (security boundary — proves the request came from a valid Privy
- * session). If an `X-Privy-Id-Token` header is also present, parses it
- * locally to extract linked accounts (email, wallets) without making a
- * Privy API call. Falls back to `getUser(userId)` (rate-limited) when
- * the id-token isn't supplied.
+ * Migrated from the deprecated @privy-io/server-auth to @privy-io/node.
+ * The new SDK exposes verify helpers under `client.utils().auth()` and
+ * uses snake_case field names on the User payload — both surface
+ * differences are absorbed here so route handlers see the same flat
+ * shape they always did.
  *
- * Returns a flat shape so route handlers don't need to know about
- * Privy's LinkedAccount discriminated union — they just want the email
- * and a list of solana addresses.
+ * Verifies the access token from `Authorization: Bearer …` (security
+ * boundary — proves the request came from a valid Privy session). When
+ * an `X-Privy-Id-Token` header is also present, parses it locally to
+ * extract linked accounts (email, wallets) — no Privy API call, so no
+ * rate limit.
  */
 
 const APP_ID = process.env.NEXT_PUBLIC_PRIVY_APP_ID?.trim();
@@ -23,7 +24,7 @@ let _client: PrivyClient | null = null;
 function getClient(): PrivyClient | null {
   if (_client) return _client;
   if (!APP_ID || !APP_SECRET) return null;
-  _client = new PrivyClient(APP_ID, APP_SECRET);
+  _client = new PrivyClient({ appId: APP_ID, appSecret: APP_SECRET });
   return _client;
 }
 
@@ -40,14 +41,15 @@ export type PrivyAuthError =
 export type PrivyAuthOk = { ok: true } & PrivyAuthResult;
 
 /**
- * Verify a Privy session from the request headers.
+ * Verify a Privy session from request headers.
  *
- *  Authorization: Bearer <accessToken>     (required — security boundary)
- *  X-Privy-Id-Token: <idToken>              (optional — avoids rate-limited API call)
+ *   Authorization: Bearer <accessToken>   (required — security boundary)
+ *   X-Privy-Id-Token: <idToken>            (optional — avoids API call)
  *
- * Returns the verified DID plus best-effort linked email + Solana wallets.
- * Both lookup branches (id-token parse vs server-side getUser) yield
- * the same shape; callers shouldn't have to care which path served.
+ * Returns the verified DID + best-effort linked email / Solana wallets.
+ * When the id-token is absent, returns the DID only with empty arrays
+ * (the new SDK doesn't offer a no-rate-limit getUser-by-id fallback;
+ * the client should send the id-token whenever it wants linked data).
  */
 export async function verifyPrivyAuth(
   req: Request,
@@ -58,39 +60,37 @@ export async function verifyPrivyAuth(
   }
 
   const auth = req.headers.get("authorization") ?? "";
-  const token = auth.startsWith("Bearer ") ? auth.slice("Bearer ".length).trim() : "";
-  if (!token) {
+  const accessToken = auth.startsWith("Bearer ")
+    ? auth.slice("Bearer ".length).trim()
+    : "";
+  if (!accessToken) {
     return { ok: false, status: 401, reason: "missing-token" };
   }
 
+  const authUtils = client.utils().auth();
+
   let userId: string;
   try {
-    const claims = await client.verifyAuthToken(token);
-    userId = claims.userId;
+    const claims = await authUtils.verifyAccessToken(accessToken);
+    userId = claims.user_id;
   } catch (err) {
-    console.warn("[privy-auth] verify failed", err);
+    console.warn("[privy-auth] verifyAccessToken failed", err);
     return { ok: false, status: 401, reason: "invalid-token" };
   }
 
-  // Try the id-token fast path first; fall back to the deprecated
-  // getUser(userId) only if the client didn't supply one. Both yield
-  // the same User shape.
+  // Optional id-token parse for linked accounts. If absent or invalid
+  // we return DID only — the caller can still match on privy_did, just
+  // not on email/pubkey backfill.
   const idToken = req.headers.get("x-privy-id-token")?.trim() ?? "";
-  let user: Awaited<ReturnType<typeof client.getUser>> | null = null;
-  try {
-    if (idToken) {
-      user = await client.getUser({ idToken });
-    } else {
-      user = await client.getUser(userId);
-    }
-  } catch (err) {
-    // If id-token parse fails, retry against the API one time so we
-    // still return useful claims rather than refusing the request.
-    console.warn("[privy-auth] getUser failed, retrying via userId", err);
+  let user: User | null = null;
+  if (idToken) {
     try {
-      user = await client.getUser(userId);
-    } catch (err2) {
-      console.warn("[privy-auth] getUser retry also failed — returning DID only", err2);
+      user = await authUtils.verifyIdentityToken(idToken);
+    } catch (err) {
+      console.warn(
+        "[privy-auth] verifyIdentityToken failed, returning DID only",
+        err,
+      );
     }
   }
 
@@ -100,13 +100,12 @@ export async function verifyPrivyAuth(
   return { ok: true, userId, email, solanaWallets };
 }
 
-function extractEmail(user: Awaited<ReturnType<PrivyClient["getUser"]>> | null): string | null {
+function extractEmail(user: User | null): string | null {
   if (!user) return null;
-  // The User object exposes a top-level `email` for the primary email
-  // account, plus linked Email/Google/etc accounts. We want the address
-  // they actually used — prefer the primary, then any linked email,
-  // then any oauth provider that exposes an email.
-  const accounts = user.linkedAccounts ?? [];
+  const accounts: LinkedAccount[] = user.linked_accounts ?? [];
+
+  // Prefer the directly-linked email account; fall back to a verified
+  // OAuth account that surfaces an email field.
   for (const a of accounts) {
     if (a.type === "email" && "address" in a && typeof a.address === "string") {
       return a.address.toLowerCase();
@@ -124,17 +123,19 @@ function extractEmail(user: Awaited<ReturnType<PrivyClient["getUser"]>> | null):
   return null;
 }
 
-function extractSolanaWallets(
-  user: Awaited<ReturnType<PrivyClient["getUser"]>> | null,
-): string[] {
+function extractSolanaWallets(user: User | null): string[] {
   if (!user) return [];
+  const accounts: LinkedAccount[] = user.linked_accounts ?? [];
   const out: string[] = [];
-  for (const a of user.linkedAccounts ?? []) {
-    // Privy types its wallet entries as `wallet` with a `chainType` field.
-    if (a.type === "wallet" && "chainType" in a && a.chainType === "solana") {
-      if ("address" in a && typeof a.address === "string") {
-        out.push(a.address);
-      }
+  for (const a of accounts) {
+    if (
+      a.type === "wallet" &&
+      "chain_type" in a &&
+      a.chain_type === "solana" &&
+      "address" in a &&
+      typeof a.address === "string"
+    ) {
+      out.push(a.address);
     }
   }
   return out;

--- a/app/package.json
+++ b/app/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@percolatorct/sdk": "2.0.9",
+    "@privy-io/node": "^0.18.0",
     "@privy-io/react-auth": "^3.14.1",
-    "@privy-io/server-auth": "^1.32.5",
     "@sentry/nextjs": "^10.39.0",
     "@solana-program/memo": "^0.11.0",
     "@solana/kit": "^6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,12 +66,12 @@ importers:
       '@percolatorct/sdk':
         specifier: 2.0.9
         version: 2.0.9(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@privy-io/node':
+        specifier: ^0.18.0
+        version: 0.18.0(@solana/kit@6.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       '@privy-io/react-auth':
         specifier: ^3.14.1
         version: 3.14.1(@solana-program/memo@0.11.0(@solana/kit@6.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/system@0.10.0(@solana/kit@6.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/token@0.9.0(@solana/kit@6.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/kit@6.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@18.3.1))(@types/react@19.2.13)(@upstash/redis@1.36.4)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@privy-io/server-auth':
-        specifier: ^1.32.5
-        version: 1.32.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       '@sentry/nextjs':
         specifier: ^10.39.0
         version: 10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.105.2(esbuild@0.27.3))
@@ -1393,9 +1393,6 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.8
 
-  '@privy-io/api-base@1.7.0':
-    resolution: {integrity: sha512-ji6ARQAAuW/FzRTgft9NCjRuouWX9t+J7JMmvLPsnXQJDFEV9mqh4sWXZhQ8ddTq/iDZ4z/yz1ORJqN8bYAi4Q==}
-
   '@privy-io/api-base@1.8.2':
     resolution: {integrity: sha512-pEvZ73GnC2OB/w35MGCPhqZ8mnApXgUpXxM0t9qZmNzvDNoMKBLPgysUXouAx7E4jO8REJPuwX70Y1AqJ/51kg==}
 
@@ -1424,11 +1421,28 @@ packages:
       viem:
         optional: true
 
+  '@privy-io/node@0.18.0':
+    resolution: {integrity: sha512-DA+/f+nqJGB3lJ6b2qpan0OWIyAhoSXd/Cfo40Ww9fSXC3KKQ6eVHnOKiEO6KQ1DpVdswkkuBoG9uK9YHUST9w==}
+    peerDependencies:
+      '@solana/kit': ^5.1.0
+      '@x402/evm': ^2.3.0
+      '@x402/fetch': ^2.3.0
+      '@x402/svm': ^2.3.0
+      viem: ^2.24.1
+    peerDependenciesMeta:
+      '@solana/kit':
+        optional: true
+      '@x402/evm':
+        optional: true
+      '@x402/fetch':
+        optional: true
+      '@x402/svm':
+        optional: true
+      viem:
+        optional: true
+
   '@privy-io/popup@0.0.2':
     resolution: {integrity: sha512-kkxzZ5TFseqnZRDVhBR1Si9mTHc1jW+hLSbYviauK80enJOGsOGmxeeC/U0t0kLZGLpn0Jj5v5lNS2bmQ4as/Q==}
-
-  '@privy-io/public-api@2.45.2':
-    resolution: {integrity: sha512-TSuaFq65PPInb0CBJ9dO/vLh4u4oWXVpv5KxShbVsuaArZ8lig+Orl/HUR1Hri6643zXoBqWlWx9wDt4MQvz9A==}
 
   '@privy-io/react-auth@3.14.1':
     resolution: {integrity: sha512-1lBzoG8kXgsEhUedhsLnV7iZajMQ6R4R3nw7rEgBGFaXx+37tVQlvBV6mV368T1SqRDSAeFpyp1Ujh7Obx/GQg==}
@@ -1457,18 +1471,6 @@ packages:
 
   '@privy-io/routes@0.0.7':
     resolution: {integrity: sha512-87tiO1u3icR/vB/fv0SS9YkfeiDDTx/2GS2EUlC3BN7cU3O/ngAGutuX6977z5x1ps59l85AjekZCPOHMWin6w==}
-
-  '@privy-io/server-auth@1.32.5':
-    resolution: {integrity: sha512-e087vImrFHP4yAMx8alyCeCm6gk2JG/q7eSklFoST5mPTUV9TGKx7XNIyKOQQHxwKMpk5SBVIlkyJcqg3CuxSw==}
-    deprecated: This package is deprecated. If you are looking for the latest features and support, use @privy-io/node instead.
-    peerDependencies:
-      ethers: ^6
-      viem: ^2.24.1
-    peerDependenciesMeta:
-      ethers:
-        optional: true
-      viem:
-        optional: true
 
   '@privy-io/urls@0.0.3':
     resolution: {integrity: sha512-cococ82ycPJc+wSCHUG0TrVJXF2PIkmDH8TLV+oGqBr14Q7ziRI63aCFIp6FpSRhdDDo9jmB0VR9NjCak4ptMA==}
@@ -3890,9 +3892,6 @@ packages:
   base-x@3.0.11:
     resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
 
-  base-x@4.0.1:
-    resolution: {integrity: sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==}
-
   base-x@5.0.1:
     resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
 
@@ -3960,9 +3959,6 @@ packages:
 
   bs58@4.0.1:
     resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
-
-  bs58@5.0.0:
-    resolution: {integrity: sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==}
 
   bs58@6.0.0:
     resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
@@ -6104,9 +6100,6 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
-  redaxios@0.5.1:
-    resolution: {integrity: sha512-FSD2AmfdbkYwl7KDExYQlVvIrFz6Yd83pGfaGjBzM9F6rpq8g652Q4Yq5QD4c+nf4g2AgeElv1y+8ajUPiOYMg==}
-
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
@@ -6636,9 +6629,6 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
-  ts-case-convert@2.1.0:
-    resolution: {integrity: sha512-Ye79el/pHYXfoew6kqhMwCoxp4NWjKNcm2kBzpmEMIU9dd9aBmHNNFtZ+WTm0rz1ngyDmfqDXDlyUnBXayiD0w==}
-
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
@@ -6667,10 +6657,6 @@ packages:
   type-fest@0.7.1:
     resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
     engines: {node: '>=8'}
-
-  type-fest@3.13.1:
-    resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
-    engines: {node: '>=14.16'}
 
   type-fest@5.6.0:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
@@ -8609,10 +8595,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@privy-io/api-base@1.7.0':
-    dependencies:
-      zod: 3.25.76
-
   '@privy-io/api-base@1.8.2':
     dependencies:
       zod: 3.25.76
@@ -8652,19 +8634,22 @@ snapshots:
     optionalDependencies:
       viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
 
-  '@privy-io/popup@0.0.2': {}
-
-  '@privy-io/public-api@2.45.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+  '@privy-io/node@0.18.0(@solana/kit@6.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
-      '@privy-io/api-base': 1.7.0
-      bs58: 5.0.0
-      libphonenumber-js: 1.12.37
-      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - bufferutil
-      - typescript
-      - utf-8-validate
+      '@hpke/chacha20poly1305': 1.8.0
+      '@hpke/core': 1.9.0
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+      canonicalize: 2.1.0
+      jose: 6.1.3
+      lru-cache: 11.2.5
+      svix: 1.92.2
+    optionalDependencies:
+      '@solana/kit': 6.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+
+  '@privy-io/popup@0.0.2': {}
 
   '@privy-io/react-auth@3.14.1(@solana-program/memo@0.11.0(@solana/kit@6.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/system@0.10.0(@solana/kit@6.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/token@0.9.0(@solana/kit@6.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/kit@6.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@18.3.1))(@types/react@19.2.13)(@upstash/redis@1.36.4)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
@@ -8757,31 +8742,6 @@ snapshots:
   '@privy-io/routes@0.0.7':
     dependencies:
       '@privy-io/api-types': 0.5.0
-
-  '@privy-io/server-auth@1.32.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
-    dependencies:
-      '@hpke/chacha20poly1305': 1.8.0
-      '@hpke/core': 1.9.0
-      '@noble/curves': 1.9.7
-      '@noble/hashes': 1.8.0
-      '@privy-io/public-api': 2.45.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@scure/base': 1.2.6
-      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      canonicalize: 2.1.0
-      dotenv: 16.6.1
-      jose: 4.15.9
-      node-fetch-native: 1.6.7
-      redaxios: 0.5.1
-      svix: 1.92.2
-      ts-case-convert: 2.1.0
-      type-fest: 3.13.1
-    optionalDependencies:
-      viem: 2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - typescript
-      - utf-8-validate
 
   '@privy-io/urls@0.0.3': {}
 
@@ -12845,8 +12805,6 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  base-x@4.0.1: {}
-
   base-x@5.0.1: {}
 
   base64-js@1.5.1: {}
@@ -12912,10 +12870,6 @@ snapshots:
   bs58@4.0.1:
     dependencies:
       base-x: 3.0.11
-
-  bs58@5.0.0:
-    dependencies:
-      base-x: 4.0.1
 
   bs58@6.0.0:
     dependencies:
@@ -15302,8 +15256,6 @@ snapshots:
 
   real-require@0.2.0: {}
 
-  redaxios@0.5.1: {}
-
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
@@ -15939,8 +15891,6 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-case-convert@2.1.0: {}
-
   tsconfig-paths@3.15.0:
     dependencies:
       '@types/json5': 0.0.29
@@ -15968,8 +15918,6 @@ snapshots:
   type-fest@0.20.2: {}
 
   type-fest@0.7.1: {}
-
-  type-fest@3.13.1: {}
 
   type-fest@5.6.0:
     dependencies:


### PR DESCRIPTION
\`@privy-io/server-auth\` 1.32.5 is deprecated upstream — \`npm view\` shows:

> This package is deprecated. If you are looking for the latest features and support, use @privy-io/node instead.

Same vendor, new package under their Stainless-generated SDK. This PR migrates the helper.

## Surface differences absorbed in \`app/lib/privy-auth.ts\`

| Old (\`server-auth\`) | New (\`@privy-io/node\`) |
|---|---|
| \`new PrivyClient(appId, appSecret)\` | \`new PrivyClient({ appId, appSecret })\` |
| \`client.verifyAuthToken(token)\` | \`client.utils().auth().verifyAccessToken(token)\` |
| \`client.getUser({ idToken })\` | \`client.utils().auth().verifyIdentityToken(token)\` |
| \`{ userId }\` (camelCase) | \`{ user_id }\` (snake_case) |
| \`User.linkedAccounts\` | \`User.linked_accounts\` |
| \`chainType: \"solana\"\` | \`chain_type: \"solana\"\` |

The helper's exported shape (\`{ ok, userId, email, solanaWallets }\`) is unchanged, so \`verifyPrivyAuth(req)\` works exactly as before. No call-site changes required in \`/api/waitlist/whoami\` or \`/api/waitlist/signup\`.

## Removed behaviour

The old SDK had a deprecated \`getUser(userId)\` fallback (rate-limited API call) for cases where the client didn't send an id-token. The new SDK only exposes token-based identity parsing. When the client doesn't send \`X-Privy-Id-Token\`, we now return DID-only and skip email/pubkey backfill — the caller still matches on \`privy_did\` and the signup flow still works.

Practically: clients currently send the id-token (the hook already calls \`useIdentityToken()\`), so this code path is exercised every time and the fallback was unused.

## Tests
\`\`\`
pnpm tsc --noEmit                                                # clean
pnpm vitest run __tests__/api/waitlist-signup-shape.test.ts \\
                __tests__/api/waitlist-signup-email-abuse.test.ts \\
                __tests__/lib/waitlist-referral-code.test.ts     # 17 passed
\`\`\`

## Dep churn
- removed: \`@privy-io/server-auth@1.32.5\`
- added: \`@privy-io/node@0.18.0\`