### PR TITLE
fix: pass boolean value to inert attribute in ChartIndicatorMenu

### DIFF
--- a/app/components/trade/ChartIndicatorMenu.tsx
+++ b/app/components/trade/ChartIndicatorMenu.tsx
@@ -130,8 +130,7 @@ export const ChartIndicatorMenu: FC<ChartIndicatorMenuProps> = ({
         // when closed. Without this, Tab walks through every toggle and
         // input even though the panel is invisible (opacity:0 alone keeps
         // children in the focus tree).
-        // @ts-expect-error - inert is a valid HTML attribute, React types lag
-        inert={!open ? "" : undefined}
+        inert={!open ? true : undefined}
         className={[
           // z-[60] so the mobile bottom-sheet variant sits ABOVE the global
           // MobileBottomNav (z-50) — at z-20 the nav was painting over the


### PR DESCRIPTION
## Summary

This PR fixes a React boolean attribute issue in `ChartIndicatorMenu` that caused a React/Next.js development overlay on the markets/trade page during local playground testing.

While running the Percolator playground locally, the markets/trade page showed the following React warning/error:

```text
Received an empty string for a boolean attribute inert. This will treat the attribute as if it were false. Either pass false to silence this warning, or pass true if you used an empty string in earlier versions of React to indicate this attribute is true.
```

The issue pointed to:

```text
app/components/trade/ChartIndicatorMenu.tsx
```

## Root Cause

`ChartIndicatorMenu` was passing an empty string (`""`) to the boolean HTML attribute `inert`.

Before:

```tsx
// @ts-expect-error - inert is a valid HTML attribute, React types lag
inert={!open ? "" : undefined}
```

`inert` is a boolean HTML attribute, so React expects it to receive either a boolean value or `undefined`, not an empty string. This caused the React/Next.js development overlay and interrupted clean local UI testing.

## What Changed

This PR updates the `inert` prop to pass a proper boolean value:

```tsx
inert={!open ? true : undefined}
```

It also removes the now-unused `@ts-expect-error` directive, since the corrected prop is type-safe.

## Impact

This fix improves frontend reliability on the markets/trade page.

The previous behavior caused a development overlay during local testing, making the page appear broken even though the issue was caused by invalid boolean attribute handling.

After this change:

- The menu still becomes inert when closed.
- The menu remains interactive when open.
- React no longer receives an invalid empty string for a boolean attribute.
- The unnecessary TypeScript suppression is removed.
- Local beta testing on the markets/trade page is cleaner.

## Validation

Validated locally with:

```bash
npx tsc --noEmit
```

The TypeScript check passes after the fix.

I also verified that the previous React boolean attribute warning related to `inert` no longer appears after updating the prop value.

## Severity

Medium.

This is a frontend/runtime issue affecting local beta testing and markets/trade page rendering quality. It is not a security-critical issue and does not affect protocol funds or on-chain state.

## Files Changed

```text
app/components/trade/ChartIndicatorMenu.tsx
```

## Notes

This PR is intentionally small and focused. It only fixes the invalid `inert` boolean attribute handling in `ChartIndicatorMenu` and does not include unrelated local setup, backend, RPC, wallet, or environment configuration changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the indicator panel’s closed-state behavior so it correctly stays non-interactive when hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->