### PR TITLE
fix(email): switch to light theme + add logo (defeats client dark-mode mangling)

### DIFF
--- a/app/lib/waitlist/email-template.ts
+++ b/app/lib/waitlist/email-template.ts
@@ -1,46 +1,57 @@
 /**
- * Transactional email template — matches the percolator.trade product UI:
- * dark background, mono accents, sharp edges, accent-purple highlights.
+ * Transactional email template — light theme, maximum email-client
+ * compatibility. Previously dark-themed; switched after Apple Mail /
+ * iOS Mail / a few other clients force-rendered the dark bg as light
+ * but left the light-on-dark text colors alone, producing unreadable
+ * light-on-light copy. Light theme dodges that whole class of failure.
  *
- * Constraints baked into this design (so future edits don't break clients):
- *  - All CSS inline. Email clients strip <style> blocks.
- *  - Table-based layout (one outer <table>) for legacy Outlook compatibility.
- *  - No CSS variables, no flexbox, no grid. Just width/padding/inline styles.
- *  - No web fonts. System sans for prose, system mono for code/labels.
- *  - Sharp corners (`border-radius: 0`) to match the product's aesthetic.
- *  - Solid colors only — no gradients (render unevenly across clients).
- *  - Dark background with explicit foreground colors on every element
- *    (Outlook desktop and a few corporate clients break on color
- *    inheritance even in 2026).
+ * Constraints baked into this design:
+ *   - All CSS inline. Email clients strip <style> blocks.
+ *   - Table-based layout (one outer <table>) for legacy Outlook.
+ *   - No CSS vars, no flexbox, no grid.
+ *   - No web fonts. System sans + system mono.
+ *   - Sharp corners (`border-radius: 0`) to match the product.
+ *   - Solid colors only — no gradients (uneven cross-client).
+ *   - Explicit colors on EVERY text element (some clients break
+ *     color inheritance on container darkening).
+ *   - No `color-scheme: dark` hint — let the client render in its
+ *     default mode; we've made sure both light + dark forced-mode
+ *     renderings stay readable.
  *
- * Brand palette used here matches CSS vars in app/globals.css:
- *   bg:        #0D0E15      (--bg)
- *   panel:     #15161F      (--panel-bg)
- *   border:    #2E2F3F      (--border, slightly lighter for visibility)
- *   text:      #F0F0F8      (--text)
- *   muted:     #8A8BA8      (--text-secondary)
- *   dim:       #5A5B72      (--text-dim)
- *   accent:    #9945FF      (Solana purple)
- *   cyan:      #14F195      (Solana green/cyan)
+ * Brand palette (light):
+ *   page bg:   #F8F8FC (very light cool gray)
+ *   panel bg:  #FFFFFF (white card)
+ *   border:    #E0E0EC
+ *   text:      #0D0E15 (near-black for body)
+ *   muted:     #4A4B62 (warm dark grey — readable on both light + inverted)
+ *   dim:       #8A8BA8 (mid grey for chrome)
+ *   accent:    #9945FF (Solana purple)
+ *   cyan:      #14BB6F (slightly darker green than --cyan so it stays readable on white)
+ *
+ * Logo:
+ *   Hosted public asset at percolator.trade/images/logo-icon.png.
+ *   Width-constrained inline; works in all clients.
  */
 
 const SANS = `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
 const MONO = `ui-monospace, SFMono-Regular, "SF Mono", Consolas, monospace`;
 
 const COLOR = {
-  bg: "#0D0E15",
-  panel: "#15161F",
-  border: "#2E2F3F",
-  text: "#F0F0F8",
-  muted: "#8A8BA8",
-  dim: "#5A5B72",
+  bg: "#F8F8FC",
+  panel: "#FFFFFF",
+  border: "#E0E0EC",
+  text: "#0D0E15",
+  muted: "#4A4B62",
+  dim: "#8A8BA8",
   accent: "#9945FF",
-  cyan: "#14F195",
+  cyan: "#14BB6F",
   long: "#23C47C",
 };
 
+const LOGO_URL = "https://percolator.trade/images/logo-icon.png";
+
 export interface EmailLayout {
-  /** Window-bar label — appears top-left, monospaced, accent-tinted. */
+  /** Window-bar label — top-left, monospaced, dim. */
   preheader: string;
   /** Hidden preview text shown by mail clients in the inbox list. */
   previewText: string;
@@ -50,8 +61,7 @@ export interface EmailLayout {
   headline: string;
   /** Optional intro line shown immediately under the headline. */
   intro?: string;
-  /** Inner content — pre-rendered HTML fragments (use renderCodeBlock,
-   *  renderParagraph, renderDivider helpers below). */
+  /** Inner content — pre-rendered HTML fragments. */
   contentHtml: string;
   /** Optional CTA button rendered above the footer. */
   cta?: { label: string; href: string };
@@ -67,13 +77,17 @@ export function renderParagraph(text: string): string {
 /**
  * Renders the referral-code block — outlined sharp box, label in
  * accent-purple uppercase mono, code in big bold mono, share URL below.
+ *
+ * Background is set to a very light gray tint so the box stands out
+ * against the white card on light clients, AND keeps usable contrast
+ * if a client force-inverts the panel.
  */
 export function renderCodeBlock(code: string, shareUrl: string): string {
   return `
     <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin:0 0 22px 0; border-collapse:collapse;">
       <tr>
