### PR TITLE
feat(waitlist): bot-defense (consolidated) — invisible Turnstile + IP/code limits + UA gate

### DIFF
--- a/app/__tests__/api/waitlist-signup-bot-ua.test.ts
+++ b/app/__tests__/api/waitlist-signup-bot-ua.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Waitlist signup — bot user-agent gate.
+ *
+ * Complements the Turnstile + rate-limit defenses: a cheap pre-filter that
+ * rejects scripted clients (python/curl/aiohttp/etc. + the wave's hardcoded
+ * Chrome/120 spoof + missing/stub UAs) before the network Turnstile verify.
+ * Real browsers and wallet in-app browsers never match.
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const ROUTE = path.resolve(__dirname, "../../app/api/waitlist/signup/route.ts");
+
+describe("/api/waitlist/signup bot user-agent gate", () => {
+  const source = fs.readFileSync(ROUTE, "utf8");
+
+  it("defines a bot user-agent matcher covering scripted clients", () => {
+    expect(source).toContain("isBotUserAgent");
+    expect(source).toMatch(/python|aiohttp|requests|urllib|curl/i);
+  });
+
+  it("blocks the hardcoded Chrome/120 spoof (escape hatch via env)", () => {
+    expect(source).toMatch(/Chrome\\\/120\\\.0\\\.0\\\.0 Safari/);
+    expect(source).toContain("WAITLIST_ALLOW_CHROME120");
+  });
+
+  it("invokes the gate in the handler and rejects with 403", () => {
+    expect(source).toMatch(/if \(isBotUserAgent\(userAgent\)\)/);
+    const idx = source.indexOf("if (isBotUserAgent(userAgent))");
+    expect(source.slice(idx, idx + 200)).toMatch(/status:\s*403/);
+  });
+});

--- a/app/__tests__/api/waitlist-signup-ip.test.ts
+++ b/app/__tests__/api/waitlist-signup-ip.test.ts
@@ -121,4 +121,40 @@ describe("/api/waitlist/signup IP capture + rate limit", () => {
     expect(rateLimitIdx).toBeGreaterThan(0);
     expect(captchaIdx).toBeLessThan(rateLimitIdx);
   });
+
+  it("rate-limits per referral code in addition to per IP", () => {
+    const source = fs.readFileSync(ROUTE_PATH, "utf8");
+    // Helper module shape mirrors the email + IP limiter pattern.
+    expect(source).toContain("getRefCodeLimiter()");
+    expect(source).toMatch(/refCodeLimiter\.limit\(referredByCode\)/);
+    expect(source).toContain(
+      "this referral code is at its hourly cap",
+    );
+    expect(source).toMatch(/status:\s*429/);
+  });
+
+  it("places the refcode rate-limit AFTER the existence check", () => {
+    // An invalid code must be rejected before it consumes any budget —
+    // otherwise an attacker could submit many invalid codes from one
+    // IP to exhaust the rate-limit slots of arbitrary codes they
+    // happened to guess. Pin the ordering.
+    //
+    // The marker is the call expression itself — it appears only at
+    // the in-handler check, not in any helper-block comments above.
+    const source = fs.readFileSync(ROUTE_PATH, "utf8");
+    const existenceIdx = source.indexOf("waitlist_referral_code_exists");
+    const refLimitIdx = source.indexOf("refCodeLimiter.limit(referredByCode)");
+    expect(existenceIdx).toBeGreaterThan(0);
+    expect(refLimitIdx).toBeGreaterThan(0);
+    expect(refLimitIdx).toBeGreaterThan(existenceIdx);
+  });
+
+  it("wraps the refcode limit() call in try/catch (fail-open)", () => {
+    // Matches the per-IP limiter posture — a transient Upstash blip
+    // shouldn't bubble up as an unhandled 500.
+    const source = fs.readFileSync(ROUTE_PATH, "utf8");
+    expect(source).toMatch(
+      /refcode rate-limit check failed, falling open/,
+    );
+  });
 });

--- a/app/__tests__/api/waitlist-signup-ip.test.ts
+++ b/app/__tests__/api/waitlist-signup-ip.test.ts
@@ -1,10 +1,11 @@
 /**
- * Source-pattern guards for the waitlist signup route's IP capture +
- * per-IP rate limit. Mirrors the existing waitlist-signup-shape style
- * — greps the route source so a future refactor can't silently drop
- * the IP write, lose the rate-limit gate, or move the limit so it
- * fires before the idempotent-refresh fast-path (which would block
- * honest users from reloading their own waitlist row).
+ * Source-pattern guards for the waitlist signup route's IP capture,
+ * per-IP rate limit, and Cloudflare Turnstile gate. Mirrors the
+ * existing waitlist-signup-shape style — greps the route source so a
+ * future refactor can't silently drop a write, lose a gate, or
+ * reorder them in a way that defeats the design (e.g. moving the
+ * captcha verify AFTER the IP rate limit would let bots burn the
+ * limiter without solving the challenge).
  */
 
 import { describe, it, expect } from "vitest";
@@ -72,5 +73,35 @@ describe("/api/waitlist/signup IP capture + rate limit", () => {
     expect(source).toMatch(
       /createHash\("sha256"\)\.update\(ip\)\.digest\("hex"\)/,
     );
+  });
+
+  it("verifies the Turnstile token before any other expensive work", () => {
+    const source = fs.readFileSync(ROUTE_PATH, "utf8");
+    expect(source).toContain(
+      `import { verifyTurnstile } from "@/lib/waitlist/turnstile"`,
+    );
+    expect(source).toMatch(/await verifyTurnstile\(turnstileToken, clientIp\)/);
+  });
+
+  it("rejects with 400 when the captcha verdict is not ok", () => {
+    const source = fs.readFileSync(ROUTE_PATH, "utf8");
+    expect(source).toContain("captcha required");
+    expect(source).toContain("captcha verification failed");
+    // The error body carries a `captcha: reason` field so the UI can
+    // tell "missing token" apart from "Cloudflare said no".
+    expect(source).toMatch(/captcha:\s*turnstileVerdict\.reason/);
+  });
+
+  it("places the Turnstile gate BEFORE the per-IP rate limit", () => {
+    // Order matters: a bad token must short-circuit BEFORE we consume
+    // any Upstash budget. If the rate limit ran first an attacker
+    // could burn the per-IP cap with garbage tokens and DoS legitimate
+    // signups from the same network.
+    const source = fs.readFileSync(ROUTE_PATH, "utf8");
+    const captchaIdx = source.indexOf("Cloudflare Turnstile gate");
+    const rateLimitIdx = source.indexOf("Per-IP rate limit");
+    expect(captchaIdx).toBeGreaterThan(0);
+    expect(rateLimitIdx).toBeGreaterThan(0);
+    expect(captchaIdx).toBeLessThan(rateLimitIdx);
   });
 });

--- a/app/__tests__/api/waitlist-signup-ip.test.ts
+++ b/app/__tests__/api/waitlist-signup-ip.test.ts
@@ -52,17 +52,34 @@ describe("/api/waitlist/signup IP capture + rate limit", () => {
     expect(source).toMatch(/status:\s*429/);
   });
 
-  it("places the per-IP rate limit AFTER the sign-in fast-path", () => {
-    // The fast-path returns idempotently for existing wallet signups
-    // before the rate limit runs; otherwise honest users refreshing
-    // their row would consume the per-IP budget and eventually get
-    // 429'd from their own waitlist page.
+  it("places the per-IP rate limit BEFORE the sign-in fast-path", () => {
+    // Earlier the fast-path ran first to spare honest refreshers from
+    // the per-IP budget, but that left the Supabase service-role
+    // SELECT inside the fast-path reachable without consuming captcha
+    // or rate-limit — an attacker with locally-generated ed25519
+    // keys could fire valid-shape signups and hammer the DB. The
+    // gates now run BEFORE the fast-path; the UX cost (one captcha
+    // solve per session for returning users) is much smaller than
+    // the security cost of the bypass.
     const source = fs.readFileSync(ROUTE_PATH, "utf8");
     const fastPathIdx = source.indexOf("Sign-in fast path for existing");
     const ipLimitIdx = source.indexOf("Per-IP rate limit");
     expect(fastPathIdx).toBeGreaterThan(0);
     expect(ipLimitIdx).toBeGreaterThan(0);
-    expect(ipLimitIdx).toBeGreaterThan(fastPathIdx);
+    expect(ipLimitIdx).toBeLessThan(fastPathIdx);
+  });
+
+  it("places the Turnstile gate BEFORE the sign-in fast-path", () => {
+    // Same rationale as the per-IP rate-limit ordering test above:
+    // the fast-path's Supabase service-role read must be gated on
+    // captcha so a locally-generated valid signature isn't a free
+    // DB-probe oracle.
+    const source = fs.readFileSync(ROUTE_PATH, "utf8");
+    const fastPathIdx = source.indexOf("Sign-in fast path for existing");
+    const captchaIdx = source.indexOf("Cloudflare Turnstile gate");
+    expect(fastPathIdx).toBeGreaterThan(0);
+    expect(captchaIdx).toBeGreaterThan(0);
+    expect(captchaIdx).toBeLessThan(fastPathIdx);
   });
 
   it("uses sha256 of the raw IP as the Redis key, never the cleartext", () => {

--- a/app/__tests__/api/waitlist-signup-ip.test.ts
+++ b/app/__tests__/api/waitlist-signup-ip.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Source-pattern guards for the waitlist signup route's IP capture +
+ * per-IP rate limit. Mirrors the existing waitlist-signup-shape style
+ * — greps the route source so a future refactor can't silently drop
+ * the IP write, lose the rate-limit gate, or move the limit so it
+ * fires before the idempotent-refresh fast-path (which would block
+ * honest users from reloading their own waitlist row).
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const ROUTE_PATH = path.resolve(
+  __dirname,
+  "../../app/api/waitlist/signup/route.ts",
+);
+
+describe("/api/waitlist/signup IP capture + rate limit", () => {
+  it("imports getClientIp + hashIp from the dedicated helper module", () => {
+    const source = fs.readFileSync(ROUTE_PATH, "utf8");
+    expect(source).toContain(
+      `import { getClientIp, hashIp } from "@/lib/waitlist/client-ip"`,
+    );
+  });
+
+  it("extracts the client IP from the request headers", () => {
+    const source = fs.readFileSync(ROUTE_PATH, "utf8");
+    expect(source).toMatch(/const\s+clientIp\s*=\s*getClientIp\(req\.headers\)/);
+  });
+
+  it("derives the IP hash with the WAITLIST_IP_SALT env var", () => {
+    const source = fs.readFileSync(ROUTE_PATH, "utf8");
+    expect(source).toContain(
+      "hashIp(clientIp, process.env.WAITLIST_IP_SALT)",
+    );
+  });
+
+  it("writes ip_address and ip_hash onto the inserted row", () => {
+    const source = fs.readFileSync(ROUTE_PATH, "utf8");
+    expect(source).toMatch(/baseRow\.ip_address\s*=\s*clientIp/);
+    expect(source).toMatch(/baseRow\.ip_hash\s*=\s*clientIpHash/);
+  });
+
+  it("rate-limits per IP and returns 429 when the cap is exceeded", () => {
+    const source = fs.readFileSync(ROUTE_PATH, "utf8");
+    expect(source).toContain("getIpLimiter()");
+    expect(source).toMatch(
+      /too many signups from this network — try again later/,
+    );
+    expect(source).toMatch(/status:\s*429/);
+  });
+
+  it("places the per-IP rate limit AFTER the sign-in fast-path", () => {
+    // The fast-path returns idempotently for existing wallet signups
+    // before the rate limit runs; otherwise honest users refreshing
+    // their row would consume the per-IP budget and eventually get
+    // 429'd from their own waitlist page.
+    const source = fs.readFileSync(ROUTE_PATH, "utf8");
+    const fastPathIdx = source.indexOf("Sign-in fast path for existing");
+    const ipLimitIdx = source.indexOf("Per-IP rate limit");
+    expect(fastPathIdx).toBeGreaterThan(0);
+    expect(ipLimitIdx).toBeGreaterThan(0);
+    expect(ipLimitIdx).toBeGreaterThan(fastPathIdx);
+  });
+
+  it("uses sha256 of the raw IP as the Redis key, never the cleartext", () => {
+    const source = fs.readFileSync(ROUTE_PATH, "utf8");
+    // The ipRateKey helper hashes the IP before it becomes the Redis
+    // key. The route must call that helper, not pass the raw IP.
+    expect(source).toContain("ipRateKey(clientIp)");
+    expect(source).toMatch(
+      /createHash\("sha256"\)\.update\(ip\)\.digest\("hex"\)/,
+    );
+  });
+});

--- a/app/__tests__/api/waitlist-signup-shape.test.ts
+++ b/app/__tests__/api/waitlist-signup-shape.test.ts
@@ -65,4 +65,34 @@ describe("/api/waitlist/signup input shape", () => {
     );
     expect(source).toMatch(/status:\s*400/);
   });
+
+  it("rejects disposable email domains at signup, not just in admin", () => {
+    const source = fs.readFileSync(ROUTE_PATH, "utf8");
+    // Import from the shared module — pins the single-source-of-truth
+    // contract. If a future refactor re-defines the list inline in the
+    // route, the admin panel's count would silently drift from what
+    // the route blocks.
+    expect(source).toContain(
+      `import { isDisposableEmail } from "@/lib/waitlist/disposable-domains"`,
+    );
+    // The check runs inside the email-shape branch, returns 400, and
+    // the error string does NOT echo the rejected domain (no need to
+    // confirm to a bot which entries are on the list).
+    expect(source).toMatch(/if\s*\(\s*isDisposableEmail\s*\(\s*emailRaw\s*\)\s*\)/);
+    expect(source).toContain("this email provider isn't accepted");
+  });
+
+  it("places the disposable check INSIDE the email-shape branch", () => {
+    // Defence-in-depth: the disposable check should only run after the
+    // email passed shape validation. If a future refactor moves it
+    // above the shape check, malformed inputs could reach the helper
+    // (it'd return false for them, but the route would then fall
+    // through to the wallet path with a half-validated email field).
+    const source = fs.readFileSync(ROUTE_PATH, "utf8");
+    const emailShapeIdx = source.indexOf("EMAIL_RE.test(emailRaw)");
+    const disposableCheckIdx = source.indexOf("isDisposableEmail(emailRaw)");
+    expect(emailShapeIdx).toBeGreaterThan(0);
+    expect(disposableCheckIdx).toBeGreaterThan(0);
+    expect(disposableCheckIdx).toBeGreaterThan(emailShapeIdx);
+  });
 });

--- a/app/__tests__/api/waitlist-signup-shape.test.ts
+++ b/app/__tests__/api/waitlist-signup-shape.test.ts
@@ -95,4 +95,44 @@ describe("/api/waitlist/signup input shape", () => {
     expect(disposableCheckIdx).toBeGreaterThan(0);
     expect(disposableCheckIdx).toBeGreaterThan(emailShapeIdx);
   });
+
+  it("enforces a minimum time-on-page (dwell) before accepting a submit", () => {
+    const source = fs.readFileSync(ROUTE_PATH, "utf8");
+    // Floor + stale cap constants present.
+    expect(source).toMatch(/MIN_DWELL_MS\s*=\s*1500/);
+    expect(source).toMatch(/MAX_STALE_MS\s*=\s*7\s*\*\s*24\s*\*\s*60\s*\*\s*60\s*\*\s*1000/);
+    // Reads from the body, validates as a finite number.
+    expect(source).toMatch(/typeof\s+b\.mounted_at\s*===\s*"number"/);
+    expect(source).toContain("Number.isFinite(b.mounted_at)");
+    // Rejects with 400 (opaque error so a bot can't refine its script
+    // off our copy).
+    expect(source).toContain("request rejected — refresh the page");
+  });
+
+  it("places the dwell check immediately after the honeypot", () => {
+    // The check is essentially free (one branch, no I/O) so positioning
+    // it as the very first non-trivial gate maximises the work saved
+    // when the dwell is wrong — a missing `mounted_at` short-circuits
+    // BEFORE the captcha siteverify call and BEFORE the wallet
+    // signature verify.
+    const source = fs.readFileSync(ROUTE_PATH, "utf8");
+    const honeypotIdx = source.indexOf("Honeypot — silently accept");
+    const dwellIdx = source.indexOf("Time-on-page (dwell) check");
+    const captchaIdx = source.indexOf("Cloudflare Turnstile gate");
+    expect(honeypotIdx).toBeGreaterThan(0);
+    expect(dwellIdx).toBeGreaterThan(0);
+    expect(captchaIdx).toBeGreaterThan(0);
+    expect(dwellIdx).toBeGreaterThan(honeypotIdx);
+    expect(dwellIdx).toBeLessThan(captchaIdx);
+  });
+
+  it("rejects when dwell is below the floor, above the cap, or negative", () => {
+    // The conditional should cover three independent fail modes,
+    // not just the under-floor case. Pin all three so a future
+    // refactor that drops one branch is flagged.
+    const source = fs.readFileSync(ROUTE_PATH, "utf8");
+    expect(source).toMatch(/dwellMs\s*<\s*0/);
+    expect(source).toMatch(/dwellMs\s*<\s*MIN_DWELL_MS/);
+    expect(source).toMatch(/dwellMs\s*>\s*MAX_STALE_MS/);
+  });
 });

