### PR TITLE
fix(admin): surface distinct 503 reasons (PRIVY_APP_SECRET vs allowlist)

### DIFF
--- a/app/app/admin/page.tsx
+++ b/app/app/admin/page.tsx
@@ -521,6 +521,24 @@ export default function AdminDashboard() {
   // wrong and can act: set env var, switch account, etc.
 
   if (authError) {
+    // Infer the missing env var from the server's error message so the
+    // panel tells the operator exactly what's wrong (PRIVY_APP_SECRET
+    // vs PRIVY_ADMIN_EMAILS — both surface as 503).
+    const missingEnv = authError.message.includes("PRIVY_APP_SECRET")
+      ? "PRIVY_APP_SECRET"
+      : authError.message.includes("PRIVY_ADMIN_EMAILS")
+        ? "PRIVY_ADMIN_EMAILS"
+        : null;
+    const title =
+      authError.kind === "not-configured"
+        ? missingEnv === "PRIVY_APP_SECRET"
+          ? "Set PRIVY_APP_SECRET on Vercel"
+          : missingEnv === "PRIVY_ADMIN_EMAILS"
+            ? "Set PRIVY_ADMIN_EMAILS on Vercel"
+            : "Admin server is not configured"
+        : authError.kind === "forbidden"
+          ? "Your email isn't an admin"
+          : "Something went wrong";
     return (
       <div className="min-h-screen flex items-center justify-center p-4">
         <div className="w-full max-w-md rounded-none border border-[var(--border)] bg-[var(--panel-bg)] p-8">
@@ -531,17 +549,16 @@ export default function AdminDashboard() {
                 ? "Forbidden"
                 : "Admin check failed"}
           </div>
-          <h1 className="mb-4 text-xl font-bold text-[var(--text)]">
-            {authError.kind === "not-configured"
-              ? "Set PRIVY_ADMIN_EMAILS on Vercel"
-              : authError.kind === "forbidden"
-                ? "Your email isn't an admin"
-                : "Something went wrong"}
-          </h1>
+          <h1 className="mb-4 text-xl font-bold text-[var(--text)]">{title}</h1>
           <p className="mb-6 text-[13px] leading-relaxed text-[var(--text-secondary)]">
             {authError.message}
           </p>
-          {authError.kind === "not-configured" && (
+          {missingEnv === "PRIVY_APP_SECRET" && (
+            <pre className="mb-6 overflow-x-auto rounded-none border border-[var(--border)] bg-[var(--bg)] p-3 font-mono text-[11px] text-[var(--text)]">
+{`PRIVY_APP_SECRET=<paste from Privy dashboard → App Settings → API Keys>`}
+            </pre>
+          )}
+          {missingEnv === "PRIVY_ADMIN_EMAILS" && (
             <pre className="mb-6 overflow-x-auto rounded-none border border-[var(--border)] bg-[var(--bg)] p-3 font-mono text-[11px] text-[var(--text)]">
 {`PRIVY_ADMIN_EMAILS=dark@percolator.trade,squid@percolator.trade`}
             </pre>

--- a/app/lib/admin-session.ts
+++ b/app/lib/admin-session.ts
@@ -72,19 +72,46 @@ export async function requireAdminSession(
 
   const auth = await verifyPrivyAuth(req);
   if (!auth.ok) {
+    // Distinguish the two 503 paths the caller cares about — Privy
+    // server SDK unconfigured vs allowlist unconfigured (handled above)
+    // — so the admin page can tell the operator which env var to set.
+    const message =
+      auth.status === 503
+        ? "PRIVY_APP_SECRET not configured on the server"
+        : auth.reason === "invalid-token"
+          ? "Session expired or invalid — sign in again"
+          : "No Privy session";
     return {
       ok: false,
       response: NextResponse.json(
-        { error: "Unauthorized" },
+        { error: message },
         { status: auth.status },
       ),
     };
   }
 
-  if (!auth.email || !adminEmails.has(auth.email)) {
+  if (!auth.email) {
     return {
       ok: false,
-      response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+      response: NextResponse.json(
+        {
+          error:
+            "Privy session has no verified email — make sure the client sends X-Privy-Id-Token",
+        },
+        { status: 403 },
+      ),
+    };
+  }
+
+  if (!adminEmails.has(auth.email)) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        {
+          error: `Email ${auth.email} is not on the PRIVY_ADMIN_EMAILS allowlist`,
+        },
+        { status: 403 },
+      ),
     };
   }
 


### PR DESCRIPTION
Operator set \`PRIVY_ADMIN_EMAILS\` but still saw \"ADMIN AUTH NOT CONFIGURED\" with subtitle \"Unauthorized\" — confusing because two different misconfigurations were collapsing to one error panel:

- \`PRIVY_ADMIN_EMAILS\` unset (allowlist empty) 
- \`PRIVY_APP_SECRET\` unset (Privy server SDK can't verify tokens)

Both surface as 503 but require different env vars.

## Fix

\`lib/admin-session.ts\` — surface the actual reason verifyPrivyAuth failed in the error body, instead of squashing to \"Unauthorized\". Per-status messages:
- 503 from Privy → \`PRIVY_APP_SECRET not configured on the server\`
- 401 invalid → \`Session expired or invalid — sign in again\`
- 401 missing → \`No Privy session\`
- 403 no email → tells operator to send \`X-Privy-Id-Token\` (or it'll be the email check itself)
- 403 not-on-list → \`Email <x> is not on the PRIVY_ADMIN_EMAILS allowlist\` (helps you know which account you're signed in as)

\`app/admin/page.tsx\` — infers which env var is missing from the server message and shows the matching template in the code block on the panel. So when \`PRIVY_APP_SECRET\` is missing, the panel says \"Set PRIVY_APP_SECRET on Vercel\" with the right template, not \"Set PRIVY_ADMIN_EMAILS\".

## Type-check
\`pnpm tsc --noEmit\` — clean.