### PR TITLE
fix(security): only render http(s) bug-report page_url as a clickable link (admin stored XSS)

### DIFF
--- a/app/app/admin/page.tsx
+++ b/app/app/admin/page.tsx
@@ -1206,14 +1206,26 @@ export default function AdminDashboard() {
                   {selectedBug.page_url && (
                     <div className="min-w-0">
                       <span className="text-[var(--text-muted)]">URL:</span>{" "}
-                      <a
-                        href={selectedBug.page_url}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="text-[var(--accent)] hover:underline break-all"
-                      >
-                        {selectedBug.page_url}
-                      </a>
+                      {/* page_url comes from the PUBLIC, unauthenticated POST /api/bugs
+                          submission. React 18 does not block javascript:/data:/vbscript
+                          URLs in href (only React 19 does), so an attacker could plant a
+                          javascript: URL that runs in the admin origin when an operator
+                          clicks it. Only render a clickable link for http(s); otherwise
+                          show inert (JSX-escaped) text. */}
+                      {/^https?:\/\//i.test(selectedBug.page_url) ? (
+                        <a
+                          href={selectedBug.page_url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="text-[var(--accent)] hover:underline break-all"
+                        >
+                          {selectedBug.page_url}
+                        </a>
+                      ) : (
+                        <span className="text-[var(--text-secondary)] break-all">
+                          {selectedBug.page_url}
+                        </span>
+                      )}
                     </div>
                   )}
                 </div>


### PR DESCRIPTION
## Summary

The admin bug dashboard renders a bug report's `page_url` directly into an anchor `href` with **no URL-scheme allow-list** (`app/app/admin/page.tsx`):

```tsx
{selectedBug.page_url && (
  <a href={selectedBug.page_url} target="_blank" rel="noreferrer" ...>
    {selectedBug.page_url}
  </a>
)}
```

`page_url` originates from the **public, unauthenticated** `POST /api/bugs` submission (the route's own comment marks it "Public endpoint"). React is pinned to **18.3.1** (`app/package.json`), and React 18 does **not** block `javascript:` / `data:` / `vbscript:` URLs in `href` — that built-in guard only landed in React 19.

## Impact (stored XSS → admin action)

An attacker submits a bug whose `page_url` is e.g. `javascript:fetch('/api/admin/bugs?...', {method:'PATCH', ...})`. When an operator opens that report in the dashboard and clicks the rendered link, the script executes **in the admin origin**. The admin API routes authorize on the browser-resident Privy session (`middleware.ts`), so the payload runs with the **admin's** privileges.

Severity **Medium**: it's stored + cross-privilege, but requires the admin to click the link (targeted, not a drive-by). The repo comments suggest sanitisation "lives in percolator-api" (a separate service not in this repo) — but the render boundary should not depend on an out-of-repo backend always stripping schemes.

## Fix

Render a clickable `<a>` only when `page_url` matches `^https?://`; otherwise show it as inert, JSX-escaped text (still fully visible to the operator, just not clickable/executable). Independent of any backend sanitisation.

```tsx
{/^https?:\/\//i.test(selectedBug.page_url) ? (
  <a href={selectedBug.page_url} target="_blank" rel="noreferrer" ...>{selectedBug.page_url}</a>
) : (
  <span className="...">{selectedBug.page_url}</span>
)}
```

Belt-and-suspenders for later: bumping React to 19 would add the built-in `javascript:`-URL block, and confirming percolator-api allow-lists schemes on write.

Verified: `tsc --noEmit` reports no errors in the edited file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)