### PR TITLE
feat(waitlist): referral tier system A/B/C/... + unblock /admin on waitlist host

### DIFF
--- a/app/app/api/admin/waitlist/leaderboard/route.ts
+++ b/app/app/api/admin/waitlist/leaderboard/route.ts
@@ -15,6 +15,7 @@ interface LeaderboardRow {
   twitter_handle: string | null;
   signups_referred: number | string;
   joined_at: string;
+  tier: number | null;
 }
 
 interface AdminLeaderboardEntry {
@@ -25,6 +26,7 @@ interface AdminLeaderboardEntry {
   twitterHandle: string | null;
   signupsReferred: number;
   joinedAt: string;
+  tier: number;
 }
 
 /**
@@ -75,6 +77,7 @@ export async function GET() {
           twitterHandle: r.twitter_handle,
           signupsReferred: Number.isFinite(n) ? Number(n) : 0,
           joinedAt: r.joined_at,
+          tier: typeof r.tier === "number" ? r.tier : 0,
         };
       });
 

--- a/app/app/api/admin/waitlist/stats/route.ts
+++ b/app/app/api/admin/waitlist/stats/route.ts
@@ -33,7 +33,7 @@ export async function GET() {
     const { data: rows, error } = await supabase
       .from("waitlist")
       .select(
-        "id, pubkey, email, referral_code, referred_by_code, referral_code_emailed_at, twitter_handle, created_at",
+        "id, pubkey, email, referral_code, referred_by_code, referral_code_emailed_at, twitter_handle, created_at, tier",
       );
     if (error) {
       console.error("[admin/waitlist/stats] select error", error);
@@ -52,8 +52,26 @@ export async function GET() {
       referral_code_emailed_at: string | null;
       twitter_handle: string | null;
       created_at: string;
+      tier: number | null;
     };
     const all = (rows ?? []) as Row[];
+
+    // ── Tier breakdown (A = 0, B = 1, ...) ────────────────────────────
+    // Computed from the row data so it stays in sync with whatever the
+    // table actually says. tier defaults to 0 in the DB, so pre-migration
+    // rows count as A.
+    const tierCounts = new Map<number, number>();
+    for (const r of all) {
+      const t = typeof r.tier === "number" ? r.tier : 0;
+      tierCounts.set(t, (tierCounts.get(t) ?? 0) + 1);
+    }
+    const tierBreakdown = Array.from(tierCounts.entries())
+      .sort(([a], [b]) => a - b)
+      .map(([tier, count]) => ({
+        tier,
+        count,
+        label: tier >= 0 && tier <= 25 ? String.fromCharCode(65 + tier) : `t${tier}`,
+      }));
 
     // ── Totals + breakdown by signup method ────────────────────────────
     const totalSignups = all.length;
@@ -186,6 +204,7 @@ export async function GET() {
         walletOnlyNoEmail,
       },
       recency: { last24h, last7d },
+      tierBreakdown,
       integrity: {
         selfReferrals,
         backfillComplete: withoutCode === 0,

--- a/app/app/api/waitlist/signup/route.ts
+++ b/app/app/api/waitlist/signup/route.ts
@@ -470,6 +470,23 @@ export async function POST(req: Request) {
   baseRow.referred_by_code = referredByCode;
   if (privyDid) baseRow.privy_did = privyDid;
 
+  // Compute the tier for this new row from the referrer's tier
+  // (tier = referrer.tier + 1). Falls back to 0 if the RPC isn't
+  // available yet (migration not applied) — the column default also
+  // catches that case, so the insert succeeds either way.
+  try {
+    const service = getWaitlistServiceSupabase();
+    const { data: tierData } = await service.rpc(
+      "waitlist_tier_for_referrer",
+      { p_code: referredByCode },
+    );
+    if (typeof tierData === "number" && tierData >= 0) {
+      baseRow.tier = tierData;
+    }
+  } catch (err) {
+    console.warn("[waitlist-signup] tier resolution failed, falling back to default", err);
+  }
+
   const MAX_CODE_ATTEMPTS = 8;
   let referralCode: string | null = null;
   let isDuplicate = false;

--- a/app/components/admin/WaitlistLeaderboardSection.tsx
+++ b/app/components/admin/WaitlistLeaderboardSection.tsx
@@ -55,6 +55,7 @@ interface AdminLeaderboardEntry {
   twitterHandle: string | null;
   signupsReferred: number;
   joinedAt: string;
+  tier: number;
 }
 
 interface WaitlistStats {
@@ -84,6 +85,7 @@ interface WaitlistStats {
     walletOnlyNoEmail: number;
   };
   recency: { last24h: number; last7d: number };
+  tierBreakdown?: { tier: number; count: number; label: string }[];
   integrity: {
     selfReferrals: number;
     backfillComplete: boolean;
@@ -91,6 +93,18 @@ interface WaitlistStats {
     allCodesValidShape: boolean;
     noOrphanedReferrers: boolean;
   };
+}
+
+function tierLabel(tier: number): string {
+  return tier >= 0 && tier <= 25 ? String.fromCharCode(65 + tier) : `t${tier}`;
+}
+
+function tierColor(tier: number): string {
+  // A = solid accent, B = cyan, C = amber, D+ = dim.
+  if (tier === 0) return "var(--accent)";
+  if (tier === 1) return "var(--cyan)";
+  if (tier === 2) return "#fbbf24";
+  return "var(--text-secondary)";
 }
 
 const fetcher = async (url: string) => {
@@ -319,6 +333,47 @@ export function WaitlistLeaderboardSection() {
             </div>
           </div>
 
+          {/* Referral tier breakdown — A = the 126 pre-invite roots, B = referred by A, etc. */}
+          {stats.tierBreakdown && stats.tierBreakdown.length > 0 && (
+            <div className={`${card} p-4 mb-4`}>
+              <div className={`${labelStyle} mb-3`}>Referral Tiers</div>
+              <div className="grid grid-cols-2 md:grid-cols-6 gap-2">
+                {stats.tierBreakdown.map(({ tier, count, label }) => (
+                  <div
+                    key={tier}
+                    className="rounded-none border border-[var(--border)]/60 bg-[var(--bg)]/40 p-3"
+                  >
+                    <div className="flex items-center gap-2">
+                      <span
+                        className="inline-flex h-5 min-w-5 items-center justify-center rounded-sm border px-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.14em]"
+                        style={{
+                          color: tierColor(tier),
+                          borderColor: `${tierColor(tier)}66`,
+                          backgroundColor: `${tierColor(tier)}14`,
+                        }}
+                      >
+                        {label}
+                      </span>
+                      <span className="font-mono text-[10px] uppercase tracking-[0.15em] text-[var(--text-muted)]">
+                        tier {tier}
+                      </span>
+                    </div>
+                    <div
+                      className="mt-1 font-mono text-[18px] font-bold text-[var(--text)]"
+                      style={{ fontVariantNumeric: "tabular-nums" }}
+                    >
+                      {count.toLocaleString()}
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <p className="mt-3 text-[11px] text-[var(--text-muted)]">
+                Tier = generation in the referral tree. A = pre-invite roots (the 126
+                grandfathered signups), B = referred by an A, C = referred by a B, etc.
+              </p>
+            </div>
+          )}
+
           {/* Integrity checks — green tick or red flag for each invariant */}
           <div className={`${card} p-4 mb-4`}>
             <div className={`${labelStyle} mb-3`}>Integrity Checks</div>
@@ -499,6 +554,9 @@ export function WaitlistLeaderboardSection() {
                     Rank
                   </th>
                   <th className="px-3 py-2 text-left text-[10px] font-bold uppercase tracking-[0.12em]">
+                    Tier
+                  </th>
+                  <th className="px-3 py-2 text-left text-[10px] font-bold uppercase tracking-[0.12em]">
                     Code
                   </th>
                   <th className="px-3 py-2 text-left text-[10px] font-bold uppercase tracking-[0.12em]">
@@ -526,6 +584,18 @@ export function WaitlistLeaderboardSection() {
                   >
                     <td className="px-3 py-2 font-mono text-[var(--text-muted)]">
                       #{row.rank}
+                    </td>
+                    <td className="px-3 py-2">
+                      <span
+                        className="inline-flex h-5 min-w-5 items-center justify-center rounded-sm border px-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.14em]"
+                        style={{
+                          color: tierColor(row.tier ?? 0),
+                          borderColor: `${tierColor(row.tier ?? 0)}66`,
+                          backgroundColor: `${tierColor(row.tier ?? 0)}14`,
+                        }}
+                      >
+                        {tierLabel(row.tier ?? 0)}
+                      </span>
                     </td>
                     <td className="px-3 py-2 font-mono font-bold text-[var(--text)]">
                       {row.referralCode}

--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -241,6 +241,8 @@ const REDIRECT_HOSTS = new Set([
 // here — they continue to live on mainnet.percolatorlaunch.com.
 const WAITLIST_HOST_ALLOWED_PREFIXES = [
   "/waitlist",
+  "/admin",        // operator dashboard (waitlist leaderboard + tiers, oracle admin, bug review)
+  "/r",            // referral-link landings (/r/<code>)
   "/pitch",        // investor-facing deck (still accessible, just not linked from nav)
   "/pitch-2",      // 10-slide narration variant for 2-min pitch video
   "/demo-shots",   // launcher page for capturing pitch screenshots from the real UI

--- a/supabase-waitlist-tiers-migration.sql
+++ b/supabase-waitlist-tiers-migration.sql
@@ -1,0 +1,152 @@
+-- Referral tier system for the waitlist.
+--
+-- Each row gets an integer `tier` indicating its generation in the
+-- referral tree:
+--   tier 0  = "A" — root referrers (the 126 grandfathered signups
+--                   who joined before invite-only)
+--   tier 1  = "B" — referred by a tier-A user
+--   tier 2  = "C" — referred by a tier-B user
+--   …       continues alphabetically (Z = tier 25, then numeric)
+--
+-- A SECURITY DEFINER helper resolves a referrer's tier from a code,
+-- so the signup route can compute the new row's tier with one RPC
+-- call instead of an explicit SELECT (keeps the route's RLS posture
+-- intact — it talks to functions, not rows).
+--
+-- Run this on the waitlist Supabase project (ref: pqivhfxyyswivraymlfu).
+-- Idempotent — safe to re-run. Apply AFTER the privy_did migration.
+
+-- ── Column ───────────────────────────────────────────────────────────
+alter table public.waitlist
+  add column if not exists tier int not null default 0;
+
+-- Existing rows: all 126 pre-invite signups are tier 0 (= A).
+-- The default already gave them that, but be explicit so re-running
+-- after a partial deploy converges on the right state.
+update public.waitlist set tier = 0 where tier is null;
+
+-- ── Index ────────────────────────────────────────────────────────────
+-- Used by the admin leaderboard tier breakdown and any future
+-- "filter by tier" query.
+create index if not exists waitlist_tier_idx on public.waitlist (tier);
+
+-- ── Helper RPC: compute new row's tier from referrer code ────────────
+--
+-- The signup route calls this to derive the new row's tier without
+-- needing a direct read on the waitlist table (preserves the
+-- anon-no-SELECT invariant — the function is SECURITY DEFINER, the
+-- anon caller never sees rows, only the resulting int).
+--
+-- Returns:
+--   0   when p_code is null/empty (caller is a tier-A root signup —
+--       shouldn't happen now that invite-only requires a referrer,
+--       but kept for the grandfathered path)
+--   N+1 when p_code matches a row with tier N
+--   0   when p_code doesn't match any row (defensive — caller will
+--       have already validated existence via waitlist_referral_code_exists)
+create or replace function public.waitlist_tier_for_referrer(p_code text)
+returns int
+language sql
+security definer
+set search_path = public
+as $$
+  select coalesce(
+    (select tier + 1 from public.waitlist where referral_code = p_code limit 1),
+    0
+  );
+$$;
+
+-- Service-role only — the signup route runs under service-role,
+-- and exposing this to anon would let a public caller probe the
+-- tier distribution of arbitrary codes (a weak side channel into
+-- the referrer's identity, since tier correlates with join-order).
+revoke all on function public.waitlist_tier_for_referrer(text) from public;
+revoke all on function public.waitlist_tier_for_referrer(text) from anon;
+do $$ begin
+  if exists (select 1 from pg_roles where rolname = 'authenticated') then
+    execute 'revoke all on function public.waitlist_tier_for_referrer(text) from authenticated';
+  end if;
+end $$;
+
+-- ── Optional: tier breakdown view (admin reads via service-role) ─────
+-- Convenience for the admin stats panel. Drop-and-recreate so re-runs
+-- pick up any schema additions without manual migration.
+create or replace function public.waitlist_tier_breakdown()
+returns table (tier int, count bigint, label text)
+language sql
+security definer
+set search_path = public
+as $$
+  with totals as (
+    select tier, count(*)::bigint as cnt
+    from public.waitlist
+    group by tier
+  )
+  select
+    tier,
+    cnt as count,
+    -- 'A' for tier 0 through 'Z' for tier 25; numeric beyond that.
+    case
+      when tier between 0 and 25 then chr(65 + tier)
+      else 't' || tier::text
+    end as label
+  from totals
+  order by tier asc;
+$$;
+
+revoke all on function public.waitlist_tier_breakdown() from public;
+revoke all on function public.waitlist_tier_breakdown() from anon;
+do $$ begin
+  if exists (select 1 from pg_roles where rolname = 'authenticated') then
+    execute 'revoke all on function public.waitlist_tier_breakdown() from authenticated';
+  end if;
+end $$;
+
+-- ── Update the leaderboard RPC to include each row's tier ───────────
+-- Keeps backward-compat: existing callers that ignore the new column
+-- still work. New callers can read `tier` to render the A/B/C badge.
+create or replace function public.waitlist_referral_leaderboard()
+returns table (
+  referral_code text,
+  owner_pubkey text,
+  owner_email text,
+  twitter_handle text,
+  signups_referred bigint,
+  joined_at timestamptz,
+  tier int
+)
+language sql
+security definer
+set search_path = public
+as $$
+  select
+    w.referral_code,
+    w.pubkey         as owner_pubkey,
+    w.email          as owner_email,
+    w.twitter_handle,
+    coalesce(c.cnt, 0) as signups_referred,
+    w.created_at     as joined_at,
+    w.tier
+  from public.waitlist w
+  left join (
+    select referred_by_code, count(*) as cnt
+    from public.waitlist
+    where referred_by_code is not null
+    group by referred_by_code
+  ) c on c.referred_by_code = w.referral_code
+  where w.referral_code is not null
+  order by signups_referred desc, w.created_at asc;
+$$;
+
+revoke all on function public.waitlist_referral_leaderboard() from public;
+revoke all on function public.waitlist_referral_leaderboard() from anon;
+do $$ begin
+  if exists (select 1 from pg_roles where rolname = 'authenticated') then
+    execute 'revoke all on function public.waitlist_referral_leaderboard() from authenticated';
+  end if;
+end $$;
+
+-- ── Verification probes ──────────────────────────────────────────────
+-- select * from public.waitlist_tier_breakdown();
+-- select * from public.waitlist_referral_leaderboard() limit 5;
+-- select public.waitlist_tier_for_referrer((select referral_code from public.waitlist limit 1));


### PR DESCRIPTION
Two things in one PR:

## 1. Referral tier system

The 126 grandfathered signups = **Tier A** (root). Anyone who joins via their refs = **B**. Refs from a B = **C**. Continues alphabetically up to Z, then numeric.

### Schema (\`supabase-waitlist-tiers-migration.sql\`)
- \`tier int default 0\` on \`waitlist\` + index
- \`waitlist_tier_for_referrer(p_code text) → int\` — service-role helper used by the signup route to compute \`referrer.tier + 1\`
- \`waitlist_tier_breakdown() → table (tier, count, label)\` — for the admin panel
- \`waitlist_referral_leaderboard()\` updated to include each row's tier

### Code
- **Signup route** — calls the helper RPC on insert; falls back to default 0 if the RPC isn't available yet (migration not applied)
- **\`/api/admin/waitlist/stats\`** — adds \`tierBreakdown\` array
- **\`/api/admin/waitlist/leaderboard\`** — passes the per-row tier
- **\`WaitlistLeaderboardSection\`** — new \"Referral Tiers\" KPI grid above the integrity checks + new Tier column on the leaderboard with letter badges (A=accent, B=cyan, C=amber, D+=dim)

## 2. \`/admin\` unblocked on percolator.trade

Visiting percolator.trade/admin was redirecting to /waitlist because middleware's \`WAITLIST_HOST_ALLOWED_PREFIXES\` didn't include \`/admin\` (or \`/r\` for referral landings). Adds both. The admin login + session check inside the page still gates access server-side — this is just host-level pass-through.

## Operator action

Apply on the waitlist Supabase project (after the privy_did migration if you haven't yet — both are independent column adds and idempotent):

\`\`\`sql
-- supabase-waitlist-tiers-migration.sql
alter table public.waitlist add column if not exists tier int not null default 0;
create index if not exists waitlist_tier_idx on public.waitlist (tier);
-- + the two helper RPCs + the updated leaderboard RPC (see the file)
\`\`\`

Until applied, the new tier column won't exist and the signup route silently falls back to default 0 (degrade-safe). After applied, the admin UI will start showing the tier breakdown immediately.

## Type-check
\`pnpm tsc --noEmit\` — clean.