### PR TITLE
fix(v17): add 128KB heap frame to all wrapper transactions (#176)

### DIFF
--- a/app/app/api/mobile/create-market/route.ts
+++ b/app/app/api/mobile/create-market/route.ts
@@ -29,6 +29,7 @@ import {
   Transaction,
   TransactionInstruction,
   Connection,
+  ComputeBudgetProgram,
 } from "@solana/web3.js";
 import {
   createAssociatedTokenAccountInstruction,
@@ -322,6 +323,10 @@ export async function POST(req: NextRequest) {
     const initMarketIx = buildIx({ programId, keys: initMarketKeys, data: initMarketData });
 
     const tx0 = new Transaction({ recentBlockhash: blockhash, feePayer: deployerPk });
+    // v17 wrapper installs a custom 128KB heap allocator and aborts unless the tx
+    // requests the full heap frame. Must be the FIRST instruction. (issue #176)
+    tx0.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
+    tx0.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }));
     tx0.add(createSlabIx, createVaultAtaIx, seedTransferIx, initMarketIx);
     tx0.partialSign(slabKp); // server co-signs as the new slab account
 
@@ -356,6 +361,10 @@ export async function POST(req: NextRequest) {
     });
 
     const tx1 = new Transaction({ recentBlockhash: blockhash, feePayer: deployerPk });
+    // v17 wrapper installs a custom 128KB heap allocator and aborts unless the tx
+    // requests the full heap frame. Must be the FIRST instruction. (issue #176)
+    tx1.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
+    tx1.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }));
     tx1.add(createPortfolioIx, initPortfolioIx);
     tx1.partialSign(lpPortfolioKp); // server co-signs as the new portfolio account
 
@@ -406,6 +415,11 @@ export async function POST(req: NextRequest) {
     });
 
     const tx2 = new Transaction({ recentBlockhash: blockhash, feePayer: deployerPk });
+    // Contains SetMatcherConfig (wrapper tag 68). The v17 wrapper installs a custom
+    // 128KB heap allocator and aborts unless the tx requests the full heap frame.
+    // Must be the FIRST instruction. (issue #176)
+    tx2.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
+    tx2.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }));
     tx2.add(createCtxIx, matcherInitIx, setMatcherConfigIx);
     tx2.partialSign(matcherCtxKp); // server co-signs as the new matcher context account
 
@@ -459,6 +473,10 @@ export async function POST(req: NextRequest) {
     });
 
     const tx3 = new Transaction({ recentBlockhash: blockhash, feePayer: deployerPk });
+    // v17 wrapper installs a custom 128KB heap allocator and aborts unless the tx
+    // requests the full heap frame. Must be the FIRST instruction. (issue #176)
+    tx3.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
+    tx3.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }));
     tx3.add(depositIx, topupIx, crankIx3);
 
     // Insurance LP mint creation removed — moved to percolator-stake program.

--- a/app/app/api/oracle/advance-phase/route.ts
+++ b/app/app/api/oracle/advance-phase/route.ts
@@ -126,6 +126,10 @@ export async function POST(req: NextRequest) {
     const ix = buildIx({ programId, keys, data });
 
     const tx = new Transaction().add(
+      // AdvanceOraclePhase is a wrapper-program instruction. The v17 wrapper installs
+      // a custom 128KB heap allocator and aborts unless the tx requests the full heap
+      // frame. Must be the FIRST instruction. (issue #176)
+      ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }),
       ComputeBudgetProgram.setComputeUnitLimit({ units: 50_000 }),
       ix,
     );

--- a/app/app/api/oracle/set-price-cap/route.ts
+++ b/app/app/api/oracle/set-price-cap/route.ts
@@ -202,6 +202,9 @@ export async function POST(req: NextRequest) {
 
       const tx = new Transaction();
       tx.add(
+        // v17 wrapper installs a custom 128KB heap allocator and aborts unless the
+        // tx requests the full heap frame. Must be the FIRST instruction. (issue #176)
+        ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }),
         ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 50_000 }),
         ComputeBudgetProgram.setComputeUnitLimit({ units: 50_000 }),
         ix,

