### PR TITLE
fix(create): make disabled wizard button labels legible

### DIFF
--- a/app/components/create/StepParameters.tsx
+++ b/app/components/create/StepParameters.tsx
@@ -210,7 +210,7 @@ export const StepParameters: FC<StepParametersProps> = ({
           type="button"
           onClick={onContinue}
           disabled={!canContinue || feeConflict}
-          className="flex-1 border border-[var(--accent)]/50 bg-[var(--accent)]/[0.08] py-3 text-[13px] font-bold uppercase tracking-[0.1em] text-[var(--accent)] transition-all duration-200 hud-btn-corners hover:border-[var(--accent)] hover:bg-[var(--accent)]/[0.15] disabled:cursor-not-allowed disabled:border-[var(--border)] disabled:bg-transparent disabled:text-[var(--text-dim)] disabled:opacity-50"
+          className="flex-1 border border-[var(--accent)]/50 bg-[var(--accent)]/[0.08] py-3 text-[13px] font-bold uppercase tracking-[0.1em] text-[var(--accent)] transition-all duration-200 hud-btn-corners hover:border-[var(--accent)] hover:bg-[var(--accent)]/[0.15] disabled:cursor-not-allowed disabled:border-[var(--border)] disabled:bg-transparent disabled:text-[var(--text-secondary)]"
         >
           CONTINUE →
         </button>

--- a/app/components/create/StepReview.tsx
+++ b/app/components/create/StepReview.tsx
@@ -269,7 +269,7 @@ export const StepReview: FC<StepReviewProps> = ({
           type="button"
           onClick={onLaunch}
           disabled={!canLaunch || !mintValid || !mintExistsOnNetwork}
-          className="flex-1 border border-[var(--accent)]/50 bg-[var(--accent)]/[0.08] py-3.5 text-[14px] font-bold uppercase tracking-[0.1em] text-[var(--accent)] transition-all duration-200 hud-btn-corners hover:border-[var(--accent)] hover:bg-[var(--accent)]/[0.15] disabled:cursor-not-allowed disabled:border-[var(--border)] disabled:bg-transparent disabled:text-[var(--text-dim)] disabled:opacity-50"
+          className="flex-1 border border-[var(--accent)]/50 bg-[var(--accent)]/[0.08] py-3.5 text-[14px] font-bold uppercase tracking-[0.1em] text-[var(--accent)] transition-all duration-200 hud-btn-corners hover:border-[var(--accent)] hover:bg-[var(--accent)]/[0.15] disabled:cursor-not-allowed disabled:border-[var(--border)] disabled:bg-transparent disabled:text-[var(--text-secondary)]"
         >
           {launchButtonLabel}
         </button>

--- a/app/components/create/StepTokenSelect.tsx
+++ b/app/components/create/StepTokenSelect.tsx
@@ -488,7 +488,7 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
         type="button"
         onClick={onContinue}
         disabled={!effectiveCanContinue}
-        className="w-full border border-[var(--accent)]/50 bg-[var(--accent)]/[0.08] py-3 text-[13px] font-bold uppercase tracking-[0.1em] text-[var(--accent)] transition-all duration-200 hud-btn-corners hover:border-[var(--accent)] hover:bg-[var(--accent)]/[0.15] disabled:cursor-not-allowed disabled:border-[var(--border)] disabled:bg-transparent disabled:text-[var(--text-dim)] disabled:opacity-50"
+        className="w-full border border-[var(--accent)]/50 bg-[var(--accent)]/[0.08] py-3 text-[13px] font-bold uppercase tracking-[0.1em] text-[var(--accent)] transition-all duration-200 hud-btn-corners hover:border-[var(--accent)] hover:bg-[var(--accent)]/[0.15] disabled:cursor-not-allowed disabled:border-[var(--border)] disabled:bg-transparent disabled:text-[var(--text-secondary)]"
       >
         {mintNetworkStatus === "loading" ? "VALIDATING..." : mintNetworkStatus === "mirroring" ? "MIRRORING..." : "CONTINUE →"}
       </button>


### PR DESCRIPTION
## What

Fixes near-invisible disabled button labels in the create-market wizard (all three steps: Token Select, Parameters, Review).

On step 4, the launch button's disabled label — e.g. **"No Tokens — Mint First"** — was almost unreadable:

The disabled classes stacked `text-[var(--text-dim)]` (`#2A2E3D` in the dark theme, nearly the background color) **and** `opacity-50` on top, double-fading the text into the background. These labels carry information (they tell the user *why* the button is disabled and what to do next), so they need to stay legible.

## Fix

Match the disabled-button convention used everywhere else in the app (OrderTicket, PositionPanel, modals, etc.): a single fade, no near-background text color.

- `disabled:text-[var(--text-dim)]` → `disabled:text-[var(--text-secondary)]`
- removed `disabled:opacity-50`

The dimmed border + transparent background still clearly signal the disabled state.

## Testing

- `npx tsc --noEmit` — clean, 0 errors
- `pnpm test` — no new failures from this change (the diff is class strings only; the failures present locally also occur on a clean `main` checkout on Windows and are unrelated to these components)
- Contrast math (dark theme): `#2A2E3D` at 50% opacity is ~1.2:1 against the dark background — effectively invisible; `#7A7F96` at full opacity is ~4.9:1 — readable, still clearly muted

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated disabled-button appearance across the create flow to use a clearer secondary text color.
  * Removed the dimmed opacity effect from disabled states for a more consistent look.
  * Affected buttons include Continue and Launch, with disabled behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->