### PR TITLE
feat(seo): canonical sitemap/robots, per-page + per-market metadata, JSON-LD, analytics (GA4 + Vercel + Cloudflare)

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -81,3 +81,23 @@ NEXT_PUBLIC_WAITLIST_SUPABASE_KEY=
 # re-submits return referral_code: null and the success card can't show the
 # code again on refresh.
 WAITLIST_SUPABASE_SERVICE_ROLE_KEY=
+
+# ── Analytics & SEO (added in feat/seo-analytics) ─────────────────────────────
+# All optional. Each provider stays inert (no init, no network) until its key is
+# set, so the app builds and runs cleanly without them.
+#
+# Google Analytics 4 measurement id. Defaults to the project's id (G-1SPWXBNZVP),
+# baked into lib/analytics-config.ts. Only set this to OVERRIDE the default.
+# GA only loads on the production deployment (preview/local are excluded).
+NEXT_PUBLIC_GA_ID=
+# Google Search Console verification token (search.google.com → HTML tag method).
+# Renders <meta name="google-site-verification" …> on every page.
+NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=
+# Cloudflare Web Analytics beacon token. Defaults to the project's token
+# (bdffc34064dd46f1a1d4aeeb39aa4db5), baked into lib/analytics-config.ts. Public;
+# only set this to OVERRIDE. Beacon loads on production only. Domain is DNS-only on
+# Cloudflare, so the manual snippet (injected by the app) is the required setup.
+NEXT_PUBLIC_CF_BEACON_TOKEN=
+# Analytics stack = GA4 + Vercel Web Analytics + Cloudflare Web Analytics.
+# Vercel Speed Insights is intentionally NOT used (metered); Core Web Vitals come
+# free from Search Console / PageSpeed Insights.

