### PR TITLE
docs(layout): fix GH#2097 oracle phase vs VRAM padding collision

### DIFF
--- a/app/__tests__/lib/gh2097-padding-layout-guards.test.ts
+++ b/app/__tests__/lib/gh2097-padding-layout-guards.test.ts
@@ -1,0 +1,60 @@
+/**
+ * GH#2097 — VRAM vs Oracle Phase layout collision guards.
+ *
+ * https://github.com/dcccrypto/percolator-launch/issues/2097
+ *
+ * The on-chain fix lands in percolator-prog; these tests pin the byte-layout
+ * contract so future padding packing cannot reintroduce silent aliasing.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  GH2097_COLLIDING_PACKED_LAYOUT,
+  GH2097_DISJOINT_PADDING_LAYOUT,
+  GH2097_ORACLE_PHASE_RANGES,
+  GH2097_VRAM_RANGES,
+  assertDisjointRanges,
+  byteRangesOverlap,
+} from "@/lib/market-config-padding-layout";
+
+describe("GH#2097 packed layout (documented bug)", () => {
+  it("cumul_vol overlaps ewmv", () => {
+    const cumul = GH2097_COLLIDING_PACKED_LAYOUT.find((r) => r.label === "cumul_vol")!;
+    const ewmv = GH2097_COLLIDING_PACKED_LAYOUT.find((r) => r.label === "ewmv")!;
+    expect(byteRangesOverlap(cumul, ewmv)).toBe(true);
+  });
+
+  it("phase2_delta overlaps vol_margin_scale", () => {
+    const phase2 = GH2097_COLLIDING_PACKED_LAYOUT.find((r) => r.label === "phase2_delta")!;
+    const vram = GH2097_COLLIDING_PACKED_LAYOUT.find((r) => r.label === "vol_margin_scale")!;
+    expect(byteRangesOverlap(phase2, vram)).toBe(true);
+  });
+
+  it("last_vol_price overlaps both cumul_vol and ewmv", () => {
+    const price = GH2097_COLLIDING_PACKED_LAYOUT.find((r) => r.label === "last_vol_price")!;
+    const cumul = GH2097_COLLIDING_PACKED_LAYOUT.find((r) => r.label === "cumul_vol")!;
+    const ewmv = GH2097_COLLIDING_PACKED_LAYOUT.find((r) => r.label === "ewmv")!;
+    expect(byteRangesOverlap(price, cumul)).toBe(true);
+    expect(byteRangesOverlap(price, ewmv)).toBe(true);
+  });
+});
+
+describe("GH#2097 disjoint layout (recommended fix)", () => {
+  it("all recommended ranges are pairwise disjoint", () => {
+    expect(assertDisjointRanges(GH2097_DISJOINT_PADDING_LAYOUT)).toBe(true);
+  });
+
+  it("oracle phase block does not overlap VRAM block", () => {
+    for (const oracle of GH2097_ORACLE_PHASE_RANGES) {
+      for (const vram of GH2097_VRAM_RANGES) {
+        expect(byteRangesOverlap(oracle, vram)).toBe(false);
+      }
+    }
+  });
+
+  it("cumulative_volume and phase2_delta_slots are in separate ranges", () => {
+    const cumul = GH2097_DISJOINT_PADDING_LAYOUT.find((r) => r.label === "cumulative_volume_usd_e6")!;
+    const phase2 = GH2097_DISJOINT_PADDING_LAYOUT.find((r) => r.label === "phase2_delta_slots")!;
+    expect(byteRangesOverlap(cumul, phase2)).toBe(false);
+  });
+});

--- a/app/lib/market-config-padding-layout.ts
+++ b/app/lib/market-config-padding-layout.ts
@@ -1,0 +1,72 @@
+/**
+ * GH#2097 / PERC-8452: MarketConfig padding layout contract.
+ *
+ * Oracle Phase (PERC-622) and VRAM state must never share byte ranges inside
+ * `_insurance_isolation_padding`. The collision described in GH#2097 is dormant
+ * today because VRAM persistence is not enabled, but packing both subsystems into
+ * bytes [4..14] would corrupt cumulative volume and phase-2 transition metadata.
+ *
+ * Implementers in percolator-prog should use typed fields (see PERC-622 design doc)
+ * or the disjoint byte map below — never the overlapping packed layout.
+ */
+
+/** Inclusive byte range within a padding blob. */
+export type ByteRange = { start: number; end: number; label: string };
+
+/** Returns true when two inclusive ranges share at least one byte. */
+export function byteRangesOverlap(a: ByteRange, b: ByteRange): boolean {
+  return a.start <= b.end && b.start <= a.end;
+}
+
+/** True when no pair in `ranges` overlaps. */
+export function assertDisjointRanges(ranges: ByteRange[]): boolean {
+  for (let i = 0; i < ranges.length; i++) {
+    for (let j = i + 1; j < ranges.length; j++) {
+      if (byteRangesOverlap(ranges[i], ranges[j])) return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Documented collision from GH#2097 — Oracle Phase vs VRAM packed into the same
+ * `_insurance_isolation_padding[4..14]` window. These ranges overlap by design
+ * (the bug). Kept as regression documentation; must stay overlapping so CI
+ * catches accidental "fixes" that erase the reproducer.
+ */
+export const GH2097_COLLIDING_PACKED_LAYOUT: ByteRange[] = [
+  { start: 3, end: 10, label: "cumul_vol" },
+  { start: 4, end: 7, label: "ewmv" },
+  { start: 8, end: 11, label: "last_vol_price" },
+  { start: 11, end: 13, label: "phase2_delta" },
+  { start: 12, end: 13, label: "vol_margin_scale" },
+];
+
+/**
+ * Recommended disjoint layout inside a 42-byte expanded isolation padding block.
+ * Oracle Phase occupies bytes 0..27; VRAM occupies bytes 28..41.
+ */
+export const GH2097_DISJOINT_PADDING_LAYOUT: ByteRange[] = [
+  { start: 0, end: 0, label: "oracle_phase" },
+  { start: 1, end: 7, label: "oracle_phase_reserved" },
+  { start: 8, end: 15, label: "cumulative_volume_usd_e6" },
+  { start: 16, end: 19, label: "phase2_delta_slots" },
+  { start: 20, end: 27, label: "market_created_slot" },
+  { start: 28, end: 31, label: "vram_reserved" },
+  { start: 32, end: 35, label: "ewmv_e6" },
+  { start: 36, end: 39, label: "last_vol_price_e6" },
+  { start: 40, end: 41, label: "vol_margin_scale_bps" },
+];
+
+/** Oracle-only sub-ranges from the disjoint map (bytes 0..27). */
+export const GH2097_ORACLE_PHASE_RANGES: ByteRange[] =
+  GH2097_DISJOINT_PADDING_LAYOUT.filter((r) =>
+    ["oracle_phase", "oracle_phase_reserved", "cumulative_volume_usd_e6", "phase2_delta_slots", "market_created_slot"].includes(
+      r.label,
+    ),
+  );
+
+/** VRAM-only sub-ranges from the disjoint map (bytes 28..41). */
+export const GH2097_VRAM_RANGES: ByteRange[] = GH2097_DISJOINT_PADDING_LAYOUT.filter((r) =>
+  ["vram_reserved", "ewmv_e6", "last_vol_price_e6", "vol_margin_scale_bps"].includes(r.label),
+);

--- a/docs/GH-2097-vram-oracle-phase-layout.md
+++ b/docs/GH-2097-vram-oracle-phase-layout.md
@@ -1,0 +1,86 @@
+# GH#2097: VRAM vs Oracle Phase Layout Collision
+
+**Issue:** [dcccrypto/percolator-launch#2097](https://github.com/dcccrypto/percolator-launch/issues/2097)  
+**Related:** PERC-622 (oracle phase), PERC-8452 (k2_bps layout analysis in percolator-prog)  
+**Status:** Dormant in production — VRAM persistence is not enabled; collision triggers only if both subsystems share `_insurance_isolation_padding[4..14]`.
+
+---
+
+## Summary
+
+`_insurance_isolation_padding` bytes `[4..14]` in `MarketConfig` were slated to hold **both**:
+
+1. **Oracle Phase state** (PERC-622): `cumulative_volume`, `phase2_delta_slots`, …
+2. **VRAM state**: `ewmv`, `last_vol_price`, `vol_margin_scale_bps`, …
+
+Those byte ranges overlap. Enabling VRAM on any market would corrupt oracle phase tracking; advancing oracle phase would corrupt VRAM state.
+
+---
+
+## Overlapping ranges (buggy packed layout)
+
+| Field | Byte range (in padding) | Width |
+|-------|-------------------------|-------|
+| `cumul_vol` | `[3..11]` | 8 |
+| `ewmv` | `[4..8]` | 4 |
+| `last_vol_price` | `[8..12]` | 4 |
+| `phase2_delta` | `[11..14]` | 3 |
+| `vol_margin_scale` | `[12..14]` | 2 |
+
+Critical overlaps:
+
+- `cumul_vol` ∩ `ewmv` ≠ ∅
+- `ewmv` ∩ `last_vol_price` ≠ ∅
+- `phase2_delta` ∩ `vol_margin_scale` ≠ ∅
+
+---
+
+## Recommended fix
+
+**Do not pack both subsystems into the same padding window.**
+
+### Option A — Typed fields (preferred)
+
+Follow [PERC-622-oracle-phase-transition-design.md](./PERC-622-oracle-phase-transition-design.md) §4.1: append explicit `MarketConfig` fields for oracle phase (`oracle_phase`, `cumulative_volume_usd_e6`, `phase1_oracle_authority`, …). Place VRAM persistence in a **separate** field block after PERC-8452 reserved space. Expand `CONFIG_LEN` with a coordinated program + SDK migration.
+
+### Option B — Disjoint padding map
+
+If byte packing is unavoidable short-term, use non-overlapping regions inside an expanded padding blob:
+
+```
+Bytes 0..15   — Oracle Phase (phase byte, cumulative volume u64, …)
+Bytes 16..27  — Oracle metadata (phase2_delta u32, market_created_slot u64)
+Bytes 28..41  — VRAM (ewmv, last_vol_price, vol_margin_scale_bps)
+```
+
+The layout contract and Vitest guards live in:
+
+- `app/lib/market-config-padding-layout.ts`
+- `app/__tests__/lib/gh2097-padding-layout-guards.test.ts`
+
+---
+
+## Implementation checklist (percolator-prog)
+
+- [ ] Remove any raw-byte accessors that alias oracle + VRAM into `_insurance_isolation_padding[4..14]`
+- [ ] Wire `get_cumulative_volume` / `set_phase2_delta_slots` to dedicated storage (not stubs)
+- [ ] Add `drift_detection` compile-time offset tests mirroring the disjoint map
+- [ ] Bump SDK + slab tier builds atomically when `CONFIG_LEN` changes
+
+---
+
+## Risk if unfixed
+
+| Scenario | Outcome |
+|----------|---------|
+| Enable VRAM on a market | `cumulative_volume` / `phase2_delta` corrupted → wrong phase transitions |
+| Advance oracle phase | VRAM EWMA / margin scale corrupted → wrong margin / funding |
+| Both active | Mutual destruction of both subsystems' state |
+
+---
+
+## References
+
+- [Issue #2097](https://github.com/dcccrypto/percolator-launch/issues/2097)
+- [PERC-622 design](./PERC-622-oracle-phase-transition-design.md)
+- [Threat model — VRAM audit](./threat-model.md#vram-audit-results-idle-audit-2026-03-31-0000-utc)

--- a/docs/PERC-622-oracle-phase-transition-design.md
+++ b/docs/PERC-622-oracle-phase-transition-design.md
@@ -139,6 +139,12 @@ Total: 1,024 + 96 = 1,120 bytes. Within 10KB account limit comfortably. Needs `r
 - Existing markets (pre-PERC-622) default to `oracle_phase = 2` (Phase 3 / mature) via a fallback: if `market_created_slot` is from before the protocol upgrade slot, treat as Phase 3.
 - New markets start at `oracle_phase = 0` (Phase 1) from InitMarket.
 
+### 4.4 GH#2097 — do not pack into `_insurance_isolation_padding`
+
+Oracle Phase fields must **not** share bytes `[4..14]` of `_insurance_isolation_padding` with VRAM fields (`ewmv`, `last_vol_price`, `vol_margin_scale_bps`). That packed layout collides on `cumulative_volume` and `phase2_delta_slots` (see [GH-2097-vram-oracle-phase-layout.md](./GH-2097-vram-oracle-phase-layout.md)).
+
+Use the explicit typed fields in §4.1, or the disjoint byte map in `app/lib/market-config-padding-layout.ts`. Never alias both subsystems into the same padding window.
+
 ---
 
 ## 5. Oracle Source Logic Per Phase


### PR DESCRIPTION
## Summary

Fixes layout guidance for dcccrypto/percolator-launch#2097.

Oracle Phase (PERC-622) and VRAM fields must not share `_insurance_isolation_padding[4..14]` — the packed layout collides on `cumulative_volume`, `phase2_delta_slots`, `ewmv`, and `vol_margin_scale_bps`. The bug is dormant today (VRAM not enabled) but would cause mutual state corruption if both subsystems were activated on the same byte map.

This PR:
- Adds `docs/GH-2097-vram-oracle-phase-layout.md` with byte-range analysis and implementation checklist for percolator-prog
- Adds `app/lib/market-config-padding-layout.ts` — disjoint padding contract + overlap helpers
- Adds Vitest guards in `app/__tests__/lib/gh2097-padding-layout-guards.test.ts`
- Updates PERC-622 design doc §4.4 to forbid packing into `_insurance_isolation_padding`

Closes #2097 (documentation + layout contract). Follow-up on-chain wiring remains in percolator-prog.

## Test plan

- [ ] `pnpm --filter app test __tests__/lib/gh2097-padding-layout-guards.test.ts`
- [ ] CI Test Suite passes