### PR TITLE
fix(admin): show server's actual 403 message instead of hardcoded one

### DIFF
--- a/app/app/admin/page.tsx
+++ b/app/app/admin/page.tsx
@@ -361,9 +361,17 @@ export default function AdminDashboard() {
           return;
         }
         if (res.status === 403) {
+          // The server tells us exactly which emails are on the
+          // session (PR #2188 — multi-email match). Show that
+          // verbatim so the operator can see which account they're
+          // signed in as and which one needs adding to the allowlist.
+          const body = await res
+            .json()
+            .catch(() => ({ error: "" }));
           setAuthError({
             kind: "forbidden",
             message:
+              (body as { error?: string }).error ||
               "You're signed in via Privy, but your email isn't on the admin allowlist (PRIVY_ADMIN_EMAILS). Sign out and use an admin email, or ask an operator to add yours.",
           });
           setLoading(false);


### PR DESCRIPTION
PR #2188 added a server message that lists every email Privy has on the session, so the operator can see which account they're signed in as. But the admin page kept overriding it with the generic hardcoded text — defeating the point.

One-line fix: read \`body.error\` like the 503 path does. Falls back to the old generic copy if the body is empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced admin page error handling to display server-provided error messages instead of generic fallback text, offering more specific feedback about authentication and allowlist matching details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dcccrypto/percolator-launch/pull/2189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->