### PR TITLE
fix: align position nft flow with v16 state

### DIFF
--- a/app/__tests__/lib/nft-program-v16.test.ts
+++ b/app/__tests__/lib/nft-program-v16.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { Keypair, PublicKey } from "@solana/web3.js";
+import {
+  deriveNftMint,
+  deriveNftPda,
+  parsePositionNftAccount,
+  PERCOLATOR_NFT_PROGRAM_ID,
+  POSITION_NFT_STATE_LEN,
+} from "../../lib/nft-program";
+
+const POSITION_NFT_MAGIC = 0x5045_5243_4e46_5400n;
+
+function u16Le(value: number): Uint8Array {
+  const out = new Uint8Array(2);
+  new DataView(out.buffer).setUint16(0, value, true);
+  return out;
+}
+
+function writeI128(view: DataView, offset: number, value: bigint) {
+  const unsigned = value < 0n ? (1n << 128n) + value : value;
+  view.setBigUint64(offset, unsigned & 0xffff_ffff_ffff_ffffn, true);
+  view.setBigUint64(offset + 8, unsigned >> 64n, true);
+}
+
+describe("percolator-nft v16 helpers", () => {
+  it("derives PositionNft PDA from portfolio account and asset index", () => {
+    const portfolio = new PublicKey("11111111111111111111111111111111");
+    const staleSlab = new PublicKey("So11111111111111111111111111111111111111112");
+    const assetIndex = 7;
+
+    const [actual] = deriveNftPda(portfolio, assetIndex);
+    const [expected] = PublicKey.findProgramAddressSync(
+      [new TextEncoder().encode("position_nft"), portfolio.toBytes(), u16Le(assetIndex)],
+      PERCOLATOR_NFT_PROGRAM_ID
+    );
+    const [staleLaunchPda] = PublicKey.findProgramAddressSync(
+      [new TextEncoder().encode("position_nft"), staleSlab.toBytes(), u16Le(assetIndex)],
+      PERCOLATOR_NFT_PROGRAM_ID
+    );
+
+    expect(actual.equals(expected)).toBe(true);
+    expect(actual.equals(staleLaunchPda)).toBe(false);
+  });
+
+  it("parses the 199-byte PositionNftV16 layout", () => {
+    const portfolio = Keypair.generate().publicKey;
+    const mint = Keypair.generate().publicKey;
+    const owner = Keypair.generate().publicKey;
+    const data = new Uint8Array(POSITION_NFT_STATE_LEN);
+    const view = new DataView(data.buffer);
+
+    view.setBigUint64(0, POSITION_NFT_MAGIC, true);
+    data[8] = 2;
+    data[9] = 201;
+    data.set(portfolio.toBytes(), 10);
+    data.set(mint.toBytes(), 42);
+    view.setUint32(74, 7, true);
+    data[78] = 1;
+    writeI128(view, 79, -123n);
+    writeI128(view, 95, 456n);
+    view.setBigUint64(111, 987n, true);
+    view.setBigUint64(119, 654n, true);
+    data.set(owner.toBytes(), 127);
+    view.setBigInt64(159, 1_710_000_000n, true);
+
+    const parsed = parsePositionNftAccount(data);
+
+    expect(parsed.version).toBe(2);
+    expect(parsed.bump).toBe(201);
+    expect(parsed.portfolioAccount.equals(portfolio)).toBe(true);
+    expect(parsed.mint.equals(mint)).toBe(true);
+    expect(parsed.assetIndex).toBe(7);
+    expect(parsed.sideAtMint).toBe(1);
+    expect(parsed.basisPosQAtMint).toBe(-123n);
+    expect(parsed.positionSize).toBe(123n);
+    expect(parsed.fSnapAtMint).toBe(456n);
+    expect(parsed.marketIdAtMint).toBe(987n);
+    expect(parsed.epochSnapAtMint).toBe(654n);
+    expect(parsed.positionOwner.equals(owner)).toBe(true);
+    expect(parsed.mintedAt).toBe(1_710_000_000n);
+  });
+
+  it("rejects stale lengths and stale mint PDA derivation", () => {
+    expect(POSITION_NFT_STATE_LEN).toBe(199);
+    expect(() => parsePositionNftAccount(new Uint8Array(198))).toThrow(/too small/i);
+    expect(() => deriveNftMint(Keypair.generate().publicKey, 0)).toThrow(/fresh signer/i);
+  });
+});

