### PR TITLE
feat(admin): pivot admin auth from dead Supabase to Privy + email allowlist

### DIFF
--- a/app/.env.local.example
+++ b/app/.env.local.example
@@ -21,3 +21,10 @@ NEXT_PUBLIC_PRIVY_APP_ID=
 # dashboard (App Settings → API Keys). Without it both routes degrade
 # gracefully (the form still works, just no auto-detection of returning users).
 PRIVY_APP_SECRET=
+
+# Admin allowlist — comma-separated emails. The /admin dashboard verifies
+# the Privy session server-side (requireAdminSession in lib/admin-session.ts)
+# and only lets users whose verified Privy email is in this list through.
+# Lowercase the entries. Without this set, /admin always 503s.
+# Example: PRIVY_ADMIN_EMAILS=dark@percolator.trade,squid@percolator.trade
+PRIVY_ADMIN_EMAILS=

--- a/app/app/admin/login/page.tsx
+++ b/app/app/admin/login/page.tsx
@@ -1,94 +1,80 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { createBrowserClient } from "@supabase/ssr";
+import { usePrivy } from "@privy-io/react-auth";
 
-function getAuthClient() {
-  return createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  );
-}
-
+/**
+ * Admin login — delegates to Privy's modal (email + OTP, optional 2FA
+ * once enabled in the Privy dashboard). Whether the logged-in user is
+ * an admin is decided server-side from PRIVY_ADMIN_EMAILS, so this
+ * page just gets them through Privy and bounces them to /admin where
+ * the page-level guard does the actual gate.
+ */
 const card = "rounded-none bg-[var(--panel-bg)] border border-[var(--border)] p-8";
-const labelStyle = "block text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-muted)] mb-1.5";
-const inputStyle =
-  "w-full rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] px-3 py-2.5 text-[13px] text-[var(--text)] placeholder:text-[var(--text-dim)] focus:border-[var(--accent)] focus:outline-none transition-colors";
 
 export default function AdminLoginPage() {
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [error, setError] = useState("");
-  const [loading, setLoading] = useState(false);
   const router = useRouter();
+  const { ready, authenticated, login, user } = usePrivy();
 
-  const handleLogin = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setLoading(true);
-    setError("");
-
-    const { error: authError } = await getAuthClient().auth.signInWithPassword({
-      email,
-      password,
-    });
-
-    if (authError) {
-      setError(authError.message);
-      setLoading(false);
-      return;
+  useEffect(() => {
+    if (ready && authenticated) {
+      router.replace("/admin");
     }
+  }, [ready, authenticated, router]);
 
-    router.push("/admin");
-  };
+  if (!ready) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-4">
+        <div className={`${card} w-full max-w-sm text-center`}>
+          <p className="font-mono text-[11px] uppercase tracking-[0.15em] text-[var(--text-muted)]">
+            Loading session...
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <div className="min-h-screen flex items-center justify-center px-4">
-      <div className={`${card} w-full max-w-[400px]`}>
-        <div className="mb-6">
-          <div className="text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--accent)] mb-1">
-            Percolator
-          </div>
-          <h1 className="text-lg font-bold text-[var(--text)]">Admin Access</h1>
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <div className={`${card} w-full max-w-sm`}>
+        <div className="mb-1 text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-muted)]">
+          Percolator
         </div>
+        <h1 className="text-xl font-bold text-[var(--text)] mb-6">Admin Login</h1>
 
-        <form onSubmit={handleLogin} className="space-y-4">
-          <div>
-            <label className={labelStyle}>Email</label>
-            <input
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              className={inputStyle}
-              placeholder="Email address"
-              required
-            />
+        {authenticated ? (
+          <div className="space-y-3">
+            <p className="text-[13px] text-[var(--text-secondary)]">
+              Signed in as{" "}
+              <span className="font-mono text-[var(--text)]">
+                {user?.email?.address ?? user?.id}
+              </span>
+            </p>
+            <button
+              onClick={() => router.replace("/admin")}
+              className="block w-full rounded-none border border-[var(--accent)]/60 bg-[var(--accent)]/[0.12] px-4 py-3 text-[12px] font-bold uppercase tracking-[0.14em] text-[var(--text)] transition-colors hover:bg-[var(--accent)]/20"
+            >
+              Continue to admin &rarr;
+            </button>
           </div>
-
-          <div>
-            <label className={labelStyle}>Password</label>
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className={inputStyle}
-              placeholder="Enter password"
-              required
-            />
+        ) : (
+          <div className="space-y-3">
+            <p className="text-[13px] leading-relaxed text-[var(--text-secondary)]">
+              Sign in via Privy. Email + 2FA. Only addresses listed in
+              <code className="mx-1 font-mono text-[12px] text-[var(--text)]">
+                PRIVY_ADMIN_EMAILS
+              </code>
+              can reach the dashboard.
+            </p>
+            <button
+              onClick={login}
+              className="block w-full rounded-none border border-[var(--accent)]/60 bg-[var(--accent)]/[0.12] px-4 py-3 text-[12px] font-bold uppercase tracking-[0.14em] text-[var(--text)] transition-colors hover:bg-[var(--accent)]/20"
+            >
+              Sign in with Privy &rarr;
+            </button>
           </div>
-
-          {error && (
-            <div className="text-[12px] text-[var(--short)]">{error}</div>
-          )}
-
-          <button
-            type="submit"
-            disabled={loading}
-            className="w-full rounded-none bg-[var(--accent)] px-4 py-2.5 text-[12px] font-bold uppercase tracking-[0.15em] text-white hover:opacity-90 transition-opacity disabled:opacity-50"
-          >
-            {loading ? "Signing in..." : "Sign In"}
-          </button>
-        </form>
+        )}
       </div>
     </div>
   );

