### PR TITLE
fix(admin): match against ALL linked emails, not just the first

### DIFF
--- a/app/lib/admin-session.ts
+++ b/app/lib/admin-session.ts
@@ -90,7 +90,7 @@ export async function requireAdminSession(
     };
   }
 
-  if (!auth.email) {
+  if (auth.emails.length === 0) {
     return {
       ok: false,
       response: NextResponse.json(
@@ -103,17 +103,22 @@ export async function requireAdminSession(
     };
   }
 
-  if (!adminEmails.has(auth.email)) {
+  // Any-match: a Privy user can have multiple linked emails (direct
+  // + Google OAuth + Apple OAuth). Accept if ANY of them is on the
+  // allowlist. Otherwise surface the full list so the operator can
+  // see exactly what Privy associates with their session.
+  const matched = auth.emails.find((e) => adminEmails.has(e)) ?? null;
+  if (!matched) {
     return {
       ok: false,
       response: NextResponse.json(
         {
-          error: `Email ${auth.email} is not on the PRIVY_ADMIN_EMAILS allowlist`,
+          error: `Signed in as ${auth.emails.join(", ")} — none of these is on PRIVY_ADMIN_EMAILS. Add one, or sign in with an allowlisted email.`,
         },
         { status: 403 },
       ),
     };
   }
 
-  return { ok: true, userId: auth.userId, email: auth.email };
+  return { ok: true, userId: auth.userId, email: matched };
 }

--- a/app/lib/privy-auth.ts
+++ b/app/lib/privy-auth.ts
@@ -30,7 +30,8 @@ function getClient(): PrivyClient | null {
 
 export interface PrivyAuthResult {
   userId: string; // Privy DID, e.g. "did:privy:cl…"
-  email: string | null; // lowercased
+  email: string | null; // primary email (lowercased) — for storage/display
+  emails: string[]; // ALL verified emails (lowercased) — for allowlist matching
   solanaWallets: string[]; // base58 pubkeys
 }
 
@@ -94,33 +95,40 @@ export async function verifyPrivyAuth(
     }
   }
 
-  const email = extractEmail(user);
+  const emails = extractAllEmails(user);
   const solanaWallets = extractSolanaWallets(user);
 
-  return { ok: true, userId, email, solanaWallets };
+  return {
+    ok: true,
+    userId,
+    email: emails[0] ?? null,
+    emails,
+    solanaWallets,
+  };
 }
 
-function extractEmail(user: User | null): string | null {
-  if (!user) return null;
+/**
+ * Collects every verified email Privy has linked to the user — direct
+ * email logins, Google/Apple OAuth emails, etc. Returns lowercased and
+ * deduped. Callers that need any-match semantics (admin allowlist
+ * check) should iterate this array, not the single-email field.
+ */
+function extractAllEmails(user: User | null): string[] {
+  if (!user) return [];
   const accounts: LinkedAccount[] = user.linked_accounts ?? [];
-
-  // Prefer the directly-linked email account; fall back to a verified
-  // OAuth account that surfaces an email field.
+  const seen = new Set<string>();
   for (const a of accounts) {
     if (a.type === "email" && "address" in a && typeof a.address === "string") {
-      return a.address.toLowerCase();
-    }
-  }
-  for (const a of accounts) {
-    if (
+      seen.add(a.address.toLowerCase());
+    } else if (
       (a.type === "google_oauth" || a.type === "apple_oauth") &&
       "email" in a &&
       typeof a.email === "string"
     ) {
-      return a.email.toLowerCase();
+      seen.add(a.email.toLowerCase());
     }
   }
-  return null;
+  return [...seen];
 }
 
 function extractSolanaWallets(user: User | null): string[] {


### PR DESCRIPTION
Operator reported \"Your email isn't an admin\" after signing in with \`dark@percolator.trade\`. Root cause: my \`extractEmail\` returned only the FIRST email in \`user.linked_accounts\`. A Privy user that has multiple linked emails (e.g. dark@percolator.trade via OTP plus a Google OAuth on a different address) gets one of them checked — and if it's not the allowlisted one, 403 even though the right address is right there in the session.

## Fix

- \`privy-auth.ts\` now exposes \`emails: string[]\` (all verified emails, lowercased + deduped) alongside the existing single \`email\` field for backwards compat.
- \`admin-session.ts\` switches to any-match semantics: accept if ANY linked email is on the allowlist. Picks the matched email as the canonical one in the returned shape.
- The 403 error now lists every email Privy associates with the session, so the operator can see exactly which account they signed in as. Sample:
  > Signed in as foo@bar.com, dark@percolator.trade — none of these is on PRIVY_ADMIN_EMAILS. Add one, or sign in with an allowlisted email.

## Type-check
\`pnpm tsc --noEmit\` — clean.