### PR TITLE
fix(build): resolve @percolatorct/sdk via public git dep (unblocks v17 build/deploy)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -12,7 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@percolatorct/sdk": "file:/Users/khubair/percolator-sdk",
+    "@percolatorct/sdk": "github:dcccrypto/percolator-sdk#1a174d3",
     "@privy-io/node": "^0.18.0",
     "@privy-io/react-auth": "^3.14.1",
     "@sentry/nextjs": "^10.39.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "tsx": "^4.21.0"
   },
   "dependencies": {
-    "@percolatorct/sdk": "file:/Users/khubair/percolator-sdk",
+    "@percolatorct/sdk": "github:dcccrypto/percolator-sdk#1a174d3",
     "@solana/spl-token": "^0.4.14",
     "@solana/web3.js": "^1.98.4",
     "dotenv": "^17.3.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
   .:
     dependencies:
       '@percolatorct/sdk':
-        specifier: file:/Users/khubair/percolator-sdk
-        version: file:../../percolator-sdk(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+        specifier: github:dcccrypto/percolator-sdk#1a174d3
+        version: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/1a174d3cd00794286da5ffc92bf240bad60784f2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/spl-token':
         specifier: ^0.4.14
         version: 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
@@ -64,8 +64,8 @@ importers:
   app:
     dependencies:
       '@percolatorct/sdk':
-        specifier: file:/Users/khubair/percolator-sdk
-        version: file:../../percolator-sdk(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+        specifier: github:dcccrypto/percolator-sdk#1a174d3
+        version: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/1a174d3cd00794286da5ffc92bf240bad60784f2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@privy-io/node':
         specifier: ^0.18.0
         version: 0.18.0(@solana/kit@6.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.46.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
@@ -1372,8 +1372,9 @@ packages:
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
     deprecated: 'The package is now available as "qr": npm install qr'
 
-  '@percolatorct/sdk@file:../../percolator-sdk':
-    resolution: {directory: ../../percolator-sdk, type: directory}
+  '@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/1a174d3cd00794286da5ffc92bf240bad60784f2':
+    resolution: {tarball: https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/1a174d3cd00794286da5ffc92bf240bad60784f2}
+    version: 3.0.0
     engines: {node: '>=20.0.0'}
 
   '@phosphor-icons/webcomponents@2.1.5':
@@ -8592,7 +8593,7 @@ snapshots:
 
   '@paulmillr/qr@0.2.1': {}
 
-  '@percolatorct/sdk@file:../../percolator-sdk(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+  '@percolatorct/sdk@https://codeload.github.com/dcccrypto/percolator-sdk/tar.gz/1a174d3cd00794286da5ffc92bf240bad60784f2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)


### PR DESCRIPTION
## Problem
The v17 app code imports SDK 3.0.0 functions (`encodeCreateLpVaultV17`, `encodePermissionlessCrank`, `encodeCreateLpVault`, …) but `package.json` pinned `@percolatorct/sdk` to `file:/Users/khubair/percolator-sdk` — a **machine-local path that doesn't exist on Vercel**, and npm only publishes **2.0.9** (no v17 functions). So the deploy build failed resolving the SDK, and the local `main` worktree had a stale 2.0.9 installed.

## Fix
Repoint `@percolatorct/sdk` to a **public git dependency** pinned to the SDK repo's `origin/main` commit: `github:dcccrypto/percolator-sdk#1a174d3` — version 3.0.0, all v17 encoders in **committed `dist/`**, no build step. Vercel-fetchable (public repo); lockfile pins the exact tarball for reproducibility.

## Verified
- `tsc --noEmit -p app/tsconfig.json` → **PASS** (missing-encoder errors gone)
- `next build` → **completes**, all routes compiled

Only 3 files change: `package.json`, `app/package.json`, `pnpm-lock.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core dependency version management to enhance development stability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->