--- a/app/__tests__/lib/waitlist-client-ip.test.ts
+++ b/app/__tests__/lib/waitlist-client-ip.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Header-precedence + IP-hashing tests for the waitlist client-IP helper.
+ *
+ * The route trusts header values from upstream proxies. Wrong precedence
+ * here would let a client inject a fake IP via `x-forwarded-for` and
+ * bypass the per-IP rate limit. The tests pin:
+ *
+ *   1. cf-connecting-ip wins over x-real-ip wins over x-forwarded-for.
+ *   2. x-forwarded-for chain handling takes the LEFTMOST entry only.
+ *   3. IPv6 bracketed-with-port is normalised.
+ *   4. IPv4 with trailing port is stripped.
+ *   5. Garbage in any header → null returned (route writes NULL).
+ *   6. Hash requires a salt; returns null without one.
+ *   7. Same IP + same salt → stable hash; different salt → different hash.
+ */
+
+import { describe, it, expect } from "vitest";
+import { getClientIp, hashIp } from "../../lib/waitlist/client-ip";
+
+function headers(map: Record<string, string>): Headers {
+  const h = new Headers();
+  for (const [k, v] of Object.entries(map)) h.set(k, v);
+  return h;
+}
+
+describe("getClientIp", () => {
+  it("prefers cf-connecting-ip over x-real-ip and x-forwarded-for", () => {
+    const h = headers({
+      "cf-connecting-ip": "203.0.113.10",
+      "x-real-ip": "198.51.100.1",
+      "x-forwarded-for": "192.0.2.1, 10.0.0.1",
+    });
+    expect(getClientIp(h)).toBe("203.0.113.10");
+  });
+
+  it("falls back to x-real-ip when cf-connecting-ip absent", () => {
+    const h = headers({
+      "x-real-ip": "198.51.100.1",
+      "x-forwarded-for": "192.0.2.1, 10.0.0.1",
+    });
+    expect(getClientIp(h)).toBe("198.51.100.1");
+  });
+
+  it("falls back to leftmost x-forwarded-for entry when both above absent", () => {
+    const h = headers({ "x-forwarded-for": "192.0.2.1, 10.0.0.1, 172.16.0.1" });
+    expect(getClientIp(h)).toBe("192.0.2.1");
+  });
+
+  it("returns null when no forwarding header is present", () => {
+    expect(getClientIp(headers({}))).toBeNull();
+  });
+
+  it("returns null when the header value is malformed garbage", () => {
+    const h = headers({ "cf-connecting-ip": "not-an-ip!@#$" });
+    expect(getClientIp(h)).toBeNull();
+  });
+
+  it("returns null when the header value is empty after trim", () => {
+    const h = headers({ "x-forwarded-for": "   ,   ,   " });
+    expect(getClientIp(h)).toBeNull();
+  });
+
+  it("strips the trailing port off an IPv4 with :port", () => {
+    const h = headers({ "cf-connecting-ip": "192.0.2.1:51234" });
+    expect(getClientIp(h)).toBe("192.0.2.1");
+  });
+
+  it("strips the brackets off a bracketed IPv6", () => {
+    const h = headers({ "cf-connecting-ip": "[2001:db8::1]:443" });
+    expect(getClientIp(h)).toBe("2001:db8::1");
+  });
+
+  it("returns a bare IPv6 unmodified", () => {
+    const h = headers({ "cf-connecting-ip": "2001:db8::1" });
+    expect(getClientIp(h)).toBe("2001:db8::1");
+  });
+
+  it("does not treat the colon in IPv6 as a port separator", () => {
+    // Same hex format, no brackets — we must not strip after the first colon.
+    const h = headers({ "cf-connecting-ip": "fe80::1" });
+    expect(getClientIp(h)).toBe("fe80::1");
+  });
+
+  it("rejects implausibly long header values", () => {
+    const h = headers({ "cf-connecting-ip": "1.2.3.4" + "5".repeat(100) });
+    expect(getClientIp(h)).toBeNull();
+  });
+});
+
+describe("hashIp", () => {
+  it("returns null when no salt is configured", () => {
+    expect(hashIp("203.0.113.10", undefined)).toBeNull();
+    expect(hashIp("203.0.113.10", null)).toBeNull();
+    expect(hashIp("203.0.113.10", "")).toBeNull();
+  });
+
+  it("returns a 64-char hex string when a salt is configured", () => {
+    const h = hashIp("203.0.113.10", "test-salt");
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("returns the same hash for the same ip + salt across calls", () => {
+    const a = hashIp("203.0.113.10", "test-salt");
+    const b = hashIp("203.0.113.10", "test-salt");
+    expect(a).toBe(b);
+  });
+
+  it("returns different hashes when the salt changes", () => {
+    const a = hashIp("203.0.113.10", "salt-A");
+    const b = hashIp("203.0.113.10", "salt-B");
+    expect(a).not.toBe(b);
+  });
+
+  it("returns different hashes for different IPs under the same salt", () => {
+    const a = hashIp("203.0.113.10", "test-salt");
+    const b = hashIp("203.0.113.11", "test-salt");
+    expect(a).not.toBe(b);
+  });
+});

--- a/app/__tests__/lib/waitlist-client-ip.test.ts
+++ b/app/__tests__/lib/waitlist-client-ip.test.ts
@@ -85,6 +85,26 @@ describe("getClientIp", () => {
     const h = headers({ "cf-connecting-ip": "1.2.3.4" + "5".repeat(100) });
     expect(getClientIp(h)).toBeNull();
   });
+
+  // Regression: an earlier loose-regex validator accepted these as
+  // "plausible," let them through to Postgres `inet` cast which
+  // rejected them with 22P02, and crashed the signup INSERT. The
+  // current `net.isIP()`-based check rejects them at the front door.
+  it.each([
+    "1.2.3.4.5",
+    "::::::",
+    "a:b:c:d.e",
+    "............",
+    "------",
+    "999.999.999.999",
+    "1.2.3",
+    "g::1",
+    "2001:db8::1::2",
+  ])("rejects malformed IP-looking string %s", (bad) => {
+    expect(getClientIp(headers({ "cf-connecting-ip": bad }))).toBeNull();
+    expect(getClientIp(headers({ "x-real-ip": bad }))).toBeNull();
+    expect(getClientIp(headers({ "x-forwarded-for": bad }))).toBeNull();
+  });
 });
 
 describe("hashIp", () => {

--- a/app/__tests__/lib/waitlist-client-ip.test.ts
+++ b/app/__tests__/lib/waitlist-client-ip.test.ts
@@ -14,8 +14,14 @@
  *   7. Same IP + same salt → stable hash; different salt → different hash.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { getClientIp, hashIp } from "../../lib/waitlist/client-ip";
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+afterEach(() => {
+  if (ORIGINAL_NODE_ENV === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+});
 
 function headers(map: Record<string, string>): Headers {
   const h = new Headers();
@@ -84,6 +90,31 @@ describe("getClientIp", () => {
   it("rejects implausibly long header values", () => {
     const h = headers({ "cf-connecting-ip": "1.2.3.4" + "5".repeat(100) });
     expect(getClientIp(h)).toBeNull();
+  });
+
+  // In production we refuse to trust x-forwarded-for entirely — CF or
+  // Vercel set cf-connecting-ip / x-real-ip for legitimate traffic, so
+  // a request reaching the XFF fallback in prod implies a spoofing
+  // attempt (e.g., direct-to-Vercel bypassing Cloudflare).
+  it("ignores x-forwarded-for fallback when NODE_ENV === production", () => {
+    process.env.NODE_ENV = "production";
+    expect(
+      getClientIp(headers({ "x-forwarded-for": "192.0.2.1" })),
+    ).toBeNull();
+  });
+
+  it("still trusts cf-connecting-ip in production", () => {
+    process.env.NODE_ENV = "production";
+    expect(
+      getClientIp(headers({ "cf-connecting-ip": "203.0.113.10" })),
+    ).toBe("203.0.113.10");
+  });
+
+  it("still trusts x-real-ip in production", () => {
+    process.env.NODE_ENV = "production";
+    expect(getClientIp(headers({ "x-real-ip": "198.51.100.1" }))).toBe(
+      "198.51.100.1",
+    );
   });
 
   // Regression: an earlier loose-regex validator accepted these as

--- a/app/__tests__/lib/waitlist-client-ip.test.ts
+++ b/app/__tests__/lib/waitlist-client-ip.test.ts
@@ -115,25 +115,41 @@ describe("hashIp", () => {
   });
 
   it("returns a 64-char hex string when a salt is configured", () => {
-    const h = hashIp("203.0.113.10", "test-salt");
+    const h = hashIp("203.0.113.10", "0123456789abcdef");
     expect(h).toMatch(/^[0-9a-f]{64}$/);
   });
 
   it("returns the same hash for the same ip + salt across calls", () => {
-    const a = hashIp("203.0.113.10", "test-salt");
-    const b = hashIp("203.0.113.10", "test-salt");
+    const a = hashIp("203.0.113.10", "stable-salt-1234");
+    const b = hashIp("203.0.113.10", "stable-salt-1234");
     expect(a).toBe(b);
   });
 
   it("returns different hashes when the salt changes", () => {
-    const a = hashIp("203.0.113.10", "salt-A");
-    const b = hashIp("203.0.113.10", "salt-B");
+    const a = hashIp("203.0.113.10", "first-salt-abcde");
+    const b = hashIp("203.0.113.10", "second-salt-xyzw");
     expect(a).not.toBe(b);
   });
 
   it("returns different hashes for different IPs under the same salt", () => {
-    const a = hashIp("203.0.113.10", "test-salt");
-    const b = hashIp("203.0.113.11", "test-salt");
+    const a = hashIp("203.0.113.10", "shared-salt-1234");
+    const b = hashIp("203.0.113.11", "shared-salt-1234");
     expect(a).not.toBe(b);
+  });
+
+  // Regression: previous version accepted any truthy salt. A one-char
+  // salt only multiplies precompute cost by 256, leaving the IPv4
+  // space brute-forceable in seconds. Min length 16 (≈ 128 bits) is
+  // the standard salt floor.
+  it.each(["x", "ab", "shortsalt"])(
+    "returns null when salt is below 16 chars (%s)",
+    (badSalt) => {
+      expect(hashIp("203.0.113.10", badSalt)).toBeNull();
+    },
+  );
+
+  it("accepts the boundary salt length of exactly 16 chars", () => {
+    const h = hashIp("203.0.113.10", "x".repeat(16));
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
   });
 });

--- a/app/__tests__/lib/waitlist-disposable-domains.test.ts
+++ b/app/__tests__/lib/waitlist-disposable-domains.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Disposable-email helper behaviour.
+ *
+ * The list is the single source of truth shared between the signup
+ * route (rejects at the door) and the admin spam panel (post-facto
+ * detection). These tests pin the match semantics so a future refactor
+ * can't accidentally:
+ *   • switch to a subdomain match (legit forwarders would be blocked)
+ *   • re-introduce case sensitivity (the caller lowercases; the helper
+ *     trusts that contract — both directions of the contract should
+ *     break loudly here if violated)
+ *   • drop the lastIndexOf("@") in favour of indexOf (display-name
+ *     emails like "Alice <a@x>" would then match against "x>" or
+ *     similar garbage)
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  DISPOSABLE_EMAIL_DOMAINS,
+  isDisposableEmail,
+} from "../../lib/waitlist/disposable-domains";
+
+describe("DISPOSABLE_EMAIL_DOMAINS", () => {
+  it("is a non-empty ReadonlySet", () => {
+    expect(DISPOSABLE_EMAIL_DOMAINS.size).toBeGreaterThan(0);
+  });
+
+  it("contains the canonical throwaway providers", () => {
+    // Smoke-check that the list is roughly the right shape — pinned
+    // against the well-known names so an accidental wipe is obvious.
+    for (const known of [
+      "mailinator.com",
+      "guerrillamail.com",
+      "10minutemail.com",
+      "yopmail.com",
+      "tempmail.com",
+    ]) {
+      expect(DISPOSABLE_EMAIL_DOMAINS.has(known)).toBe(true);
+    }
+  });
+
+  it("does NOT contain mainstream providers", () => {
+    // Defence against an accidental "add all .com" entry — the legit
+    // providers below must always be allowed through.
+    for (const real of [
+      "gmail.com",
+      "outlook.com",
+      "yahoo.com",
+      "icloud.com",
+      "proton.me",
+      "protonmail.com",
+      "fastmail.com",
+      "hey.com",
+    ]) {
+      expect(DISPOSABLE_EMAIL_DOMAINS.has(real)).toBe(false);
+    }
+  });
+});
+
+describe("isDisposableEmail", () => {
+  it("flags a basic mailinator address", () => {
+    expect(isDisposableEmail("alice@mailinator.com")).toBe(true);
+  });
+
+  it("flags every entry in the blocklist for a trivial local part", () => {
+    // Walk every entry — catches a regression where the helper used
+    // indexOf instead of lastIndexOf, or strip-port-style cruft.
+    for (const dom of DISPOSABLE_EMAIL_DOMAINS) {
+      expect(isDisposableEmail(`user@${dom}`)).toBe(true);
+    }
+  });
+
+  it("returns false for canonical real providers", () => {
+    for (const real of [
+      "alice@gmail.com",
+      "bob@outlook.com",
+      "carol@yahoo.com",
+      "dave@icloud.com",
+      "eve@proton.me",
+    ]) {
+      expect(isDisposableEmail(real)).toBe(false);
+    }
+  });
+
+  it("matches the LAST @-segment (display-name immunity)", () => {
+    // If isDisposableEmail used indexOf instead of lastIndexOf, a
+    // pasted display-name shape like the below would slice to
+    // "mailinator.com>" and miss the match. Pin the correct semantics.
+    // (The signup route's EMAIL_RE already rejects display-name shapes
+    // before this helper runs, but the helper itself must be robust.)
+    expect(isDisposableEmail("Alice <alice@mailinator.com>")).toBe(false);
+    // ...because the last `@` is followed by "mailinator.com>" which
+    // isn't in the set. Confirms the helper doesn't try to be too
+    // clever about parsing.
+  });
+
+  it("treats subdomains as NOT disposable", () => {
+    // Documented design choice — legit forwarders sometimes live on
+    // vendor subdomains. Stricter matching would risk false positives.
+    expect(isDisposableEmail("user@mail.mailinator.com")).toBe(false);
+  });
+
+  it("does NOT lowercase input — caller's contract", () => {
+    // The signup route lowercases before calling. If a caller passes
+    // mixed case, the helper returns false (the blocklist entries are
+    // all lowercase). This is the contract; a regression that
+    // auto-lowercased here would mask bugs at the caller.
+    expect(isDisposableEmail("User@Mailinator.com")).toBe(false);
+  });
+
+  it("returns false for malformed shapes", () => {
+    expect(isDisposableEmail("")).toBe(false);
+    expect(isDisposableEmail("@mailinator.com")).toBe(false); // no local
+    expect(isDisposableEmail("user@")).toBe(false); // no domain
+    expect(isDisposableEmail("user")).toBe(false); // no @
+  });
+});

--- a/app/__tests__/lib/waitlist-turnstile.test.ts
+++ b/app/__tests__/lib/waitlist-turnstile.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Cloudflare Turnstile server-side verification posture.
+ *
+ * The wire format to siteverify is fixed by Cloudflare's docs and pinned
+ * here so a future refactor can't switch to JSON, drop the remoteip
+ * hint, or change the secret-handling. The prod / non-prod fail-mode
+ * inversion is the load-bearing security property: missing secret in
+ * prod rejects, missing secret in dev accepts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { verifyTurnstile } from "../../lib/waitlist/turnstile";
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.TURNSTILE_SECRET;
+  delete process.env.NODE_ENV;
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe("verifyTurnstile", () => {
+  it("fails CLOSED in production when TURNSTILE_SECRET is missing", async () => {
+    process.env.NODE_ENV = "production";
+    const v = await verifyTurnstile("any-token", "203.0.113.10");
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.reason).toBe("not_configured");
+  });
+
+  it("fails OPEN in non-production when TURNSTILE_SECRET is missing", async () => {
+    process.env.NODE_ENV = "development";
+    const v = await verifyTurnstile("any-token", "203.0.113.10");
+    expect(v.ok).toBe(true);
+  });
+
+  it("rejects empty / missing tokens even with a secret configured", async () => {
+    process.env.TURNSTILE_SECRET = "test-secret";
+    const a = await verifyTurnstile(null, "203.0.113.10");
+    const b = await verifyTurnstile(undefined, "203.0.113.10");
+    const c = await verifyTurnstile("", "203.0.113.10");
+    for (const v of [a, b, c]) {
+      expect(v.ok).toBe(false);
+      if (!v.ok) expect(v.reason).toBe("missing_token");
+    }
+  });
+
+  it("returns ok:true when Cloudflare reports success:true", async () => {
+    process.env.TURNSTILE_SECRET = "test-secret";
+    const fetchMock = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ success: true }), { status: 200 }),
+      );
+    const v = await verifyTurnstile("good-token", "203.0.113.10");
+    expect(v.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("returns ok:false with verification_failed when success:false", async () => {
+    process.env.TURNSTILE_SECRET = "test-secret";
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ success: false }), { status: 200 }),
+    );
+    const v = await verifyTurnstile("bad-token", "203.0.113.10");
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.reason).toBe("verification_failed");
+  });
+
+  it("returns ok:false with verification_error on Cloudflare 5xx", async () => {
+    process.env.TURNSTILE_SECRET = "test-secret";
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response("Bad Gateway", { status: 502 }),
+    );
+    const v = await verifyTurnstile("any-token", "203.0.113.10");
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.reason).toBe("verification_error");
+  });
+
+  it("returns ok:false with verification_error on network throw (fail-CLOSED)", async () => {
+    process.env.TURNSTILE_SECRET = "test-secret";
+    vi.spyOn(global, "fetch").mockRejectedValue(new Error("network down"));
+    const v = await verifyTurnstile("any-token", "203.0.113.10");
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.reason).toBe("verification_error");
+  });
+
+  it("forwards secret + response + remoteip in URL-encoded body", async () => {
+    process.env.TURNSTILE_SECRET = "test-secret";
+    let capturedBody = "";
+    vi.spyOn(global, "fetch").mockImplementation(async (_url, init) => {
+      capturedBody = String(init?.body ?? "");
+      return new Response(JSON.stringify({ success: true }), { status: 200 });
+    });
+    await verifyTurnstile("the-token", "203.0.113.10");
+    const params = new URLSearchParams(capturedBody);
+    expect(params.get("secret")).toBe("test-secret");
+    expect(params.get("response")).toBe("the-token");
+    expect(params.get("remoteip")).toBe("203.0.113.10");
+  });
+
+  it("omits remoteip when no client IP was extracted", async () => {
+    process.env.TURNSTILE_SECRET = "test-secret";
+    let capturedBody = "";
+    vi.spyOn(global, "fetch").mockImplementation(async (_url, init) => {
+      capturedBody = String(init?.body ?? "");
+      return new Response(JSON.stringify({ success: true }), { status: 200 });
+    });
+    await verifyTurnstile("the-token", null);
+    const params = new URLSearchParams(capturedBody);
+    expect(params.has("remoteip")).toBe(false);
+  });
+
+  it("POSTs to Cloudflare's canonical siteverify URL", async () => {
+    process.env.TURNSTILE_SECRET = "test-secret";
+    let capturedUrl = "";
+    vi.spyOn(global, "fetch").mockImplementation(async (url) => {
+      capturedUrl = String(url);
+      return new Response(JSON.stringify({ success: true }), { status: 200 });
+    });
+    await verifyTurnstile("the-token", null);
+    expect(capturedUrl).toBe(
+      "https://challenges.cloudflare.com/turnstile/v0/siteverify",
+    );
+  });
+});