--- a/app/__tests__/setup.ts
+++ b/app/__tests__/setup.ts
@@ -4,19 +4,21 @@ import '@testing-library/jest-dom';
 
 // jsdom doesn't implement window.matchMedia — mock it so hooks like
 // usePrefersReducedMotion don't throw during component tests.
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: vi.fn((query: string) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  })),
-});
+if (typeof window !== 'undefined') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
 
 // Cleanup after each test
 afterEach(() => {

--- a/app/hooks/useBurnPositionNft.ts
+++ b/app/hooks/useBurnPositionNft.ts
@@ -1,31 +1,21 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { PublicKey, TransactionInstruction } from "@solana/web3.js";
+import { TransactionInstruction } from "@solana/web3.js";
 import { TOKEN_2022_PROGRAM_ID, getAssociatedTokenAddressSync } from "@solana/spl-token";
 import { useWalletCompat, useConnectionCompat } from "@/hooks/useWalletCompat";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { useUserAccount } from "@/hooks/useUserAccount";
 import { usePositionNft } from "@/hooks/usePositionNft";
-import { encodeBurnPositionNft } from "@percolatorct/sdk";
 import { sendTx } from "@/lib/tx";
 import { humanizeError } from "@/lib/errorMessages";
 import { useToast } from "@/hooks/useToast";
-
-const NFT_PROGRAM_ID = new PublicKey("FqhKJT9gtScjrmfUuRMjeg7cXNpif1fqsy5Jh65tJmTS");
-
-/**
- * Derive the position_nft PDA.
- * Seeds: ["position_nft", slab_key, user_idx as u16 LE]
- */
-function deriveNftPda(programId: PublicKey, slab: PublicKey, userIdx: number): [PublicKey, number] {
-  const idxBuf = new Uint8Array(2);
-  new DataView(idxBuf.buffer).setUint16(0, userIdx, true);
-  return PublicKey.findProgramAddressSync(
-    [Buffer.from("position_nft"), slab.toBytes(), idxBuf],
-    programId,
-  );
-}
+import {
+  deriveMintAuthority,
+  deriveNftPda,
+  NFT_BURN_TAG,
+  PERCOLATOR_NFT_PROGRAM_ID,
+} from "@/lib/nft-program";
 
 export function useBurnPositionNft(slabAddress: string) {
   const { publicKey: walletPubkey } = useWalletCompat();
@@ -49,16 +39,15 @@ export function useBurnPositionNft(slabAddress: string) {
     setError(null);
 
     try {
-      const slabPk = new PublicKey(slabAddress);
-      const userIdx = userAccount.idx;
+      const portfolioPk = userAccount.portfolioPubkey;
+      const assetIndex = userAccount.assetIndex;
+      if (!portfolioPk || assetIndex === undefined) {
+        throw new Error("No active v17 portfolio position found to burn as an NFT");
+      }
 
-      // Derive PDAs — NFT PDA uses NFT program, vault auth uses wrapper program
-      const nftProgId = NFT_PROGRAM_ID;
-      const [nftPda] = deriveNftPda(nftProgId, slabPk, userIdx);
-      const [vaultAuth] = PublicKey.findProgramAddressSync(
-        [Buffer.from("vault"), slabPk.toBuffer()],
-        programId!,
-      );
+      const nftProgId = PERCOLATOR_NFT_PROGRAM_ID;
+      const [nftPda] = deriveNftPda(portfolioPk, assetIndex, nftProgId);
+      const [mintAuth] = deriveMintAuthority(nftProgId);
 
       // Owner's Token-2022 ATA for the NFT mint
       const ownerAta = getAssociatedTokenAddressSync(
@@ -68,21 +57,20 @@ export function useBurnPositionNft(slabAddress: string) {
         TOKEN_2022_PROGRAM_ID,
       );
 
-      // Build BurnPositionNft instruction (tag 66)
-      // Accounts: [owner(signer), slab, nft_pda, nft_mint, owner_ata, vault_auth, token22]
+      // Build standalone NFT BurnPositionNft instruction (tag 1).
+      // Accounts: [holder, nft_pda, nft_mint, holder_ata, portfolio, mint_auth, token22]
       const ix = new TransactionInstruction({
         programId: nftProgId,
         keys: [
-          { pubkey: walletPubkey, isSigner: true, isWritable: true },    // owner
-          { pubkey: slabPk, isSigner: false, isWritable: true },         // slab
+          { pubkey: walletPubkey, isSigner: true, isWritable: true },    // holder
           { pubkey: nftPda, isSigner: false, isWritable: true },         // nft_pda
           { pubkey: nftMint, isSigner: false, isWritable: true },        // nft_mint
-          { pubkey: ownerAta, isSigner: false, isWritable: true },       // owner_ata
-          { pubkey: vaultAuth, isSigner: false, isWritable: false },     // vault_auth PDA
+          { pubkey: ownerAta, isSigner: false, isWritable: true },       // holder_ata
+          { pubkey: portfolioPk, isSigner: false, isWritable: false },   // portfolio
+          { pubkey: mintAuth, isSigner: false, isWritable: false },      // mint_authority PDA
           { pubkey: TOKEN_2022_PROGRAM_ID, isSigner: false, isWritable: false }, // token-2022
         ],
-        // NFT program uses tag 1 for BurnPositionNft (not SDK's tag which is for the wrapper)
-        data: Buffer.from([1]),
+        data: Buffer.from([NFT_BURN_TAG]),
       });
 
       const sig = await sendTx({

--- a/app/hooks/useMintPositionNft.ts
+++ b/app/hooks/useMintPositionNft.ts
@@ -1,16 +1,21 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { PublicKey, Keypair, TransactionInstruction, SYSVAR_RENT_PUBKEY, SystemProgram } from "@solana/web3.js";
+import { Keypair, TransactionInstruction, SystemProgram } from "@solana/web3.js";
 import { TOKEN_2022_PROGRAM_ID, getAssociatedTokenAddressSync, ASSOCIATED_TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { useWalletCompat, useConnectionCompat } from "@/hooks/useWalletCompat";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { useUserAccount } from "@/hooks/useUserAccount";
-import { encodeMintPositionNft, getProgramId } from "@percolatorct/sdk";
 import { sendTx } from "@/lib/tx";
 import { humanizeError } from "@/lib/errorMessages";
 import { useToast } from "@/hooks/useToast";
-import { PERCOLATOR_NFT_PROGRAM_ID, deriveNftPda } from "@/lib/nft-program";
+import {
+  deriveExtraAccountMetas,
+  deriveMintAuthority,
+  deriveNftPda,
+  NFT_MINT_TAG,
+  PERCOLATOR_NFT_PROGRAM_ID,
+} from "@/lib/nft-program";
 
 export function useMintPositionNft(slabAddress: string) {
   const { publicKey: walletPubkey } = useWalletCompat();
@@ -33,27 +38,24 @@ export function useMintPositionNft(slabAddress: string) {
     setError(null);
 
     try {
-      const slabPk = new PublicKey(slabAddress);
-      const userIdx = userAccount.idx;
+      const portfolioPk = userAccount.portfolioPubkey;
+      const assetIndex = userAccount.assetIndex;
+      if (!portfolioPk || assetIndex === undefined) {
+        throw new Error("No active v17 portfolio position found to mint as an NFT");
+      }
       const nftProgId = PERCOLATOR_NFT_PROGRAM_ID;
 
       // Derive PDA for state, generate fresh keypair for mint
-      const [nftPda] = deriveNftPda(slabPk, userIdx);
+      const [nftPda] = deriveNftPda(portfolioPk, assetIndex);
       // nft_mint is a fresh keypair (not a PDA) — the program creates it via
       // create_account which requires the mint account to sign the transaction
       const nftMintKeypair = Keypair.generate();
       const nftMint = nftMintKeypair.publicKey;
 
       // mint_authority PDA: ["mint_authority"] on NFT program
-      const [mintAuth] = PublicKey.findProgramAddressSync(
-        [Buffer.from("mint_authority")],
-        nftProgId,
-      );
+      const [mintAuth] = deriveMintAuthority(nftProgId);
       // extra-account-metas PDA: ["extra-account-metas", nft_mint] on NFT program
-      const [extraMetas] = PublicKey.findProgramAddressSync(
-        [Buffer.from("extra-account-metas"), nftMint.toBuffer()],
-        nftProgId,
-      );
+      const [extraMetas] = deriveExtraAccountMetas(nftMint, nftProgId);
 
       // Owner's Token-2022 ATA for the NFT mint
       const ownerAta = getAssociatedTokenAddressSync(
@@ -64,7 +66,7 @@ export function useMintPositionNft(slabAddress: string) {
       );
 
       // MintPositionNft (tag 0 on NFT program)
-      // 10 accounts: owner, nft_pda, nft_mint, owner_ata, slab, mint_auth, token22, ata_program, system, extra_metas
+      // 10 accounts: owner, nft_pda, nft_mint, owner_ata, portfolio, mint_auth, token22, ata_program, system, extra_metas
       const ix = new TransactionInstruction({
         programId: nftProgId,
         keys: [
@@ -72,14 +74,14 @@ export function useMintPositionNft(slabAddress: string) {
           { pubkey: nftPda, isSigner: false, isWritable: true },          // 1: nft_pda
           { pubkey: nftMint, isSigner: true, isWritable: true },          // 2: nft_mint (SIGNER — fresh keypair)
           { pubkey: ownerAta, isSigner: false, isWritable: true },        // 3: owner_ata
-          { pubkey: slabPk, isSigner: false, isWritable: false },         // 4: slab (read-only)
+          { pubkey: portfolioPk, isSigner: false, isWritable: true },     // 4: portfolio
           { pubkey: mintAuth, isSigner: false, isWritable: false },       // 5: mint_authority PDA
           { pubkey: TOKEN_2022_PROGRAM_ID, isSigner: false, isWritable: false }, // 6: token-2022
           { pubkey: ASSOCIATED_TOKEN_PROGRAM_ID, isSigner: false, isWritable: false }, // 7: ata_program
           { pubkey: SystemProgram.programId, isSigner: false, isWritable: false }, // 8: system
           { pubkey: extraMetas, isSigner: false, isWritable: true },      // 9: extra_account_metas PDA
         ],
-        data: Buffer.from([0, userIdx & 0xff, (userIdx >> 8) & 0xff]),
+        data: Buffer.from([NFT_MINT_TAG, assetIndex & 0xff, (assetIndex >> 8) & 0xff]),
       });
 
       // Build and sign manually — Privy embedded wallets can't handle extra

--- a/app/hooks/usePositionNft.ts
+++ b/app/hooks/usePositionNft.ts
@@ -31,8 +31,8 @@ export interface UsePositionNftResult {
  * Hook: derives the position_nft PDA for the current user, fetches the
  * account, and parses the NFT mint + settlement flag.
  *
- * PDA seeds: ["position_nft", slab, user_idx_u16_LE]
- * Layout per percolator-nft program (PERC-303).
+ * PDA seeds: ["position_nft", portfolio_account, asset_index_u16_LE]
+ * Layout per percolator-nft v16.
  */
 export function usePositionNft(slabAddress: string): UsePositionNftResult {
   const { connection } = useConnectionCompat();
@@ -55,11 +55,13 @@ export function usePositionNft(slabAddress: string): UsePositionNftResult {
   // changes when the user index or program/slab identity changes, so key the
   // effect on those primitives alone. Refetches after mint/burn can be
   // wired later via a manual trigger if needed.
-  const userIdx = userAccount?.idx ?? null;
+  const portfolioPubkey = userAccount?.portfolioPubkey ?? null;
+  const portfolioPubkeyStr = portfolioPubkey?.toBase58() ?? null;
+  const assetIndex = userAccount?.assetIndex ?? null;
   const programIdStr = slabProgramId?.toBase58() ?? null;
 
   useEffect(() => {
-    if (userIdx === null || !programIdStr || !slabAddress) {
+    if (!portfolioPubkey || assetIndex === null || !programIdStr || !slabAddress) {
       setState({
         hasMintedNft: false,
         nftMint: null,
@@ -74,8 +76,7 @@ export function usePositionNft(slabAddress: string): UsePositionNftResult {
 
     (async () => {
       try {
-        const slabPk = new PublicKey(slabAddress);
-        const [nftPda] = deriveNftPda(slabPk, userIdx, PERCOLATOR_NFT_PROGRAM_ID);
+        const [nftPda] = deriveNftPda(portfolioPubkey, assetIndex, PERCOLATOR_NFT_PROGRAM_ID);
         const pdaStr = nftPda.toBase58();
 
         if (mockMode) {
@@ -151,7 +152,7 @@ export function usePositionNft(slabAddress: string): UsePositionNftResult {
     // Deliberately excluding `connection` — it's from context and stable in
     // practice; including the object reference was part of the flicker bug.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [userIdx, programIdStr, slabAddress, mockMode]);
+  }, [portfolioPubkeyStr, assetIndex, programIdStr, slabAddress, mockMode]);
 
   return state;
 }

--- a/app/hooks/useUserAccount.ts
+++ b/app/hooks/useUserAccount.ts
@@ -9,6 +9,10 @@ import { AccountKind, isV17Account, parsePortfolioV17, type Account } from "@per
 export interface UserAccountInfo {
   idx: number;
   account: Account;
+  /** v17 standalone portfolio account used by percolator-nft v16. */
+  portfolioPubkey?: PublicKey;
+  /** Active v17 asset index bound by percolator-nft v16. */
+  assetIndex?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -135,7 +139,13 @@ export function useUserAccount(): UserAccountInfo | null {
         }
         const data = results[0].account.data;
         const portfolio = parsePortfolioV17(data instanceof Buffer ? data : Buffer.from(data));
-        setV17Account({ idx: 0, account: portfolioV17ToAccount(portfolio) });
+        const activeLeg = portfolio.legs.find((l) => l.active);
+        setV17Account({
+          idx: 0,
+          account: portfolioV17ToAccount(portfolio),
+          portfolioPubkey: results[0].pubkey,
+          assetIndex: activeLeg?.assetIndex,
+        });
       } catch {
         if (!cancelled) setV17Account(null);
       }

--- a/app/lib/nft-program.ts
+++ b/app/lib/nft-program.ts
@@ -5,21 +5,9 @@
  * main Percolator program) that acts as the Token-2022 TransferHook and owns
  * the mint_authority PDA used for position NFT mints.
  *
- * PDA seeds (authoritative — matches percolator-prog src/percolator.rs §position_nft):
- *   PositionNft state : ["position_nft",      slab_key, user_idx_u16_LE]
- *   PositionNft mint  : ["position_nft_mint", slab_key, user_idx_u16_LE]
- *   Mint authority    : ["mint_authority"]  (NFT program only)
- *
- * PositionNftState on-chain layout (128 bytes, PERC-608):
- *   [0..8]    magic             u64
- *   [8..40]   mint              [u8; 32]
- *   [40..72]  slab              [u8; 32]
- *   [72..104] owner             [u8; 32]
- *   [104..106] user_idx         u16 LE
- *   [106]     pending_settlement u8
- *   [107]     bump              u8
- *   [108]     mint_bump         u8
- *   [109..128] _reserved        [u8; 19]
+ * PDA seeds (matches percolator-nft/src/state_v16.rs):
+ *   PositionNft state : ["position_nft", portfolio_account, asset_index_u16_LE]
+ *   Mint authority    : ["mint_authority"]
  */
 
 import { PublicKey } from "@solana/web3.js";
@@ -49,10 +37,21 @@ export const NFT_BURN_TAG = 1;
 
 const _textEncoder = new TextEncoder();
 
-function _idxBuf(userIdx: number): Uint8Array {
+function _u16Buf(value: number, label: string): Uint8Array {
+  if (!Number.isInteger(value) || value < 0 || value > 0xffff) {
+    throw new Error(`${label} must be a u16`);
+  }
   const buf = new Uint8Array(2);
-  new DataView(buf.buffer).setUint16(0, userIdx, true); // little-endian u16
+  new DataView(buf.buffer).setUint16(0, value, true);
   return buf;
+}
+
+function readI128(view: DataView, offset: number): bigint {
+  const lo = view.getBigUint64(offset, true);
+  const hi = view.getBigUint64(offset + 8, true);
+  const unsigned = (hi << 64n) | lo;
+  const signBit = 1n << 127n;
+  return unsigned >= signBit ? unsigned - (1n << 128n) : unsigned;
 }
 
 // ---------------------------------------------------------------------------
@@ -61,54 +60,33 @@ function _idxBuf(userIdx: number): Uint8Array {
 
 /**
  * Derive the `PositionNft` state PDA.
- * Seeds: ["position_nft", slab, user_idx_u16_LE]
- *
- * @param slab     - The slab account public key.
- * @param userIdx  - The user index (u16).
- * @param programId - Override program ID (defaults to PERCOLATOR_NFT_PROGRAM_ID).
+ * Seeds: ["position_nft", portfolio_account, asset_index_u16_LE]
  */
 export function deriveNftPda(
-  slab: PublicKey,
-  userIdx: number,
+  portfolioAccount: PublicKey,
+  assetIndex: number,
   programId: PublicKey = PERCOLATOR_NFT_PROGRAM_ID
 ): [PublicKey, number] {
   return PublicKey.findProgramAddressSync(
-    [_textEncoder.encode("position_nft"), slab.toBytes(), _idxBuf(userIdx)],
+    [_textEncoder.encode("position_nft"), portfolioAccount.toBytes(), _u16Buf(assetIndex, "assetIndex")],
     programId
   );
 }
 
 /**
- * Derive the `PositionNft` mint PDA.
- * Seeds: ["position_nft_mint", slab, user_idx_u16_LE]
- *
- * @param slab     - The slab account public key.
- * @param userIdx  - The user index (u16).
- * @param programId - Override program ID (defaults to PERCOLATOR_NFT_PROGRAM_ID).
+ * @deprecated v16 Position NFT mints are fresh signer keypairs, not PDAs.
  */
 export function deriveNftMint(
-  slab: PublicKey,
-  userIdx: number,
-  programId: PublicKey = PERCOLATOR_NFT_PROGRAM_ID
+  _portfolioAccount: PublicKey,
+  _assetIndex: number,
+  _programId: PublicKey = PERCOLATOR_NFT_PROGRAM_ID
 ): [PublicKey, number] {
-  return PublicKey.findProgramAddressSync(
-    [
-      _textEncoder.encode("position_nft_mint"),
-      slab.toBytes(),
-      _idxBuf(userIdx),
-    ],
-    programId
-  );
+  throw new Error("deriveNftMint: v16 NFT mint is a fresh signer keypair, not a PDA");
 }
 
 /**
  * Derive the `mint_authority` PDA for the NFT program.
  * Seeds: ["mint_authority"]
- *
- * This PDA is the CPI signer used by the TransferHook when calling
- * TransferOwnershipCpi on the main Percolator program.
- *
- * @param programId - Override program ID (defaults to PERCOLATOR_NFT_PROGRAM_ID).
  */
 export function deriveMintAuthority(
   programId: PublicKey = PERCOLATOR_NFT_PROGRAM_ID
@@ -119,66 +97,66 @@ export function deriveMintAuthority(
   );
 }
 
+/**
+ * Derive the Token-2022 ExtraAccountMetaList PDA for a Position NFT mint.
+ * Seeds: ["extra-account-metas", nft_mint]
+ */
+export function deriveExtraAccountMetas(
+  nftMint: PublicKey,
+  programId: PublicKey = PERCOLATOR_NFT_PROGRAM_ID
+): [PublicKey, number] {
+  return PublicKey.findProgramAddressSync(
+    [_textEncoder.encode("extra-account-metas"), nftMint.toBytes()],
+    programId
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Account parser
 // ---------------------------------------------------------------------------
 
-/**
- * Byte length of a valid PositionNft account (208 bytes).
- *
- * Matches `percolator-nft/src/state.rs::PositionNft`, which carries a
- * static size assert (`assert!(size_of::<PositionNft>() == 208)`). Any
- * other value means the parser and on-chain struct are out of sync —
- * this whole file was written against a long-superseded draft that put
- * the mint at offset 8, which caused the frontend to read a 32-byte
- * window spanning the header + padding + slab as a phony "mint"
- * pubkey (TokenAccountNotFoundError on every transfer / burn).
- */
-export const POSITION_NFT_STATE_LEN = 208;
+/** Byte length of a valid PositionNftV16 account. */
+export const POSITION_NFT_STATE_LEN = 199;
+
+const POSITION_NFT_MAGIC = 0x5045_5243_4e46_5400n;
+const POSITION_NFT_VERSION = 2;
 
 /**
- * Parse a `PositionNft` account buffer.
+ * Parse a `PositionNftV16` account buffer.
  *
- * Canonical layout (percolator-nft/src/state.rs, 208 bytes):
- *   [0..8]    magic              u64
- *   [8]       version            u8
- *   [9]       bump               u8
- *   [10..16]  _pad0
- *   [16..48]  slab               [u8; 32]
- *   [48..50]  user_idx           u16 LE
- *   [50..56]  _pad1
- *   [56..88]  nft_mint           [u8; 32]
- *   [88..96]  entry_price_e6     u64
- *   [96..104] position_size      u64
- *   [104]     is_long            u8 (1 = long, 0 = short)
- *   [105..112] _pad2
- *   [112..128] position_basis_q  i128
- *   [128..144] last_funding_index_e18 i128
- *   [144..152] minted_at          i64
- *   [152..160] account_id         u64
- *   [160..192] position_owner     [u8; 32]   (PERC-N1)
- *   [192..208] _reserved1
- *
- * `pendingSettlement` no longer exists as a field; the old parser
- * synthesised it from a byte that is now part of `_pad2`. Callers that
- * want to detect a closed-but-not-burned state should check
- * `positionSize === 0n` instead.
- *
- * `mintBump` likewise doesn't exist — the NFT mint is a caller-provided
- * keypair (not a PDA), so there is no bump. The field is dropped.
- *
- * @throws if `data` is shorter than POSITION_NFT_STATE_LEN.
+ * Canonical layout (percolator-nft/src/state_v16.rs, 199 bytes):
+ *   [0..8]     magic                  u64 ("PERCNFT\0")
+ *   [8]        version                u8
+ *   [9]        bump                   u8
+ *   [10..42]   portfolio_account      [u8; 32]
+ *   [42..74]   nft_mint               [u8; 32]
+ *   [74..78]   asset_index            u32 LE
+ *   [78]       side_at_mint           u8
+ *   [79..95]   basis_pos_q_at_mint    i128
+ *   [95..111]  f_snap_at_mint         i128
+ *   [111..119] market_id_at_mint      u64
+ *   [119..127] epoch_snap_at_mint     u64
+ *   [127..159] position_owner_at_mint [u8; 32]
+ *   [159..167] minted_at              i64
+ *   [167..199] _reserved
  */
-export function parsePositionNftAccount(data: Buffer): {
+export function parsePositionNftAccount(data: Uint8Array): {
+  version: number;
   mint: PublicKey;
-  slab: PublicKey;
-  userIdx: number;
+  nftMint: PublicKey;
+  portfolioAccount: PublicKey;
+  assetIndex: number;
   bump: number;
+  sideAtMint: number;
   isLong: boolean;
   positionSize: bigint;
-  entryPriceE6: bigint;
+  basisPosQAtMint: bigint;
+  fSnapAtMint: bigint;
+  marketIdAtMint: bigint;
+  epochSnapAtMint: bigint;
   mintedAt: bigint;
   positionOwner: PublicKey;
+  positionOwnerAtMint: PublicKey;
 } {
   if (data.length < POSITION_NFT_STATE_LEN) {
     throw new Error(
@@ -186,29 +164,36 @@ export function parsePositionNftAccount(data: Buffer): {
     );
   }
 
-  // DataView is scoped to the logical account-data slice so callers can
-  // pass either a full Buffer or a subarray without offset drift.
   const dv = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  const magic = dv.getBigUint64(0, true);
+  if (magic !== POSITION_NFT_MAGIC) {
+    throw new Error("PositionNft account has invalid magic");
+  }
+  if (data[8] !== POSITION_NFT_VERSION) {
+    throw new Error(`PositionNft account has invalid version: ${data[8]}`);
+  }
 
-  const bump = data[9];
-  const slab = new PublicKey(data.subarray(16, 48));
-  const userIdx = dv.getUint16(48, true);
-  const mint = new PublicKey(data.subarray(56, 88));
-  const entryPriceE6 = dv.getBigUint64(88, true);
-  const positionSize = dv.getBigUint64(96, true);
-  const isLong = data[104] === 1;
-  const mintedAt = dv.getBigInt64(144, true);
-  const positionOwner = new PublicKey(data.subarray(160, 192));
+  const nftMint = new PublicKey(data.subarray(42, 74));
+  const basisPosQAtMint = readI128(dv, 79);
+  const positionOwnerAtMint = new PublicKey(data.subarray(127, 159));
+  const positionSize = basisPosQAtMint < 0n ? -basisPosQAtMint : basisPosQAtMint;
 
   return {
-    mint,
-    slab,
-    userIdx,
-    bump,
-    isLong,
+    version: data[8],
+    mint: nftMint,
+    nftMint,
+    portfolioAccount: new PublicKey(data.subarray(10, 42)),
+    assetIndex: dv.getUint32(74, true),
+    bump: data[9],
+    sideAtMint: data[78],
+    isLong: data[78] === 1,
     positionSize,
-    entryPriceE6,
-    mintedAt,
-    positionOwner,
+    basisPosQAtMint,
+    fSnapAtMint: readI128(dv, 95),
+    marketIdAtMint: dv.getBigUint64(111, true),
+    epochSnapAtMint: dv.getBigUint64(119, true),
+    mintedAt: dv.getBigInt64(159, true),
+    positionOwner: positionOwnerAtMint,
+    positionOwnerAtMint,
   };
 }


### PR DESCRIPTION
## Summary

Fixes dcccrypto/percolator-launch#2226.

The launch Position NFT UI was still using the stale `(slab, user_idx)` model while the current `percolator-nft` v16 program derives and validates NFTs by `(portfolio_account, asset_index)`. This PR realigns the local launch helpers and hooks with the v16 program.

## Changes

- Update the local NFT helper to derive `PositionNft` from `portfolio_account + asset_index`.
- Parse the current 199-byte `PositionNftV16` layout instead of the stale 208-byte layout.
- Carry `portfolioPubkey` and active `assetIndex` from the v17 portfolio scan in `useUserAccount`.
- Update mint to pass the portfolio account and encode `asset_index`.
- Update burn to send `[holder, nft_pda, nft_mint, holder_ata, portfolio, mint_auth, token_program]`.
- Add a focused v16 NFT helper regression test.
- Guard the shared test setup's DOM-only `window.matchMedia` mock so pure Node tests can run.

## Tests

```bash
cd app && pnpm exec vitest run __tests__/lib/nft-program-v16.test.ts
cd app && pnpm exec tsc --noEmit --pretty false
git diff --check
```
