### PR TITLE
fix(rpc): bound getProgramAccounts proxy queries

### DIFF
--- a/app/__tests__/api/rpc-origin-guard.test.ts
+++ b/app/__tests__/api/rpc-origin-guard.test.ts
@@ -170,7 +170,6 @@ describe("/api/rpc no-Origin server-call gate", () => {
 describe("/api/rpc getProgramAccounts guard", () => {
   const originalFetch = global.fetch;
   const originalDefaultNetwork = process.env.NEXT_PUBLIC_DEFAULT_NETWORK;
-  const KNOWN_PROGRAM = "ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv";
   const SPL_TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
 
   let originalLocalNetwork: string | null = null;
@@ -232,32 +231,58 @@ describe("/api/rpc getProgramAccounts guard", () => {
     expect(global.fetch).not.toHaveBeenCalled();
     const body = await res.json();
     expect(body.error.code).toBe(-32602);
-    expect(body.error.message).toContain("target is not allowed");
+    expect(body.error.message).toContain("bounding filter");
   });
 
-  it("requires filters even for allowlisted getProgramAccounts targets", async () => {
+  it("rejects non-bounding getProgramAccounts filters before proxying", async () => {
     const res = await POST(
       makeReq({
         jsonrpc: "2.0",
         id: 2205,
         method: "getProgramAccounts",
-        params: [KNOWN_PROGRAM],
+        params: [SPL_TOKEN_PROGRAM, { filters: [{ unsupported: true }] }],
       }),
     );
 
     expect(res.status).toBe(400);
     expect(global.fetch).not.toHaveBeenCalled();
     const body = await res.json();
-    expect(body.error.message).toContain("at least one filter");
+    expect(body.error.message).toContain("dataSize or memcmp");
   });
 
-  it("allows filtered getProgramAccounts for known Percolator programs", async () => {
+  it("allows dataSize-bounded getProgramAccounts requests", async () => {
     const res = await POST(
       makeReq({
         jsonrpc: "2.0",
         id: 2206,
         method: "getProgramAccounts",
-        params: [KNOWN_PROGRAM, { filters: [{ dataSize: 128 }] }],
+        params: [SPL_TOKEN_PROGRAM, { filters: [{ dataSize: 165 }] }],
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows memcmp-bounded getProgramAccounts requests", async () => {
+    const res = await POST(
+      makeReq({
+        jsonrpc: "2.0",
+        id: 2207,
+        method: "getProgramAccounts",
+        params: [
+          SPL_TOKEN_PROGRAM,
+          {
+            filters: [
+              {
+                memcmp: {
+                  offset: 0,
+                  bytes: "11111111111111111111111111111111",
+                },
+              },
+            ],
+          },
+        ],
       }),
     );
 

--- a/app/__tests__/api/rpc-origin-guard.test.ts
+++ b/app/__tests__/api/rpc-origin-guard.test.ts
@@ -166,3 +166,102 @@ describe("/api/rpc no-Origin server-call gate", () => {
     expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("/api/rpc getProgramAccounts guard", () => {
+  const originalFetch = global.fetch;
+  const originalDefaultNetwork = process.env.NEXT_PUBLIC_DEFAULT_NETWORK;
+  const KNOWN_PROGRAM = "ESa89R5Es3rJ5mnwGybVRG1GrNt9etP11Z5V2QWD4edv";
+  const SPL_TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+
+  let originalLocalNetwork: string | null = null;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = vi.fn().mockResolvedValue({
+      json: async () => ({ jsonrpc: "2.0", id: 1, result: [] }),
+    } as Response) as typeof fetch;
+    process.env.NEXT_PUBLIC_DEFAULT_NETWORK = "mainnet";
+    try {
+      originalLocalNetwork = window.localStorage.getItem("percolator-network");
+      window.localStorage.setItem("percolator-network", "mainnet");
+    } catch {
+      originalLocalNetwork = null;
+    }
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    if (originalDefaultNetwork === undefined) {
+      delete process.env.NEXT_PUBLIC_DEFAULT_NETWORK;
+    } else {
+      process.env.NEXT_PUBLIC_DEFAULT_NETWORK = originalDefaultNetwork;
+    }
+    try {
+      if (originalLocalNetwork === null) {
+        window.localStorage.removeItem("percolator-network");
+      } else {
+        window.localStorage.setItem("percolator-network", originalLocalNetwork);
+      }
+    } catch {
+      // localStorage may be unavailable in non-browser test runners.
+    }
+  });
+
+  function makeReq(body: unknown): NextRequest {
+    return new NextRequest("http://localhost/api/rpc", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        origin: "https://percolatorlaunch.com",
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it("blocks unbounded getProgramAccounts sweeps against SPL Token before proxying", async () => {
+    const res = await POST(
+      makeReq({
+        jsonrpc: "2.0",
+        id: 2204,
+        method: "getProgramAccounts",
+        params: [SPL_TOKEN_PROGRAM],
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(global.fetch).not.toHaveBeenCalled();
+    const body = await res.json();
+    expect(body.error.code).toBe(-32602);
+    expect(body.error.message).toContain("target is not allowed");
+  });
+
+  it("requires filters even for allowlisted getProgramAccounts targets", async () => {
+    const res = await POST(
+      makeReq({
+        jsonrpc: "2.0",
+        id: 2205,
+        method: "getProgramAccounts",
+        params: [KNOWN_PROGRAM],
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(global.fetch).not.toHaveBeenCalled();
+    const body = await res.json();
+    expect(body.error.message).toContain("at least one filter");
+  });
+
+  it("allows filtered getProgramAccounts for known Percolator programs", async () => {
+    const res = await POST(
+      makeReq({
+        jsonrpc: "2.0",
+        id: 2206,
+        method: "getProgramAccounts",
+        params: [KNOWN_PROGRAM, { filters: [{ dataSize: 128 }] }],
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/app/api/rpc/route.ts
+++ b/app/app/api/rpc/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getAllProgramIds, getRpcEndpoint } from "@/lib/config";
+import { getRpcEndpoint } from "@/lib/config";
 import { createHash, timingSafeEqual } from "crypto";
 
 export const dynamic = "force-dynamic";
@@ -265,23 +265,18 @@ function validateGetProgramAccounts(req: Record<string, unknown>) {
     return jsonRpcValidationError(req.id ?? null, "getProgramAccounts requires array params");
   }
 
-  const targetProgram = params[0];
-  if (typeof targetProgram !== "string" || targetProgram.trim() === "") {
-    return jsonRpcValidationError(req.id ?? null, "getProgramAccounts requires a program id");
-  }
-
-  const allowedPrograms = getAllProgramIds();
-  if (!allowedPrograms.includes(targetProgram)) {
-    console.warn("[/api/rpc] Blocked getProgramAccounts for non-allowlisted program", {
-      targetProgram,
-    });
-    return jsonRpcValidationError(req.id ?? null, "getProgramAccounts target is not allowed");
-  }
-
   const config = params[1];
   const filters = isRecord(config) ? config.filters : undefined;
-  if (!Array.isArray(filters) || filters.length === 0) {
-    return jsonRpcValidationError(req.id ?? null, "getProgramAccounts requires at least one filter");
+  const bounded =
+    Array.isArray(filters) &&
+    filters.some((filter) => isRecord(filter) && ("dataSize" in filter || "memcmp" in filter));
+
+  if (!bounded) {
+    console.warn("[/api/rpc] Blocked unbounded getProgramAccounts");
+    return jsonRpcValidationError(
+      req.id ?? null,
+      "getProgramAccounts requires a bounding filter (dataSize or memcmp)",
+    );
   }
 
   return null;

--- a/app/app/api/rpc/route.ts
+++ b/app/app/api/rpc/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getRpcEndpoint } from "@/lib/config";
+import { getAllProgramIds, getRpcEndpoint } from "@/lib/config";
 import { createHash, timingSafeEqual } from "crypto";
 
 export const dynamic = "force-dynamic";
@@ -247,6 +247,46 @@ interface JsonRpcRequest {
   params?: unknown;
 }
 
+function jsonRpcValidationError(id: unknown, message: string) {
+  return {
+    jsonrpc: "2.0",
+    error: { code: -32602, message },
+    id,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function validateGetProgramAccounts(req: Record<string, unknown>) {
+  const params = req.params;
+  if (!Array.isArray(params)) {
+    return jsonRpcValidationError(req.id ?? null, "getProgramAccounts requires array params");
+  }
+
+  const targetProgram = params[0];
+  if (typeof targetProgram !== "string" || targetProgram.trim() === "") {
+    return jsonRpcValidationError(req.id ?? null, "getProgramAccounts requires a program id");
+  }
+
+  const allowedPrograms = getAllProgramIds();
+  if (!allowedPrograms.includes(targetProgram)) {
+    console.warn("[/api/rpc] Blocked getProgramAccounts for non-allowlisted program", {
+      targetProgram,
+    });
+    return jsonRpcValidationError(req.id ?? null, "getProgramAccounts target is not allowed");
+  }
+
+  const config = params[1];
+  const filters = isRecord(config) ? config.filters : undefined;
+  if (!Array.isArray(filters) || filters.length === 0) {
+    return jsonRpcValidationError(req.id ?? null, "getProgramAccounts requires at least one filter");
+  }
+
+  return null;
+}
+
 /** Validate a single JSON-RPC request, return error response or null if valid */
 function validateRequest(req: Record<string, unknown>): { jsonrpc: string; error: { code: number; message: string }; id: unknown } | null {
   const method = req?.method;
@@ -264,6 +304,9 @@ function validateRequest(req: Record<string, unknown>): { jsonrpc: string; error
       error: { code: -32601, message: `Method not allowed: ${method}` },
       id: req?.id ?? null,
     };
+  }
+  if (method === "getProgramAccounts") {
+    return validateGetProgramAccounts(req);
   }
   return null;
 }


### PR DESCRIPTION
## Summary

Fixes #2204.

The public `/api/rpc` proxy allowed `getProgramAccounts` and forwarded its params directly to the upstream RPC provider. That meant a first-party browser origin could ask the server-side Helius key for huge full-program sweeps such as the SPL Token program.

This PR adds a request-level guard before proxying:

- `getProgramAccounts` must include a non-empty `filters` array with at least one bounding `dataSize` or `memcmp` filter.
- Invalid requests return a JSON-RPC `-32602` validation error and never call upstream `fetch()`.

This now matches the mitigation already noted by maintainers in #2211, while keeping POST-level regression coverage in this PR.

## PoC / Regression

Added POST-level tests in `app/__tests__/api/rpc-origin-guard.test.ts`:

- blocks the issue #2204 SPL Token full-sweep shape before proxying:

```json
{
  "jsonrpc": "2.0",
  "id": 2204,
  "method": "getProgramAccounts",
  "params": ["TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"]
}
```

- blocks non-bounding filters such as `[{ "unsupported": true }]`
- allows `dataSize`-bounded requests
- allows `memcmp`-bounded requests

The blocking tests assert `fetch()` is not called, proving the proxy rejects the request before it can consume Helius quota or allocate a huge response.

## Verification

- `git diff --check`
- `node_modules/.bin/vitest run __tests__/api/rpc-origin-guard.test.ts` from `app/` passed locally: 16 tests passed.

Note: local verification reused the existing dependency install from the main checkout via temporary symlinks to avoid duplicating a ~1.5GB `node_modules` tree on a low-disk workspace. The symlinks were removed before committing.