--- a/app/app/admin/layout.tsx
+++ b/app/app/admin/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { pageMetadata } from "@/lib/seo";
+
+// Admin area — excluded from search index (also Disallowed in robots.txt).
+export const metadata: Metadata = pageMetadata({
+  title: "Admin",
+  description: "Percolator admin.",
+  path: "/admin",
+  noindex: true,
+});
+
+export default function AdminLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/app/app/agents/layout.tsx
+++ b/app/app/agents/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { pageMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = pageMetadata({
+  title: "Build with AI Agents",
+  description:
+    "Point your AI coding agent at Percolator's open-source code and architecture context to build and ship features on permissionless Solana perps.",
+  path: "/agents",
+  keywords: ["AI coding agents", "build on Solana", "agentic engineering", "open source perps"],
+});
+
+export default function AgentsLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/app/app/create/layout.tsx
+++ b/app/app/create/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { pageMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = pageMetadata({
+  title: "Launch a Perpetual Market",
+  description:
+    "Create a permissionless perpetual futures market for any Solana token in minutes. Fully on-chain, transparent, and no permission required.",
+  path: "/create",
+  keywords: ["launch perp market", "create perpetual", "permissionless markets", "Solana"],
+});
+
+export default function CreateLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/app/app/dashboard/layout.tsx
+++ b/app/app/dashboard/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { pageMetadata } from "@/lib/seo";
+
+// Personalized (wallet-scoped) — excluded from search index.
+export const metadata: Metadata = pageMetadata({
+  title: "Dashboard",
+  description: "Your Percolator dashboard.",
+  path: "/dashboard",
+  noindex: true,
+});
+
+export default function DashboardLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/app/app/demo-shots/layout.tsx
+++ b/app/app/demo-shots/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { pageMetadata } from "@/lib/seo";
+
+// Internal demo/screenshot page — excluded from search index.
+export const metadata: Metadata = pageMetadata({
+  title: "Demo",
+  description: "Percolator demo screens.",
+  path: "/demo-shots",
+  noindex: true,
+});
+
+export default function DemoShotsLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/app/app/devnet-mint/layout.tsx
+++ b/app/app/devnet-mint/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { pageMetadata } from "@/lib/seo";
+
+// Devnet utility — excluded from search index (also Disallowed in robots.txt).
+export const metadata: Metadata = pageMetadata({
+  title: "Devnet Mint",
+  description: "Mint devnet test tokens for Percolator.",
+  path: "/devnet-mint",
+  noindex: true,
+});
+
+export default function DevnetMintLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/app/app/earn/[slab]/layout.tsx
+++ b/app/app/earn/[slab]/layout.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { SITE_NAME, SITE_URL, TWITTER_HANDLE } from "@/lib/seo";
+import { fetchMarketMeta } from "@/lib/market-meta";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slab: string }>;
+}): Promise<Metadata> {
+  const { slab } = await params;
+  const market = await fetchMarketMeta(slab);
+
+  const canonicalSlab = market?.slabAddress ?? slab;
+  const path = `/earn/${canonicalSlab}`;
+  const url = `${SITE_URL}${path}`;
+
+  const sym = market?.symbol || "";
+  const title = sym ? `${sym} Liquidity Vault — Earn Yield` : "Liquidity Vault — Earn Yield";
+  const description = sym
+    ? `Provide liquidity to the ${sym} perpetual market on Percolator and earn trading fees and funding. Transparent, on-chain LP vault on Solana.`
+    : "Provide liquidity to Percolator perpetual markets and earn fees and funding. Transparent, on-chain LP vaults on Solana.";
+  const ogTitle = `${title} | ${SITE_NAME}`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: path },
+    openGraph: {
+      title: ogTitle,
+      description,
+      url,
+      siteName: SITE_NAME,
+      type: "website",
+      locale: "en_US",
+    },
+    twitter: {
+      card: "summary_large_image",
+      site: TWITTER_HANDLE,
+      title: ogTitle,
+      description,
+    },
+    robots: { index: true, follow: true, googleBot: { index: true, follow: true } },
+  };
+}
+
+export default function EarnSlabLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/app/app/earn/layout.tsx
+++ b/app/app/earn/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { pageMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = pageMetadata({
+  title: "Earn Yield as a Liquidity Provider",
+  description:
+    "Provide liquidity to Percolator perp markets and earn trading fees and funding. Transparent, on-chain LP vaults for Solana perpetuals.",
+  path: "/earn",
+  keywords: ["DeFi yield", "liquidity provider", "LP vault", "Solana yield"],
+});
+
+export default function EarnLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/app/app/guide/layout.tsx
+++ b/app/app/guide/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { pageMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = pageMetadata({
+  title: "Guide — How Percolator Works",
+  description:
+    "Learn how to trade perps, provide liquidity, and launch markets on Percolator — the permissionless perpetual futures protocol on Solana.",
+  path: "/guide",
+  keywords: ["how to trade perps", "perps guide", "Solana DeFi guide", "Percolator docs"],
+});
+
+export default function GuideLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/app/app/join/layout.tsx
+++ b/app/app/join/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { pageMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = pageMetadata({
+  title: "Join the Team",
+  description:
+    "Contribute to Percolator. We're looking for developers, designers, and community builders to grow permissionless perps on Solana.",
+  path: "/join",
+  keywords: ["Percolator jobs", "Solana DeFi careers", "crypto contributor", "web3 jobs"],
+});
+
+export default function JoinLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -13,6 +13,11 @@ import { CursorGlow } from "@/components/ui/CursorGlow";
 import { MusicPlayer } from "@/components/ui/MusicPlayer";
 import { MainnetBetaBanner } from "@/components/layout/MainnetBetaBanner";
 import { ChromeGate } from "@/components/layout/ChromeGate";
+import { JsonLd } from "@/components/seo/JsonLd";
+import { organizationSchema, websiteSchema } from "@/lib/structured-data";
+import { Analytics } from "@vercel/analytics/next";
+import { GoogleAnalytics } from "@/components/analytics/GoogleAnalytics";
+import { CloudflareAnalytics } from "@/components/analytics/CloudflareAnalytics";
 
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"], display: "swap" });
 const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"], display: "swap" });
@@ -33,15 +38,23 @@ export const metadata: Metadata = {
   // direct 200 (X's card renderer won't follow a 301 on the image URL, which
   // left the card image blank).
   metadataBase: new URL("https://percolator.trade"),
-  title: "Percolator | Permissionless Perpetual Markets on Solana",
+  // `default` is the home-page title; `template` appends " | Percolator" to any
+  // bare title set by a child route segment (see lib/seo.ts → pageMetadata).
+  title: {
+    default: "Percolator | Permissionless Perpetual Markets on Solana",
+    template: "%s | Percolator",
+  },
   description: "Launch and trade perpetual futures for any Solana token. Fully on-chain, permissionless, transparent.",
   keywords: ["Solana", "perpetual futures", "DeFi", "trading", "perps", "on-chain"],
+  applicationName: "Percolator",
+  alternates: { canonical: "/" },
   icons: {
     icon: '/icon.png',
     apple: '/icon.png',
   },
   openGraph: {
     url: "https://percolator.trade",
+    siteName: "Percolator",
     title: "Percolator — Permissionless Perps on Solana",
     description: "Launch and trade perpetual futures for any Solana token.",
     type: "website",
@@ -49,6 +62,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
+    site: "@PercolatorTrade",
     title: "Percolator — Permissionless Perps on Solana",
     description: "Launch and trade perpetual futures for any Solana token.",
   },
@@ -57,6 +71,11 @@ export const metadata: Metadata = {
     follow: true,
     googleBot: { index: true, follow: true },
   },
+  // GSC verification — set NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION in Vercel env.
+  // Renders <meta name="google-site-verification" …> only when present.
+  verification: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION
+    ? { google: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION }
+    : undefined,
 };
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
@@ -80,6 +99,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         />
       </head>
         <body suppressHydrationWarning className="min-h-screen antialiased" data-nonce={nonce}>
+        <JsonLd data={[organizationSchema(), websiteSchema()]} />
         <Providers>
           <CursorGlow />
           <div className="relative z-[1] flex min-h-screen flex-col">
@@ -96,6 +116,9 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             <MusicPlayer />
           </ChromeGate>
         </Providers>
+        <GoogleAnalytics nonce={nonce} />
+        <CloudflareAnalytics nonce={nonce} />
+        <Analytics />
       </body>
     </html>
   );

--- a/app/app/leaderboard/layout.tsx
+++ b/app/app/leaderboard/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { pageMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = pageMetadata({
+  title: "Trader Leaderboard",
+  description:
+    "See the top traders on Percolator ranked by PnL and volume. Live leaderboard for permissionless perpetual futures on Solana.",
+  path: "/leaderboard",
+  keywords: ["trading leaderboard", "top traders", "PnL ranking", "Solana perps"],
+});
+
+export default function LeaderboardLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/app/app/markets/layout.tsx
+++ b/app/app/markets/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { pageMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = pageMetadata({
+  title: "All Perpetual Markets",
+  description:
+    "Browse every permissionless perp market on Percolator. Live prices, funding rates, open interest, and 24h volume for Solana token perpetuals.",
+  path: "/markets",
+  keywords: ["perp markets", "Solana perpetuals", "funding rates", "open interest"],
+});
+
+export default function MarketsLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/app/app/my-markets/layout.tsx
+++ b/app/app/my-markets/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { pageMetadata } from "@/lib/seo";
+
+// Personalized (wallet-scoped) — excluded from search index.
+export const metadata: Metadata = pageMetadata({
+  title: "My Markets",
+  description: "Markets you've created on Percolator.",
+  path: "/my-markets",
+  noindex: true,
+});
+
+export default function MyMarketsLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/app/app/portfolio/layout.tsx
+++ b/app/app/portfolio/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { pageMetadata } from "@/lib/seo";
+
+// Personalized (wallet-scoped) — excluded from search index.
+export const metadata: Metadata = pageMetadata({
+  title: "Portfolio",
+  description: "Your Percolator positions, balances, and PnL.",
+  path: "/portfolio",
+  noindex: true,
+});
+
+export default function PortfolioLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/app/app/report-bug/layout.tsx
+++ b/app/app/report-bug/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { pageMetadata } from "@/lib/seo";
+
+// Utility page — excluded from search index.
+export const metadata: Metadata = pageMetadata({
+  title: "Report a Bug",
+  description: "Report a bug or issue with Percolator.",
+  path: "/report-bug",
+  noindex: true,
+});
+
+export default function ReportBugLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/app/app/sitemap.ts
+++ b/app/app/sitemap.ts
@@ -1,23 +1,36 @@
 import type { MetadataRoute } from "next";
 
-const BASE_URL = "https://percolatorlaunch.com";
+// Canonical host. percolatorlaunch.com 301s here, so every sitemap URL MUST use
+// percolator.trade — otherwise the sitemap is full of redirecting URLs, which
+// Google discourages and which wastes crawl budget.
+const BASE_URL = "https://percolator.trade";
 
 /**
- * Dynamic sitemap — generates URLs for static pages + all active markets.
- * Fixes GH#1756: robots.txt references sitemap.xml but it didn't exist.
+ * Dynamic sitemap for the canonical waitlist host (percolator.trade).
+ *
+ * IMPORTANT: percolator.trade is waitlist-gated (middleware.ts "waitlist pivot").
+ * Only paths in WAITLIST_HOST_ALLOWED_PREFIXES return 200 here; every other path
+ * 302-redirects to /waitlist. So this sitemap lists ONLY allowed, indexable
+ * paths — listing redirecting URLs (e.g. /markets, /earn) would waste crawl
+ * budget. The full trading product (markets, earn, stake, portfolio) lives on
+ * mainnet.percolatorlaunch.com and is intentionally excluded here.
+ *
+ * `/` renders the waitlist landing (rewrite) and is the canonical home, so
+ * /waitlist itself is omitted (it canonicalizes to /).
  */
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const staticRoutes: MetadataRoute.Sitemap = [
     { url: BASE_URL, changeFrequency: "daily", priority: 1.0 },
-    { url: `${BASE_URL}/trade`, changeFrequency: "hourly", priority: 0.9 },
-    { url: `${BASE_URL}/earn`, changeFrequency: "daily", priority: 0.7 },
-    { url: `${BASE_URL}/create`, changeFrequency: "weekly", priority: 0.5 },
+    { url: `${BASE_URL}/trade`, changeFrequency: "hourly", priority: 0.8 },
+    { url: `${BASE_URL}/create`, changeFrequency: "weekly", priority: 0.6 },
     { url: `${BASE_URL}/leaderboard`, changeFrequency: "hourly", priority: 0.6 },
-    { url: `${BASE_URL}/guide`, changeFrequency: "weekly", priority: 0.4 },
-    { url: `${BASE_URL}/developers`, changeFrequency: "weekly", priority: 0.4 },
+    { url: `${BASE_URL}/guide`, changeFrequency: "weekly", priority: 0.5 },
+    { url: `${BASE_URL}/developers`, changeFrequency: "weekly", priority: 0.5 },
+    { url: `${BASE_URL}/agents`, changeFrequency: "weekly", priority: 0.4 },
+    { url: `${BASE_URL}/join`, changeFrequency: "weekly", priority: 0.4 },
   ];
 
-  // Fetch active markets for dynamic /trade/[slab] routes
+  // Per-market /trade/[slab] routes (the /trade prefix is allowed on the host).
   let marketRoutes: MetadataRoute.Sitemap = [];
   try {
     const res = await fetch(`${BASE_URL}/api/markets`, {
@@ -29,7 +42,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       marketRoutes = markets.map((m) => ({
         url: `${BASE_URL}/trade/${m.slab_address}`,
         changeFrequency: "hourly" as const,
-        priority: 0.8,
+        priority: 0.7,
       }));
     }
   } catch {

--- a/app/app/stake/layout.tsx
+++ b/app/app/stake/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { pageMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = pageMetadata({
+  title: "Stake into Percolator Pools",
+  description:
+    "Deposit into Percolator pools to earn protocol yield and help backstop permissionless perpetual markets on Solana.",
+  path: "/stake",
+  keywords: ["staking", "Solana staking", "DeFi pools", "protocol yield"],
+});
+
+export default function StakeLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/app/app/trade/[slab]/layout.tsx
+++ b/app/app/trade/[slab]/layout.tsx
@@ -1,0 +1,79 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { SITE_NAME, SITE_URL, TWITTER_HANDLE } from "@/lib/seo";
+import { fetchMarketMeta, formatUsd } from "@/lib/market-meta";
+import { JsonLd } from "@/components/seo/JsonLd";
+import { marketSchema, breadcrumbSchema } from "@/lib/structured-data";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slab: string }>;
+}): Promise<Metadata> {
+  const { slab } = await params;
+  const market = await fetchMarketMeta(slab);
+
+  // Canonical always points to the resolved address form (slug + address render
+  // the same page — collapse them onto one canonical URL).
+  const canonicalSlab = market?.slabAddress ?? slab;
+  const path = `/trade/${canonicalSlab}`;
+  const url = `${SITE_URL}${path}`;
+
+  const sym = market?.symbol || "";
+  const title = sym ? `${sym}-PERP Perpetual Futures` : "Perpetual Futures Market";
+  const priceStr = market?.price ? ` Mark price ${formatUsd(market.price)}.` : "";
+  const description = sym
+    ? `Trade ${sym} perpetual futures on Percolator — on-chain, permissionless, and self-custodial.${priceStr} Live funding, deep liquidity, no signup, on Solana.`
+    : "Trade on-chain perpetual futures on Percolator — permissionless and self-custodial, on Solana.";
+  const ogTitle = `${title} | ${SITE_NAME}`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: path },
+    openGraph: {
+      title: ogTitle,
+      description,
+      url,
+      siteName: SITE_NAME,
+      type: "website",
+      locale: "en_US",
+    },
+    twitter: {
+      card: "summary_large_image",
+      site: TWITTER_HANDLE,
+      title: ogTitle,
+      description,
+    },
+    robots: { index: true, follow: true, googleBot: { index: true, follow: true } },
+  };
+}
+
+export default async function TradeSlabLayout({
+  children,
+  params,
+}: {
+  children: ReactNode;
+  params: Promise<{ slab: string }>;
+}) {
+  const { slab } = await params;
+  const market = await fetchMarketMeta(slab); // cached (revalidate 300) — shared with generateMetadata
+  const canonicalSlab = market?.slabAddress ?? slab;
+  const sym = market?.symbol || "";
+  const path = `/trade/${canonicalSlab}`;
+
+  return (
+    <>
+      <JsonLd
+        data={[
+          marketSchema({ symbol: sym, path }),
+          breadcrumbSchema([
+            { name: "Markets", path: "/markets" },
+            { name: sym ? `${sym}-PERP` : "Market", path },
+          ]),
+        ]}
+      />
+      {children}
+    </>
+  );
+}

--- a/app/app/trade/layout.tsx
+++ b/app/app/trade/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { pageMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = pageMetadata({
+  title: "Trade Perpetual Futures on Solana",
+  description:
+    "Trade on-chain perpetual futures for any Solana token. Deep liquidity, transparent funding rates, and self-custodial positions — no signup required.",
+  path: "/trade",
+  keywords: ["Solana perps", "perpetual futures", "on-chain trading", "DeFi perps"],
+});
+
+export default function TradeLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/app/app/waitlist/page.tsx
+++ b/app/app/waitlist/page.tsx
@@ -9,6 +9,8 @@ import { resolveActiveWallet, usePreferredWallet } from "@/hooks/usePreferredWal
 import { useWaitlistWhoami } from "@/hooks/useWaitlistWhoami";
 import { TurnstileGate } from "@/components/waitlist/TurnstileGate";
 import bs58 from "bs58";
+import { track } from "@/lib/analytics";
+import { ANALYTICS_EVENTS } from "@/lib/analytics-config";
 
 /**
  * Reads the inbound referrer code from the URL.
@@ -688,6 +690,10 @@ function EmailFlow({
           position: json.position ?? null,
           referralCode: json.referral_code ?? null,
         });
+        track(ANALYTICS_EVENTS.WAITLIST_JOINED, {
+          method: "email",
+          position: json.position ?? null,
+        });
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : "submit failed";
         setState({ kind: "error", reason: msg });
@@ -988,6 +994,11 @@ function SignupFlow({
         kind: "done",
         position: json.position ?? null,
         referralCode: json.referral_code ?? null,
+        returning: json.returning === true,
+      });
+      track(ANALYTICS_EVENTS.WAITLIST_JOINED, {
+        method: "wallet",
+        position: json.position ?? null,
         returning: json.returning === true,
       });
     } catch (e: unknown) {

--- a/app/app/wallet/layout.tsx
+++ b/app/app/wallet/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { pageMetadata } from "@/lib/seo";
+
+// Personalized (wallet-scoped) — excluded from search index.
+export const metadata: Metadata = pageMetadata({
+  title: "Wallet",
+  description: "Manage your Percolator wallet and balances.",
+  path: "/wallet",
+  noindex: true,
+});
+
+export default function WalletLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/app/components/analytics/CloudflareAnalytics.tsx
+++ b/app/components/analytics/CloudflareAnalytics.tsx
@@ -1,0 +1,28 @@
+import Script from "next/script";
+import { CF_BEACON_TOKEN } from "@/lib/analytics-config";
+
+/**
+ * Cloudflare Web Analytics beacon. Renders nothing until NEXT_PUBLIC_CF_BEACON_TOKEN
+ * is set, and only on the production deployment (preview/local excluded).
+ *
+ * The domain is DNS-only on Cloudflare (NOT proxied), so per Cloudflare docs the
+ * manual JS snippet is the required setup (automatic injection only works for
+ * proxied/orange-cloud sites). The beacon loads from static.cloudflareinsights.com
+ * (CSP script-src) and reports to cloudflareinsights.com/cdn-cgi/rum (CSP
+ * connect-src) — both allowlisted in middleware.ts.
+ * https://developers.cloudflare.com/web-analytics/get-started/
+ */
+export function CloudflareAnalytics({ nonce }: { nonce?: string }) {
+  const isProd = process.env.VERCEL_ENV
+    ? process.env.VERCEL_ENV === "production"
+    : process.env.NODE_ENV === "production";
+  if (!CF_BEACON_TOKEN || !isProd) return null;
+  return (
+    <Script
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      strategy="afterInteractive"
+      nonce={nonce}
+      data-cf-beacon={`{"token": "${CF_BEACON_TOKEN}"}`}
+    />
+  );
+}

--- a/app/components/analytics/GoogleAnalytics.tsx
+++ b/app/components/analytics/GoogleAnalytics.tsx
@@ -1,0 +1,34 @@
+import Script from "next/script";
+import { GA_ID } from "@/lib/analytics-config";
+
+/**
+ * GA4 (gtag.js). Renders nothing when NEXT_PUBLIC_GA_ID is unset.
+ *
+ * The middleware enforces a strict, nonce-based CSP. `gtag.js` itself is an
+ * external-src script (allowed via the googletagmanager.com script-src entry),
+ * and the inline init below carries the per-request `nonce` so it isn't blocked.
+ */
+export function GoogleAnalytics({ nonce }: { nonce?: string }) {
+  // Only load GA on the real production deployment — keep preview deploys and
+  // local dev out of the GA4 property. On Vercel, VERCEL_ENV is
+  // "production" | "preview" | "development".
+  const isProd = process.env.VERCEL_ENV
+    ? process.env.VERCEL_ENV === "production"
+    : process.env.NODE_ENV === "production";
+  if (!GA_ID || !isProd) return null;
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+        strategy="afterInteractive"
+        nonce={nonce}
+      />
+      <Script id="ga-init" strategy="afterInteractive" nonce={nonce}>
+        {`window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', '${GA_ID}', { send_page_view: true });`}
+      </Script>
+    </>
+  );
+}

--- a/app/components/seo/JsonLd.tsx
+++ b/app/components/seo/JsonLd.tsx
@@ -1,0 +1,14 @@
+import type { ReactElement } from "react";
+
+/**
+ * Renders a JSON-LD structured-data block.
+ *
+ * `<script type="application/ld+json">` is a non-executable data block, so it is
+ * NOT subject to the CSP `script-src` directive and needs no nonce. We still
+ * escape "<" to prevent any string field (e.g. a market symbol) from breaking
+ * out of the script element.
+ */
+export function JsonLd({ data }: { data: object | object[] }): ReactElement {
+  const json = JSON.stringify(data).replace(/</g, "\\u003c");
+  return <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: json }} />;
+}

