### PR TITLE
fix(waitlist-sql): DROP waitlist_referral_leaderboard before recreating

### DIFF
--- a/supabase-waitlist-tiers-migration.sql
+++ b/supabase-waitlist-tiers-migration.sql
@@ -103,8 +103,13 @@ do $$ begin
 end $$;
 
 -- ── Update the leaderboard RPC to include each row's tier ───────────
--- Keeps backward-compat: existing callers that ignore the new column
--- still work. New callers can read `tier` to render the A/B/C badge.
+-- Postgres won't let CREATE OR REPLACE change a function's return type
+-- (returning table (..., tier int) widens the row shape), so we DROP
+-- first. The previous version exists from the original waitlist schema
+-- migration; this DROP-then-CREATE is the documented Postgres idiom for
+-- "add a column to a SETOF/RETURNS TABLE function".
+drop function if exists public.waitlist_referral_leaderboard();
+
 create or replace function public.waitlist_referral_leaderboard()
 returns table (
   referral_code text,


### PR DESCRIPTION
Operator hit:

\`\`\`
ERROR: 42P13 cannot change return type of existing function
DETAIL: Row type defined by OUT parameters is different.
HINT: Use DROP FUNCTION waitlist_referral_leaderboard() first.
\`\`\`

\`CREATE OR REPLACE\` can't widen a function's \`RETURNS TABLE\` shape. The tiers migration adds a \`tier int\` column to \`waitlist_referral_leaderboard()\`'s return — different row type from the original definition in \`supabase-waitlist-schema.sql\`. Postgres refuses.

Adds an explicit \`DROP FUNCTION IF EXISTS\` before the \`CREATE\`. Idempotent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the waitlist referral leaderboard to include tier information in the results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dcccrypto/percolator-launch/pull/2184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->