--- a/app/hooks/useCloseMarket.ts
+++ b/app/hooks/useCloseMarket.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { PublicKey, Transaction } from "@solana/web3.js";
+import { PublicKey, Transaction, ComputeBudgetProgram } from "@solana/web3.js";
 import { getAssociatedTokenAddress, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import {
   parseHeader,
@@ -156,6 +156,10 @@ export function useCloseMarket() {
           recentBlockhash: blockhash,
           feePayer: walletCompat.publicKey,
         });
+        // v17 wrapper installs a custom 128KB heap allocator and aborts unless the
+        // tx requests the full heap frame. Must be the FIRST instruction. (issue #176)
+        tx.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
+        tx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }));
         tx.add(ix);
 
         const signed = await walletCompat.signTransaction(tx);

--- a/app/hooks/useTransferPositionNft.ts
+++ b/app/hooks/useTransferPositionNft.ts
@@ -295,6 +295,10 @@ export function useTransferPositionNft(slabAddress: string) {
 
         stage = "assembling transaction";
         const tx = new Transaction();
+        // The TransferChecked hook CPIs the v17 wrapper (TransferOwnershipCpi tag 69),
+        // which installs a custom 128KB heap allocator and aborts unless the tx
+        // requests the full heap frame. Must be the FIRST instruction. (issue #176)
+        tx.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
         tx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 300_000 }));
         tx.add(ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 100_000 }));
         tx.add(createDestAtaIx);

--- a/app/lib/tx.ts
+++ b/app/lib/tx.ts
@@ -393,6 +393,10 @@ export async function sendTx({
       );
 
       const tx = new Transaction();
+      // v17 wrapper installs a custom 128KB heap allocator and aborts ("Access
+      // violation in heap section") on its first heap allocation unless the tx
+      // requests the full heap frame. Must be the FIRST instruction. (issue #176)
+      tx.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
       tx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: computeUnits }));
       tx.add(ComputeBudgetProgram.setComputeUnitPrice({ microLamports: priorityFee }));
       for (const ix of cleanInstructions) {

--- a/scripts/admin-resolve-and-close.ts
+++ b/scripts/admin-resolve-and-close.ts
@@ -21,7 +21,7 @@
  *   7: oracle
  */
 
-import { Connection, PublicKey, Keypair, TransactionInstruction, SYSVAR_CLOCK_PUBKEY, Transaction, sendAndConfirmTransaction } from "@solana/web3.js";
+import { Connection, PublicKey, Keypair, TransactionInstruction, SYSVAR_CLOCK_PUBKEY, Transaction, sendAndConfirmTransaction, ComputeBudgetProgram } from "@solana/web3.js";
 import { getAssociatedTokenAddressSync, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { fetchSlab, parseAllAccounts, parseConfig, parseHeader } from "@percolatorct/sdk";
 import fs from "fs";
@@ -87,7 +87,12 @@ async function main() {
   });
 
   try {
-    const resolveTx = new Transaction().add(resolveIx);
+    const resolveTx = new Transaction();
+    // v17 wrapper installs a custom 128KB heap allocator and aborts unless the tx
+    // requests the full heap frame. Must be the FIRST instruction. (issue #176)
+    resolveTx.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
+    resolveTx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }));
+    resolveTx.add(resolveIx);
     const resolveSig = await sendAndConfirmTransaction(conn, resolveTx, [adminKey]);
     console.log("ResolveMarket OK:", resolveSig);
   } catch (e) {
@@ -132,7 +137,12 @@ async function main() {
     });
 
     try {
-      const closeTx = new Transaction().add(closeIx);
+      const closeTx = new Transaction();
+      // v17 wrapper installs a custom 128KB heap allocator and aborts unless the tx
+      // requests the full heap frame. Must be the FIRST instruction. (issue #176)
+      closeTx.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
+      closeTx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }));
+      closeTx.add(closeIx);
       const closeSig = await sendAndConfirmTransaction(conn, closeTx, [adminKey]);
       console.log(`  ForceClose #${idx} OK:`, closeSig);
     } catch (e) {

--- a/scripts/close-and-recover.ts
+++ b/scripts/close-and-recover.ts
@@ -59,6 +59,9 @@ async function main() {
   // Step 1: ResolveMarket
   console.log("\n--- ResolveMarket (tag 19) ---");
   const resolveTx = new Transaction();
+  // v17 wrapper installs a custom 128KB heap allocator and aborts unless the tx
+  // requests the full heap frame. Must be the FIRST instruction. (issue #176)
+  resolveTx.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
   resolveTx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 400_000 }));
   resolveTx.add(ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 50_000 }));
   resolveTx.add(new TransactionInstruction({
@@ -91,6 +94,9 @@ async function main() {
     closeData.writeUInt16LE(idx, 1);
 
     const closeTx = new Transaction();
+    // v17 wrapper installs a custom 128KB heap allocator and aborts unless the tx
+    // requests the full heap frame. Must be the FIRST instruction. (issue #176)
+    closeTx.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
     closeTx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 400_000 }));
     closeTx.add(ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 50_000 }));
 
