### PR TITLE
fix(waitlist): server-side bot hardening on signup endpoint

### DIFF
--- a/app/__tests__/api/waitlist-signup-bot-hardening.test.ts
+++ b/app/__tests__/api/waitlist-signup-bot-hardening.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Waitlist signup — bot-wave hardening guards.
+ *
+ * After the Jun-2026 wave (scripts POSTing straight to /api/waitlist/signup,
+ * bypassing the Privy widget + Turnstile, hammering one referral code at
+ * machine cadence with disposable/attacker email domains), the route gained
+ * server-side defenses that bind regardless of the client:
+ *   1. bot user-agent gate (rejects python/curl/etc. + spoofed UAs)
+ *   2. disposable / attacker-controlled email domain denylist
+ *   3. per-referral-code hourly rate limit
+ *   4. per-IP hourly rate limit
+ *   5. ip_hash persistence (hashed, never raw) for future traceability
+ *
+ * This guards the route source so a refactor that drops a defense trips CI.
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const ROUTE_PATH = path.resolve(
+  __dirname,
+  "../../app/api/waitlist/signup/route.ts",
+);
+
+describe("/api/waitlist/signup bot-wave hardening", () => {
+  const source = fs.readFileSync(ROUTE_PATH, "utf8");
+
+  it("rejects non-browser / scripted user agents", () => {
+    expect(source).toContain("isBotUserAgent");
+    expect(source).toMatch(/python|aiohttp|curl/i);
+    // gate is invoked in the handler and returns a non-2xx
+    expect(source).toMatch(/if \(isBotUserAgent\(userAgent\)\)/);
+    expect(source).toMatch(/status:\s*403/);
+  });
+
+  it("denies disposable / attacker-controlled email domains", () => {
+    expect(source).toContain("DISPOSABLE_EMAIL_DOMAINS");
+    expect(source).toContain("isDisposableEmailDomain");
+    // the attacker catch-alls from the wave must be listed
+    expect(source).toContain("tirtamulya.xyz");
+    expect(source).toContain("wshu.net");
+    expect(source).toContain("akaikadot.com");
+  });
+
+  it("enforces a per-referral-code hourly rate limit", () => {
+    expect(source).toContain("WAITLIST_PER_CODE_HOURLY_CAP");
+    expect(source).toMatch(/perCode\.limit\(referredByCode\)/);
+  });
+
+  it("enforces a per-IP hourly rate limit", () => {
+    expect(source).toContain("WAITLIST_PER_IP_HOURLY_CAP");
+    expect(source).toMatch(/perIp\.limit\(ipHash\)/);
+  });
+
+  it("fails open when Upstash is unconfigured (local dev / CI)", () => {
+    expect(source).toMatch(
+      /if \(!url \|\| !token\) return \{ perCode: null, perIp: null \}/,
+    );
+  });
+
+  it("persists a hashed ip (never the raw IP) on insert", () => {
+    expect(source).toContain("ip_hash: ipHash");
+    expect(source).toMatch(
+      /createHash\("sha256"\)\.update\(ip\)\.digest\("hex"\)/,
+    );
+  });
+});

--- a/app/app/api/waitlist/signup/route.ts
+++ b/app/app/api/waitlist/signup/route.ts
@@ -101,6 +101,117 @@ async function shouldSendConfirmationEmail(email: string): Promise<boolean> {
   return e.success;
 }
 