-        <td style="padding:18px 18px 16px 18px; background:${COLOR.bg}; border:1px solid ${COLOR.accent}40;">
-          <div style="font-family:${MONO}; font-size:10.5px; letter-spacing:0.18em; text-transform:uppercase; color:${COLOR.accent}; margin:0 0 8px 0;">
+        <td style="padding:18px 18px 16px 18px; background:#F8F8FC; border:1px solid ${COLOR.accent};">
+          <div style="font-family:${MONO}; font-size:10.5px; letter-spacing:0.18em; text-transform:uppercase; color:${COLOR.accent}; margin:0 0 8px 0; font-weight:700;">
             Your referral code
           </div>
           <div style="font-family:${MONO}; font-size:26px; font-weight:700; letter-spacing:0.08em; color:${COLOR.text}; line-height:1;">
@@ -81,7 +95,7 @@ export function renderCodeBlock(code: string, shareUrl: string): string {
           </div>
           <div style="height:14px; line-height:14px; font-size:0;">&nbsp;</div>
           <div style="font-family:${MONO}; font-size:11.5px; color:${COLOR.muted}; word-break:break-all;">
-            <span style="color:${COLOR.dim};">$&nbsp;</span><a href="${shareUrl}" style="color:${COLOR.cyan}; text-decoration:none;">${shareUrl.replace(/^https?:\/\//, "")}</a>
+            <span style="color:${COLOR.dim};">$&nbsp;</span><a href="${shareUrl}" style="color:${COLOR.accent}; text-decoration:underline;">${shareUrl.replace(/^https?:\/\//, "")}</a>
           </div>
         </td>
       </tr>
@@ -90,27 +104,26 @@ export function renderCodeBlock(code: string, shareUrl: string): string {
 }
 
 /**
- * Renders a `prefix · text` status line in the terminal-prompt style
- * used in the product UI (PromptLine component).
+ * Renders a `prefix · text` status line in the terminal-prompt style.
  */
 export function renderStatusLine(prefix: string, text: string, color: string = COLOR.cyan): string {
   return `
     <div style="font-family:${MONO}; font-size:11.5px; color:${COLOR.dim}; margin:0 0 14px 0;">
-      <span>${prefix}</span> <span style="color:${color};">${text}</span>
+      <span style="color:${COLOR.dim};">${prefix}</span> <span style="color:${color}; font-weight:600;">${text}</span>
     </div>
   `.trim();
 }
 
 /**
- * Renders a CTA button. Outlined sharp box with accent-purple background
- * and white text. Uses bgcolor attribute + inline style for legacy Outlook.
+ * Renders a CTA button. Sharp accent-purple block, white uppercase
+ * mono label. Uses bgcolor attribute + inline style for legacy Outlook.
  */
 export function renderCta(label: string, href: string): string {
   return `
     <table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin:0 0 20px 0; border-collapse:collapse;">
       <tr>
         <td bgcolor="${COLOR.accent}" style="background:${COLOR.accent}; padding:0;">
-          <a href="${href}" target="_blank" rel="noopener noreferrer" style="display:inline-block; padding:11px 22px; font-family:${MONO}; font-size:12px; font-weight:700; letter-spacing:0.16em; text-transform:uppercase; color:#FFFFFF; text-decoration:none;">
+          <a href="${href}" target="_blank" rel="noopener noreferrer" style="display:inline-block; padding:12px 24px; font-family:${MONO}; font-size:12px; font-weight:700; letter-spacing:0.16em; text-transform:uppercase; color:#FFFFFF; text-decoration:none;">
             ${label}&nbsp;&rarr;
           </a>
         </td>
@@ -119,20 +132,13 @@ export function renderCta(label: string, href: string): string {
   `.trim();
 }
 
-/**
- * Renders a horizontal divider that matches the in-product
- * `border-[var(--border)]/30` look.
- */
 export function renderDivider(): string {
   return `<div style="height:1px; line-height:1px; font-size:0; background:${COLOR.border}; margin:22px 0;">&nbsp;</div>`;
 }
 
 /**
- * Composes the full HTML email. Pre-header (window-bar) → headline →
- * intro → content → CTA → divider → footer.
- *
- * The outer table sets the page background so dark mode is preserved
- * even when clients invert images-only or rewrite linked colors.
+ * Composes the full HTML email. Top logo row → window-bar header →
+ * headline → intro → content → CTA → divider → footer.
  */
 export function renderEmail(layout: EmailLayout): string {
   const { preheader, previewText, headline, intro, contentHtml, cta } = layout;
@@ -148,25 +154,39 @@ export function renderEmail(layout: EmailLayout): string {
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="x-apple-disable-message-reformatting">
-  <meta name="color-scheme" content="dark">
-  <meta name="supported-color-schemes" content="dark">
   <title>Percolator</title>
 </head>
 <body style="margin:0; padding:0; background:${COLOR.bg}; color:${COLOR.text}; font-family:${SANS}; -webkit-font-smoothing:antialiased; -moz-osx-font-smoothing:grayscale;">
-  <!-- Preview text: shown in inbox preview, hidden from email body. -->
+  <!-- Preview text — shown in inbox preview, hidden from email body. -->
   <div style="display:none; max-height:0; max-width:0; overflow:hidden; opacity:0; mso-hide:all;">
-    ${previewText}&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;
+    ${previewText}&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;
   </div>
 
   <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" bgcolor="${COLOR.bg}" style="background:${COLOR.bg}; border-collapse:collapse;">
     <tr>
-      <td align="center" style="padding:40px 16px 28px 16px;">
+      <td align="center" style="padding:32px 16px 28px 16px;">
+
+        <!-- Logo row, sits above the card so it survives card-bg inversions. -->
+        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" style="max-width:600px; width:100%; border-collapse:collapse; margin-bottom:14px;">
+          <tr>
+            <td align="center" style="padding:0 0 4px 0;">
+              <a href="https://percolator.trade" style="text-decoration:none;">
+                <img src="${LOGO_URL}" alt="Percolator" width="40" height="40" style="display:block; margin:0 auto; width:40px; height:40px; border:0;">
+              </a>
+            </td>
+          </tr>
+          <tr>
+            <td align="center" style="padding:6px 0 0 0; font-family:${MONO}; font-size:11px; letter-spacing:0.22em; text-transform:uppercase; color:${COLOR.dim};">
+              percolator trade
+            </td>
+          </tr>
+        </table>
 
         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" style="max-width:600px; width:100%; border-collapse:collapse; background:${COLOR.panel}; border:1px solid ${COLOR.border};">
 
-          <!-- Window-bar header: traffic lights + label, matches the SignupCard frame. -->
+          <!-- Window-bar header: traffic-light dots + mono label, matches the SignupCard frame. -->
           <tr>
-            <td style="padding:14px 22px 12px 22px; border-bottom:1px solid ${COLOR.border};">
+            <td style="padding:14px 22px 12px 22px; border-bottom:1px solid ${COLOR.border}; background:${COLOR.panel};">
               <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="border-collapse:collapse;">
                 <tr>
                   <td align="left" style="font-family:${MONO}; font-size:10.5px; letter-spacing:0.18em; text-transform:uppercase; color:${COLOR.muted};">
@@ -182,7 +202,7 @@ export function renderEmail(layout: EmailLayout): string {
 
           <!-- Body -->
           <tr>
-            <td style="padding:26px 28px 24px 28px;">
+            <td style="padding:26px 28px 24px 28px; background:${COLOR.panel};">
               <h1 style="margin:0 0 12px 0; font-family:${SANS}; font-size:26px; line-height:1.18; font-weight:700; letter-spacing:-0.015em; color:${COLOR.text};">
                 ${headline}
               </h1>
@@ -224,10 +244,6 @@ export function renderEmail(layout: EmailLayout): string {
 </html>`;
 }
 
-/**
- * Renders the corresponding plain-text body for clients that strip HTML.
- * Mirrors the HTML structure: pre-header, headline, content blocks.
- */
 export function renderPlainText(opts: {
   preheader: string;
   headline: string;
@@ -239,13 +255,9 @@ export function renderPlainText(opts: {
 }
 
 // ────────────────────────────────────────────────────────────────────────
-// Specific email renderers (one per send-site so the routes stay tiny).
+// Specific email renderers
 // ────────────────────────────────────────────────────────────────────────
 
-/**
- * The referral-code backfill blast — sent to existing email-path signups
- * who joined before invite codes existed.
- */
 export function renderReferralCodeEmail(code: string): { html: string; text: string; subject: string } {
   const shareUrl = `https://percolator.trade/r/${code}`;
   const html = renderEmail({
@@ -273,13 +285,6 @@ export function renderReferralCodeEmail(code: string): { html: string; text: str
   return { html, text, subject: "Your Percolator referral code" };
 }
 
-/**
- * The new-signup confirmation email — sent immediately after a successful
- * `/api/waitlist/signup` for the email path.
- *
- * `position` may be null when the position lookup fails (we still send the
- * email, just without the "you're #N" line).
- */
 export function renderWelcomeEmail(opts: {
   position: number | null;
   referralCode: string | null;
@@ -298,7 +303,7 @@ export function renderWelcomeEmail(opts: {
         "We also created a Solana wallet under your email (Privy embedded). When mainnet opens, the dApp at percolator.trade will recognise that wallet and unlock your priority access automatically — no extra step.",
       )
     : renderParagraph(
-        `Have a Solana wallet? <a href="https://percolator.trade/#reserve" style="color:${COLOR.cyan}; text-decoration:none;">Sign up with your wallet too</a> — we send a wallet-native notification on chain when mainnet opens, so you get pinged in Phantom even if you miss this email.`,
+        `Have a Solana wallet? <a href="https://percolator.trade/#reserve" style="color:${COLOR.accent}; text-decoration:underline;">Sign up with your wallet too</a> — we send a wallet-native notification on chain when mainnet opens, so you get pinged in Phantom even if you miss this email.`,
       );
 
   const html = renderEmail({


### PR DESCRIPTION
The first referral-code blast went out on the dark template and Apple Mail / iOS Mail rendered it as light-on-light unreadable mush (operator screenshot showed it). Plus no logo.

Switching to light-themed removes the whole \"client decides to invert your bg but leaves your text colors\" failure class — and light is the safer transactional default anyway.

## Changes
- **Palette flipped to light**: page bg \`#F8F8FC\`, card \`#FFFFFF\`, text \`#0D0E15\`, muted \`#4A4B62\`, dim \`#8A8BA8\`. Accent purple + cyan kept for brand recognition (cyan slightly darkened to \`#14BB6F\` for white-bg contrast).
- **Logo added** above the card — \`<img src=\"https://percolator.trade/images/logo-icon.png\" width=\"40\" height=\"40\">\` plus a \"PERCOLATOR TRADE\" wordmark beneath in tracked mono.
- **Removed \`meta name=\"color-scheme\" content=\"dark\"\`** — clients were honoring it inconsistently. Without it the email renders in client default mode, which is what we want.
- **Strong-contrast colors on every element** so even if a client force-inverts, copy stays readable in both directions.
- **Explicit \`color:\` on every text element** (some clients break inheritance when they recolor containers).

No compat regressions — still table layout, inline CSS, system fonts, no gradients, sharp corners.

Used by both \`/api/admin/waitlist/backfill-emails\` and \`/api/waitlist/signup\` automatically (shared module).