### PR TITLE
fix(config): gate localStorage network override behind build-time deployment network

### DIFF
--- a/app/lib/config.ts
+++ b/app/lib/config.ts
@@ -5,6 +5,13 @@
 export type Network = "mainnet" | "devnet";
 
 export function getNetwork(): Network {
+  // NEXT_PUBLIC_DEFAULT_NETWORK is baked into the client bundle at build time.
+  // On mainnet deployments this check is enforced before localStorage is read,
+  // so an XSS payload calling localStorage.setItem("percolator-network","devnet")
+  // cannot redirect a mainnet frontend to devnet config or devnet program IDs.
+  const deploymentNet = process.env.NEXT_PUBLIC_DEFAULT_NETWORK?.trim();
+  if (deploymentNet === "mainnet") return "mainnet";
+
   if (typeof window !== "undefined") {
     try {
       const override = localStorage.getItem("percolator-network") as Network | null;
@@ -13,9 +20,7 @@ export function getNetwork(): Network {
       // localStorage may be unavailable (SSR, iframes, or test environments)
     }
   }
-  // Trim env var to handle trailing whitespace/newlines (Vercel env var copy-paste issue)
-  const envNet = process.env.NEXT_PUBLIC_DEFAULT_NETWORK?.trim();
-  if (envNet === "mainnet" || envNet === "devnet") return envNet;
+  if (deploymentNet === "devnet") return "devnet";
   // Default fail-closed to mainnet; prevents devnet-only features (pre-fund, faucet)
   // from activating on misconfigured production deployments.
   // Set NEXT_PUBLIC_DEFAULT_NETWORK=devnet explicitly for devnet environments.


### PR DESCRIPTION
## Summary

- `getNetwork()` now reads `NEXT_PUBLIC_DEFAULT_NETWORK` before consulting localStorage
- On mainnet deployments the function returns `"mainnet"` immediately, so XSS or browser extensions cannot override to devnet
- The localStorage override is preserved for devnet deployments where it is the intended testing mechanism

## Testing

- Build with `NEXT_PUBLIC_DEFAULT_NETWORK=mainnet`; confirm `localStorage.setItem("percolator-network","devnet")` has no effect on `getNetwork()`
- Build with `NEXT_PUBLIC_DEFAULT_NETWORK=devnet`; confirm localStorage override still works
- Confirm `setNetwork()` still writes to localStorage (the write path is unchanged; the read guard is deployment-gated)

Closes #2229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default network selection so the app now consistently opens on the deployment’s network when set to mainnet or devnet.
  * Prevented client-side saved network preferences from overriding a mainnet deployment, reducing unexpected network switches.
  * Kept the existing safe fallback behavior for unsupported or missing network settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->