--- a/app/lib/analytics-config.ts
+++ b/app/lib/analytics-config.ts
@@ -1,0 +1,33 @@
+/**
+ * Analytics configuration — safe to import from both server and client components.
+ *
+ * NEXT_PUBLIC_* vars are inlined at build time. When the key is unset, GA4 is
+ * simply not initialized (no errors, no network calls), so the app builds and
+ * runs cleanly before the owner adds credentials. Vercel Web Analytics + Speed
+ * Insights need no env vars (enabled in the Vercel dashboard).
+ */
+// GA4 Measurement ID. This is public (it ships in client HTML on every page), so
+// the project's id is a safe committed default; NEXT_PUBLIC_GA_ID overrides it.
+export const GA_ID = process.env.NEXT_PUBLIC_GA_ID || "G-1SPWXBNZVP";
+
+export const gaEnabled = Boolean(GA_ID);
+
+// Cloudflare Web Analytics beacon token (Cloudflare dashboard → Web Analytics →
+// your site → "JS snippet" → the value of data-cf-beacon `token`). Public, safe
+// to commit; set as default once known. The beacon renders only when present.
+export const CF_BEACON_TOKEN =
+  process.env.NEXT_PUBLIC_CF_BEACON_TOKEN || "bdffc34064dd46f1a1d4aeeb39aa4db5";
+export const cfAnalyticsEnabled = Boolean(CF_BEACON_TOKEN);
+
+/** Canonical conversion-event names. Keep stable — renames break funnels/dashboards. */
+export const ANALYTICS_EVENTS = {
+  WAITLIST_SUBMITTED: "waitlist_submitted",
+  WAITLIST_JOINED: "waitlist_joined",
+  REFERRAL_LANDED: "referral_landed",
+  WALLET_CONNECTED: "wallet_connected",
+  MARKET_CREATED: "market_created",
+  TRADE_CTA_CLICKED: "trade_cta_clicked",
+} as const;
+
+export type AnalyticsEvent =
+  (typeof ANALYTICS_EVENTS)[keyof typeof ANALYTICS_EVENTS];

