### PR TITLE
fix(oracle): validate slab addresses against on-chain owner before signing

### DIFF
--- a/app/app/api/oracle/set-price-cap/route.ts
+++ b/app/app/api/oracle/set-price-cap/route.ts
@@ -166,13 +166,40 @@ export async function POST(req: NextRequest) {
       }
 
       const ourPubkey = keypair.publicKey.toBase58();
-      slabAddresses = (data ?? [])
-        .filter((m: { oracle_authority: string | null }) =>
-          m.oracle_authority === ourPubkey,
-        )
-        .map((m: { slab_address: string }) => m.slab_address);
+      // Safety cap: prevent a DB row injection from triggering unbounded
+      // CRANK_KEYPAIR transactions and draining the keeper wallet.
+      const MAX_SLAB_BATCH = 50;
+      const rawAddresses = (data ?? [])
+        .filter((m: { oracle_authority: string | null }) => m.oracle_authority === ourPubkey)
+        .map((m: { slab_address: string }) => m.slab_address)
+        .slice(0, MAX_SLAB_BATCH);
 
-      console.info(`[set-price-cap] Found ${slabAddresses.length} admin-oracle markets to cap`);
+      // Validate each slab address against on-chain account ownership before signing.
+      // An injected row pointing to an attacker-controlled account would be rejected
+      // here instead of producing a signed transaction that exposes the crank key.
+      const candidatePubkeys: PublicKey[] = [];
+      for (const addr of rawAddresses) {
+        try {
+          candidatePubkeys.push(new PublicKey(addr));
+        } catch {
+          console.warn(`[set-price-cap] Invalid pubkey format, skipping: ${addr}`);
+        }
+      }
+      if (candidatePubkeys.length > 0) {
+        const accountInfos = await connection.getMultipleAccountsInfo(candidatePubkeys, "confirmed");
+        slabAddresses = candidatePubkeys
+          .filter((pk, i) => {
+            const info = accountInfos[i];
+            if (!info || !info.owner.equals(programId)) {
+              console.warn(`[set-price-cap] ${pk.toBase58()} not owned by program -- skipping`);
+              return false;
+            }
+            return true;
+          })
+          .map((pk) => pk.toBase58());
+      }
+
+      console.info(`[set-price-cap] Found ${slabAddresses.length} validated admin-oracle markets to cap`);
     } catch (err) {
       console.error("[set-price-cap] Error fetching markets:", err);
       return NextResponse.json({ error: "Failed to fetch markets" }, { status: 500 });


### PR DESCRIPTION
## Summary

- Fetch candidate slab addresses from Supabase as before, but now validate each against the on-chain account owner using `getMultipleAccountsInfo` before any transaction is built
- Addresses not owned by the configured `programId` are skipped with a warning; they are never signed over
- Batch capped at 50 slabs per invocation to prevent wallet drain from injected rows
- Invalid base58 addresses are caught individually and skipped rather than aborting the whole batch

## Testing

- Confirm a legitimate slab owned by the program is included in the batch
- Confirm a fake slab (owned by System Program or wrong program) is skipped with a console warning and no transaction is submitted
- Confirm the endpoint accepts at most 50 slabs even when the database has more matching rows

Closes #ISSUE_NUM