### PR TITLE
fix(app): use canonical client ip helper

### DIFF
--- a/app/app/api/devnet-mirror-mint/route.ts
+++ b/app/app/api/devnet-mirror-mint/route.ts
@@ -22,6 +22,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { getClientIp } from "@/lib/get-client-ip";
 import { Redis } from "@upstash/redis";
 import { Ratelimit } from "@upstash/ratelimit";
 import {
@@ -127,19 +128,7 @@ async function checkMintRateLimit(ip: string): Promise<{ allowed: boolean; retry
   return checkMintRateLimitFallback(ip);
 }
 
-/** Extract client IP from request headers, respecting proxy depth env var. */
-function getClientIp(req: NextRequest): string {
-  const PROXY_DEPTH = Math.max(0, Number(process.env.TRUSTED_PROXY_DEPTH ?? 1));
-  if (PROXY_DEPTH > 0) {
-    const forwarded = req.headers.get("x-forwarded-for");
-    if (forwarded) {
-      const ips = forwarded.split(",").map((s) => s.trim());
-      const idx = Math.max(0, ips.length - PROXY_DEPTH);
-      return ips[idx] ?? "unknown";
-    }
-  }
-  return "unknown";
-}
+
 
 const NETWORK =
   process.env.NEXT_PUBLIC_DEFAULT_NETWORK?.trim() ??


### PR DESCRIPTION
## Summary

- Removed the duplicate `getClientIp` implementation from `devnet-mirror-mint`
- Imported the canonical `getClientIp` helper from `@/lib/get-client-ip`
- Keeps client IP extraction behavior consistent across the app

## Testing

- [ ] pnpm --filter @percolator/app build

Build could not complete locally due to an unrelated Rollup/Rolldown type mismatch in `app/vitest.config.ts`.

Closes #2195

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization by consolidating client IP extraction logic into a shared utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->