--- a/app/lib/analytics.ts
+++ b/app/lib/analytics.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { track as vercelTrack } from "@vercel/analytics";
+import { GA_ID } from "@/lib/analytics-config";
+
+type AllowedValue = string | number | boolean | null;
+export type EventProps = Record<string, AllowedValue | undefined>;
+
+/**
+ * Fire a conversion event to GA4 (gtag) and Vercel Web Analytics.
+ *
+ * (Cloudflare Web Analytics is pageview/RUM only — no custom-event API — so it
+ * isn't a target here.) Safe to call anywhere on the client; no-ops on the
+ * server and when a provider isn't loaded. Never throws.
+ */
+export function track(event: string, props?: EventProps): void {
+  if (typeof window === "undefined") return;
+
+  const clean: Record<string, AllowedValue> = {};
+  if (props) {
+    for (const [k, v] of Object.entries(props)) {
+      if (v !== undefined) clean[k] = v;
+    }
+  }
+
+  // Vercel Web Analytics (custom events)
+  try {
+    vercelTrack(event, clean);
+  } catch {
+    /* noop */
+  }
+
+  // GA4 (gtag)
+  try {
+    const gtag = (window as unknown as { gtag?: (...args: unknown[]) => void }).gtag;
+    if (GA_ID && typeof gtag === "function") gtag("event", event, clean);
+  } catch {
+    /* noop */
+  }
+}

