### PR TITLE
fix(security): restrict authenticated-role SELECT on ideas + job_applications (completes N7)

### DIFF
--- a/supabase/migrations/20260617000000_fix_pii_authenticated_role_ideas_jobs.sql
+++ b/supabase/migrations/20260617000000_fix_pii_authenticated_role_ideas_jobs.sql
@@ -1,0 +1,47 @@
+-- Migration: 20260617000000_fix_pii_authenticated_role_ideas_jobs.sql
+-- Completes audit finding N7 (Medium) for the two tables migration 034 missed.
+--
+-- 026_fix_pii_exposure.sql column-restricted the 'anon' role on bug_reports,
+-- job_applications and ideas, but then re-granted UNRESTRICTED `SELECT` on all
+-- three to the 'authenticated' role (lines 93-101) on the assumption that
+-- "admin users authenticate via Supabase auth and use the authenticated role".
+--
+-- That assumption no longer holds: the app moved its admin auth to Privy
+-- (see app/lib/admin-session.ts), so the Supabase 'authenticated' role is no
+-- longer the admin — it is any user who can obtain an 'authenticated' JWT from
+-- the project (e.g. via anon/email self-signup with the public anon key).
+-- With the SELECT policies still USING(true), such a user can read every
+-- column directly via PostgREST, bypassing the API routes' column allow-lists.
+--
+-- 034_fix_pii_authenticated_role.sql fixed exactly this — but ONLY for
+-- bug_reports. job_applications (email, ip, admin_notes, cv_data) and ideas
+-- (ip, contact, admin_notes) were left with the unrestricted authenticated
+-- grant. This migration applies the same REVOKE + column-restricted GRANT to
+-- both, using the identical safe-column lists 026 already chose for 'anon'.
+--
+-- service_role (used by the API routes) is unaffected and retains full access.
+
+-- ── job_applications: hide email, ip, admin_notes, cv_data ──────────────────
+REVOKE SELECT ON job_applications FROM authenticated;
+
+GRANT SELECT (
+  id, name, twitter_handle, desired_role, experience_level,
+  about, portfolio_links, cv_filename, availability, solana_wallet,
+  status, created_at
+) ON job_applications TO authenticated;
+
+-- ── ideas: hide ip, contact, admin_notes ───────────────────────────────────
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'ideas'
+  ) THEN
+    REVOKE SELECT ON ideas FROM authenticated;
+    GRANT SELECT (id, handle, idea, status, created_at) ON ideas TO authenticated;
+    RAISE NOTICE 'ideas: authenticated-role PII column grants applied';
+  ELSE
+    RAISE NOTICE 'ideas: table does not exist, skipping';
+  END IF;
+END
+$$;


### PR DESCRIPTION
## Summary

Migration `026_fix_pii_exposure.sql` column-restricted the **anon** role on `bug_reports`, `job_applications`, and `ideas` — but then re-granted **unrestricted** `SELECT` on all three to the **authenticated** role (lines 93-101), on the stated assumption that *"admin users authenticate via Supabase auth and use the authenticated role."*

That assumption no longer holds. Admin auth has moved to **Privy** (`app/lib/admin-session.ts`), so the Supabase `authenticated` role is no longer the admin — it's **any** user who can obtain an `authenticated` JWT from the project (e.g. via anon/email self-signup with the public anon key). Since the row-level `SELECT` policies are still `USING(true)`, such a user can read **every column directly via PostgREST**, bypassing the API routes' careful column allow-lists (`app/app/api/ideas/route.ts:24`, admin-gated applications GET, etc. — the route layer isn't in the path).

Migration `034_fix_pii_authenticated_role.sql` recognized and fixed exactly this (audit finding **N7**) — but **only for `bug_reports`**. The other two tables were left exposed:
- `job_applications` → `email`, `ip`, `admin_notes`, `cv_data` (resumes)
- `ideas` → `ip`, `contact`, `admin_notes`

```
$ grep -n 'authenticated' supabase/migrations/026_fix_pii_exposure.sql
93:GRANT SELECT ON bug_reports TO authenticated;
94:GRANT SELECT ON job_applications TO authenticated;   # <-- unrestricted
98:    GRANT SELECT ON ideas TO authenticated;          # <-- unrestricted
# 034 only REVOKE/re-GRANTs bug_reports; no later migration touches the other two.
```

## Severity

**Medium.** Crosses a PII boundary (emails + uploaded CV blobs). Gated on the precondition that the Supabase project still permits anon/email self-signup (so an `authenticated` JWT is obtainable) — if self-signup is disabled in the dashboard this degrades to defense-in-depth. Either way it's the unfinished half of a fix you already shipped, and the safe direction is to close it. (Not a `service_role` leak — that's the separate git-history-key issue class.)

## Fix

New migration mirroring `034` for the two remaining tables, reusing the **identical safe-column lists** `026` already chose for the `anon` role. `service_role` (the API routes) is unaffected and retains full access.

```sql
REVOKE SELECT ON job_applications FROM authenticated;
GRANT SELECT (id, name, twitter_handle, desired_role, experience_level,
              about, portfolio_links, cv_filename, availability,
              solana_wallet, status, created_at) ON job_applications TO authenticated;

-- ideas (guarded on table existence, matching 026)
REVOKE SELECT ON ideas FROM authenticated;
GRANT SELECT (id, handle, idea, status, created_at) ON ideas TO authenticated;
```

Recommend also confirming anon/email self-signup is disabled on the Supabase project unless intentionally used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security controls on job applications and ideas. Email addresses, contact details, IP information, and administrative notes are now restricted from unauthorized access based on user roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->