@@ -125,6 +131,9 @@ async function main() {
   // Step 3: Close slab to recover rent
   console.log("\n--- CloseOrphanSlab (tag 29) ---");
   const closeSlab = new Transaction();
+  // v17 wrapper installs a custom 128KB heap allocator and aborts unless the tx
+  // requests the full heap frame. Must be the FIRST instruction. (issue #176)
+  closeSlab.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
   closeSlab.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 100_000 }));
   closeSlab.add(ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 50_000 }));
   closeSlab.add(new TransactionInstruction({

--- a/scripts/close-market-full.ts
+++ b/scripts/close-market-full.ts
@@ -100,6 +100,9 @@ async function main() {
       closeData.writeUInt16LE(idx, 1);
 
       const tx = new Transaction();
+      // v17 wrapper installs a custom 128KB heap allocator and aborts unless the tx
+      // requests the full heap frame. Must be the FIRST instruction. (issue #176)
+      tx.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
       tx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 400_000 }));
       tx.add(ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 100_000 }));
 
@@ -145,6 +148,9 @@ async function main() {
       const adminAta = getAssociatedTokenAddressSync(USDC_MINT, admin.publicKey);
 
       const tx = new Transaction();
+      // v17 wrapper installs a custom 128KB heap allocator and aborts unless the tx
+      // requests the full heap frame. Must be the FIRST instruction. (issue #176)
+      tx.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
       tx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 200_000 }));
       tx.add(ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 100_000 }));
       tx.add(new TransactionInstruction({
@@ -177,6 +183,9 @@ async function main() {
       console.log("  Slab already closed");
     } else {
       const tx = new Transaction();
+      // v17 wrapper installs a custom 128KB heap allocator and aborts unless the tx
+      // requests the full heap frame. Must be the FIRST instruction. (issue #176)
+      tx.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
       tx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 200_000 }));
       tx.add(ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 100_000 }));
       tx.add(new TransactionInstruction({

--- a/scripts/create-market.ts
+++ b/scripts/create-market.ts
@@ -465,6 +465,9 @@ async function main() {
   );
 
   const tx1 = new Transaction();
+  // v17 wrapper installs a custom 128KB heap allocator and aborts unless the tx
+  // requests the full heap frame. Must be the FIRST instruction. (issue #176)
+  tx1.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
   tx1.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }));
   tx1.add(ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 50_000 }));
   // Create the slab account (program-owned, rent-exempt)
@@ -530,6 +533,9 @@ async function main() {
   console.log("TX2: SetDexPool (pin DEX pool for Hyperp oracle)...");
 
   const tx2 = new Transaction();
+  // v17 wrapper installs a custom 128KB heap allocator and aborts unless the tx
+  // requests the full heap frame. Must be the FIRST instruction. (issue #176)
+  tx2.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
   tx2.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 100_000 }));
   tx2.add(ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 50_000 }));
   tx2.add(
@@ -573,6 +579,10 @@ async function main() {
   const ctxRent = await conn.getMinimumBalanceForRentExemption(MATCHER_CTX_SIZE);
 
   const tx3 = new Transaction();
+  // Contains a wrapper instruction. The v17 wrapper installs a custom 128KB heap
+  // allocator and aborts unless the tx requests the full heap frame. Must be the
+  // FIRST instruction. (issue #176)
+  tx3.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
   tx3.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 300_000 }));
   tx3.add(ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 50_000 }));
   // Pre-allocate the matcher context account (InitMatcherCtx in TX4 will fill it)
