### PR TITLE
fix(security): requireAuth fails closed in all environments when INDEXER_API_KEY unset (#2223)

### DIFF
--- a/app/__tests__/lib/api-auth.test.ts
+++ b/app/__tests__/lib/api-auth.test.ts
@@ -23,31 +23,25 @@ describe("requireAuth", () => {
     process.env = { ...originalEnv };
   });
 
-  describe("dev mode (no INDEXER_API_KEY set)", () => {
-    it("allows all requests in non-production", () => {
-      delete process.env.INDEXER_API_KEY;
-      process.env.NODE_ENV = "development";
-      expect(requireAuth(mockRequest())).toBe(true);
-    });
+  // Differential (anti-hollow): confirm the exact FAIL direction, then the PASS direction.
+  // Without INDEXER_API_KEY, every call must be rejected regardless of NODE_ENV — staging
+  // and preview deployments run as NODE_ENV=development but serve real data.
+  describe("fail-closed when INDEXER_API_KEY is not configured", () => {
+    for (const env of ["production", "development", "test", undefined] as const) {
+      const label = env ?? "(unset)";
+      it(`rejects all requests in NODE_ENV=${label} — wrong path`, () => {
+        delete process.env.INDEXER_API_KEY;
+        if (env === undefined) delete process.env.NODE_ENV;
+        else process.env.NODE_ENV = env;
+        expect(requireAuth(mockRequest())).toBe(false);
+        expect(requireAuth(mockRequest({ "x-api-key": "anything" }))).toBe(false);
+      });
+    }
 
-    it("allows requests with any header in dev", () => {
-      delete process.env.INDEXER_API_KEY;
-      process.env.NODE_ENV = "development";
-      expect(requireAuth(mockRequest({ "x-api-key": "anything" }))).toBe(true);
-    });
-  });
-
-  describe("production without key configured (R2-S9)", () => {
-    it("rejects all requests when INDEXER_API_KEY is not set", () => {
-      delete process.env.INDEXER_API_KEY;
-      process.env.NODE_ENV = "production";
-      expect(requireAuth(mockRequest())).toBe(false);
-    });
-
-    it("rejects even requests with an x-api-key header", () => {
-      delete process.env.INDEXER_API_KEY;
-      process.env.NODE_ENV = "production";
-      expect(requireAuth(mockRequest({ "x-api-key": "some-key" }))).toBe(false);
+    it("passes once INDEXER_API_KEY is set — right path", () => {
+      delete process.env.NODE_ENV; // not production
+      process.env.INDEXER_API_KEY = "dev-local-key";
+      expect(requireAuth(mockRequest({ "x-api-key": "dev-local-key" }))).toBe(true);
     });
   });
 

--- a/app/lib/api-auth.ts
+++ b/app/lib/api-auth.ts
@@ -5,15 +5,14 @@ import { NextRequest, NextResponse } from "next/server";
  * Simple API key auth for internal/indexer routes.
  * Checks `x-api-key` header against INDEXER_API_KEY env var.
  * Uses timing-safe comparison (PERC-597) to prevent timing-oracle attacks.
- * R2-S9: In production without a configured key, rejects all requests.
+ * Fail-closed: when INDEXER_API_KEY is not configured, all requests are
+ * rejected in every environment. Staging/preview deployments are not
+ * "production" but serve real data, so NODE_ENV cannot gate this check.
+ * Set any non-empty INDEXER_API_KEY value for local development.
  */
 export function requireAuth(req: NextRequest): boolean {
   const expectedKey = process.env.INDEXER_API_KEY?.trim() || undefined;
-  if (!expectedKey) {
-    // R2-S9: In production, reject all requests if auth key is not configured
-    if (process.env.NODE_ENV === "production") return false;
-    return true; // No key configured = open (dev mode only)
-  }
+  if (!expectedKey) return false;
   const providedKey = req.headers.get("x-api-key");
   if (!providedKey) return false;
 


### PR DESCRIPTION
Fixes #2223.

## What changed

`app/lib/api-auth.ts` — removed the `NODE_ENV === "production"` gate that caused `requireAuth` to return `true` (open) on any non-production deployment without `INDEXER_API_KEY` set.

Before:
```ts
if (!expectedKey) {
  if (process.env.NODE_ENV === "production") return false;
  return true; // No key configured = open (dev mode only)
}
```

After:
```ts
if (!expectedKey) return false;
```

## Why NODE_ENV is the wrong gate

`NODE_ENV` is a build/runtime mode signal, not a deployment-tier signal. Railway preview apps and Vercel preview branches run as `NODE_ENV=development`. Any such deployment without `INDEXER_API_KEY` configured served `GET /api/bugs` (all bug reports + submitter handles), `GET /api/stats`, and the two logo routes unauthenticated to anyone.

## Test changes (`app/__tests__/lib/api-auth.test.ts`)

- Removed: two `"dev mode allows everything"` assertions (those were the wrong invariant)
- Added: parametric fail-closed assertions across all four `NODE_ENV` values (`production`, `development`, `test`, unset) — both wrong-path (no key → 401) and right-path (key set + correct header → 200) to form a differential proof

## Migration

No config changes required for correctly-configured deployments. Operators running local dev without `INDEXER_API_KEY` will now get 401s — set `INDEXER_API_KEY=dev` (or any non-empty value) in `.env.local` to restore the open-dev behaviour explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API authentication requirements have been tightened. All requests now require valid credentials across all deployment environments, with no exceptions. Previously, authentication could be bypassed under certain conditions; this behavior has changed. Requests without proper credentials are now consistently rejected regardless of environment or deployment state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->