--- a/app/lib/market-meta.ts
+++ b/app/lib/market-meta.ts
@@ -1,0 +1,46 @@
+import { SITE_URL } from "@/lib/seo";
+
+/**
+ * Server-only helper for per-market metadata (generateMetadata) and JSON-LD.
+ *
+ * The [slab] route accepts EITHER a base58 slab address OR a symbol slug, and
+ * both render the same page — so the canonical URL must always use the resolved
+ * `slabAddress` to avoid duplicate-content splits. Falls back to generic
+ * metadata when the market can't be resolved (returns null, never throws).
+ */
+export type MarketMeta = {
+  /** Normalized symbol without the -PERP suffix, e.g. "SOL". Empty if unknown. */
+  symbol: string;
+  /** Canonical on-chain slab address (use for canonical URL). */
+  slabAddress: string;
+  /** Best available USD price, or null. */
+  price: number | null;
+};
+
+export async function fetchMarketMeta(slab: string): Promise<MarketMeta | null> {
+  try {
+    const res = await fetch(`${SITE_URL}/api/markets/${encodeURIComponent(slab)}`, {
+      next: { revalidate: 300 },
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    const m = data?.market;
+    if (!m) return null;
+    const symbol = String(m.symbol ?? "").toUpperCase().replace(/-PERP$/, "");
+    const price =
+      typeof m.last_price === "number" ? m.last_price
+      : typeof m.mark_price === "number" ? m.mark_price
+      : typeof m.index_price === "number" ? m.index_price
+      : null;
+    return { symbol, slabAddress: String(m.slab_address ?? slab), price };
+  } catch {
+    return null;
+  }
+}
+
+export function formatUsd(n: number): string {
+  if (n >= 1000) return `$${n.toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
+  if (n >= 1) return `$${n.toFixed(2)}`;
+  if (n >= 0.01) return `$${n.toFixed(4)}`;
+  return `$${n.toPrecision(2)}`;
+}

--- a/app/lib/seo.ts
+++ b/app/lib/seo.ts
@@ -1,0 +1,56 @@
+import type { Metadata } from "next";
+
+/**
+ * Shared metadata helpers for per-route SEO.
+ *
+ * Most pages are `"use client"` components and cannot `export const metadata`.
+ * The fix is a sibling server-component `layout.tsx` per route that re-exports
+ * `pageMetadata({...})`. `metadataBase` (set in app/layout.tsx) is
+ * https://percolator.trade, so relative canonical paths resolve correctly.
+ */
+
+export const SITE_NAME = "Percolator";
+export const SITE_URL = "https://percolator.trade";
+export const TWITTER_HANDLE = "@PercolatorTrade";
+
+type PageMetaOpts = {
+  /** Bare page title (no brand). The root template appends " | Percolator". */
+  title: string;
+  description: string;
+  /** Absolute path beginning with "/", e.g. "/trade". Used for canonical + og:url. */
+  path: string;
+  /** Personalized/private pages should not be indexed. */
+  noindex?: boolean;
+  keywords?: string[];
+};
+
+export function pageMetadata({ title, description, path, noindex, keywords }: PageMetaOpts): Metadata {
+  const ogTitle = `${title} | ${SITE_NAME}`;
+  const url = `${SITE_URL}${path}`;
+  return {
+    title,
+    description,
+    ...(keywords ? { keywords } : {}),
+    alternates: { canonical: path },
+    openGraph: {
+      title: ogTitle,
+      description,
+      url,
+      siteName: SITE_NAME,
+      type: "website",
+      locale: "en_US",
+    },
+    twitter: {
+      card: "summary_large_image",
+      site: TWITTER_HANDLE,
+      title: ogTitle,
+      description,
+    },
+    robots: noindex
+      ? { index: false, follow: false, googleBot: { index: false, follow: false } }
+      : { index: true, follow: true, googleBot: { index: true, follow: true } },
+  };
+}
+
+/** Minimal passthrough layout body — routes render children unchanged. */
+export type SeoLayoutProps = { children: React.ReactNode };

--- a/app/lib/structured-data.ts
+++ b/app/lib/structured-data.ts
@@ -1,0 +1,63 @@
+import { SITE_NAME, SITE_URL } from "@/lib/seo";
+
+const LOGO_URL = `${SITE_URL}/icon.png`;
+const SAME_AS = [
+  "https://x.com/PercolatorTrade",
+  "https://github.com/dcccrypto/percolator-launch",
+  "https://discord.gg/fJa4BDBxPN",
+];
+
+/** Organization schema — sitewide brand/entity signals. */
+export function organizationSchema() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: SITE_NAME,
+    url: SITE_URL,
+    logo: LOGO_URL,
+    description:
+      "Permissionless perpetual futures for any Solana token — fully on-chain, transparent, and self-custodial.",
+    sameAs: SAME_AS,
+  };
+}
+
+/** WebSite schema — names the site entity for the homepage. */
+export function websiteSchema() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: SITE_NAME,
+    url: SITE_URL,
+    publisher: { "@type": "Organization", name: SITE_NAME, url: SITE_URL },
+  };
+}
+
+/** BreadcrumbList schema for nested pages. */
+export function breadcrumbSchema(items: { name: string; path: string }[]) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((it, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: it.name,
+      item: `${SITE_URL}${it.path}`,
+    })),
+  };
+}
+
+/** FinancialProduct schema for a perpetual market page. */
+export function marketSchema(opts: { symbol: string; path: string }) {
+  const name = opts.symbol ? `${opts.symbol}-PERP Perpetual Futures` : "Perpetual Futures Market";
+  return {
+    "@context": "https://schema.org",
+    "@type": "FinancialProduct",
+    name,
+    category: "Perpetual Futures",
+    url: `${SITE_URL}${opts.path}`,
+    provider: { "@type": "Organization", name: SITE_NAME, url: SITE_URL },
+    description: opts.symbol
+      ? `On-chain ${opts.symbol} perpetual futures market on Percolator — permissionless and self-custodial, on Solana.`
+      : "On-chain perpetual futures market on Percolator — permissionless and self-custodial, on Solana.",
+  };
+}

--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -271,6 +271,9 @@ function isAllowedOnWaitlistHost(pathname: string): boolean {
   if (pathname === "/") return true;
   if (pathname.startsWith("/api/")) return true;
   if (pathname.startsWith("/_next/")) return true;
+  // Vercel Web Analytics beacons (/_vercel/insights/*). Without this they'd
+  // 302 to /waitlist and no analytics would be recorded on the waitlist host.
+  if (pathname.startsWith("/_vercel/")) return true;
   if (WAITLIST_HOST_ALLOWED_METADATA_ROUTES.has(pathname)) return true;
   if (/\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|woff2?|ttf|map)$/i.test(pathname)) return true;
   for (const p of WAITLIST_HOST_ALLOWED_PREFIXES) {
@@ -484,7 +487,10 @@ function addSecurityHeaders(response: NextResponse, nonce?: string) {
     // by `components/waitlist/TurnstileGate.tsx` on the /waitlist surface
     // to render the bot-defence challenge; without this entry the script
     // is blocked and every submit button stays disabled.
-    `script-src 'self' ${scriptNonce}'unsafe-inline' https://cdn.vercel-insights.com https://challenges.cloudflare.com`,
+    // Analytics: googletagmanager.com loads gtag.js (GA4);
+    // static.cloudflareinsights.com loads the Cloudflare Web Analytics beacon.
+    // Vercel Web Analytics loads from same-origin /_vercel/* (covered by 'self').
+    `script-src 'self' ${scriptNonce}'unsafe-inline' https://cdn.vercel-insights.com https://challenges.cloudflare.com https://www.googletagmanager.com https://static.cloudflareinsights.com`,
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "font-src 'self' https://fonts.gstatic.com",
     "img-src 'self' data: https: blob:",
@@ -497,7 +503,7 @@ function addSecurityHeaders(response: NextResponse, nonce?: string) {
     // challenges.cloudflare.com is appended for the Turnstile widget's
     // XHR back-channel (telemetry + challenge-state checks). Same
     // origin as the script load.
-    "connect-src 'self' https://*.solana.com wss://*.solana.com https://*.supabase.co wss://*.supabase.co https://*.vercel-insights.com https://api.coingecko.com https://api.geckoterminal.com https://*.helius-rpc.com wss://*.helius-rpc.com https://api.dexscreener.com https://hermes.pyth.network https://*.up.railway.app wss://*.up.railway.app https://api.percolatorlaunch.com wss://api.percolatorlaunch.com https://lite.jup.ag https://token.jup.ag https://tokens.jup.ag https://auth.privy.io https://embedded-wallets.privy.io https://*.privy.systems https://*.rpc.privy.systems https://explorer-api.walletconnect.com wss://relay.walletconnect.com wss://relay.walletconnect.org wss://www.walletlink.org https://challenges.cloudflare.com blob:",
+    "connect-src 'self' https://*.solana.com wss://*.solana.com https://*.supabase.co wss://*.supabase.co https://*.vercel-insights.com https://api.coingecko.com https://api.geckoterminal.com https://*.helius-rpc.com wss://*.helius-rpc.com https://api.dexscreener.com https://hermes.pyth.network https://*.up.railway.app wss://*.up.railway.app https://api.percolatorlaunch.com wss://api.percolatorlaunch.com https://lite.jup.ag https://token.jup.ag https://tokens.jup.ag https://auth.privy.io https://embedded-wallets.privy.io https://*.privy.systems https://*.rpc.privy.systems https://explorer-api.walletconnect.com wss://relay.walletconnect.com wss://relay.walletconnect.org wss://www.walletlink.org https://challenges.cloudflare.com https://www.googletagmanager.com https://*.google-analytics.com https://*.analytics.google.com https://cloudflareinsights.com blob:",
     // Removed https://*.vercel.app wildcard (issue #635) — no legitimate use case for embedding
     // arbitrary Vercel-hosted content in iframes. frame-src controls outbound iframe embedding.
     // challenges.cloudflare.com is the iframe origin the Turnstile widget

--- a/app/package.json
+++ b/app/package.json
@@ -24,6 +24,7 @@
     "@supabase/supabase-js": "^2.97.0",
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.36.4",
+    "@vercel/analytics": "^2.0.1",
     "bs58": "^6.0.0",
     "buffer": "^6.0.3",
     "gsap": "^3.14.2",

--- a/app/public/robots.txt
+++ b/app/public/robots.txt
@@ -1,7 +1,11 @@
 User-agent: *
 Allow: /
+Disallow: /admin
+Disallow: /api/
 Disallow: /faucet
 Disallow: /devnet-mint
 Disallow: /openclaw
 Disallow: /pitch
-Sitemap: https://percolatorlaunch.com/sitemap.xml
+Disallow: /pitch-2
+Disallow: /demo-shots
+Sitemap: https://percolator.trade/sitemap.xml

--- a/docs/SEO_ANALYTICS_AUDIT.md
+++ b/docs/SEO_ANALYTICS_AUDIT.md
@@ -1,0 +1,168 @@
+# SEO & Analytics Audit — percolator.trade
+
+_Audit date: 2026-06-08 · App: `app/` (Next.js 16.2.3, App Router, Vercel) · Canonical host: `percolator.trade`_
+
+## Executive summary
+
+The site has a solid technical baseline (global metadata, dynamic sitemap, robots.txt, HTTPS,
+canonical-domain 301) but three things are actively costing organic performance:
+
+1. **Domain split-brain** — the sitemap and `robots.txt` advertise `percolatorlaunch.com`
+   (which 301s to `percolator.trade`), so the live sitemap is full of redirecting URLs. **HIGH.**
+2. **No analytics at all** — only Sentry (errors). Zero measurement of traffic, organic search,
+   Core Web Vitals, or waitlist conversion. **HIGH** (can't improve what you can't measure).
+3. **Duplicate metadata sitewide** — almost every page is a `"use client"` component and inherits
+   one generic root `<title>`/description. Only `/developers` and `/openclaw` are unique. **HIGH.**
+
+Plus a large untapped opportunity: **programmatic SEO** on per-market pages (`/trade/[slab]`),
+which currently share the generic title and carry no structured data.
+
+---
+
+## ⚠️ Critical context: host architecture (waitlist pivot, 2026-05-08)
+
+`middleware.ts` runs a **host-based gate** that fundamentally shapes the SEO surface:
+
+| Host | Role | Indexable? |
+|------|------|-----------|
+| `percolator.trade` | **Canonical SEO host.** `/` is *rewritten* to the waitlist landing. Only an allowlist of paths returns 200; everything else **302-redirects to `/waitlist`**. | Yes (this is the target) |
+| `mainnet.percolatorlaunch.com` | Full trading product (markets, earn, stake, portfolio, …) | Strategy TBD (see open question) |
+| `percolatorlaunch.com` (apex) | 301 → `percolator.trade` | No |
+
+**Allowed (200) on `percolator.trade`:** `/`, `/waitlist`, `/trade`, `/create`, `/guide`,
+`/developers`, `/agents`, `/leaderboard`, `/join`, `/pitch`, `/pitch-2`, `/demo-shots`, `/r`,
+`/admin`, `/bugs`, `/report-bug`, `/openclaw` + metadata routes (`/robots.txt`, `/sitemap.xml`,
+`/opengraph-image`, `/twitter-image`).
+
+**Redirected → `/waitlist` on `percolator.trade`:** `/markets`, `/earn`, `/stake`, `/portfolio`,
+`/dashboard`, `/wallet`, `/my-markets`, `/devnet-mint`, `/faucet`.
+
+Implications already applied:
+- **`sitemap.ts` now lists only allowed-200 paths** (dropped `/markets`, `/earn`, `/stake`,
+  `/earn/[slab]` — they'd be redirecting URLs, the exact problem we set out to fix).
+- **`/waitlist` layout removed** so `/` and `/waitlist` both inherit the brand homepage metadata
+  with canonical `/` (the de-facto homepage is the waitlist landing).
+- Per-page metadata for `/markets`, `/earn`, `/stake`, etc. is still in place — it serves on the
+  mainnet host where those pages render; it's simply never reached on `percolator.trade`.
+
+**Open question (needs owner decision):** should `mainnet.percolatorlaunch.com` be indexed, or
+`noindex`'d to avoid duplicate content with `percolator.trade`? And should the trading pages
+(`/trade`, `/create`) be promoted as SEO landing pages pre-launch, or kept out of the index until
+public launch? See the end of this doc.
+
+---
+
+## Findings
+
+### Technical SEO
+
+| # | Issue | Impact | Evidence | Fix |
+|---|-------|--------|----------|-----|
+| T1 | Sitemap URLs use non-canonical host | HIGH | `app/sitemap.ts:3` `BASE_URL = https://percolatorlaunch.com` — every entry 301s to `percolator.trade` | Point `BASE_URL` to `https://percolator.trade` |
+| T2 | `robots.txt` Sitemap ref uses non-canonical host | HIGH | `app/public/robots.txt:7` `Sitemap: https://percolatorlaunch.com/sitemap.xml` (served live on percolator.trade) | Point to `https://percolator.trade/sitemap.xml` |
+| T3 | Sitemap missing many indexable routes | MED | `sitemap.ts` lists 7 static routes; app has `/markets`, `/earn`, `/stake`, `/portfolio`, `/join`, `/agents`, `/guide`, etc. | Expand static list + add `/earn/[slab]` |
+| T4 | No per-page canonical tags | MED | No `alternates.canonical` anywhere except none | Add self-referencing canonicals per route |
+| T5 | Core Web Vitals unmeasured | MED | No CWV/RUM tooling installed | Use free CrUX field data via Search Console Core Web Vitals report + PageSpeed Insights (Vercel Speed Insights skipped — metered cost) |
+
+Confirmed OK: `percolatorlaunch.com` → 301 → `percolator.trade`; `robots.txt` & `sitemap.xml` both 200;
+HTTPS + HSTS (`next.config.ts:34`); `/markets/[slab]` → 301 → `/trade/[slab]` (`next.config.ts:54`)
+so it must stay OUT of the sitemap.
+
+### On-page SEO
+
+| # | Issue | Impact | Evidence | Fix |
+|---|-------|--------|----------|-----|
+| O1 | Duplicate `<title>`/description on ~28 pages | HIGH | `home, trade, markets, earn, leaderboard, guide, create, stake, …` are `"use client"` → can't `export const metadata` → inherit root `layout.tsx:36` | Add per-route `layout.tsx` server wrappers exporting metadata (model: `app/developers/page.tsx:13`) |
+| O2 | Dynamic market pages have no unique metadata | HIGH | `/trade/[slab]/page.tsx:1` is `"use client"`; no `generateMetadata` | Add `[slab]/layout.tsx` with `generateMetadata` (symbol, price, OG) |
+| O3 | No structured data (JSON-LD) | MED | none in tree | Organization + WebSite (root); FinancialProduct + BreadcrumbList (markets) |
+| O4 | OG/Twitter images not per-page | LOW | global `opengraph-image.tsx` only | Optional: dynamic OG image per market |
+
+### Analytics (currently none)
+
+| # | Gap | Plan |
+|---|-----|------|
+| A1 | No traffic analytics | GA4 + Vercel Web Analytics + Cloudflare Web Analytics |
+| A2 | No Core Web Vitals RUM | Free CrUX via Search Console + PageSpeed Insights (Vercel Speed Insights skipped — metered cost) |
+| A3 | No organic-search reporting | GA4 (gtag.js) + Google Search Console |
+| A5 | No conversion events | Track waitlist signup, wallet connect, create-market, trade CTA |
+
+CSP note: `middleware.ts` `script-src` + `connect-src` extended for GA4
+(`googletagmanager.com`, `*.google-analytics.com`). Vercel insights domains are already allowlisted.
+(PostHog was evaluated and dropped — not needed.)
+
+---
+
+## Prioritized action plan
+
+**P0 — Crawl/index correctness (no credentials needed)**
+- [ ] T1/T2 Fix sitemap + robots domain → `percolator.trade`
+- [ ] T3 Expand sitemap routes (+ `/earn/[slab]`)
+
+**P1 — On-page (no credentials)**
+- [ ] O1 Per-route `layout.tsx` metadata for all client pages + canonicals (T4)
+- [ ] O2 `generateMetadata` for `/trade/[slab]`, `/earn/[slab]`
+- [ ] O3 JSON-LD: Organization + WebSite (root), FinancialProduct + Breadcrumb (markets)
+
+**P2 — Analytics (needs env keys; scaffolded to no-op until set)**
+- [ ] A1 Traffic analytics: GA4 + Vercel Web Analytics + Cloudflare beacon (A2 CWV: free via Search Console / PageSpeed Insights)
+- [ ] A3 GA4 + CSP update
+- [ ] A5 Conversion events
+
+**P3 — Search Console (needs user action)**
+- [ ] Verify `percolator.trade` property, submit `sitemap.xml`, set `metadata.verification.google`
+
+---
+
+## Credentials / manual steps needed from owner
+
+| Item | Env var | Where to get it |
+|------|---------|-----------------|
+| GA4 Measurement ID | `NEXT_PUBLIC_GA_ID` (`G-XXXXXXX`) | analytics.google.com → Admin → Data Streams |
+| GSC verification | `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION` | search.google.com/search-console (HTML-tag method) |
+| Vercel Web Analytics | _none_ | Enable in Vercel dashboard → Analytics tab |
+| Cloudflare beacon token | `NEXT_PUBLIC_CF_BEACON_TOKEN` | Cloudflare dashboard → Web Analytics → site → JS snippet |
+
+_Until the env vars are set, the analytics integrations compile and render nothing (no errors)._
+
+---
+
+## Manual steps (owner)
+
+### Google Search Console
+1. Add a property for `https://percolator.trade` (URL-prefix) at search.google.com/search-console.
+2. Verification: easiest is **DNS TXT** (works regardless of the waitlist gate). Alternatively use
+   the **HTML tag** method → copy the token into `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION` (it renders
+   on `/`, which the verifier fetches).
+3. Submit `https://percolator.trade/sitemap.xml`.
+4. (Optional) Add a separate property for `mainnet.percolatorlaunch.com` only if it will be indexed.
+
+### Analytics providers: GA4 + Vercel Web Analytics + Cloudflare Web Analytics
+- All three run together. **Speed Insights is the only one excluded** (metered cost); Core Web
+  Vitals are covered for free by the Search Console Core Web Vitals report + PageSpeed Insights.
+- **Vercel Web Analytics:** enable in the Vercel dashboard (Analytics tab); `<Analytics/>` is wired
+  and `/_vercel/*` beacons are allowlisted past the waitlist gate.
+- **Cloudflare Web Analytics:** the domain is **DNS-only** (not proxied — the setup Vercel
+  recommends), so per Cloudflare docs the **manual JS snippet is required** (automatic injection is
+  proxy-only). Set `NEXT_PUBLIC_CF_BEACON_TOKEN` (CF dashboard → Web Analytics). The app injects the
+  beacon nonce-correctly; CSP allows `static.cloudflareinsights.com` (script) +
+  `cloudflareinsights.com` (connect → `/cdn-cgi/rum`). Because traffic never hits Cloudflare's edge,
+  Rocket Loader / "Cache Everything" / auto-injection are non-issues.
+
+### GA4
+- ID `G-1SPWXBNZVP` is hardcoded as the default in `lib/analytics-config.ts` (loads on production
+  only). `NEXT_PUBLIC_GA_ID` overrides it but is not required. CSP already allows
+  `googletagmanager.com` and `*.google-analytics.com`.
+- Conversion event `waitlist_joined` (`method: email|wallet`, `position`) already fires on signup.
+
+---
+
+## Open question for the owner
+
+**Indexing strategy for the trading product.** Right now `percolator.trade` is a waitlist landing;
+the app lives on `mainnet.percolatorlaunch.com`. Decide:
+1. **Waitlist-focused (default):** index only `percolator.trade` (waitlist + content pages),
+   `noindex` the mainnet app host. Keeps the index clean pre-launch. ✅ matches current code.
+2. **Index the app now:** add per-market `noindex`→index on the mainnet host, add a second sitemap,
+   and set canonicals cross-host. More work; risks thin/duplicate pages pre-launch.
+3. **Promote trade pages on percolator.trade:** treat `/trade`, `/trade/[slab]` as public SEO
+   landing pages even pre-launch (they're already allowed + have per-market metadata + JSON-LD).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       '@upstash/redis':
         specifier: ^1.36.4
         version: 1.36.4
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       bs58:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3411,6 +3414,35 @@ packages:
   '@upstash/redis@1.36.4':
     resolution: {integrity: sha512-w4s/msmyMqxOxaVhC8TQ2whJ77+Zd8YaSFokXL4mULQopaYb4xNJcm/PedtFQyLJn65nneySw9IwYnlMBBmFHg==}
 
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
   '@vitejs/plugin-react@5.1.4':
     resolution: {integrity: sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5959,9 +5991,6 @@ packages:
   preact@10.24.2:
     resolution: {integrity: sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q==}
 
-  preact@10.28.4:
-    resolution: {integrity: sha512-uKFfOHWuSNpRFVTnljsCluEFq57OKT+0QdOiQo8XWnQ/pSvg7OpX5eNOejELXJMWy+BwM2nobz0FkvzmnpCNsQ==}
-
   preact@10.29.1:
     resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
 
@@ -7474,7 +7503,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       clsx: 1.2.1
       eventemitter3: 5.0.4
-      preact: 10.28.4
+      preact: 10.29.1
 
   '@coinbase/wallet-sdk@4.3.6(@types/react@19.2.13)(bufferutil@4.1.0)(immer@11.1.4)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
@@ -11373,6 +11402,11 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
+  '@vercel/analytics@2.0.1(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+    optionalDependencies:
+      next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+
   '@vitejs/plugin-react@5.1.4(vite@8.0.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@20.19.32)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.29.0
@@ -15120,8 +15154,6 @@ snapshots:
       xtend: 4.0.2
 
   preact@10.24.2: {}
-
-  preact@10.28.4: {}
 
   preact@10.29.1: {}
 


### PR DESCRIPTION
## Summary
End-to-end SEO + analytics pass for **percolator.trade**.

### SEO
- **Fix domain split** — `sitemap.ts` + `robots.txt` now use canonical `percolator.trade` (was `percolatorlaunch.com`, which 301s). Sitemap lists **only paths that return 200** on the waitlist-gated host (per `middleware.ts` host pivot), so no redirecting URLs.
- **Per-page metadata** — per-route `layout.tsx` (unique title/description/canonical) for every client page; personalized pages `noindex`. `/waitlist` layout removed so `/` and `/waitlist` share the brand homepage metadata with canonical `/`.
- **Programmatic** — `generateMetadata` for `/trade/[slab]` + `/earn/[slab]` (canonical pinned to resolved `slab_address` to dedupe slug vs address).
- **JSON-LD** — Organization + WebSite (root), FinancialProduct + Breadcrumb (market pages).
- Root title template + GSC verification hook (`NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION`).

### Analytics — GA4 + Vercel Web Analytics + Cloudflare Web Analytics
- **GA4** (`G-1SPWXBNZVP`), nonce-aware, production-only.
- **Vercel Web Analytics** (`<Analytics/>`); `/_vercel/*` allowlisted past the waitlist gate.
- **Cloudflare Web Analytics** beacon — DNS-only manual setup (per CF docs, since the domain is not proxied); injected through the app so it carries the CSP nonce.
- `waitlist_joined` conversion event on signup (email/wallet).
- CSP extended: `googletagmanager.com`, `*.google-analytics.com`, `static.cloudflareinsights.com`, `cloudflareinsights.com`.
- Speed Insights and PostHog intentionally excluded.

### Verification
- `tsc --noEmit` clean, `next build` clean.
- Runtime curl of `/trade`: GA4 (external + inline init) and the Cloudflare beacon both emit and carry the matching per-request CSP nonce; external hosts allowlisted.

### Owner follow-ups
- Enable Vercel Web Analytics in the Vercel dashboard.
- Submit `sitemap.xml` in Search Console after deploy.

Details: `docs/SEO_ANALYTICS_AUDIT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added Cloudflare Turnstile CAPTCHA requirement to waitlist signup
* IP-based rate limiting to prevent signup abuse
* Disposable email domain blocking for signup validation
* Bot user-agent detection and blocking for signups
* Google Analytics integration
* Cloudflare Web Analytics integration
* JSON-LD structured data for enhanced SEO

**Improvements**
* Admin waitlist dashboard now displays IP-based abuse signals and metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->