@@ -640,6 +650,9 @@ async function main() {
   console.log("TX4: InitMatcherCtx (initialize matcher for LP slot 0)...");
 
   const tx4 = new Transaction();
+  // v17 wrapper installs a custom 128KB heap allocator and aborts unless the tx
+  // requests the full heap frame. Must be the FIRST instruction. (issue #176)
+  tx4.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
   tx4.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 400_000 }));
   tx4.add(ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 50_000 }));
   tx4.add(
@@ -690,6 +703,9 @@ async function main() {
     );
 
     const tx5 = new Transaction();
+    // v17 wrapper installs a custom 128KB heap allocator and aborts unless the tx
+    // requests the full heap frame. Must be the FIRST instruction. (issue #176)
+    tx5.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
     tx5.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 100_000 }));
     tx5.add(ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 50_000 }));
     tx5.add(

--- a/scripts/floating-maker.ts
+++ b/scripts/floating-maker.ts
@@ -175,6 +175,9 @@ async function sendTx(
   computeUnits = 400_000,
 ): Promise<string> {
   const tx = new Transaction();
+  // v17 wrapper installs a custom 128KB heap allocator and aborts unless the tx
+  // requests the full heap frame. Must be the FIRST instruction. (issue #176)
+  tx.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
   tx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: computeUnits }));
   for (const ix of ixs) tx.add(ix);
   return sendAndConfirmTransaction(connection, tx, signers, {

--- a/scripts/refund-user.ts
+++ b/scripts/refund-user.ts
@@ -25,6 +25,9 @@ async function main() {
   // Step 1: WithdrawInsurance from wrapper (tag 20) — admin gets USDC from vault
   console.log("Step 1: WithdrawInsurance (10 USDC from vault → admin ATA)...");
   const tx1 = new Transaction();
+  // v17 wrapper installs a custom 128KB heap allocator and aborts unless the tx
+  // requests the full heap frame. Must be the FIRST instruction. (issue #176)
+  tx1.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
   tx1.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 200_000 }));
   tx1.add(ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 100_000 }));
   tx1.add(new TransactionInstruction({

--- a/scripts/rescue-and-close-slab.ts
+++ b/scripts/rescue-and-close-slab.ts
@@ -21,6 +21,9 @@ async function main() {
   console.log("--- RescueOrphanVault (tag 72) ---");
   {
     const tx = new Transaction();
+    // v17 wrapper installs a custom 128KB heap allocator and aborts unless the tx
+    // requests the full heap frame. Must be the FIRST instruction. (issue #176)
+    tx.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
     tx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 1_000_000 }));
     tx.add(ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 100_000 }));
     tx.add(new TransactionInstruction({
@@ -45,6 +48,9 @@ async function main() {
   console.log("\n--- CloseOrphanSlab (tag 73) ---");
   {
     const tx = new Transaction();
+    // v17 wrapper installs a custom 128KB heap allocator and aborts unless the tx
+    // requests the full heap frame. Must be the FIRST instruction. (issue #176)
+    tx.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
     tx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 1_000_000 }));
     tx.add(ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 100_000 }));
     tx.add(new TransactionInstruction({

--- a/scripts/rescue-and-recreate.ts
+++ b/scripts/rescue-and-recreate.ts
@@ -85,6 +85,9 @@ async function sendTx(
   label: string,
 ): Promise<string> {
   const tx = new Transaction().add(
+    // v17 wrapper installs a custom 128KB heap allocator and aborts unless the tx
+    // requests the full heap frame. Must be the FIRST instruction. (issue #176)
+    ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }),
     ComputeBudgetProgram.setComputeUnitLimit({ units: 400_000 }),
     ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 10_000 }),
     ...instructions,


### PR DESCRIPTION
## v17 deploy blocker fix (client-side) — issue #176

The v17 wrapper program installs a custom **128KB** `BumpAllocator` (`V16_HEAP_FRAME_BYTES`) that bumps *down* from `heap_base+128KB`. The entrypoint's `deserialize()` makes the first heap allocation on **every** instruction, so any tx to the wrapper **aborts** ("Access violation in heap section") under Solana's default 32KB heap — unless the tx includes `ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 })`.

No client requested one. This PR adds it to every wrapper-transaction send site in this repo. Central `sendTx` (covers 17 hooks) + 7 bypass sites (close-market, NFT-transfer, mobile create-market ×4 with added CU limit, 2 oracle routes) + 8 ops scripts. Skipped stake-program/system/Raydium txs (recorded).

**Verification:** `tsc --noEmit -p app/tsconfig.json` PASS; heap-frame inserted first at all 27 wrapper sites.

⚠️ **DO NOT MERGE until the v17 cutover is human-gated** — this repo deploys to prod on merge. Draft until then. The change is forward-compatible (harmless on the current program; required for v17).

Refs dcccrypto/percolator-stake#176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced transaction construction across API endpoints, user interface components, and administrative scripts to optimize system resource allocation. These updates improve transaction reliability and efficiency for market creation, oracle operations, price management, account closure, position transfers, market resolution, and account recovery workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->