--- a/app/app/admin/page.tsx
+++ b/app/app/admin/page.tsx
@@ -2,17 +2,20 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { createBrowserClient } from "@supabase/ssr";
-import type { User } from "@supabase/supabase-js";
+import { usePrivy } from "@privy-io/react-auth";
+import { useAdminFetch } from "@/hooks/useAdminFetch";
 import { OracleAdminSection } from "@/components/admin/OracleAdminSection";
 import { OracleFreshnessSection } from "@/components/admin/OracleFreshnessSection";
 import { WaitlistLeaderboardSection } from "@/components/admin/WaitlistLeaderboardSection";
 
-function getAuthClient() {
-  return createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  );
+/**
+ * Admin user shape. Pivoted from a Supabase User to a slim Privy
+ * shape — see lib/admin-session.ts for the server-side gate
+ * (verifyPrivyAuth + PRIVY_ADMIN_EMAILS allowlist).
+ */
+interface AdminUser {
+  userId: string;
+  email: string;
 }
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -297,7 +300,9 @@ function SectionHeader({ children }: { children: React.ReactNode }) {
 
 export default function AdminDashboard() {
   const router = useRouter();
-  const [user, setUser] = useState<User | null>(null);
+  const { ready, authenticated, logout } = usePrivy();
+  const adminFetch = useAdminFetch();
+  const [user, setUser] = useState<AdminUser | null>(null);
   const [loading, setLoading] = useState(true);
   const [bugs, setBugs] = useState<BugReport[]>([]);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
@@ -311,29 +316,45 @@ export default function AdminDashboard() {
   const [statsLoading, setStatsLoading] = useState(false);
 
   // ── Auth ───────────────────────────────────────────────────────────────────
+  // Privy session → /api/admin/whoami → 200 means in PRIVY_ADMIN_EMAILS.
+  // Anything else sends them to /admin/login. The server-side route is the
+  // canonical gate — this client check exists so we can render the dashboard
+  // without flashing it to non-admins.
 
   useEffect(() => {
-    getAuthClient()
-      .auth.getUser()
-      .then(async ({ data }) => {
-        if (!data.user) {
-          router.push("/admin/login");
+    if (!ready) return;
+    if (!authenticated) {
+      router.replace("/admin/login");
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await adminFetch("/api/admin/whoami");
+        if (cancelled) return;
+        if (res.status === 200) {
+          const json = (await res.json()) as { email: string; userId: string };
+          setUser({ email: json.email, userId: json.userId });
+          setLoading(false);
           return;
         }
-        const { data: adminRow } = await getAuthClient()
-          .from("admin_users")
-          .select("id")
-          .eq("email", data.user.email!)
-          .maybeSingle();
-        if (!adminRow) {
-          await getAuthClient().auth.signOut();
-          router.push("/admin/login");
+        if (res.status === 403) {
+          // Logged in via Privy but not in the admin allowlist.
+          await logout();
+          router.replace("/admin/login");
           return;
         }
-        setUser(data.user);
-        setLoading(false);
-      });
-  }, [router]);
+        // 401/503/other — push back to login and let that page show
+        // a useful state.
+        router.replace("/admin/login");
+      } catch {
+        if (!cancelled) router.replace("/admin/login");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [ready, authenticated, router, adminFetch, logout]);
 
   // ── Data fetching ──────────────────────────────────────────────────────────
 
@@ -341,11 +362,11 @@ export default function AdminDashboard() {
     // Use server-side /api/admin/bugs which fetches with service_role, returning
     // all columns including those restricted from the authenticated Supabase role
     // by migration 034 (twitter_handle, admin_notes, bounty_wallet, ip, etc.).
-    const res = await fetch("/api/admin/bugs").catch(() => null);
+    const res = await adminFetch("/api/admin/bugs").catch(() => null);
     if (!res?.ok) return;
     const data = await res.json().catch(() => null);
     if (Array.isArray(data)) setBugs(data as BugReport[]);
-  }, []);
+  }, [adminFetch]);
 
   const fetchPlatformStats = useCallback(async () => {
     setStatsLoading(true);
@@ -391,7 +412,7 @@ export default function AdminDashboard() {
 
   const updateStatus = async (bugId: string, newStatus: string) => {
     setSaving(true);
-    const res = await fetch("/api/admin/bugs", {
+    const res = await adminFetch("/api/admin/bugs", {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ id: bugId, status: newStatus }),
@@ -411,7 +432,7 @@ export default function AdminDashboard() {
   const saveNotes = async () => {
     if (!selectedBug) return;
     setSaving(true);
-    const res = await fetch("/api/admin/bugs", {
+    const res = await adminFetch("/api/admin/bugs", {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ id: selectedBug.id, admin_notes: adminNotes }),
@@ -429,7 +450,7 @@ export default function AdminDashboard() {
   };
 
   const signOut = async () => {
-    await getAuthClient().auth.signOut();
+    await logout();
     router.push("/admin/login");
   };
 

--- a/app/app/api/admin/bugs/route.ts
+++ b/app/app/api/admin/bugs/route.ts
@@ -24,8 +24,8 @@ import { requireAdminSession } from "@/lib/admin-session";
 
 export const dynamic = "force-dynamic";
 
-export async function GET() {
-  const auth = await requireAdminSession();
+export async function GET(req: Request) {
+  const auth = await requireAdminSession(req);
   if (!auth.ok) return auth.response;
 
   const sb = getServiceClient();
@@ -46,7 +46,7 @@ export async function GET() {
 }
 
 export async function PATCH(req: NextRequest) {
-  const auth = await requireAdminSession();
+  const auth = await requireAdminSession(req);
   if (!auth.ok) return auth.response;
 
   const sb = getServiceClient();

--- a/app/app/api/admin/waitlist/backfill-emails/route.ts
+++ b/app/app/api/admin/waitlist/backfill-emails/route.ts
@@ -28,8 +28,8 @@ function sleep(ms: number): Promise<void> {
  * GET — return the pending count without sending anything.
  * The admin UI uses this to decide whether to show the "Send emails" button.
  */
-export async function GET() {
-  const auth = await requireAdminSession();
+export async function GET(req: Request) {
+  const auth = await requireAdminSession(req);
   if (!auth.ok) return auth.response;
   try {
     const supabase = getWaitlistServiceSupabase();
@@ -65,8 +65,8 @@ export async function GET() {
  * `referral_code_emailed_at IS NOT NULL` so already-emailed users
  * are never re-sent.
  */
-export async function POST() {
-  const auth = await requireAdminSession();
+export async function POST(req: Request) {
+  const auth = await requireAdminSession(req);
   if (!auth.ok) return auth.response;
 
   const resendKey = process.env.RESEND_API_KEY?.trim();

--- a/app/app/api/admin/waitlist/leaderboard/route.ts
+++ b/app/app/api/admin/waitlist/leaderboard/route.ts
@@ -44,8 +44,8 @@ interface AdminLeaderboardEntry {
  *    (people gaming for visibility) before we want that loop running
  *  - the leaderboard is an operator tool for now, not a user-facing one
  */
-export async function GET() {
-  const auth = await requireAdminSession();
+export async function GET(req: Request) {
+  const auth = await requireAdminSession(req);
   if (!auth.ok) return auth.response;
 
   try {

--- a/app/app/api/admin/waitlist/stats/route.ts
+++ b/app/app/api/admin/waitlist/stats/route.ts
@@ -19,8 +19,8 @@ export const dynamic = "force-dynamic";
  * Service-role reads only — anon path stays revoked. Admin session
  * required.
  */
-export async function GET() {
-  const auth = await requireAdminSession();
+export async function GET(req: Request) {
+  const auth = await requireAdminSession(req);
   if (!auth.ok) return auth.response;
 
   try {

--- a/app/app/api/admin/whoami/route.ts
+++ b/app/app/api/admin/whoami/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { requireAdminSession } from "@/lib/admin-session";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/admin/whoami
+ *
+ * Tiny endpoint the /admin page calls on mount to decide whether to
+ * render the dashboard or bounce to /admin/login. Returns the
+ * verified email + Privy DID when the caller is in the allowlist.
+ *
+ * Response shapes:
+ *   200 { ok: true, email, userId }       — admin, render dashboard
+ *   401 { error: "..." }                   — no Privy session, send to login
+ *   403 { error: "Forbidden" }             — logged in but not an admin
+ *   503 { error: "..." }                   — server misconfig (no allowlist or no Privy secret)
+ */
+export async function GET(req: Request) {
+  const auth = await requireAdminSession(req);
+  if (!auth.ok) return auth.response;
+  return NextResponse.json({
+    ok: true,
+    email: auth.email,
+    userId: auth.userId,
+  });
+}

--- a/app/app/api/applications/route.ts
+++ b/app/app/api/applications/route.ts
@@ -19,8 +19,8 @@ const TABLE = "job_applications";
  * Lists job applications (full PII). **Auth:** Supabase session + `admin_users` row
  * (same model as `GET /api/admin/bugs`). Not gated by `INDEXER_API_KEY`.
  */
-export async function GET() {
-  const auth = await requireAdminSession();
+export async function GET(req: Request) {
+  const auth = await requireAdminSession(req);
   if (!auth.ok) return auth.response;
 
   try {

--- a/app/components/admin/WaitlistLeaderboardSection.tsx
+++ b/app/components/admin/WaitlistLeaderboardSection.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import useSWR from "swr";
+import { useAdminFetch } from "@/hooks/useAdminFetch";
 
 const card = "rounded-none bg-[var(--panel-bg)] border border-[var(--border)]";
 const labelStyle =
@@ -107,11 +108,8 @@ function tierColor(tier: number): string {
   return "var(--text-secondary)";
 }
 
-const fetcher = async (url: string) => {
-  const res = await fetch(url, { credentials: "include" });
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  return res.json();
-};
+// Fetcher is now built inside the component from useAdminFetch so the
+// Privy access + identity tokens get attached to every admin call.
 
 function truncatePubkey(pubkey: string | null): string {
   if (!pubkey) return "—";
@@ -145,6 +143,16 @@ function formatDate(iso: string): string {
  * a sanitisation layer + sign-off on the gamification surface.
  */
 export function WaitlistLeaderboardSection() {
+  const adminFetch = useAdminFetch();
+  const fetcher = useMemo(
+    () => async (url: string) => {
+      const res = await adminFetch(url);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return res.json();
+    },
+    [adminFetch],
+  );
+
   const [limit, setLimit] = useState<10 | 25 | 100>(25);
   const { data, error, isLoading, mutate } = useSWR<{
     leaderboard: AdminLeaderboardEntry[];
@@ -201,9 +209,8 @@ export function WaitlistLeaderboardSection() {
       // the run (which the server mirrors from the CLI script — re-running
       // after a flag-failure would double-email those users).
       while (true) {
-        const res = await fetch("/api/admin/waitlist/backfill-emails", {
+        const res = await adminFetch("/api/admin/waitlist/backfill-emails", {
           method: "POST",
-          credentials: "include",
         });
         if (!res.ok) {
           const body = await res.json().catch(() => ({}));

--- a/app/hooks/useAdminFetch.ts
+++ b/app/hooks/useAdminFetch.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useCallback } from "react";
+import { usePrivy, useIdentityToken } from "@privy-io/react-auth";
+
+/**
+ * Hook returning a `fetch`-like function that automatically attaches
+ * the caller's Privy access token + id token to outgoing requests.
+ *
+ * Use this for any admin API call — /api/admin/* routes verify both
+ * tokens server-side via requireAdminSession (Privy + email allowlist
+ * check). Pages that aren't logged into Privy will hit 401 on the
+ * server and the page-level guard should redirect them to login
+ * before that happens.
+ *
+ * Example:
+ *   const adminFetch = useAdminFetch();
+ *   const res = await adminFetch("/api/admin/bugs");
+ */
+export function useAdminFetch(): (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response> {
+  const { getAccessToken } = usePrivy();
+  const { identityToken } = useIdentityToken();
+
+  return useCallback(
+    async (input, init) => {
+      const accessToken = await getAccessToken();
+      const headers: Record<string, string> = {
+        ...(init?.headers as Record<string, string> | undefined),
+      };
+      if (accessToken) headers["Authorization"] = `Bearer ${accessToken}`;
+      if (identityToken) headers["x-privy-id-token"] = identityToken;
+      return fetch(input, { ...init, headers });
+    },
+    [getAccessToken, identityToken],
+  );
+}

--- a/app/lib/admin-session.ts
+++ b/app/lib/admin-session.ts
@@ -1,86 +1,92 @@
-import { createServerClient } from "@supabase/ssr";
-import { cookies } from "next/headers";
-import type { User } from "@supabase/supabase-js";
 import { NextResponse } from "next/server";
-import { getServiceClient } from "@/lib/supabase";
-
-export type AdminSessionResult =
-  | { ok: true; user: User }
-  | { ok: false; response: NextResponse };
-
-function normalizeEmail(value: string): string {
-  return value.trim().toLowerCase();
-}
+import { verifyPrivyAuth } from "@/lib/privy-auth";
 
 /**
- * Verify Supabase Auth session (cookies) and membership in `admin_users`.
- * For Route Handlers that return PII using `getServiceClient()`.
+ * Admin auth, pivoted from Supabase Auth + admin_users table to
+ * Privy session + email allowlist.
+ *
+ * Why the change: the original implementation required a working
+ * trading Supabase project (NEXT_PUBLIC_SUPABASE_URL) to verify
+ * Supabase Auth cookies + read the admin_users table. When that
+ * project went down, admin login broke entirely.
+ *
+ * The new model:
+ *  1. Caller (admin route handler or the admin page itself) attaches
+ *     a Privy access token in `Authorization: Bearer …` plus an
+ *     identity token in `X-Privy-Id-Token`. verifyPrivyAuth verifies
+ *     both via @privy-io/node and extracts the user's linked email.
+ *  2. We check the verified email against PRIVY_ADMIN_EMAILS, a
+ *     comma-separated env-var allowlist (case-insensitive). Members
+ *     are admins; everyone else gets 403.
+ *
+ * The email comes from a verified Privy identity token, so we trust
+ * Privy's OTP / 2FA verification implicitly — when Privy 2FA is
+ * enabled in the dashboard, admins step through the second factor
+ * before a session is issued, then any request bearing that session
+ * is an authenticated-second-factor request.
  */
-export async function requireAdminSession(): Promise<AdminSessionResult> {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-  if (!supabaseUrl || !supabaseAnonKey) {
-    return {
-      ok: false,
-      response: NextResponse.json({ error: "Admin auth is not configured" }, { status: 503 }),
-    };
-  }
 
-  const cookieStore = await cookies();
-  const supabase = createServerClient(
-    supabaseUrl,
-    supabaseAnonKey,
-    {
-      cookies: {
-        getAll() {
-          return cookieStore.getAll();
-        },
-        setAll() {
-          /* read-only in Route Handlers */
-        },
-      },
-    },
+function normalizeEmail(s: string): string {
+  return s.trim().toLowerCase();
+}
+
+// Resolved fresh on each call so env edits take effect on the next
+// request without needing a process restart.
+function getAdminEmailSet(): Set<string> {
+  const raw = (process.env.PRIVY_ADMIN_EMAILS ?? "").trim();
+  return new Set(
+    raw
+      .split(",")
+      .map(normalizeEmail)
+      .filter(Boolean),
   );
+}
 
-  const {
-    data: { user },
-    error,
-  } = await supabase.auth.getUser();
-  if (error || !user) {
+export type AdminSessionResult =
+  | { ok: true; userId: string; email: string }
+  | { ok: false; response: NextResponse };
+
+/**
+ * Verify the caller is an admin. Pass the incoming Request so we can
+ * read the Privy headers off it.
+ *
+ * Returns 503 when the allowlist is empty (config error — refuse to
+ * silently allow everyone). 401 on missing/invalid Privy token. 403
+ * when the verified email isn't in the allowlist (or the token has
+ * no verified email, which usually means the client forgot to send
+ * the X-Privy-Id-Token header).
+ */
+export async function requireAdminSession(
+  req: Request,
+): Promise<AdminSessionResult> {
+  const adminEmails = getAdminEmailSet();
+  if (adminEmails.size === 0) {
     return {
       ok: false,
-      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+      response: NextResponse.json(
+        { error: "PRIVY_ADMIN_EMAILS not configured" },
+        { status: 503 },
+      ),
     };
   }
-  if (!user.email) {
+
+  const auth = await verifyPrivyAuth(req);
+  if (!auth.ok) {
     return {
       ok: false,
-      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+      response: NextResponse.json(
+        { error: "Unauthorized" },
+        { status: auth.status },
+      ),
     };
   }
 
-  if (!user.email_confirmed_at) {
-    return {
-      ok: false,
-      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
-    };
-  }
-
-  const email = normalizeEmail(user.email);
-
-  const sb = getServiceClient();
-  const { data: adminRow } = await sb
-    .from("admin_users")
-    .select("id")
-    .eq("email", email)
-    .maybeSingle();
-
-  if (!adminRow) {
+  if (!auth.email || !adminEmails.has(auth.email)) {
     return {
       ok: false,
       response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
     };
   }
 
-  return { ok: true, user };
+  return { ok: true, userId: auth.userId, email: auth.email };
 }

--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { createServerClient } from "@supabase/ssr";
 import { Redis } from "@upstash/redis";
 import { Ratelimit } from "@upstash/ratelimit";
 import { BLOCKED_SLAB_ADDRESSES } from "@/lib/blocklist";
@@ -353,50 +352,27 @@ export async function middleware(request: NextRequest) {
     });
   }
 
-  // ── Admin route guard (server-side session check) ──────────────────────────
-  // The /admin page component does a client-side auth check, but that fires
-  // after pre-render HTML is served (visible with JS disabled).  This guard
-  // ensures any unauthenticated request to /admin/* is redirected before any
-  // server-rendered content is produced.  Actual data is also protected by
-  // Supabase RLS + admin_users table, so this is defense-in-depth (LOW risk).
+  // ── Admin route guard ──────────────────────────────────────────────────────
+  // Was a Supabase Auth + admin_users check, but we pivoted admin auth to
+  // Privy + PRIVY_ADMIN_EMAILS (see lib/admin-session.ts) when the trading
+  // Supabase project went away. Privy session lives in the browser and gets
+  // attached to admin API calls via useAdminFetch, so the middleware can't
+  // verify the Privy session in the Edge runtime without bundling the SDK.
+  //
+  // Instead:
+  //   • The /admin page itself calls /api/admin/whoami on mount and bounces
+  //     to /admin/login if the Privy session isn't an allowlisted admin.
+  //   • Every /api/admin/* route gates on requireAdminSession(req) server-
+  //     side, so even if the page leaked HTML the data is locked down.
+  //
+  // We still attach the security headers + skip /admin/login from any host-
+  // level redirects above.
   const isAdminRoute =
     request.nextUrl.pathname.startsWith("/admin") &&
     !request.nextUrl.pathname.startsWith("/admin/login");
 
   if (isAdminRoute) {
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-    const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-    if (!supabaseUrl || !supabaseAnonKey) {
-      // Env vars missing — redirect to login rather than expose admin
-      const loginUrl = new URL("/admin/login", request.url);
-      return NextResponse.redirect(loginUrl);
-    }
-
     const response = NextResponse.next();
-    const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
-      cookies: {
-        getAll() {
-          return request.cookies.getAll();
-        },
-        setAll(cookiesToSet) {
-          cookiesToSet.forEach(({ name, value, options }) => {
-            response.cookies.set(name, value, options);
-          });
-        },
-      },
-    });
-
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      const loginUrl = new URL("/admin/login", request.url);
-      return NextResponse.redirect(loginUrl);
-    }
-
-    // User is authenticated — continue to admin route with security headers
     addSecurityHeaders(response);
     return response;
   }


### PR DESCRIPTION
The original admin auth required the trading Supabase project — it verified Supabase Auth cookies and read membership from an \`admin_users\` table. That project went away, taking admin login with it. This PR replaces that dependency with the Privy session you already have logged in, gated by a simple email allowlist.

## Auth model

1. User signs into Privy (email + OTP; 2FA when enabled in the Privy dashboard) via the new login page
2. \`/admin\` calls \`/api/admin/whoami\` on mount; the server verifies the Privy session via \`verifyPrivyAuth\` (already shipped for /api/waitlist/whoami) and checks the verified email against \`PRIVY_ADMIN_EMAILS\`
3. Every \`/api/admin/*\` route runs the same check before doing anything

## Server side
- **\`lib/admin-session.ts\`** — \`requireAdminSession(req)\` now reads Privy headers off the request, verifies via \`@privy-io/node\`, checks the verified email against the allowlist. Returns \`{ok:true,userId,email}\` or 401/403/503.
- All admin routes (\`bugs\`, \`applications\`, \`waitlist/*\`) updated to pass \`req\`
- **New \`/api/admin/whoami\`** — tiny endpoint the page calls to determine \"am I an admin\"

## Client side
- **\`hooks/useAdminFetch.ts\`** — fetch wrapper that attaches \`Authorization: Bearer <accessToken>\` + \`X-Privy-Id-Token: <idToken>\` to every admin call
- **\`/admin\` page** — replaces Supabase auth flow with Privy + /whoami check; logout via Privy
- **\`/admin/login\` page** — rewritten as a one-button \"Sign in with Privy\" landing
- **\`WaitlistLeaderboardSection\`** — module-level fetcher swapped for \`useAdminFetch\`

## Middleware
- Drops the Supabase-Auth admin gate (Edge runtime can't easily verify Privy without bundling the SDK). The page-level guard + per-route server-side gate are now the authoritative checks. Data is locked down regardless of what the page renders.

## Operator action (required before this is useful)

1. Set on Vercel (Production + Preview):
   \`\`\`
   PRIVY_ADMIN_EMAILS=dark@percolator.trade,squid@percolator.trade
   \`\`\`
2. Verify \`PRIVY_APP_SECRET\` is also set (already required by /whoami in PR #2181).
3. Enable 2FA in the Privy dashboard if you want the second factor enforced. No code change needed — Privy handles 2FA out of the box on login.

Until \`PRIVY_ADMIN_EMAILS\` is set, every admin route returns \`503 \"PRIVY_ADMIN_EMAILS not configured\"\`. That's intentional — fails closed.

## Type-check
\`pnpm tsc --noEmit\` — clean.