+// ── Signup-insert abuse limits (Jun-2026 bot-wave hardening) ──────────────
+// The wave POSTed straight to this route, bypassing the Privy widget (and its
+// Turnstile), and hammered a single referral code with thousands of scripted
+// signups at machine cadence. These caps bind server-side regardless of the
+// client:
+//   • per-referral-code — a genuine invite code won't pull dozens of signups
+//     an hour; a farm funnelling hundreds through one code trips this.
+//   • per-IP — bounds a single host even as it rotates emails/wallets.
+// Both fail open when Upstash is unconfigured (matches the email limiters /
+// middleware posture so local dev + CI keep working).
+let _codeLimiter: Ratelimit | null = null;
+let _ipLimiter: Ratelimit | null = null;
+let _abuseLimitersInitialized = false;
+
+function getAbuseLimiters(): {
+  perCode: Ratelimit | null;
+  perIp: Ratelimit | null;
+} {
+  if (_abuseLimitersInitialized) {
+    return { perCode: _codeLimiter, perIp: _ipLimiter };
+  }
+  _abuseLimitersInitialized = true;
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return { perCode: null, perIp: null };
+  try {
+    const redis = new Redis({ url, token });
+    _codeLimiter = new Ratelimit({
+      redis,
+      limiter: Ratelimit.slidingWindow(
+        Math.max(1, Number(process.env.WAITLIST_PER_CODE_HOURLY_CAP ?? 40)),
+        "1 h",
+      ),
+      prefix: "rl:wl-code",
+      analytics: false,
+    });
+    _ipLimiter = new Ratelimit({
+      redis,
+      limiter: Ratelimit.slidingWindow(
+        Math.max(1, Number(process.env.WAITLIST_PER_IP_HOURLY_CAP ?? 10)),
+        "1 h",
+      ),
+      prefix: "rl:wl-ip",
+      analytics: false,
+    });
+  } catch {
+    _codeLimiter = null;
+    _ipLimiter = null;
+  }
+  return { perCode: _codeLimiter, perIp: _ipLimiter };
+}
+
+/** Client IP via the trusted-proxy chain (mirrors lib/get-client-ip.ts;
+ *  inlined because this route handler takes a plain Request). */
+function getClientIpFromRequest(req: Request): string {
+  const depth = Math.max(0, Number(process.env.TRUSTED_PROXY_DEPTH ?? 1));
+  if (depth > 0) {
+    const fwd = req.headers.get("x-forwarded-for");
+    if (fwd) {
+      const ips = fwd.split(",").map((s) => s.trim());
+      return ips[Math.max(0, ips.length - depth)] ?? "unknown";
+    }
+  }
+  return req.headers.get("x-real-ip") ?? "unknown";
+}
+
+/** sha256 hex of the client IP. We persist this (never the raw IP) so a
+ *  future wave is dedup-able / traceable without storing PII. */
+function ipHashOf(ip: string): string {
+  return createHash("sha256").update(ip).digest("hex");
+}
+
+// Non-browser / scripted clients have no business on a human signup form.
+// The wave used Python aiohttp/requests/urllib, curl, and a hardcoded
+// Chrome/120 + bare "Mozilla/5.0" spoof. Real browsers and wallet in-app
+// browsers (Phantom/Backpack/Jupiter) never match these.
+const BOT_UA_RE =
+  /(python|aiohttp|requests|urllib|httpx|curl|wget|go-http|okhttp|axios|node-fetch|java\/|libwww|scrapy|headless|\bbot\b|spider)/i;
+function isBotUserAgent(ua: string | null): boolean {
+  if (!ua || ua.trim().length < 12) return true; // missing / stub UA
+  if (BOT_UA_RE.test(ua)) return true;
+  // Chrome/120 is a 2023 build the wave hardcoded; no real 2026 user is on it.
+  // Tunable off via WAITLIST_ALLOW_CHROME120=1 if it ever false-positives.
+  if (
+    process.env.WAITLIST_ALLOW_CHROME120 !== "1" &&
+    /Chrome\/120\.0\.0\.0 Safari/.test(ua)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+// Attacker-controlled catch-alls observed in the wave + classic disposable
+// providers. Email signups on these are rejected outright. (duck.com is
+// deliberately NOT here — it's a relay used by real privacy-minded users;
+// the per-IP / per-code caps handle the alias-farming case instead.)
+const DISPOSABLE_EMAIL_DOMAINS = new Set<string>([
+  "tirtamulya.xyz", "wshu.net", "minitts.net", "mtupu.com", "akaikadot.com",
+  "mailinator.com", "guerrillamail.com", "guerrillamail.net",
+  "guerrillamail.org", "sharklasers.com", "grr.la", "10minutemail.com",
+  "temp-mail.org", "tempmail.com", "yopmail.com", "throwawaymail.com",
+  "trashmail.com", "getnada.com", "nada.email", "dispostable.com",
+  "fakeinbox.com", "maildrop.cc", "mintemail.com", "mohmal.com",
+  "emailondeck.com", "tmail.ws", "spam4.me", "mailsac.com", "fakemail.net",
+]);
+function isDisposableEmailDomain(email: string): boolean {
+  const at = email.lastIndexOf("@");
+  if (at < 0) return false;
+  return DISPOSABLE_EMAIL_DOMAINS.has(email.slice(at + 1).toLowerCase());
+}
+
 /**
  * High-intent waitlist signup.
  *
@@ -230,6 +341,17 @@ export async function POST(req: Request) {
       : null;
   const userAgent = req.headers.get("user-agent")?.slice(0, 200) ?? null;
 
+  // ── Bot user-agent gate ─────────────────────────────────────────────────
+  // Reject scripted clients up front — the wave hit this route directly with
+  // python/curl + spoofed UAs, never touching the Privy widget or Turnstile.
+  if (isBotUserAgent(userAgent)) {
+    return NextResponse.json({ error: "unsupported client" }, { status: 403 });
+  }
+
+  // Client IP (hashed) — powers ip_hash persistence + the per-IP cap below.
+  const clientIp = getClientIpFromRequest(req);
+  const ipHash = clientIp !== "unknown" ? ipHashOf(clientIp) : null;
+
   // ── Parse all candidate fields ──────────────────────────────────────────
   const emailRaw = typeof b.email === "string" ? b.email.trim().toLowerCase() : null;
   const pubkey = typeof b.pubkey === "string" ? b.pubkey : null;
@@ -247,6 +369,12 @@ export async function POST(req: Request) {
   if (emailRaw !== null) {
     if (!emailRaw || !EMAIL_RE.test(emailRaw) || emailRaw.length > 254) {
       return NextResponse.json({ error: "invalid email" }, { status: 400 });
+    }
+    if (isDisposableEmailDomain(emailRaw)) {
+      return NextResponse.json(
+        { error: "disposable email domains are not allowed" },
+        { status: 400 },
+      );
     }
   }
 
@@ -431,6 +559,42 @@ export async function POST(req: Request) {
     );
   }
 
+  // ── Per-IP + per-referral-code rate limits (bot-wave hardening) ──────────
+  // Only reached for NEW signups — returning-wallet lookups already returned
+  // via the sign-in fast path above, so refreshing your own card never burns
+  // budget. A real invite code won't pull dozens of signups an hour and a
+  // single IP won't legitimately register many; these caps kill the
+  // farm-one-code / machine-cadence pattern at the source. Fail-open when
+  // Upstash is unconfigured. IP first (cheap global brake), then code.
+  {
+    const { perCode, perIp } = getAbuseLimiters();
+    if (perIp && ipHash) {
+      const r = await perIp.limit(ipHash);
+      if (!r.success) {
+        console.warn("[waitlist] per-IP signup cap reached", { ipHash });
+        return NextResponse.json(
+          { error: "too many signups from this network — try again later" },
+          { status: 429 },
+        );
+      }
+    }
+    if (perCode) {
+      const r = await perCode.limit(referredByCode);
+      if (!r.success) {
+        console.warn("[waitlist] per-code signup cap reached", {
+          code: referredByCode,
+        });
+        return NextResponse.json(
+          {
+            error:
+              "this referral code has hit its hourly limit — try again later",
+          },
+          { status: 429 },
+        );
+      }
+    }
+  }
+
   // Wallet signature was already verified at the top of this route
   // (before the sign-in fast-path lookup). Only the mainnet spam check
   // remains for new wallet signups — it fires here so existing-user
@@ -460,6 +624,7 @@ export async function POST(req: Request) {
     twitter_handle,
     source,
     user_agent: userAgent,
+    ip_hash: ipHash,
   };
   if (hasEmail) baseRow.email = emailRaw;
   if (hasWalletPart) {


### PR DESCRIPTION
## Why
The Jun-2026 bot wave inflated the waitlist from ~350 to ~12.3k. Investigation (full on-chain census + complete Privy cross-reference) found **~4,575 confirmed-fake** signups. The root cause: **`/api/waitlist/signup` had no bot protection** — scripts POSTed straight to it, bypassing the Privy widget and its Turnstile, hammering single referral codes at machine cadence (e.g. one code = 2,031 signups in 5h; another = 180 wallets at 0.01s intervals) using attacker-controlled email domains and spoofed user-agents.

**Privy Turnstile alone does not fix this** — it only guards the login widget; the scripts never touched Privy. These defenses bind server-side regardless of client.

## What
On `/api/waitlist/signup`:
- **Bot user-agent gate** — rejects `python`/`curl`/`aiohttp`/`requests`/`urllib`/etc., missing/stub UAs, and the hardcoded `Chrome/120` spoof → `403`.
- **Disposable / attacker-domain email denylist** — `tirtamulya.xyz`, `wshu.net`, `minitts.net`, `mtupu.com`, `akaikadot.com` + classic throwaways → `400`. (duck.com intentionally excluded — real privacy users; handled by rate limits.)
- **Per-referral-code hourly cap** (`WAITLIST_PER_CODE_HOURLY_CAP`, default 40) — kills the farm-one-code pattern. Only applies to NEW signups; returning-wallet lookups are unaffected → `429`.
- **Per-IP hourly cap** (`WAITLIST_PER_IP_HOURLY_CAP`, default 10) → `429`.
- **Persist `ip_hash`** (sha256, never raw IP) — the column existed but was never written, so we had zero IP traceability during the wave.

All limiters **fail open** when Upstash is unconfigured (matches existing email-limiter + middleware posture). New source-guard test added; existing waitlist tests pass.

## Notes
- No DB migration needed (`ip_hash` column already exists).
- Optional env: `WAITLIST_PER_CODE_HOURLY_CAP`, `WAITLIST_PER_IP_HOURLY_CAP`, `WAITLIST_ALLOW_CHROME120=1` (escape hatch).
- Follow-up worth considering: require a verified Privy session server-side for email signups (needs a small frontend change to forward the token), and Vercel BotID on the route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced waitlist signup security with improved bot detection and per-IP rate limiting to prevent automated abuse.

* **Tests**
  * Added comprehensive test suite for signup API security safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->