--- a/app/app/api/admin/waitlist/stats/route.ts
+++ b/app/app/api/admin/waitlist/stats/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getWaitlistServiceSupabase } from "@/lib/waitlist/supabase";
 import { requireAdminSession } from "@/lib/admin-session";
+import { DISPOSABLE_EMAIL_DOMAINS } from "@/lib/waitlist/disposable-domains";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -241,29 +242,13 @@ export async function GET(req: Request) {
     // shape, and timing as possible. Each one would have a different
     // failure mode for a botnet — a single bypass would still trip
     // others. The frontend shows them as a panel; operator judges.
-    const DISPOSABLE_DOMAINS = new Set<string>([
-      "mailinator.com","guerrillamail.com","guerrillamail.net","guerrillamail.org",
-      "guerrillamailblock.com","sharklasers.com","grr.la","tempmail.com",
-      "temp-mail.org","temp-mail.io","tempmailo.com","10minutemail.com",
-      "10minutemail.net","yopmail.com","yopmail.net","throwawaymail.com",
-      "trashmail.com","trashmail.de","dispostable.com","fakeinbox.com",
-      "emailondeck.com","mailnesia.com","getnada.com","nada.email",
-      "mintemail.com","mohmal.com","tmail.ws","tmpmail.org","mailpoof.com",
-      "emaildrop.io","tempr.email","mailcatch.com","spam4.me","mvrht.com",
-      "owlpic.com","spamgourmet.com","maildrop.cc","mailtemporaire.fr",
-      "mailtemp.info","my10minutemail.com","mailbox.in.ua","disbox.net",
-      "fakemail.net","tempinbox.com","temp-mail.ru","mailto.plus",
-      "fexpost.com","fexbox.org","inboxbear.com","linshiyouxiang.net",
-      "monemail.fr.nf","incognitomail.com","spambog.com","spambox.us",
-      "tafmail.com","tempmail.dev","tempmail.email","tempmail.us.com",
-      "tempmail.de","tempmail.plus","minutemail.com","jetable.org",
-      "anonbox.net","throwam.com","mailcuk.com","mailsac.com","spambox.org",
-      "byom.de","mytemp.email","tempemail.net","mvrht.net","clrmail.com",
-      "boximail.com","emltmp.com","mailsink.com","mfsa.ru","kepfree.com",
-      "boltbox.com","forexnews.bz","fivemail.de","spamavert.com",
-      "rcpt.at","tempemail.com","tempemail.co","instant-mail.de",
-      "thraml.com","trash-mail.com","fudgerub.com","mailimate.com",
-    ]);
+    //
+    // The disposable-domain list is now imported from a shared module
+    // so the signup route can reject at the door using the SAME list
+    // we surface here — without sharing, the two lists would inevitably
+    // drift and the admin counts would stop matching what the route
+    // blocks. New entries to lib/waitlist/disposable-domains.ts
+    // automatically flow through to both surfaces.
     // bot-style handle: 6+ trailing digits that aren't just a calendar year.
     const BOT_HANDLE = /^([a-z][a-z_]{1,})(\d{6,})$/i;
     const isYearLike = (d: string): boolean =>
@@ -297,7 +282,7 @@ export async function GET(req: Request) {
           const local = e.slice(0, at);
           const domain = e.slice(at + 1);
           emailDomainCount.set(domain, (emailDomainCount.get(domain) ?? 0) + 1);
-          if (DISPOSABLE_DOMAINS.has(domain)) {
+          if (DISPOSABLE_EMAIL_DOMAINS.has(domain)) {
             disposableEmails++;
             disposableDomainSet.add(domain);
           }

--- a/app/app/api/admin/waitlist/stats/route.ts
+++ b/app/app/api/admin/waitlist/stats/route.ts
@@ -43,6 +43,7 @@ export async function GET(req: Request) {
       twitter_handle: string | null;
       created_at: string;
       tier: number | null;
+      ip_hash: string | null;
     };
     const PAGE_SIZE = 1000;
     const all: Row[] = [];
@@ -50,7 +51,7 @@ export async function GET(req: Request) {
       const { data, error } = await supabase
         .from("waitlist")
         .select(
-          "id, pubkey, email, referral_code, referred_by_code, referral_code_emailed_at, twitter_handle, created_at, tier",
+          "id, pubkey, email, referral_code, referred_by_code, referral_code_emailed_at, twitter_handle, created_at, tier, ip_hash",
         )
         .order("created_at", { ascending: true })
         .range(from, from + PAGE_SIZE - 1);
@@ -277,6 +278,15 @@ export async function GET(req: Request) {
     const minuteBuckets = new Map<number, number>(); // unix-minute → count
     const referrerMinute = new Map<string, Map<number, number>>(); // code → minute → count
     const referrerHour = new Map<string, Map<number, number>>(); // code → hour → count
+    // IP-based aggregates. ip_hash is a salted SHA-256 written by the
+    // signup route — same hash from the same source IP under the same
+    // salt, so it's safe to use as a group-by key without ever surfacing
+    // the raw IP here. NULL rows pre-date IP capture or arrived through
+    // a forwarding-header-stripping proxy.
+    const ipHashCount = new Map<string, number>(); // ip_hash → total signups
+    const ipHashReferrers = new Map<string, Set<string>>(); // ip_hash → distinct referrer codes
+    const ipHashHour = new Map<string, Map<number, number>>(); // ip_hash → hour → count
+    let withoutIp = 0; // rows where ip_hash is NULL
 
     for (const r of all) {
       // Email signals
@@ -314,9 +324,9 @@ export async function GET(req: Request) {
       }
       // Timing buckets
       const t = new Date(r.created_at).getTime();
+      const hour = Number.isFinite(t) ? Math.floor(t / 3_600_000) : null;
       if (Number.isFinite(t)) {
         const minute = Math.floor(t / 60_000);
-        const hour = Math.floor(t / 3_600_000);
         minuteBuckets.set(minute, (minuteBuckets.get(minute) ?? 0) + 1);
         if (r.referred_by_code) {
           const code = r.referred_by_code;
@@ -331,8 +341,30 @@ export async function GET(req: Request) {
             hMap = new Map();
             referrerHour.set(code, hMap);
           }
-          hMap.set(hour, (hMap.get(hour) ?? 0) + 1);
+          hMap.set(hour!, (hMap.get(hour!) ?? 0) + 1);
         }
+      }
+      // IP signals
+      if (r.ip_hash) {
+        ipHashCount.set(r.ip_hash, (ipHashCount.get(r.ip_hash) ?? 0) + 1);
+        if (r.referred_by_code) {
+          let s = ipHashReferrers.get(r.ip_hash);
+          if (!s) {
+            s = new Set();
+            ipHashReferrers.set(r.ip_hash, s);
+          }
+          s.add(r.referred_by_code);
+        }
+        if (hour !== null) {
+          let h = ipHashHour.get(r.ip_hash);
+          if (!h) {
+            h = new Map();
+            ipHashHour.set(r.ip_hash, h);
+          }
+          h.set(hour, (h.get(hour) ?? 0) + 1);
+        }
+      } else {
+        withoutIp++;
       }
     }
 
@@ -386,6 +418,42 @@ export async function GET(req: Request) {
     }
     crossDomainLocals.sort((a, b) => b.domains - a.domains);
 
+    // ── IP signal post-loop aggregation ───────────────────────────────
+    // Top-8 IPs by signup count. We surface the ip_hash (12 hex chars are
+    // plenty to disambiguate in the UI; full 64-char hex is included for
+    // the operator to cross-reference against a raw lookup query). The
+    // raw ip_address column is intentionally NOT pulled into this route
+    // — analytics stays hash-only so PII doesn't show up in the admin
+    // dashboard.
+    const topIps = Array.from(ipHashCount.entries())
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 8)
+      .map(([ipHash, count]) => ({ ipHash, count }));
+
+    // IPs spanning ≥3 distinct referrer codes — a single source running
+    // signups across multiple "friends" of different referrers is a
+    // strong cluster signal, especially when paired with a high
+    // ipHashCount value.
+    const crossReferrerIps: { ipHash: string; referrers: number }[] = [];
+    for (const [ipHash, refs] of ipHashReferrers) {
+      if (refs.size >= 3) {
+        crossReferrerIps.push({ ipHash, referrers: refs.size });
+      }
+    }
+    crossReferrerIps.sort((a, b) => b.referrers - a.referrers);
+
+    // Worst single-IP single-hour velocity. Mirror of worstReferrerHour
+    // but keyed on IP — catches the case where one bot host fires many
+    // signups in a window even if it rotated referrer codes.
+    let worstIpHour: { ipHash: string; hour: number; count: number } | null = null;
+    for (const [ipHash, hMap] of ipHashHour) {
+      for (const [hour, count] of hMap) {
+        if (!worstIpHour || count > worstIpHour.count) {
+          worstIpHour = { ipHash, hour, count };
+        }
+      }
+    }
+
     const toIsoMinute = (m: number): string =>
       new Date(m * 60_000).toISOString().replace(":00.000Z", "Z");
     const toIsoHour = (h: number): string =>
@@ -414,6 +482,19 @@ export async function GET(req: Request) {
               code: worstReferrerHour.code,
               at: toIsoHour(worstReferrerHour.hour),
               count: worstReferrerHour.count,
+            }
+          : null,
+      },
+      ip: {
+        distinctIps: ipHashCount.size,
+        withoutIp,
+        topIps,
+        crossReferrerIps: crossReferrerIps.slice(0, 8),
+        worstIpHour: worstIpHour
+          ? {
+              ipHash: worstIpHour.ipHash,
+              at: toIsoHour(worstIpHour.hour),
+              count: worstIpHour.count,
             }
           : null,
       },

--- a/app/app/api/waitlist/signup/route.ts
+++ b/app/app/api/waitlist/signup/route.ts
@@ -421,14 +421,27 @@ export async function POST(req: Request) {
   if (clientIp !== null) {
     const ipLimiter = getIpLimiter();
     if (ipLimiter) {
-      const r = await ipLimiter.limit(ipRateKey(clientIp));
-      if (!r.success) {
-        return NextResponse.json(
-          {
-            error:
-              "too many signups from this network — try again later",
-          },
-          { status: 429 },
+      // Wrap the limit() call itself in try/catch so a transient
+      // Upstash blip (network error, partial outage) doesn't bubble
+      // up as an unhandled 500 to the user. Fail-open matches the
+      // posture documented on the limiter init paths at the top of
+      // this file — an Upstash outage is operator-visible via the
+      // failing health-check, not via blocked signups.
+      try {
+        const r = await ipLimiter.limit(ipRateKey(clientIp));
+        if (!r.success) {
+          return NextResponse.json(
+            {
+              error:
+                "too many signups from this network — try again later",
+            },
+            { status: 429 },
+          );
+        }
+      } catch (err) {
+        console.warn(
+          "[waitlist-signup] ip rate-limit check failed, falling open",
+          err,
         );
       }
     }

--- a/app/app/api/waitlist/signup/route.ts
+++ b/app/app/api/waitlist/signup/route.ts
@@ -177,6 +177,28 @@ function getRefCodeLimiter(): Ratelimit | null {
   return _refCodeLimiter;
 }
 
+// ── Bot user-agent gate ───────────────────────────────────────────────────
+// Cheap pre-filter ahead of the Turnstile siteverify call: scripted clients
+// have no business on a human signup form. The wave used Python
+// aiohttp/requests/urllib + curl, and a hardcoded Chrome/120 + bare
+// "Mozilla/5.0" spoof. Real browsers and wallet in-app browsers
+// (Phantom/Backpack/Jupiter) never match these. Chrome/120 is a 2023 build the
+// wave hardcoded — tunable off via WAITLIST_ALLOW_CHROME120=1 if it ever
+// false-positives on a genuine old client.
+const BOT_UA_RE =
+  /(python|aiohttp|requests|urllib|httpx|curl|wget|go-http|okhttp|axios|node-fetch|java\/|libwww|scrapy|headless|\bbot\b|spider)/i;
+function isBotUserAgent(ua: string | null): boolean {
+  if (!ua || ua.trim().length < 12) return true; // missing / stub UA
+  if (BOT_UA_RE.test(ua)) return true;
+  if (
+    process.env.WAITLIST_ALLOW_CHROME120 !== "1" &&
+    /Chrome\/120\.0\.0\.0 Safari/.test(ua)
+  ) {
+    return true;
+  }
+  return false;
+}
+
 /** Returns true iff a confirmation email may be sent to this address now.
  *  Consumes one slot from BOTH limiters on success — order matters: the
  *  global cap is checked first so a system-wide overflow doesn't burn a
@@ -366,6 +388,14 @@ export async function POST(req: Request) {
       ? b.source.slice(0, 100)
       : null;
   const userAgent = req.headers.get("user-agent")?.slice(0, 200) ?? null;
+
+  // ── Bot user-agent gate ─────────────────────────────────────────────────
+  // Reject scripted clients before the (network) Turnstile siteverify — the
+  // wave hit this route directly with python/curl + spoofed UAs.
+  if (isBotUserAgent(userAgent)) {
+    return NextResponse.json({ error: "unsupported client" }, { status: 403 });
+  }
+
   // Client IP capture for the admin spam panel + per-IP rate limit below.
   // null on proxies that strip forwarding headers — we accept the signup
   // anyway (NULL stored) rather than blocking real users for proxy

--- a/app/app/api/waitlist/signup/route.ts
+++ b/app/app/api/waitlist/signup/route.ts
@@ -15,6 +15,7 @@ import {
   generateReferralCode,
   isValidReferralCodeShape,
 } from "@/lib/waitlist/referralCode";
+import { getClientIp, hashIp } from "@/lib/waitlist/client-ip";
 
 export const runtime = "nodejs";
 
@@ -82,6 +83,48 @@ function getEmailLimiters(): {
  *  up in Redis logs / dashboards. */
 function emailRateKey(email: string): string {
   return createHash("sha256").update(email).digest("hex");
+}
+
+// ── Per-IP signup limiter ─────────────────────────────────────────────────
+// Caps fresh signup attempts to N per IP per 24h. Mirrors the email-limiter
+// fail-open posture: when Upstash isn't configured (local dev / CI / Redis
+// outage) we accept the signup rather than block the route. Only consumed
+// on signup attempts that get PAST the idempotent-refresh fast-path so a
+// real user reloading their existing waitlist row doesn't burn the budget.
+//
+// The Redis key is the SHA-256 of the raw IP — same posture as the email
+// limiter: never put PII in keys that surface in dashboards.
+let _ipLimiter: Ratelimit | null = null;
+let _ipLimiterInitialized = false;
+
+function getIpLimiter(): Ratelimit | null {
+  if (_ipLimiterInitialized) return _ipLimiter;
+  _ipLimiterInitialized = true;
+
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+
+  try {
+    const redis = new Redis({ url, token });
+    const perIpCap = Math.max(
+      1,
+      Number(process.env.WAITLIST_IP_DAILY_CAP ?? 5),
+    );
+    _ipLimiter = new Ratelimit({
+      redis,
+      limiter: Ratelimit.slidingWindow(perIpCap, "24 h"),
+      prefix: "rl:wl-ip",
+      analytics: false,
+    });
+  } catch {
+    _ipLimiter = null;
+  }
+  return _ipLimiter;
+}
+
+function ipRateKey(ip: string): string {
+  return createHash("sha256").update(ip).digest("hex");
 }
 
 /** Returns true iff a confirmation email may be sent to this address now.
@@ -229,6 +272,14 @@ export async function POST(req: Request) {
       ? b.source.slice(0, 100)
       : null;
   const userAgent = req.headers.get("user-agent")?.slice(0, 200) ?? null;
+  // Client IP capture for the admin spam panel + per-IP rate limit below.
+  // null on proxies that strip forwarding headers — we accept the signup
+  // anyway (NULL stored) rather than blocking real users for proxy
+  // behaviour outside their control. See `lib/waitlist/client-ip.ts` for
+  // header precedence and the hash-with-salt rationale.
+  const clientIp = getClientIp(req.headers);
+  const clientIpHash =
+    clientIp !== null ? hashIp(clientIp, process.env.WAITLIST_IP_SALT) : null;
 
   // ── Parse all candidate fields ──────────────────────────────────────────
   const emailRaw = typeof b.email === "string" ? b.email.trim().toLowerCase() : null;
@@ -384,6 +435,30 @@ export async function POST(req: Request) {
     }
   }
 
+  // ── Per-IP rate limit ───────────────────────────────────────────────────
+  // Bounds new-signup attempts per source IP. Positioned AFTER the
+  // sign-in fast-path above so honest users refreshing their existing
+  // row never consume the budget — only attempts that will actually try
+  // to create a new row count against the cap. Fail-open when Upstash
+  // isn't configured or when we couldn't extract a client IP at all
+  // (the failure modes match the email limiter's posture so local dev /
+  // CI / proxy oddities don't block legitimate traffic).
+  if (clientIp !== null) {
+    const ipLimiter = getIpLimiter();
+    if (ipLimiter) {
+      const r = await ipLimiter.limit(ipRateKey(clientIp));
+      if (!r.success) {
+        return NextResponse.json(
+          {
+            error:
+              "too many signups from this network — try again later",
+          },
+          { status: 429 },
+        );
+      }
+    }
+  }
+
   // ── Referrer validation (REQUIRED — invite-only) ────────────────────────
   // The waitlist is invite-only: every new signup must supply a valid
   // referral code from an existing member. Existing rows from before this
@@ -469,6 +544,12 @@ export async function POST(req: Request) {
   }
   baseRow.referred_by_code = referredByCode;
   if (privyDid) baseRow.privy_did = privyDid;
+  // IP capture for the admin spam panel — both raw (forensic lookup) and
+  // salted hash (long-term velocity analytics). Both nullable on the
+  // table so we just omit unset values; the column defaults to NULL.
+  // See `supabase-waitlist-schema.sql` for the column rationale.
+  if (clientIp) baseRow.ip_address = clientIp;
+  if (clientIpHash) baseRow.ip_hash = clientIpHash;
 
   // Compute the tier for this new row from the referrer's tier
   // (tier = referrer.tier + 1). Falls back to 0 if the RPC isn't

--- a/app/app/api/waitlist/signup/route.ts
+++ b/app/app/api/waitlist/signup/route.ts
@@ -313,6 +313,50 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: true });
   }
 
+  // ── Time-on-page (dwell) check ──────────────────────────────────────────
+  // The client captures Date.now() at component mount and sends it as
+  // `mounted_at` (ms unix epoch). Real users take seconds to read the
+  // form, solve the captcha, enter their email/wallet, and submit; a
+  // raw-HTTP bot that POSTs without ever loading the page sends nothing,
+  // and a scripted submitter that doesn't bother computing the field
+  // sends 0 or a future timestamp. We reject:
+  //   • missing / non-numeric value → no JS form interaction occurred
+  //   • dwell < 0 (mounted_at in the future) → client-clock attack
+  //     or skew that doesn't match real browsers
+  //   • dwell < MIN_DWELL_MS → submitted faster than any human can
+  //   • dwell > MAX_STALE_MS → 7-day cap closes the mounted_at:0 bypass
+  //     (which would otherwise produce a ~54-year "dwell" that passes
+  //     the floor); real users with multi-week stale tabs are rare and
+  //     they can just refresh
+  //
+  // A SOPHISTICATED bot that reads our code can spoof mounted_at to
+  // bypass this — the check is defence-in-depth, not the load-bearing
+  // gate. Pairs with Turnstile (forces a captcha solve) and the
+  // per-IP cap (bounds attempt rate) to make each successful bypass
+  // expensive.
+  //
+  // Position is RIGHT AFTER the honeypot and BEFORE the captcha verify
+  // because the check is essentially free (one branch, no I/O) — a
+  // failed mounted_at saves a Cloudflare siteverify call.
+  const MIN_DWELL_MS = 1500;
+  const MAX_STALE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+  const mountedAt =
+    typeof b.mounted_at === "number" && Number.isFinite(b.mounted_at)
+      ? b.mounted_at
+      : null;
+  const dwellMs = mountedAt !== null ? Date.now() - mountedAt : null;
+  if (
+    dwellMs === null ||
+    dwellMs < 0 ||
+    dwellMs < MIN_DWELL_MS ||
+    dwellMs > MAX_STALE_MS
+  ) {
+    return NextResponse.json(
+      { error: "request rejected — refresh the page and try again" },
+      { status: 400 },
+    );
+  }
+
   const twitter_handle =
     typeof b.twitter_handle === "string" && b.twitter_handle.trim().length > 0
       ? b.twitter_handle.trim().slice(0, 50)

--- a/app/app/api/waitlist/signup/route.ts
+++ b/app/app/api/waitlist/signup/route.ts
@@ -16,6 +16,7 @@ import {
   isValidReferralCodeShape,
 } from "@/lib/waitlist/referralCode";
 import { getClientIp, hashIp } from "@/lib/waitlist/client-ip";
+import { verifyTurnstile } from "@/lib/waitlist/turnstile";
 
 export const runtime = "nodejs";
 
@@ -433,6 +434,33 @@ export async function POST(req: Request) {
       // Fall through to the normal signup flow — worst case the user
       // gets the standard "invite required" error if they had no code.
     }
+  }
+
+  // ── Cloudflare Turnstile gate ───────────────────────────────────────────
+  // The client widget produces a single-use token after the user solves
+  // (or auto-passes through, for the invisible path) the challenge. The
+  // signup route verifies the token with Cloudflare BEFORE consuming
+  // any rate-limit budget or running expensive RPCs — a missing or
+  // invalid token short-circuits the request cheaply.
+  //
+  // Posture in `lib/waitlist/turnstile.ts`:
+  //   • prod + missing TURNSTILE_SECRET = misconfiguration, reject.
+  //   • non-prod + missing secret = fail-open (local dev keeps working).
+  //   • valid secret + missing/invalid token = always reject.
+  const turnstileToken =
+    typeof b.turnstile_token === "string" ? b.turnstile_token : null;
+  const turnstileVerdict = await verifyTurnstile(turnstileToken, clientIp);
+  if (!turnstileVerdict.ok) {
+    return NextResponse.json(
+      {
+        error:
+          turnstileVerdict.reason === "missing_token"
+            ? "captcha required — refresh and complete the challenge"
+            : "captcha verification failed — refresh and try again",
+        captcha: turnstileVerdict.reason,
+      },
+      { status: 400 },
+    );
   }
 
   // ── Per-IP rate limit ───────────────────────────────────────────────────

--- a/app/app/api/waitlist/signup/route.ts
+++ b/app/app/api/waitlist/signup/route.ts
@@ -129,6 +129,54 @@ function ipRateKey(ip: string): string {
   return createHash("sha256").update(ip).digest("hex");
 }
 
+// ── Per-referral-code burn-rate limiter ─────────────────────────────────
+// Caps how many signups can be attributed to a single referral code per
+// hour. Closes the "leaked code" attack: a bot farm that gets hold of
+// ONE valid code (a member's code posted publicly, scraped from a chat,
+// shared by mistake) could otherwise pump unbounded signups through it.
+//
+// The cap defaults to 20/hour — well below the admin spam panel's
+// amber-threshold of 40/hour for the "top referrer's busiest hour"
+// signal, so the limiter fires BEFORE the dashboard would alert.
+// A legitimate organic referrer in our existing data rarely tops 20
+// signups in a single hour; anyone doing so during a coordinated drop
+// can have the cap temporarily raised by the operator via
+// WAITLIST_REFCODE_HOURLY_CAP. Conservative defaults + per-launch
+// override is the right ratio.
+//
+// Referral codes are public-by-design (members share them in URLs and
+// posts), so the Redis key is the raw code rather than a hash — no PII
+// concern. Fail-open when Upstash isn't configured to match the email
+// + IP limiter posture.
+let _refCodeLimiter: Ratelimit | null = null;
+let _refCodeLimiterInitialized = false;
+
+function getRefCodeLimiter(): Ratelimit | null {
+  if (_refCodeLimiterInitialized) return _refCodeLimiter;
+  _refCodeLimiterInitialized = true;
+
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+
+  try {
+    const redis = new Redis({ url, token });
+    const cap = Math.max(
+      1,
+      Number(process.env.WAITLIST_REFCODE_HOURLY_CAP ?? 20),
+    );
+    _refCodeLimiter = new Ratelimit({
+      redis,
+      limiter: Ratelimit.slidingWindow(cap, "1 h"),
+      prefix: "rl:wl-refcode",
+      analytics: false,
+    });
+  } catch {
+    _refCodeLimiter = null;
+  }
+  return _refCodeLimiter;
+}
+
 /** Returns true iff a confirmation email may be sent to this address now.
  *  Consumes one slot from BOTH limiters on success — order matters: the
  *  global cap is checked first so a system-wide overflow doesn't burn a
@@ -573,6 +621,43 @@ export async function POST(req: Request) {
       { error: "referral code check failed, try again" },
       { status: 503 },
     );
+  }
+
+  // ── Per-referral-code burn-rate limit ───────────────────────────────────
+  // Closes the "leaked code" attack — a bot farm that scraped one
+  // valid code from a public post could otherwise pump unbounded
+  // signups through it. The default cap of 20/hour sits below the
+  // admin panel's amber threshold for "top referrer's busiest hour"
+  // (40), so the limiter fires before the dashboard alerts; legitimate
+  // organic referrers in our data almost never exceed 20 in a single
+  // hour, and coordinated launch drops can have the cap temporarily
+  // raised via WAITLIST_REFCODE_HOURLY_CAP. Positioned AFTER the
+  // existence-check above so an invalid code is rejected without
+  // consuming any budget — an attacker can't probe-and-burn budgets
+  // for codes they guessed by submitting many invalid candidates.
+  //
+  // Wrapped in try/catch — a transient Upstash blip falls open with
+  // a warn log rather than 500ing the user. Same posture as the per-
+  // IP + email limiters elsewhere in this route.
+  const refCodeLimiter = getRefCodeLimiter();
+  if (refCodeLimiter) {
+    try {
+      const r = await refCodeLimiter.limit(referredByCode);
+      if (!r.success) {
+        return NextResponse.json(
+          {
+            error:
+              "this referral code is at its hourly cap — try again later or use a different code",
+          },
+          { status: 429 },
+        );
+      }
+    } catch (err) {
+      console.warn(
+        "[waitlist-signup] refcode rate-limit check failed, falling open",
+        err,
+      );
+    }
   }
 
   // Wallet signature was already verified at the top of this route

--- a/app/app/api/waitlist/signup/route.ts
+++ b/app/app/api/waitlist/signup/route.ts
@@ -378,6 +378,62 @@ export async function POST(req: Request) {
     }
   }
 
+  // ── Cloudflare Turnstile gate ───────────────────────────────────────────
+  // Positioned ABOVE the sign-in fast-path because a locally-generated
+  // ed25519 key + a fresh signed message is free for an attacker to
+  // produce — without the gate here, an attacker could fire valid-shape
+  // signups at 10k+ rps, each one chewing a Supabase service-role
+  // SELECT in the fast-path's existing-row probe. The captcha verify
+  // gates that probe behind a Cloudflare challenge (cents per token at
+  // captcha-farm rates), reducing the attack to economics. UX cost on
+  // a returning honest user is one Turnstile solve per visit, which is
+  // mostly invisible on clean browsers anyway.
+  //
+  // Posture in `lib/waitlist/turnstile.ts`:
+  //   • prod + missing TURNSTILE_SECRET = misconfiguration, reject.
+  //   • non-prod + missing secret = fail-open (local dev keeps working).
+  //   • valid secret + missing/invalid token = always reject.
+  const turnstileToken =
+    typeof b.turnstile_token === "string" ? b.turnstile_token : null;
+  const turnstileVerdict = await verifyTurnstile(turnstileToken, clientIp);
+  if (!turnstileVerdict.ok) {
+    return NextResponse.json(
+      {
+        error:
+          turnstileVerdict.reason === "missing_token"
+            ? "captcha required — refresh and complete the challenge"
+            : "captcha verification failed — refresh and try again",
+        captcha: turnstileVerdict.reason,
+      },
+      { status: 400 },
+    );
+  }
+
+  // ── Per-IP rate limit ───────────────────────────────────────────────────
+  // Bounds total signup attempts per source IP, including fast-path
+  // lookups. Positioned AFTER the captcha gate so a missing/invalid
+  // token short-circuits without consuming the budget — otherwise an
+  // attacker could exhaust the per-IP cap with garbage tokens. Fail-
+  // open when Upstash isn't configured or when we couldn't extract a
+  // client IP at all (the failure modes match the email limiter's
+  // posture so local dev / CI / proxy oddities don't block legitimate
+  // traffic).
+  if (clientIp !== null) {
+    const ipLimiter = getIpLimiter();
+    if (ipLimiter) {
+      const r = await ipLimiter.limit(ipRateKey(clientIp));
+      if (!r.success) {
+        return NextResponse.json(
+          {
+            error:
+              "too many signups from this network — try again later",
+          },
+          { status: 429 },
+        );
+      }
+    }
+  }
+
   // ── Sign-in fast path for existing wallet signups ───────────────────────
   // The waitlist is invite-only NOW, but every row created before that
   // change is grandfathered (referred_by_code IS NULL). Those users need
@@ -388,6 +444,10 @@ export async function POST(req: Request) {
   // the existing code is safe. Email-path lookup would require an OTP
   // (membership oracle) and is handled by the separate backfill-emails
   // operator action.
+  //
+  // The captcha + per-IP gates above protect this Supabase service-role
+  // read from being a free probing oracle — without them, an attacker
+  // could enumerate generated pubkeys to hammer the DB.
   if (hasWalletPart) {
     try {
       const service = getWaitlistServiceSupabase();
@@ -433,57 +493,6 @@ export async function POST(req: Request) {
       console.warn("[waitlist-signup] lookup failed, falling through", err);
       // Fall through to the normal signup flow — worst case the user
       // gets the standard "invite required" error if they had no code.
-    }
-  }
-
-  // ── Cloudflare Turnstile gate ───────────────────────────────────────────
-  // The client widget produces a single-use token after the user solves
-  // (or auto-passes through, for the invisible path) the challenge. The
-  // signup route verifies the token with Cloudflare BEFORE consuming
-  // any rate-limit budget or running expensive RPCs — a missing or
-  // invalid token short-circuits the request cheaply.
-  //
-  // Posture in `lib/waitlist/turnstile.ts`:
-  //   • prod + missing TURNSTILE_SECRET = misconfiguration, reject.
-  //   • non-prod + missing secret = fail-open (local dev keeps working).
-  //   • valid secret + missing/invalid token = always reject.
-  const turnstileToken =
-    typeof b.turnstile_token === "string" ? b.turnstile_token : null;
-  const turnstileVerdict = await verifyTurnstile(turnstileToken, clientIp);
-  if (!turnstileVerdict.ok) {
-    return NextResponse.json(
-      {
-        error:
-          turnstileVerdict.reason === "missing_token"
-            ? "captcha required — refresh and complete the challenge"
-            : "captcha verification failed — refresh and try again",
-        captcha: turnstileVerdict.reason,
-      },
-      { status: 400 },
-    );
-  }
-
-  // ── Per-IP rate limit ───────────────────────────────────────────────────
-  // Bounds new-signup attempts per source IP. Positioned AFTER the
-  // sign-in fast-path above so honest users refreshing their existing
-  // row never consume the budget — only attempts that will actually try
-  // to create a new row count against the cap. Fail-open when Upstash
-  // isn't configured or when we couldn't extract a client IP at all
-  // (the failure modes match the email limiter's posture so local dev /
-  // CI / proxy oddities don't block legitimate traffic).
-  if (clientIp !== null) {
-    const ipLimiter = getIpLimiter();
-    if (ipLimiter) {
-      const r = await ipLimiter.limit(ipRateKey(clientIp));
-      if (!r.success) {
-        return NextResponse.json(
-          {
-            error:
-              "too many signups from this network — try again later",
-          },
-          { status: 429 },
-        );
-      }
     }
   }
 

--- a/app/app/api/waitlist/signup/route.ts
+++ b/app/app/api/waitlist/signup/route.ts
@@ -17,6 +17,7 @@ import {
 } from "@/lib/waitlist/referralCode";
 import { getClientIp, hashIp } from "@/lib/waitlist/client-ip";
 import { verifyTurnstile } from "@/lib/waitlist/turnstile";
+import { isDisposableEmail } from "@/lib/waitlist/disposable-domains";
 
 export const runtime = "nodejs";
 
@@ -299,6 +300,24 @@ export async function POST(req: Request) {
   if (emailRaw !== null) {
     if (!emailRaw || !EMAIL_RE.test(emailRaw) || emailRaw.length > 254) {
       return NextResponse.json({ error: "invalid email" }, { status: 400 });
+    }
+    // Disposable-domain block. The admin spam panel already flagged
+    // these post-facto; this is the same list moved to a shared
+    // module (lib/waitlist/disposable-domains.ts) and applied at the
+    // door so the row never lands in the table. Bots typically rotate
+    // through 10minutemail/mailinator/etc.; this forces them to
+    // procure real inboxes (~$0.05+/email at burner-mail-as-a-service
+    // rates) and meaningfully changes the attacker economics. The
+    // error string deliberately doesn't echo the rejected domain — no
+    // need to confirm to a bot which entries are on the list.
+    if (isDisposableEmail(emailRaw)) {
+      return NextResponse.json(
+        {
+          error:
+            "this email provider isn't accepted — please use a permanent address",
+        },
+        { status: 400 },
+      );
     }
   }
 

--- a/app/app/api/waitlist/signup/route.ts
+++ b/app/app/api/waitlist/signup/route.ts
@@ -599,6 +599,14 @@ export async function POST(req: Request) {
   const MAX_CODE_ATTEMPTS = 8;
   let referralCode: string | null = null;
   let isDuplicate = false;
+  // Defensive fallback: if a malformed IP slips through `getClientIp`'s
+  // `net.isIP()` check (Postgres `inet` is stricter than `net.isIP` for
+  // a few edge cases — zone-id IPv6, octal IPv4, leading-zero forms),
+  // the first insert will fail with `22P02 invalid input syntax for
+  // type inet`. We drop the IP columns and retry once rather than
+  // losing the signup. This is belt-and-braces — the upstream
+  // validator should already have caught it.
+  let ipColumnsDropped = false;
   for (let attempt = 0; attempt < MAX_CODE_ATTEMPTS; attempt++) {
     const candidate = generateReferralCode();
     const { error } = await supabase
@@ -607,6 +615,18 @@ export async function POST(req: Request) {
     if (!error) {
       referralCode = candidate;
       break;
+    }
+    if (error.code === "22P02" && !ipColumnsDropped) {
+      // Bad-IP cast at the database. Strip both IP columns from the
+      // row and retry once. Log so the bad value can be investigated.
+      console.warn(
+        "[waitlist] insert rejected with 22P02 — dropping ip columns and retrying",
+        { code: error.code, message: error.message },
+      );
+      delete baseRow.ip_address;
+      delete baseRow.ip_hash;
+      ipColumnsDropped = true;
+      continue;
     }
     if (error.code !== "23505") {
       console.error("[waitlist] insert error", error);

--- a/app/app/waitlist/page.tsx
+++ b/app/app/waitlist/page.tsx
@@ -7,6 +7,7 @@ import { useWallets, useSignMessage } from "@privy-io/react-auth/solana";
 import { usePrivyAvailable } from "@/hooks/usePrivySafe";
 import { resolveActiveWallet, usePreferredWallet } from "@/hooks/usePreferredWallet";
 import { useWaitlistWhoami } from "@/hooks/useWaitlistWhoami";
+import { TurnstileGate } from "@/components/waitlist/TurnstileGate";
 import bs58 from "bs58";
 
 /**
@@ -298,6 +299,21 @@ function SpecField({
 function SignupCard() {
   const privyAvailable = usePrivyAvailable();
   const [tab, setTab] = useState<"wallet" | "email">("wallet");
+  // Cloudflare Turnstile token — set by the widget callback once the
+  // user has solved (or auto-passed through) the challenge. Both
+  // signup flows below receive it via props and include it in their
+  // POST body; the server-side verifier in `lib/waitlist/turnstile.ts`
+  // is the actual trust boundary.
+  //
+  // `turnstileNonce` is incremented after a captcha-failed server
+  // response so the widget remounts and the user gets a fresh
+  // challenge (Turnstile tokens are single-use).
+  const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
+  const [turnstileNonce, setTurnstileNonce] = useState(0);
+  const resetCaptcha = useCallback(() => {
+    setTurnstileToken(null);
+    setTurnstileNonce((n) => n + 1);
+  }, []);
 
   // Auto-detect: if the visitor is already a Privy user *and* already on
   // the waitlist (by DID / wallet / email), skip the signup form entirely
@@ -379,14 +395,33 @@ function SignupCard() {
               </div>
             )}
 
+            {/* Bot challenge — visible before either path can submit.
+                The widget renders even in the wallet-tab to keep the
+                gate consistent regardless of which path the user
+                picks. `turnstileNonce` forces a remount when the
+                parent calls resetCaptcha() after a captcha-rejected
+                server response. */}
+            <div className="mb-4">
+              <TurnstileGate
+                key={turnstileNonce}
+                onToken={setTurnstileToken}
+              />
+            </div>
+
             {tab === "wallet" ? (
               privyAvailable ? (
-                <SignupFlow />
+                <SignupFlow
+                  turnstileToken={turnstileToken}
+                  resetCaptcha={resetCaptcha}
+                />
               ) : (
                 <StatusErr>Wallet provider not configured. Reload the page.</StatusErr>
               )
             ) : (
-              <EmailFlow />
+              <EmailFlow
+                turnstileToken={turnstileToken}
+                resetCaptcha={resetCaptcha}
+              />
             )}
           </>
         )}
@@ -488,7 +523,13 @@ type EmailState =
     }
   | { kind: "error"; reason: string };
 
-function EmailFlow() {
+function EmailFlow({
+  turnstileToken,
+  resetCaptcha,
+}: {
+  turnstileToken: string | null;
+  resetCaptcha: () => void;
+}) {
   const [email, setEmail] = useState("");
   const [code, setCode] = useState("");
   const [twitter, setTwitter] = useState("");
@@ -592,6 +633,7 @@ function EmailFlow() {
             twitter_handle: twitter.trim() || undefined,
             source: source ?? undefined,
             referred_by_code: referredBy.trim() || undefined,
+            turnstile_token: turnstileToken ?? undefined,
           }),
         });
         const json = (await res.json()) as {
@@ -599,8 +641,12 @@ function EmailFlow() {
           error?: string;
           position?: number | null;
           referral_code?: string | null;
+          captcha?: string;
         };
         if (!res.ok || !json.ok) {
+          // Captcha-rejected: ask the widget to remount so the user
+          // gets a fresh challenge (Turnstile tokens are single-use).
+          if (json.captcha) resetCaptcha();
           setState({ kind: "error", reason: json.error ?? `HTTP ${res.status}` });
           return;
         }
@@ -615,7 +661,17 @@ function EmailFlow() {
         setState({ kind: "error", reason: msg });
       }
     })();
-  }, [state, ready, authenticated, user, twitter, email, referredBy]);
+  }, [
+    state,
+    ready,
+    authenticated,
+    user,
+    twitter,
+    email,
+    referredBy,
+    turnstileToken,
+    resetCaptcha,
+  ]);
 
   if (state.kind === "done") {
     const shareUrl = state.referralCode
@@ -781,14 +837,16 @@ function EmailFlow() {
         <button
           className={ctaPrimary}
           onClick={onSendCode}
-          disabled={sending || !formUnlocked}
+          disabled={sending || !formUnlocked || !turnstileToken}
           tabIndex={formUnlocked ? 0 : -1}
         >
           {sending
             ? "Sending code…"
-            : formUnlocked
-              ? "Send 6-digit code →"
-              : "Enter referral code to continue"}
+            : !formUnlocked
+              ? "Enter referral code to continue"
+              : !turnstileToken
+                ? "Complete the captcha above"
+                : "Send 6-digit code →"}
         </button>
       </div>
       <NoCodeFallback />
@@ -796,7 +854,13 @@ function EmailFlow() {
   );
 }
 
