### PR TITLE
fix: remove raw Supabase error messages from logo upload 500 responses

### DIFF
--- a/app/app/api/markets/[slab]/logo/route.ts
+++ b/app/app/api/markets/[slab]/logo/route.ts
@@ -117,7 +117,7 @@ export async function POST(
 
     if (uploadError) {
       console.error("Storage upload error:", uploadError);
-      return NextResponse.json({ error: `Upload failed: ${uploadError.message}` }, { status: 500 });
+      return NextResponse.json({ error: "Upload failed. Please try again." }, { status: 500 });
     }
 
     const { data: urlData } = supabase.storage.from("logos").getPublicUrl(filePath);
@@ -130,7 +130,7 @@ export async function POST(
 
     if (updateError) {
       console.error("DB update error:", updateError);
-      return NextResponse.json({ error: `DB update failed: ${updateError.message}` }, { status: 500 });
+      return NextResponse.json({ error: "Failed to save logo URL. Please try again." }, { status: 500 });
     }
 
     uploadTimestamps.set(validSlab, Date.now());


### PR DESCRIPTION
Fixes #2235

## Changes

- `app/app/api/markets/[slab]/logo/route.ts`
  - Line 120: replace `` `Upload failed: ${uploadError.message}` `` with a generic string
  - Line 133: replace `` `DB update failed: ${updateError.message}` `` with a generic string
  - Detailed errors remain in `console.error` for server-side debugging