### PR TITLE
fix(api): use shared getClientIp in devnet-mirror-mint

### DIFF
--- a/app/__tests__/api/devnet-mirror-mint.test.ts
+++ b/app/__tests__/api/devnet-mirror-mint.test.ts
@@ -11,14 +11,14 @@
 
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { resolve } from "node:path";
 
 // ─── Trusted client IP for rate limiting ───────────────────────────────────
 
 describe("devnet-mirror-mint uses shared getClientIp (x-real-ip fallback)", () => {
   it("imports getClientIp from @/lib/get-client-ip instead of a local copy", () => {
     const source = readFileSync(
-      join(process.cwd(), "app/api/devnet-mirror-mint/route.ts"),
+      resolve(__dirname, "../../app/api/devnet-mirror-mint/route.ts"),
       "utf8",
     );
     expect(source).toContain('import { getClientIp } from "@/lib/get-client-ip"');

--- a/app/__tests__/api/devnet-mirror-mint.test.ts
+++ b/app/__tests__/api/devnet-mirror-mint.test.ts
@@ -10,6 +10,22 @@
  */
 
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// ─── Trusted client IP for rate limiting ───────────────────────────────────
+
+describe("devnet-mirror-mint uses shared getClientIp (x-real-ip fallback)", () => {
+  it("imports getClientIp from @/lib/get-client-ip instead of a local copy", () => {
+    const source = readFileSync(
+      join(process.cwd(), "app/api/devnet-mirror-mint/route.ts"),
+      "utf8",
+    );
+    expect(source).toContain('import { getClientIp } from "@/lib/get-client-ip"');
+    expect(source).toContain("const clientIp = getClientIp(req);");
+    expect(source).not.toMatch(/function getClientIp\s*\(/);
+  });
+});
 
 // ─── GH#1477: walletAddress validation ──────────────────────────────────────
 

--- a/app/__tests__/lib/symbol-utils.test.ts
+++ b/app/__tests__/lib/symbol-utils.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+  SLUG_ALIASES,
+  isPlaceholderSymbol,
+  sanitizeSymbol,
+} from "@/lib/symbol-utils";
+
+const SOL_MINT = "So11111111111111111111111111111111111111112";
+
+describe("SLUG_ALIASES", () => {
+  it("maps SOL and WSOL to the same wrapped SOL mint", () => {
+    expect(SLUG_ALIASES.SOL).toBe(SLUG_ALIASES.WSOL);
+    expect(SLUG_ALIASES.SOL).toBe(SOL_MINT);
+  });
+
+  it("includes canonical addresses for major tokens", () => {
+    expect(SLUG_ALIASES.USDC).toMatch(/^[1-9A-HJ-NP-Za-km-z]{32,44}$/);
+    expect(SLUG_ALIASES.BONK).toMatch(/^[1-9A-HJ-NP-Za-km-z]{32,44}$/);
+  });
+});
+
+describe("isPlaceholderSymbol", () => {
+  it("returns true for null, undefined, and empty string", () => {
+    expect(isPlaceholderSymbol(null, SOL_MINT)).toBe(true);
+    expect(isPlaceholderSymbol(undefined, SOL_MINT)).toBe(true);
+    expect(isPlaceholderSymbol("", SOL_MINT)).toBe(true);
+  });
+
+  it("returns false for real token names", () => {
+    expect(isPlaceholderSymbol("SOL", SOL_MINT)).toBe(false);
+    expect(isPlaceholderSymbol("USDC", "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v")).toBe(false);
+  });
+
+  it("returns true when symbol is a prefix of the mint address", () => {
+    expect(isPlaceholderSymbol("So11111", SOL_MINT)).toBe(true);
+  });
+
+  it("returns true for 8-char hex placeholders", () => {
+    expect(isPlaceholderSymbol("a1b2c3d4", "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v")).toBe(true);
+    expect(isPlaceholderSymbol("A1B2C3D4", "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v")).toBe(true);
+  });
+
+  it("returns true for truncated address patterns with ellipsis", () => {
+    expect(isPlaceholderSymbol("So11…1112", SOL_MINT)).toBe(true);
+    expect(isPlaceholderSymbol("So11...1112", SOL_MINT)).toBe(true);
+  });
+});
+
+describe("sanitizeSymbol", () => {
+  it("returns valid symbols unchanged", () => {
+    expect(sanitizeSymbol("BONK")).toBe("BONK");
+    expect(sanitizeSymbol("SOL", SOL_MINT)).toBe("SOL");
+  });
+
+  it('returns "Token" for empty or placeholder values', () => {
+    expect(sanitizeSymbol(null)).toBe("Token");
+    expect(sanitizeSymbol("")).toBe("Token");
+    expect(sanitizeSymbol("So11111", SOL_MINT)).toBe("Token");
+    expect(sanitizeSymbol("a1b2c3d4", "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v")).toBe("Token");
+  });
+
+  it("skips mint validation when mintAddress is omitted", () => {
+    expect(sanitizeSymbol("So11111")).toBe("So11111");
+  });
+});

--- a/app/app/api/devnet-mirror-mint/route.ts
+++ b/app/app/api/devnet-mirror-mint/route.ts
@@ -40,6 +40,7 @@ import {
   createInitializeMintInstruction,
 } from "@solana/spl-token";
 import { getConfig } from "@/lib/config";
+import { getClientIp } from "@/lib/get-client-ip";
 import { getServiceClient } from "@/lib/supabase";
 import { getDevnetMintSigner } from "@/lib/devnet-signer";
 import { validateTokenMetadata, validateDexScreenerResponse, validateJupiterTokenResponse } from "@/lib/token-metadata-validators";
@@ -125,20 +126,6 @@ async function checkMintRateLimit(ip: string): Promise<{ allowed: boolean; retry
 
   // Fallback to in-memory (local dev or Redis unavailable)
   return checkMintRateLimitFallback(ip);
-}
-
-/** Extract client IP from request headers, respecting proxy depth env var. */
-function getClientIp(req: NextRequest): string {
-  const PROXY_DEPTH = Math.max(0, Number(process.env.TRUSTED_PROXY_DEPTH ?? 1));
-  if (PROXY_DEPTH > 0) {
-    const forwarded = req.headers.get("x-forwarded-for");
-    if (forwarded) {
-      const ips = forwarded.split(",").map((s) => s.trim());
-      const idx = Math.max(0, ips.length - PROXY_DEPTH);
-      return ips[idx] ?? "unknown";
-    }
-  }
-  return "unknown";
 }
 
 const NETWORK =

--- a/app/lib/get-client-ip.ts
+++ b/app/lib/get-client-ip.ts
@@ -5,7 +5,7 @@
  * `x-forwarded-for` chain (rightmost hop is most-trusted). Falls back to
  * `x-real-ip` if the forwarded-for header is absent, then "unknown".
  *
- * Must stay in sync with app/app/api/devnet-mirror-mint/route.ts (getClientIp).
+ * Used by API routes for trusted-proxy-aware rate limiting.
  */
 import type { NextRequest } from "next/server";
 


### PR DESCRIPTION
## Summary

- `/api/devnet-mirror-mint` had a local copy of `getClientIp` that was missing the `x-real-ip` fallback used by the shared `@/lib/get-client-ip` helper
- On Vercel (and similar proxies), requests without `x-forwarded-for` could fall through to `"unknown"`, weakening per-IP rate limiting for devnet mirror mints
- Replaced the duplicate implementation with the shared module, matching the pattern used by other API routes
- Added unit tests for `symbol-utils` (placeholder symbol detection, sanitization, slug aliases)
- Added a regression test to ensure the route keeps importing shared `getClientIp` instead of reintroducing a local copy

## Test plan

- [ ] `pnpm --filter app test __tests__/lib/symbol-utils.test.ts`
- [ ] `pnpm --filter app test __tests__/api/devnet-mirror-mint.test.ts`
- [ ] `pnpm --filter app test __tests__/api/create-market-rate-limit.test.ts`
- [ ] Confirm CI **Test Suite** workflow passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for symbol utilities (aliases, placeholder detection, sanitization).
  * Added validation tests for API route functionality.

* **Refactoring**
  * Consolidated IP retrieval logic into a shared utility.

* **Documentation**
  * Enhanced documentation for IP utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->