-function SignupFlow() {
+function SignupFlow({
+  turnstileToken,
+  resetCaptcha,
+}: {
+  turnstileToken: string | null;
+  resetCaptcha: () => void;
+}) {
   const { ready, authenticated, login } = usePrivy();
   const { wallets } = useWallets();
   const { signMessage } = useSignMessage();
@@ -862,6 +926,7 @@ function SignupFlow() {
           twitter_handle: twitter.trim() || undefined,
           source: source ?? undefined,
           referred_by_code: referredBy.trim() || undefined,
+          turnstile_token: turnstileToken ?? undefined,
         }),
       });
       const json = (await res.json()) as {
@@ -870,8 +935,12 @@ function SignupFlow() {
         position?: number | null;
         referral_code?: string | null;
         returning?: boolean;
+        captcha?: string;
       };
       if (!res.ok || !json.ok) {
+        // Captcha-rejected: remount the widget for a fresh challenge
+        // (Turnstile tokens are single-use).
+        if (json.captcha) resetCaptcha();
         setState({ kind: "error", reason: json.error ?? `HTTP ${res.status}` });
         return;
       }
@@ -885,7 +954,15 @@ function SignupFlow() {
       const msg = e instanceof Error ? e.message : "sign cancelled";
       setState({ kind: "error", reason: msg });
     }
-  }, [activeWallet, pubkey, signMessage, twitter, referredBy]);
+  }, [
+    activeWallet,
+    pubkey,
+    signMessage,
+    twitter,
+    referredBy,
+    turnstileToken,
+    resetCaptcha,
+  ]);
 
   useEffect(() => {
     if (state.kind === "connecting" && ready && authenticated && pubkey) {
@@ -1005,15 +1082,17 @@ function SignupFlow() {
         <button
           className={ctaPrimary}
           onClick={onSign}
-          disabled={busy}
+          disabled={busy || !turnstileToken}
         >
           {state.kind === "signing"
             ? "Signing in your wallet…"
             : state.kind === "submitting"
               ? "Submitting…"
-              : formUnlocked
-                ? "Sign & claim spot →"
-                : "Sign in to check / look up code →"}
+              : !turnstileToken
+                ? "Complete the captcha above"
+                : formUnlocked
+                  ? "Sign & claim spot →"
+                  : "Sign in to check / look up code →"}
         </button>
         {!formUnlocked && (
           <p className="font-mono text-[10.5px] leading-relaxed text-[var(--text-secondary)]">
@@ -1057,13 +1136,15 @@ function SignupFlow() {
       <button
         className={ctaPrimary}
         onClick={onConnect}
-        disabled={state.kind === "connecting" || !formUnlocked}
+        disabled={state.kind === "connecting" || !formUnlocked || !turnstileToken}
       >
         {state.kind === "connecting"
           ? "Connecting…"
-          : formUnlocked
-            ? "Connect wallet →"
-            : "Enter referral code to continue"}
+          : !formUnlocked
+            ? "Enter referral code to continue"
+            : !turnstileToken
+              ? "Complete the captcha above"
+              : "Connect wallet →"}
       </button>
       <p className="font-mono text-[11px] leading-relaxed text-[var(--text-secondary)]">
         Phantom · Solflare · Backpack · Jupiter

--- a/app/app/waitlist/page.tsx
+++ b/app/app/waitlist/page.tsx
@@ -314,6 +314,15 @@ function SignupCard() {
     setTurnstileToken(null);
     setTurnstileNonce((n) => n + 1);
   }, []);
+  // Mount-time wall clock. Captured ONCE on first render via useState's
+  // lazy initialiser so React StrictMode's double-mount in dev doesn't
+  // jitter the value; both flows below send this back to the server as
+  // `mounted_at` so the route can enforce a minimum dwell time before
+  // accepting the submit. Raw-HTTP bots that never load the page omit
+  // the field; lazy scripted bots send 0 or hardcoded values that fail
+  // the server's bounds. See `/api/waitlist/signup/route.ts` for the
+  // floor + stale-cap.
+  const [mountedAt] = useState<number>(() => Date.now());
 
   // Auto-detect: if the visitor is already a Privy user *and* already on
   // the waitlist (by DID / wallet / email), skip the signup form entirely
@@ -413,6 +422,7 @@ function SignupCard() {
                 <SignupFlow
                   turnstileToken={turnstileToken}
                   resetCaptcha={resetCaptcha}
+                  mountedAt={mountedAt}
                 />
               ) : (
                 <StatusErr>Wallet provider not configured. Reload the page.</StatusErr>
@@ -421,6 +431,7 @@ function SignupCard() {
               <EmailFlow
                 turnstileToken={turnstileToken}
                 resetCaptcha={resetCaptcha}
+                mountedAt={mountedAt}
               />
             )}
           </>
@@ -526,9 +537,11 @@ type EmailState =
 function EmailFlow({
   turnstileToken,
   resetCaptcha,
+  mountedAt,
 }: {
   turnstileToken: string | null;
   resetCaptcha: () => void;
+  mountedAt: number;
 }) {
   const [email, setEmail] = useState("");
   const [code, setCode] = useState("");
@@ -652,6 +665,7 @@ function EmailFlow({
             source: source ?? undefined,
             referred_by_code: referredBy.trim() || undefined,
             turnstile_token: turnstileToken ?? undefined,
+            mounted_at: mountedAt,
           }),
         });
         const json = (await res.json()) as {
@@ -693,6 +707,7 @@ function EmailFlow({
     referredBy,
     turnstileToken,
     resetCaptcha,
+    mountedAt,
   ]);
 
   if (state.kind === "done") {
@@ -879,9 +894,11 @@ function EmailFlow({
 function SignupFlow({
   turnstileToken,
   resetCaptcha,
+  mountedAt,
 }: {
   turnstileToken: string | null;
   resetCaptcha: () => void;
+  mountedAt: number;
 }) {
   const { ready, authenticated, login } = usePrivy();
   const { wallets } = useWallets();
@@ -949,6 +966,7 @@ function SignupFlow({
           source: source ?? undefined,
           referred_by_code: referredBy.trim() || undefined,
           turnstile_token: turnstileToken ?? undefined,
+          mounted_at: mountedAt,
         }),
       });
       const json = (await res.json()) as {
@@ -984,6 +1002,7 @@ function SignupFlow({
     referredBy,
     turnstileToken,
     resetCaptcha,
+    mountedAt,
   ]);
 
   useEffect(() => {

--- a/app/app/waitlist/page.tsx
+++ b/app/app/waitlist/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import useSWR from "swr";
 import { usePrivy, useLoginWithEmail } from "@privy-io/react-auth";
 import { useWallets, useSignMessage } from "@privy-io/react-auth/solana";
@@ -536,6 +536,16 @@ function EmailFlow({
   const [referredBy, setReferredBy] = useState("");
   const [state, setState] = useState<EmailState>({ kind: "idle" });
   const { status: refStatus } = useReferralCodeValidation(referredBy);
+  // Guards against double-firing the submit fetch when the post-OTP
+  // effect re-runs because a non-state dep changed (turnstileToken
+  // expiring → onToken(null); Privy user object updating). Without
+  // this guard a re-run while state is still "verifying" can kick off
+  // a second concurrent POST before the first one's setState({ kind:
+  // "submitting" }) has flushed through React's scheduler. The ref is
+  // toggled true at fetch dispatch and false in the finally arm so a
+  // subsequent retry (user clicks "Try again" → idle → re-enter the
+  // flow) starts clean.
+  const submitInFlightRef = useRef(false);
 
   // Pre-fill the referrer input from /r/<code> landings, then scrub the
   // query param so users who copy from the address bar later don't end up
@@ -612,6 +622,13 @@ function EmailFlow({
   useEffect(() => {
     if (state.kind !== "verifying") return;
     if (!ready || !authenticated || !user) return;
+    // Guard against re-entry. The effect's dep array includes
+    // turnstileToken + the Privy user object — either can churn while
+    // state.kind is still "verifying" (token expiry mid-OTP-verify,
+    // Privy linked-accounts hydration), and a re-entry that gets past
+    // the early returns above would fire a second concurrent POST
+    // before the first's setState had a chance to flush.
+    if (submitInFlightRef.current) return;
     const userEmail =
       user.email?.address?.trim().toLowerCase() ?? email.trim().toLowerCase();
     if (!userEmail) {
@@ -619,6 +636,7 @@ function EmailFlow({
       return;
     }
 
+    submitInFlightRef.current = true;
     setState({ kind: "submitting", email: userEmail });
     (async () => {
       try {
@@ -659,6 +677,10 @@ function EmailFlow({
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : "submit failed";
         setState({ kind: "error", reason: msg });
+      } finally {
+        // Release the lock so a subsequent retry (user hits "Try again"
+        // → idle → re-enter the OTP flow) can fire cleanly.
+        submitInFlightRef.current = false;
       }
     })();
   }, [

--- a/app/components/admin/WaitlistLeaderboardSection.tsx
+++ b/app/components/admin/WaitlistLeaderboardSection.tsx
@@ -100,6 +100,13 @@ interface WaitlistStats {
       worst5Min: { startAt: string; count: number } | null;
       worstReferrerHour: { code: string; at: string; count: number } | null;
     };
+    ip: {
+      distinctIps: number;
+      withoutIp: number;
+      topIps: { ipHash: string; count: number }[];
+      crossReferrerIps: { ipHash: string; referrers: number }[];
+      worstIpHour: { ipHash: string; at: string; count: number } | null;
+    };
   };
   tierBreakdown?: { tier: number; count: number; label: string }[];
   integrity: {
@@ -212,6 +219,19 @@ function SpamSignals({
   const crossDomainCount = spam.email.crossDomainLocalParts.length;
   const crossDomainLevel: 0 | 1 | 2 =
     crossDomainCount >= 10 ? 2 : crossDomainCount >= 3 ? 1 : 0;
+  // IP-based severities. ip is undefined on legacy /stats responses
+  // (pre IP-capture deploy) — fall back to "no signal" so the panel
+  // still renders cleanly during the rollout window.
+  const ip = spam.ip;
+  const topIpCount = ip?.topIps[0]?.count ?? 0;
+  const topIpLevel: 0 | 1 | 2 =
+    topIpCount >= 20 ? 2 : topIpCount >= 10 ? 1 : 0;
+  const crossReferrerCount = ip?.crossReferrerIps.length ?? 0;
+  const crossReferrerLevel: 0 | 1 | 2 =
+    crossReferrerCount >= 10 ? 2 : crossReferrerCount >= 3 ? 1 : 0;
+  const worstIpHourCount = ip?.worstIpHour?.count ?? 0;
+  const worstIpHourLevel: 0 | 1 | 2 =
+    worstIpHourCount >= 25 ? 2 : worstIpHourCount >= 10 ? 1 : 0;
 
   const levels = [
     disposableLevel,
@@ -220,6 +240,9 @@ function SpamSignals({
     fiveMinLevel,
     refHourLevel,
     crossDomainLevel,
+    topIpLevel,
+    crossReferrerLevel,
+    worstIpHourLevel,
   ];
   const verdict = Math.max(...levels) as 0 | 1 | 2;
   const verdictLabel = verdict === 0 ? "Looks organic" : verdict === 1 ? "Watch closely" : "Signs of inflation";
@@ -304,6 +327,48 @@ function SpamSignals({
                   .join(" · ")
           }
         />
+        {ip && (
+          <>
+            <SignalRow
+              level={topIpLevel}
+              label="Most-active IP (signups from one source)"
+              value={`+${topIpCount}`}
+              detail={
+                ip.topIps.length === 0
+                  ? `${ip.distinctIps.toLocaleString()} distinct IPs · ${ip.withoutIp.toLocaleString()} legacy NULL`
+                  : `${ip.distinctIps.toLocaleString()} distinct · top ${ip.topIps
+                      .slice(0, 3)
+                      .map((x) => `${x.ipHash.slice(0, 8)}×${x.count}`)
+                      .join(" · ")}`
+              }
+            />
+            <SignalRow
+              level={crossReferrerLevel}
+              label="IPs spanning ≥3 referrer codes"
+              value={crossReferrerCount.toLocaleString()}
+              detail={
+                crossReferrerCount === 0
+                  ? "no cross-referrer IP clusters"
+                  : ip.crossReferrerIps
+                      .slice(0, 3)
+                      .map((x) => `${x.ipHash.slice(0, 8)}×${x.referrers}`)
+                      .join(" · ")
+              }
+            />
+            <SignalRow
+              level={worstIpHourLevel}
+              label="Worst single-IP hour"
+              value={`+${worstIpHourCount}`}
+              detail={
+                ip.worstIpHour
+                  ? `${ip.worstIpHour.ipHash.slice(0, 8)} · at ${formatTimeShort(
+                      ip.worstIpHour.at,
+                    )} UTC`
+                  : "—"
+              }
+            />
+          </>
+        )}
       </div>
 
       {/* Top email domains — eyeball check; healthy = gmail/outlook lead */}

--- a/app/components/waitlist/TurnstileGate.tsx
+++ b/app/components/waitlist/TurnstileGate.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+/**
+ * Cloudflare Turnstile widget for the waitlist signup form.
+ *
+ * Renders the Turnstile challenge and yields a single-use token via the
+ * `onToken` callback. The token gets bundled into the signup POST body
+ * and the server verifies it via `verifyTurnstile` in
+ * `lib/waitlist/turnstile.ts` — so this component is purely about
+ * "produce a token"; the trust boundary is server-side.
+ *
+ * Posture:
+ *   • Reads the public site key from NEXT_PUBLIC_TURNSTILE_SITE_KEY.
+ *   • When the env var is missing (local dev / no Cloudflare account)
+ *     the component immediately calls `onToken(null)` and renders
+ *     nothing. The server-side verifier matches this with a fail-OPEN
+ *     posture outside production.
+ *   • When the env var is missing IN production (operator forgot to
+ *     set it) we render an inline error and never call `onToken` —
+ *     the parent's submit buttons stay disabled.
+ *   • A widget-side `expired-callback` / `error-callback` clears the
+ *     token by calling `onToken(null)`. The parent re-disables its
+ *     submit while the user re-solves.
+ *
+ * Cloudflare's `api.js` is loaded lazily on mount and cached for the
+ * lifetime of the page — multiple instances of this component share
+ * the single script tag. The widget's render lifecycle is bound to
+ * the React component lifecycle so HMR / route changes clean up the
+ * iframe instead of leaking it.
+ */
+
+import { useEffect, useRef } from "react";
+
+const SCRIPT_SRC =
+  "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+
+// Cloudflare's official @cloudflare/turnstile-types declaration (pulled
+// in transitively by some Next.js / Cloudflare package) ambient-declares
+// `window.turnstile`. Re-declaring it here would conflict, so we use a
+// minimal local shape and a runtime cast where we touch the global. The
+// fields we use are stable per Cloudflare's published API:
+// https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/
+interface TurnstileApi {
+  render: (
+    target: HTMLElement,
+    options: {
+      sitekey: string;
+      callback: (token: string) => void;
+      "expired-callback"?: () => void;
+      "error-callback"?: () => void;
+      theme?: "light" | "dark" | "auto";
+      appearance?: "always" | "execute" | "interaction-only";
+      size?: "normal" | "compact" | "flexible";
+    },
+  ) => string;
+  remove: (widgetId: string) => void;
+  reset: (widgetId: string) => void;
+}
+
+function getTurnstile(): TurnstileApi | null {
+  if (typeof window === "undefined") return null;
+  const t = (window as unknown as { turnstile?: TurnstileApi }).turnstile;
+  return t ?? null;
+}
+
+let scriptPromise: Promise<void> | null = null;
+
+function loadTurnstileScript(): Promise<void> {
+  if (typeof window === "undefined") return Promise.resolve();
+  if (getTurnstile()) return Promise.resolve();
+  if (scriptPromise) return scriptPromise;
+
+  scriptPromise = new Promise<void>((resolve, reject) => {
+    const existing = document.querySelector<HTMLScriptElement>(
+      `script[src^="https://challenges.cloudflare.com/turnstile"]`,
+    );
+    if (existing) {
+      // Another mount already injected the script; wait for it to
+      // attach the global. Cloudflare's api.js sets window.turnstile
+      // synchronously on load.
+      existing.addEventListener("load", () => resolve());
+      existing.addEventListener("error", () =>
+        reject(new Error("turnstile script failed to load")),
+      );
+      return;
+    }
+    const script = document.createElement("script");
+    script.src = SCRIPT_SRC;
+    script.async = true;
+    script.defer = true;
+    script.addEventListener("load", () => resolve());
+    script.addEventListener("error", () =>
+      reject(new Error("turnstile script failed to load")),
+    );
+    document.head.appendChild(script);
+  });
+
+  return scriptPromise;
+}
+
+export function TurnstileGate({
+  onToken,
+  className,
+}: {
+  onToken: (token: string | null) => void;
+  className?: string;
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const widgetIdRef = useRef<string | null>(null);
+  // Hold the latest callback in a ref so the effect doesn't have to
+  // depend on it (would re-render the widget on every parent state
+  // change, which is both wasteful and visible — the widget shows a
+  // brief reload flicker).
+  const onTokenRef = useRef(onToken);
+  onTokenRef.current = onToken;
+
+  const sitekey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+
+  useEffect(() => {
+    if (!sitekey) {
+      // No site key configured — the server-side verifier is in
+      // fail-OPEN mode (non-prod) or will reject every signup
+      // (prod). Signal "no token" to the parent so its disabled-
+      // submit state reflects the missing widget.
+      onTokenRef.current(null);
+      return;
+    }
+    if (typeof window === "undefined") return;
+
+    let cancelled = false;
+    loadTurnstileScript()
+      .then(() => {
+        if (cancelled) return;
+        const turnstile = getTurnstile();
+        if (!containerRef.current || !turnstile) return;
+        widgetIdRef.current = turnstile.render(containerRef.current, {
+          sitekey,
+          callback: (token: string) => onTokenRef.current(token),
+          "expired-callback": () => onTokenRef.current(null),
+          "error-callback": () => onTokenRef.current(null),
+          theme: "dark",
+          appearance: "always",
+          size: "flexible",
+        });
+      })
+      .catch((err) => {
+        // Script load failed (CSP block, network, ad-block). Render
+        // an inline error in the placeholder via the parent's empty-
+        // token state; nothing else we can do here.
+        console.warn("[waitlist] turnstile load failed", err);
+        onTokenRef.current(null);
+      });
+
+    return () => {
+      cancelled = true;
+      const turnstile = getTurnstile();
+      if (widgetIdRef.current && turnstile) {
+        try {
+          turnstile.remove(widgetIdRef.current);
+        } catch {
+          // Widget already torn down or invalid id — non-fatal.
+        }
+        widgetIdRef.current = null;
+      }
+    };
+  }, [sitekey]);
+
+  if (!sitekey) {
+    if (process.env.NODE_ENV === "production") {
+      return (
+        <div
+          className={className}
+          style={{
+            fontFamily: "ui-monospace, SFMono-Regular, monospace",
+            fontSize: "11px",
+            color: "var(--short)",
+            border: "1px solid rgba(238,80,80,0.3)",
+            padding: "8px 10px",
+            borderRadius: "4px",
+            background: "rgba(238,80,80,0.06)",
+          }}
+        >
+          captcha unavailable — operator must set NEXT_PUBLIC_TURNSTILE_SITE_KEY
+        </div>
+      );
+    }
+    // Local dev with no key — render nothing. Server-side fail-OPEN
+    // accepts the signup without a token.
+    return null;
+  }
+
+  return <div ref={containerRef} className={className} />;
+}

--- a/app/components/waitlist/TurnstileGate.tsx
+++ b/app/components/waitlist/TurnstileGate.tsx
@@ -70,7 +70,7 @@ function loadTurnstileScript(): Promise<void> {
   if (getTurnstile()) return Promise.resolve();
   if (scriptPromise) return scriptPromise;
 
-  scriptPromise = new Promise<void>((resolve, reject) => {
+  const promise = new Promise<void>((resolve, reject) => {
     const existing = document.querySelector<HTMLScriptElement>(
       `script[src^="https://challenges.cloudflare.com/turnstile"]`,
     );
@@ -94,8 +94,23 @@ function loadTurnstileScript(): Promise<void> {
     );
     document.head.appendChild(script);
   });
+  scriptPromise = promise;
 
-  return scriptPromise;
+  // Reset the cached promise on rejection so a subsequent mount (e.g.,
+  // after the user re-solves a captcha-rejected POST and the widget
+  // remounts via turnstileNonce, or after a network outage clears)
+  // retries the script load from scratch. Without this reset the
+  // cached rejected promise routes every later mount straight to the
+  // catch arm and the widget never recovers until a full page reload.
+  //
+  // This attaches a SEPARATE catch chain that doesn't interfere with
+  // the caller's promise handlers — each .then/.catch chain on a
+  // promise sees the original rejection independently.
+  promise.catch(() => {
+    if (scriptPromise === promise) scriptPromise = null;
+  });
+
+  return promise;
 }
 
 export function TurnstileGate({

--- a/app/components/waitlist/TurnstileGate.tsx
+++ b/app/components/waitlist/TurnstileGate.tsx
@@ -154,7 +154,14 @@ export function TurnstileGate({
           "expired-callback": () => onTokenRef.current(null),
           "error-callback": () => onTokenRef.current(null),
           theme: "dark",
-          appearance: "always",
+          // Invisible for legitimate users: the widget runs in the background
+          // and only surfaces an interactive challenge if Cloudflare flags the
+          // visitor as suspicious. Keeps 100% of the server-side siteverify
+          // protection with zero UX cost on the happy path (Privy already
+          // shows its own challenge; we don't want a second visible one).
+          // NOTE: pair with a "Managed" widget type on the Cloudflare side so
+          // the invisible/interaction-only behaviour is honoured.
+          appearance: "interaction-only",
           size: "flexible",
         });
       })

--- a/app/lib/waitlist/client-ip.ts
+++ b/app/lib/waitlist/client-ip.ts
@@ -1,0 +1,110 @@
+/**
+ * Client-IP extraction + hashing for the waitlist signup route.
+ *
+ * Pulled into a tiny module so the parser logic is unit-testable in
+ * isolation from the route handler. The route then writes both the raw
+ * IP (column `ip_address`, type inet) and the salted hash (column
+ * `ip_hash`, text) — see `supabase-waitlist-schema.sql` for the column
+ * rationale.
+ */
+
+import { createHash } from "node:crypto";
+
+/**
+ * Extract the originating client IP from request headers, taking the
+ * proxy chain into account.
+ *
+ * Header precedence (most-trustworthy first):
+ *
+ *   1. `cf-connecting-ip` — Cloudflare's single-IP header. Set by
+ *      Cloudflare itself and not propagated from the client. Trusted
+ *      when the request flowed through CF, which is our production
+ *      topology (Vercel sits behind Cloudflare for percolator.trade).
+ *   2. `x-real-ip` — Set by Vercel (and most reverse proxies) to the
+ *      direct peer. Single IP, not a chain. Client-injectable in
+ *      theory but Vercel overwrites whatever the client sent.
+ *   3. `x-forwarded-for` — Comma-separated `client, proxy1, proxy2`
+ *      chain. Used only as a last resort because the chain is built
+ *      up across hops and the leftmost entry can be client-injected
+ *      at the public edge. When we fall through to this header we
+ *      take the LEFTMOST entry — that's the originating client per
+ *      RFC 7239 / de-facto convention.
+ *
+ * Returns `null` when no header gives a syntactically-plausible IP.
+ * The route writes NULL to `ip_address` in that case rather than
+ * failing the signup — a few proxies legitimately strip the
+ * forwarding headers and we shouldn't block real users for it.
+ */
+export function getClientIp(headers: Headers): string | null {
+  const cfIp = headers.get("cf-connecting-ip")?.trim();
+  if (cfIp && isPlausibleIp(cfIp)) return normaliseIp(cfIp);
+
+  const realIp = headers.get("x-real-ip")?.trim();
+  if (realIp && isPlausibleIp(realIp)) return normaliseIp(realIp);
+
+  const xff = headers.get("x-forwarded-for");
+  if (xff) {
+    const first = xff.split(",")[0]?.trim();
+    if (first && isPlausibleIp(first)) return normaliseIp(first);
+  }
+
+  return null;
+}
+
+/**
+ * SHA-256(`${ip}|${salt}`), hex-encoded. The salt is required because
+ * the ~4-billion IPv4 space is brute-forceable against an unsalted
+ * SHA-256 in well under a minute on commodity hardware — without the
+ * salt the "hash" gives no privacy advantage over the raw value.
+ *
+ * Returns `null` when no salt is configured. The route writes NULL to
+ * `ip_hash` in that case (the column is nullable; the operator should
+ * set `WAITLIST_IP_SALT` in production env to enable analytics).
+ *
+ * Stable across process restarts because the salt is configuration,
+ * not memory state. Rotating the salt deliberately breaks the
+ * aggregation in `/admin` spam signals — useful as a recovery action
+ * after a bad-actor wave you want to stop counting against future
+ * normal traffic.
+ */
+export function hashIp(ip: string, salt: string | undefined | null): string | null {
+  if (!salt) return null;
+  return createHash("sha256").update(`${ip}|${salt}`).digest("hex");
+}
+
+/**
+ * Light syntactic check — rejects obviously malformed strings without
+ * trying to fully validate IPv4 / IPv6 grammar (postgres re-validates
+ * on insert via the `inet` column type). The aim is to drop garbage
+ * before it reaches the DB, not to be a parser.
+ */
+function isPlausibleIp(s: string): boolean {
+  if (s.length < 3 || s.length > 64) return false;
+  // IPv4: digits + dots. IPv6: hex + colons + optional dots (mapped form).
+  // Allow brackets around IPv6 and a trailing :port that we strip in
+  // normaliseIp; permit them through the loose pattern here.
+  return /^[\[\]0-9a-fA-F:.\-]+$/.test(s);
+}
+
+/**
+ * Strip the cruft proxies append to the raw IP — surrounding brackets
+ * on IPv6, trailing `:port` on IPv4. IPv6 with a port is always
+ * bracketed (`[::1]:443`) so we can strip the bracket pair and the
+ * post-bracket port safely; bare IPv6 has no port and stays intact.
+ */
+function normaliseIp(raw: string): string {
+  let s = raw;
+  // Bracketed IPv6: `[2001:db8::1]:443` → `2001:db8::1`
+  if (s.startsWith("[")) {
+    const end = s.indexOf("]");
+    if (end > 0) return s.slice(1, end);
+  }
+  // IPv4 with port: `192.0.2.1:443` → `192.0.2.1`. Detect by exactly
+  // one colon AND a dot before that colon (IPv4 has dots, IPv6 has
+  // multiple colons).
+  const firstColon = s.indexOf(":");
+  if (firstColon !== -1 && s.lastIndexOf(":") === firstColon && s.indexOf(".") !== -1) {
+    return s.slice(0, firstColon);
+  }
+  return s;
+}

--- a/app/lib/waitlist/client-ip.ts
+++ b/app/lib/waitlist/client-ip.ts
@@ -77,14 +77,37 @@ function checkIp(raw: string): string | null {
 }
 
 /**
+ * Minimum salt length the hash function will accept. 16 ASCII chars
+ * ≈ 128 bits of entropy if the operator picks a random string, which
+ * is the standard floor for salts intended to defeat offline
+ * precomputation. Anything shorter is treated as "no salt" — silently
+ * accepting a 1-char salt would produce a "hash" whose precompute
+ * cost is just 256× the unsalted IPv4 enumeration (~seconds on
+ * commodity hardware), giving no real privacy advantage over the
+ * raw IP. Fail-noisily-and-store-NULL is the safer posture.
+ */
+const MIN_SALT_LENGTH = 16;
+
+/**
+ * Module-local "we've already warned about this" flag so a
+ * misconfigured deploy emits one warning at first signup rather than
+ * one per signup forever. Reset by process restart, which matches the
+ * intent — operators see it again only if the bad config persists
+ * across a restart.
+ */
+let _shortSaltWarned = false;
+
+/**
  * SHA-256(`${ip}|${salt}`), hex-encoded. The salt is required because
  * the ~4-billion IPv4 space is brute-forceable against an unsalted
  * SHA-256 in well under a minute on commodity hardware — without the
  * salt the "hash" gives no privacy advantage over the raw value.
  *
- * Returns `null` when no salt is configured. The route writes NULL to
+ * Returns `null` when no salt is configured OR when the configured
+ * salt is shorter than `MIN_SALT_LENGTH`. The route writes NULL to
  * `ip_hash` in that case (the column is nullable; the operator should
- * set `WAITLIST_IP_SALT` in production env to enable analytics).
+ * set a sufficiently long `WAITLIST_IP_SALT` in production env to
+ * enable analytics).
  *
  * Stable across process restarts because the salt is configuration,
  * not memory state. Rotating the salt deliberately breaks the
@@ -94,6 +117,16 @@ function checkIp(raw: string): string | null {
  */
 export function hashIp(ip: string, salt: string | undefined | null): string | null {
   if (!salt) return null;
+  if (salt.length < MIN_SALT_LENGTH) {
+    if (!_shortSaltWarned) {
+      _shortSaltWarned = true;
+      console.warn(
+        `[waitlist] WAITLIST_IP_SALT is ${salt.length} chars; ` +
+          `min ${MIN_SALT_LENGTH} required. Treating as unset — ip_hash will be NULL.`,
+      );
+    }
+    return null;
+  }
   return createHash("sha256").update(`${ip}|${salt}`).digest("hex");
 }
 

--- a/app/lib/waitlist/client-ip.ts
+++ b/app/lib/waitlist/client-ip.ts
@@ -25,11 +25,14 @@ import { isIP } from "node:net";
  *      direct peer. Single IP, not a chain. Client-injectable in
  *      theory but Vercel overwrites whatever the client sent.
  *   3. `x-forwarded-for` — Comma-separated `client, proxy1, proxy2`
- *      chain. Used only as a last resort because the chain is built
- *      up across hops and the leftmost entry can be client-injected
- *      at the public edge. When we fall through to this header we
- *      take the LEFTMOST entry — that's the originating client per
- *      RFC 7239 / de-facto convention.
+ *      chain. **Non-production fallback only.** In production the
+ *      CF→Vercel topology guarantees one of the two headers above
+ *      always carries the real client IP, so this last-resort path
+ *      is dead code legitimately AND spoofable by anyone who reaches
+ *      it (the leftmost entry is set by the public edge — including
+ *      a direct-to-Vercel attacker who bypassed Cloudflare). We
+ *      consult it ONLY in non-prod so local dev proxy setups that
+ *      rely on it (e.g., ngrok, custom test rigs) keep working.
  *
  * Returns `null` when no header gives a syntactically-plausible IP.
  * The route writes NULL to `ip_address` in that case rather than
@@ -44,6 +47,16 @@ export function getClientIp(headers: Headers): string | null {
   const realIp = headers.get("x-real-ip")?.trim();
   const realChecked = realIp ? checkIp(realIp) : null;
   if (realChecked) return realChecked;
+
+  // x-forwarded-for is the only header on this chain whose leftmost
+  // entry is client-injectable at the public edge. In production
+  // (CF→Vercel) one of the two headers above always wins, so reaching
+  // this fallback would imply a direct-to-Vercel attacker spoofing
+  // the chain — refuse to trust XFF in that case. Keep the dev path
+  // alive for local proxy tooling that legitimately uses it.
+  if (process.env.NODE_ENV === "production") {
+    return null;
+  }
 
   const xff = headers.get("x-forwarded-for");
   if (xff) {

--- a/app/lib/waitlist/client-ip.ts
+++ b/app/lib/waitlist/client-ip.ts
@@ -9,6 +9,7 @@
  */
 
 import { createHash } from "node:crypto";
+import { isIP } from "node:net";
 
 /**
  * Extract the originating client IP from request headers, taking the
@@ -37,18 +38,42 @@ import { createHash } from "node:crypto";
  */
 export function getClientIp(headers: Headers): string | null {
   const cfIp = headers.get("cf-connecting-ip")?.trim();
-  if (cfIp && isPlausibleIp(cfIp)) return normaliseIp(cfIp);
+  const cfChecked = cfIp ? checkIp(cfIp) : null;
+  if (cfChecked) return cfChecked;
 
   const realIp = headers.get("x-real-ip")?.trim();
-  if (realIp && isPlausibleIp(realIp)) return normaliseIp(realIp);
+  const realChecked = realIp ? checkIp(realIp) : null;
+  if (realChecked) return realChecked;
 
   const xff = headers.get("x-forwarded-for");
   if (xff) {
     const first = xff.split(",")[0]?.trim();
-    if (first && isPlausibleIp(first)) return normaliseIp(first);
+    const xffChecked = first ? checkIp(first) : null;
+    if (xffChecked) return xffChecked;
   }
 
   return null;
+}
+
+/**
+ * Normalise a header value and validate it as a real IPv4 / IPv6 address.
+ * Returns the validated address string on success, `null` on anything
+ * else. The validation uses Node's built-in `net.isIP()` which matches
+ * the grammar Postgres `inet` accepts in practice — meaning a value
+ * that passes this check will not crash the downstream `INSERT`.
+ *
+ * Pulled out of `getClientIp` so all three header paths share the same
+ * normalise + strict-check + reject logic. Earlier code had a loose
+ * `/^[\[\]0-9a-fA-F:.\-]+$/` regex that admitted strings like
+ * `"1.2.3.4.5"`, `"::::::"`, and `"a:b:c:d.e"` — each of which would
+ * pass our test but make Postgres throw `22P02` on insert, abort the
+ * whole row, and surface as a confusing 500 to the user. `net.isIP()`
+ * closes that gap.
+ */
+function checkIp(raw: string): string | null {
+  const normalised = normaliseIp(raw);
+  if (isIP(normalised) === 0) return null;
+  return normalised;
 }
 
 /**
@@ -73,24 +98,12 @@ export function hashIp(ip: string, salt: string | undefined | null): string | nu
 }
 
 /**
- * Light syntactic check — rejects obviously malformed strings without
- * trying to fully validate IPv4 / IPv6 grammar (postgres re-validates
- * on insert via the `inet` column type). The aim is to drop garbage
- * before it reaches the DB, not to be a parser.
- */
-function isPlausibleIp(s: string): boolean {
-  if (s.length < 3 || s.length > 64) return false;
-  // IPv4: digits + dots. IPv6: hex + colons + optional dots (mapped form).
-  // Allow brackets around IPv6 and a trailing :port that we strip in
-  // normaliseIp; permit them through the loose pattern here.
-  return /^[\[\]0-9a-fA-F:.\-]+$/.test(s);
-}
-
-/**
  * Strip the cruft proxies append to the raw IP — surrounding brackets
  * on IPv6, trailing `:port` on IPv4. IPv6 with a port is always
  * bracketed (`[::1]:443`) so we can strip the bracket pair and the
  * post-bracket port safely; bare IPv6 has no port and stays intact.
+ *
+ * Does NOT validate — that's `checkIp`'s job via `net.isIP()`.
  */
 function normaliseIp(raw: string): string {
   let s = raw;

--- a/app/lib/waitlist/disposable-domains.ts
+++ b/app/lib/waitlist/disposable-domains.ts
@@ -1,0 +1,76 @@
+/**
+ * Disposable / throwaway email-domain blocklist.
+ *
+ * Shared by:
+ *   • `app/api/waitlist/signup/route.ts` — rejects the signup at the
+ *     door so the row never lands in the table.
+ *   • `app/api/admin/waitlist/stats/route.ts` — flags rows that
+ *     pre-date the signup-time block (legacy entries) so the operator
+ *     can bulk-archive on the next maintenance pass.
+ *
+ * Both callers used to define this list inline and would drift the
+ * moment one updated and the other didn't. One source of truth keeps
+ * the admin panel's count consistent with what the signup route would
+ * have rejected.
+ *
+ * Match semantics: the part after the LAST `@` in the lowercased
+ * email is checked for exact membership. Subdomains are intentionally
+ * NOT matched — a legit forwarder occasionally lives at e.g.
+ * `family.mailbox.org`. Operators who want stricter matching can swap
+ * `has(domain)` for a `Set.prototype.intersection` check.
+ *
+ * Maintenance: when adding entries, keep alphabetical-ish grouping and
+ * one line per ~4 entries to keep diffs minimal. The numbered count in
+ * the JSDoc above the export below is informational — kept loosely
+ * accurate but not asserted-in-test.
+ */
+
+/**
+ * Throwaway-domain list (89 entries), captured from the long-tail of
+ * disposable-mail providers commonly used by bot farms. Coverage
+ * focuses on the 10minutemail / mailinator / guerrillamail families
+ * and their many ccTLD / wildcard mirrors.
+ */
+export const DISPOSABLE_EMAIL_DOMAINS: ReadonlySet<string> = new Set<string>([
+  "mailinator.com","guerrillamail.com","guerrillamail.net","guerrillamail.org",
+  "guerrillamailblock.com","sharklasers.com","grr.la","tempmail.com",
+  "temp-mail.org","temp-mail.io","tempmailo.com","10minutemail.com",
+  "10minutemail.net","yopmail.com","yopmail.net","throwawaymail.com",
+  "trashmail.com","trashmail.de","dispostable.com","fakeinbox.com",
+  "emailondeck.com","mailnesia.com","getnada.com","nada.email",
+  "mintemail.com","mohmal.com","tmail.ws","tmpmail.org","mailpoof.com",
+  "emaildrop.io","tempr.email","mailcatch.com","spam4.me","mvrht.com",
+  "owlpic.com","spamgourmet.com","maildrop.cc","mailtemporaire.fr",
+  "mailtemp.info","my10minutemail.com","mailbox.in.ua","disbox.net",
+  "fakemail.net","tempinbox.com","temp-mail.ru","mailto.plus",
+  "fexpost.com","fexbox.org","inboxbear.com","linshiyouxiang.net",
+  "monemail.fr.nf","incognitomail.com","spambog.com","spambox.us",
+  "tafmail.com","tempmail.dev","tempmail.email","tempmail.us.com",
+  "tempmail.de","tempmail.plus","minutemail.com","jetable.org",
+  "anonbox.net","throwam.com","mailcuk.com","mailsac.com","spambox.org",
+  "byom.de","mytemp.email","tempemail.net","mvrht.net","clrmail.com",
+  "boximail.com","emltmp.com","mailsink.com","mfsa.ru","kepfree.com",
+  "boltbox.com","forexnews.bz","fivemail.de","spamavert.com",
+  "rcpt.at","tempemail.com","tempemail.co","instant-mail.de",
+  "thraml.com","trash-mail.com","fudgerub.com","mailimate.com",
+]);
+
+/**
+ * True iff `email`'s domain is in the disposable blocklist.
+ *
+ * The caller should already have validated the email shape (this
+ * helper doesn't re-check). The domain is extracted from after the
+ * LAST `@` so display-name-format strings like `"Alice <a@x>"` won't
+ * accidentally bypass; the signup route lowercases before validation
+ * so this helper assumes lowercase input and does NOT re-lowercase.
+ *
+ * Returns `false` for malformed input (no `@`, trailing `@`,
+ * leading `@`) — the route's email-shape check rejects those first;
+ * this helper is purely the disposable-vs-real distinction.
+ */
+export function isDisposableEmail(email: string): boolean {
+  const at = email.lastIndexOf("@");
+  if (at <= 0 || at >= email.length - 1) return false;
+  const domain = email.slice(at + 1);
+  return DISPOSABLE_EMAIL_DOMAINS.has(domain);
+}

--- a/app/lib/waitlist/disposable-domains.ts
+++ b/app/lib/waitlist/disposable-domains.ts
@@ -32,6 +32,10 @@
  * and their many ccTLD / wildcard mirrors.
  */
 export const DISPOSABLE_EMAIL_DOMAINS: ReadonlySet<string> = new Set<string>([
+  // Jun-2026 bot-wave: attacker-controlled catch-all domains. Script signups
+  // to these (random/sequential local-parts) drove most of the wave;
+  // akaikadot.com surfaced Jun 6 (sequential aster1..N).
+  "tirtamulya.xyz","wshu.net","minitts.net","mtupu.com","akaikadot.com",
   "mailinator.com","guerrillamail.com","guerrillamail.net","guerrillamail.org",
   "guerrillamailblock.com","sharklasers.com","grr.la","tempmail.com",
   "temp-mail.org","temp-mail.io","tempmailo.com","10minutemail.com",

--- a/app/lib/waitlist/turnstile.ts
+++ b/app/lib/waitlist/turnstile.ts
@@ -1,0 +1,90 @@
+/**
+ * Cloudflare Turnstile server-side verification for the waitlist signup
+ * route. Pulled into a tiny module so the verify call is unit-testable
+ * with a mocked fetch and so the env-var posture is documented in one
+ * place.
+ *
+ * Posture:
+ *   • Production (NODE_ENV === "production"): fail-CLOSED. A missing
+ *     TURNSTILE_SECRET in prod is a configuration error and signups
+ *     are blocked until it's set. A missing client token is also
+ *     blocked — bots that skipped the widget never get past the gate.
+ *   • Non-prod: fail-OPEN when TURNSTILE_SECRET is missing, so local
+ *     dev / CI / smoke tests don't have to provision a Cloudflare
+ *     account to exercise the signup flow.
+ *
+ * The secret never leaves this module; the wire format to Cloudflare's
+ * siteverify endpoint is `application/x-www-form-urlencoded` per the
+ * official docs.
+ */
+
+export type TurnstileVerdict =
+  | { ok: true }
+  | { ok: false; reason: "missing_token" | "verification_failed" | "verification_error" | "not_configured" };
+
+const SITEVERIFY_URL =
+  "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+/**
+ * Verify a Turnstile widget response token against Cloudflare's
+ * siteverify endpoint. Returns `{ ok: true }` on a valid token,
+ * `{ ok: false, reason }` otherwise.
+ *
+ * `clientIp`, when supplied, is forwarded as `remoteip` so Cloudflare
+ * can cross-check against the IP the challenge was issued to. Passing
+ * the wrong IP (or omitting it) doesn't fail verification — Cloudflare
+ * treats it as a soft hint — but binding it tightens the assertion.
+ */
+export async function verifyTurnstile(
+  token: string | null | undefined,
+  clientIp: string | null,
+): Promise<TurnstileVerdict> {
+  const secret = process.env.TURNSTILE_SECRET?.trim();
+
+  if (!secret) {
+    if (process.env.NODE_ENV !== "production") {
+      // Local dev / CI: no secret → no gate. Mirrors the existing
+      // email-rate-limit fail-open posture so contributors don't
+      // have to provision Cloudflare before they can exercise the
+      // signup form.
+      return { ok: true };
+    }
+    // Prod with no secret = misconfiguration. Refuse the signup
+    // rather than silently let a bot past — the operator will see
+    // the error in logs + Sentry and fix the env var.
+    console.error("[waitlist] TURNSTILE_SECRET missing in production");
+    return { ok: false, reason: "not_configured" };
+  }
+
+  if (!token || typeof token !== "string" || token.length === 0) {
+    return { ok: false, reason: "missing_token" };
+  }
+
+  const params = new URLSearchParams({ secret, response: token });
+  if (clientIp) params.set("remoteip", clientIp);
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 5_000);
+    const res = await fetch(SITEVERIFY_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: params,
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    if (!res.ok) {
+      console.warn("[waitlist] turnstile siteverify non-2xx", res.status);
+      return { ok: false, reason: "verification_error" };
+    }
+    const data = (await res.json()) as { success?: unknown };
+    if (data?.success === true) return { ok: true };
+    return { ok: false, reason: "verification_failed" };
+  } catch (err) {
+    // Network error / abort / non-JSON. Fail-CLOSED — a Cloudflare
+    // outage shouldn't let bots past while honest users are blocked
+    // by the widget UI anyway.
+    console.error("[waitlist] turnstile siteverify error", err);
+    return { ok: false, reason: "verification_error" };
+  }
+}

--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -480,7 +480,11 @@ function addSecurityHeaders(response: NextResponse, nonce?: string) {
   const scriptNonce = nonce ? `'nonce-${nonce}' ` : "";
   const csp = [
     "default-src 'self'",
-    `script-src 'self' ${scriptNonce}'unsafe-inline' https://cdn.vercel-insights.com`,
+    // challenges.cloudflare.com: Turnstile widget script (api.js). Loaded
+    // by `components/waitlist/TurnstileGate.tsx` on the /waitlist surface
+    // to render the bot-defence challenge; without this entry the script
+    // is blocked and every submit button stays disabled.
+    `script-src 'self' ${scriptNonce}'unsafe-inline' https://cdn.vercel-insights.com https://challenges.cloudflare.com`,
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "font-src 'self' https://fonts.gstatic.com",
     "img-src 'self' data: https: blob:",
@@ -490,10 +494,15 @@ function addSecurityHeaders(response: NextResponse, nonce?: string) {
     // and REST fallback (https://). The subdomain must resolve via DNS CNAME to
     // percolator-api-production.up.railway.app — without this CSP entry browsers
     // would block the connection even after DNS is configured.
-    "connect-src 'self' https://*.solana.com wss://*.solana.com https://*.supabase.co wss://*.supabase.co https://*.vercel-insights.com https://api.coingecko.com https://api.geckoterminal.com https://*.helius-rpc.com wss://*.helius-rpc.com https://api.dexscreener.com https://hermes.pyth.network https://*.up.railway.app wss://*.up.railway.app https://api.percolatorlaunch.com wss://api.percolatorlaunch.com https://lite.jup.ag https://token.jup.ag https://tokens.jup.ag https://auth.privy.io https://embedded-wallets.privy.io https://*.privy.systems https://*.rpc.privy.systems https://explorer-api.walletconnect.com wss://relay.walletconnect.com wss://relay.walletconnect.org wss://www.walletlink.org blob:",
+    // challenges.cloudflare.com is appended for the Turnstile widget's
+    // XHR back-channel (telemetry + challenge-state checks). Same
+    // origin as the script load.
+    "connect-src 'self' https://*.solana.com wss://*.solana.com https://*.supabase.co wss://*.supabase.co https://*.vercel-insights.com https://api.coingecko.com https://api.geckoterminal.com https://*.helius-rpc.com wss://*.helius-rpc.com https://api.dexscreener.com https://hermes.pyth.network https://*.up.railway.app wss://*.up.railway.app https://api.percolatorlaunch.com wss://api.percolatorlaunch.com https://lite.jup.ag https://token.jup.ag https://tokens.jup.ag https://auth.privy.io https://embedded-wallets.privy.io https://*.privy.systems https://*.rpc.privy.systems https://explorer-api.walletconnect.com wss://relay.walletconnect.com wss://relay.walletconnect.org wss://www.walletlink.org https://challenges.cloudflare.com blob:",
     // Removed https://*.vercel.app wildcard (issue #635) — no legitimate use case for embedding
     // arbitrary Vercel-hosted content in iframes. frame-src controls outbound iframe embedding.
-    "frame-src 'self' https://auth.privy.io https://embedded-wallets.privy.io https://*.privy.systems https://phantom.app https://solflare.com https://verify.walletconnect.com https://verify.walletconnect.org",
+    // challenges.cloudflare.com is the iframe origin the Turnstile widget
+    // renders into — distinct from the api.js script-src entry above.
+    "frame-src 'self' https://auth.privy.io https://embedded-wallets.privy.io https://*.privy.systems https://phantom.app https://solflare.com https://verify.walletconnect.com https://verify.walletconnect.org https://challenges.cloudflare.com",
     // Removed https://*.vercel.app wildcard (issue #632) — any Vercel project could embed the app,
     // creating a clickjacking surface over wallet/sign flows. Keep only the specific preview URL.
     "frame-ancestors 'self' https://percolatorlaunch.com https://*.percolatorlaunch.com https://percolator-launch.vercel.app",

--- a/supabase-waitlist-schema.sql
+++ b/supabase-waitlist-schema.sql
@@ -63,7 +63,14 @@ alter table public.waitlist add column if not exists referred_by_code text;
 -- Both columns are nullable: legacy rows pre-date the capture, and a few
 -- proxies can strip the forwarding headers (the route handles that by
 -- writing NULL rather than failing the signup).
+--
+-- Both ALTERs are explicit because the CREATE TABLE above is gated on
+-- IF NOT EXISTS — projects bootstrapped before either column was added
+-- to this file would otherwise skip the create AND have no alter to
+-- catch up, leaving the downstream index creation to fail with
+-- "column does not exist".
 alter table public.waitlist add column if not exists ip_address inet;
+alter table public.waitlist add column if not exists ip_hash text;
 -- "Have we emailed this user their referral code?" Set by the signup route
 -- after a successful confirmation send (new signups) and by the one-time
 -- backfill script (pre-existing signups). Lets the backfill be re-runnable
@@ -123,7 +130,16 @@ create index if not exists waitlist_referred_by_code_idx
 -- the salt is stable, and an operator who rotates the salt deliberately
 -- breaks that aggregation as a recovery action. Partial — legacy rows
 -- and the rare strip-forwarding-header signups have NULL.
-create index if not exists waitlist_ip_hash_idx
+--
+-- CONCURRENTLY avoids the ACCESS EXCLUSIVE lock a plain CREATE INDEX
+-- would take during build — which would block every signup INSERT for
+-- the duration. On a small table the difference is sub-second but the
+-- schema file is meant to be safely re-runnable against the live
+-- project, so we use the safer form. CONCURRENTLY cannot run inside a
+-- transaction block — Supabase's SQL editor runs each top-level
+-- statement standalone so this is fine, but anyone wrapping the whole
+-- file in BEGIN/COMMIT must run this statement separately.
+create index concurrently if not exists waitlist_ip_hash_idx
   on public.waitlist (ip_hash)
   where ip_hash is not null;
 

--- a/supabase-waitlist-schema.sql
+++ b/supabase-waitlist-schema.sql
@@ -47,6 +47,23 @@ alter table public.waitlist alter column message drop not null;
 alter table public.waitlist add column if not exists email text;
 alter table public.waitlist add column if not exists referral_code text;
 alter table public.waitlist add column if not exists referred_by_code text;
+
+-- IP tracking for bot/abuse defense. Two complementary columns:
+--   • ip_address (inet): the raw IPv4/IPv6 the request arrived from, used
+--     by the operator for one-off forensic lookups in /admin. Stored raw
+--     so an operator can match a signup against a known bad host without
+--     a hashing key. Considered PII; the retention policy is operator-set
+--     (e.g. a cron that nulls ip_address older than 90 days while keeping
+--     ip_hash for analytics).
+--   • ip_hash (text): SHA-256 of the ip_address with a server-side salt,
+--     populated by the signup route alongside ip_address. Drives the
+--     velocity / cross-referrer signals in the admin spam panel. Safe to
+--     retain indefinitely because the salt is server-side and rotation
+--     of the salt unlinks past hashes from future ones.
+-- Both columns are nullable: legacy rows pre-date the capture, and a few
+-- proxies can strip the forwarding headers (the route handles that by
+-- writing NULL rather than failing the signup).
+alter table public.waitlist add column if not exists ip_address inet;
 -- "Have we emailed this user their referral code?" Set by the signup route
 -- after a successful confirmation send (new signups) and by the one-time
 -- backfill script (pre-existing signups). Lets the backfill be re-runnable
@@ -99,6 +116,16 @@ create index if not exists waitlist_referral_code_idx
 create index if not exists waitlist_referred_by_code_idx
   on public.waitlist (referred_by_code)
   where referred_by_code is not null;
+
+-- IP-velocity index for the admin spam-signals panel. Hash, not raw — the
+-- velocity queries group by ip_hash so a single botnet rotating IP-text-
+-- across-runs but reusing the same source still aggregates correctly when
+-- the salt is stable, and an operator who rotates the salt deliberately
+-- breaks that aggregation as a recovery action. Partial — legacy rows
+-- and the rare strip-forwarding-header signups have NULL.
+create index if not exists waitlist_ip_hash_idx
+  on public.waitlist (ip_hash)
+  where ip_hash is not null;
 
 -- ─── Crockford base32 code generator ────────────────────────────────────────
 -- Alphabet excludes I, L, O, U — avoids visual confusion (1/I, 0/O) and the


### PR DESCRIPTION
Consolidates the waitlist bot-defense work into one mergeable PR. **Supersedes #2192 and #2196.**

Base is **@0x-SquidSol's #2192** (all 16 commits preserved, co-authored) — a comprehensive, well-tested server-side pass — plus three changes from the post-mortem investigation of the Jun-2026 wave (which cleaned ~4,575 confirmed-fake signups via on-chain census + full Privy cross-reference).

## From #2192 (Squid) — the core defense
- Per-IP signup cap (`WAITLIST_IP_DAILY_CAP`, 5/day) + **per-referral-code burn-rate cap** (`WAITLIST_REFCODE_HOURLY_CAP`, 20/hr) — the highest-impact rule (kills farm-one-code).
- Disposable-email-domain block (shared lib), `ip_hash` (salted) + `ip_address` columns + idempotent migration.
- Cloudflare Turnstile **server-side siteverify**, ordered before the fast-path and rate limit; fail-closed in prod, fail-open in dev.
- Admin IP spam signals, minimum dwell-time check, 9 self-audit fixes, full test coverage.

## Added on top (this consolidation)
1. **Invisible Turnstile** — `appearance: "interaction-only"` so the widget is invisible for legit users (Privy already shows its own challenge). Full server-side protection, **zero UX friction**. Set the Cloudflare widget to **Managed** mode.
2. **Attacker catch-alls added to the denylist** — `tirtamulya.xyz`, `wshu.net`, `minitts.net`, `mtupu.com`, `akaikadot.com` (the wave's domains; the generic list missed them).
3. **Bot user-agent gate** — rejects `python`/`curl`/`aiohttp`/`urllib` + the hardcoded `Chrome/120` spoof + stub UAs, as a cheap pre-filter before the Turnstile network call. Escape hatch: `WAITLIST_ALLOW_CHROME120=1`.

## Tests
85 waitlist tests pass (his suite + a new bot-UA guard test); typecheck clean.

## Before merge
- Set env: `TURNSTILE_SECRET`, `NEXT_PUBLIC_TURNSTILE_SITE_KEY` (Managed widget), `WAITLIST_IP_SALT` (≥16 chars), confirm `UPSTASH_REDIS_REST_URL/TOKEN` in prod (limiters fail-open without them).
- **Security reviewer required** (touches `/api` + `middleware`).
- Run the schema migration (`supabase-waitlist-schema.sql`) — adds `ip_address` + `ip_hash` index idempotently.

Co-authored-by: 0x-SquidSol <0x-SquidSol@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)