### PR TITLE
fix(stake): brighten near-invisible muted/dim text

### DIFF
--- a/app/app/stake/page.tsx
+++ b/app/app/stake/page.tsx
@@ -230,8 +230,8 @@ function YourPositionPanel({
   if (!position) {
     return (
       <div className="border border-[var(--border)]/50 bg-[var(--panel-bg)] p-6 text-center">
-        <p className="text-[11px] uppercase tracking-[0.15em] text-[var(--text-muted)]">No open positions</p>
-        <p className="mt-1 text-[10px] text-[var(--text-dim)]">Deposit into a pool to get started</p>
+        <p className="text-[11px] uppercase tracking-[0.15em] text-[var(--text-secondary)]">No open positions</p>
+        <p className="mt-1 text-[10px] text-[var(--text-secondary)]">Deposit into a pool to get started</p>
         <a
           href="#deposit"
           className="mt-3 inline-block text-[11px] font-medium text-[var(--accent)] transition-colors hover:text-[var(--text)]"
@@ -302,7 +302,7 @@ function YourPositionPanel({
           className={`w-full rounded-md py-2.5 text-[12px] font-semibold uppercase tracking-[0.1em] transition-all duration-200 ${
             position.cooldownElapsed && !withdrawLoading
               ? "border border-[var(--cyan)]/50 bg-[var(--cyan)]/[0.10] text-[var(--cyan)] hover:border-[var(--cyan)] hover:bg-[var(--cyan)]/[0.18]"
-              : "border border-[var(--border)] bg-[var(--bg)] text-[var(--text-muted)] cursor-not-allowed"
+              : "border border-[var(--border)] bg-[var(--bg)] text-[var(--text-secondary)] cursor-not-allowed"
           }`}
         >
           {withdrawLoading
@@ -424,7 +424,7 @@ function DepositWidget({
               className={`flex-1 py-2 text-[11px] font-medium uppercase tracking-[0.1em] transition-colors duration-150 ${
                 tranche === "senior"
                   ? "bg-[var(--accent)]/[0.12] text-[var(--accent)] border-r border-[var(--border)]"
-                  : "bg-transparent text-[var(--text-muted)] border-r border-[var(--border)] hover:text-[var(--text-secondary)]"
+                  : "bg-transparent text-[var(--text-secondary)] border-r border-[var(--border)] hover:text-[var(--text)]"
               }`}
             >
               Senior
@@ -435,7 +435,7 @@ function DepositWidget({
               className={`flex-1 py-2 text-[11px] font-medium uppercase tracking-[0.1em] transition-colors duration-150 ${
                 tranche === "junior"
                   ? "bg-[var(--warning)]/[0.12] text-[var(--warning)]"
-                  : "bg-transparent text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+                  : "bg-transparent text-[var(--text-secondary)] hover:text-[var(--text)]"
               }`}
             >
               Junior
@@ -542,7 +542,7 @@ function DepositWidget({
 
         {/* CTA */}
         {!connected ? (
-          <button className="w-full rounded-md py-3 border border-[var(--border)] bg-[var(--bg)] text-[12px] font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)] cursor-not-allowed">
+          <button className="w-full rounded-md py-3 border border-[var(--border)] bg-[var(--bg)] text-[12px] font-semibold uppercase tracking-[0.1em] text-[var(--text-secondary)] cursor-not-allowed">
             Connect Wallet to Deposit
           </button>
         ) : (
@@ -552,7 +552,7 @@ function DepositWidget({
             className={`w-full rounded-md py-3 text-[12px] font-semibold uppercase tracking-[0.1em] transition-all duration-200 ${
               amountNum > 0 && !depositLoading
                 ? "border border-[var(--accent)]/50 bg-[var(--accent)]/[0.10] text-[var(--accent)] hover:border-[var(--accent)] hover:bg-[var(--accent)]/[0.18]"
-                : "border border-[var(--border)] bg-[var(--bg)] text-[var(--text-muted)] cursor-not-allowed"
+                : "border border-[var(--border)] bg-[var(--bg)] text-[var(--text-secondary)] cursor-not-allowed"
             }`}
           >
             {depositLoading ? "Depositing…" : "Deposit →"}
@@ -657,8 +657,8 @@ function PoolList({ pools, loading }: { pools: StakePool[]; loading: boolean }) 
     return (
       <div className="border border-[var(--border)]/50 bg-[var(--panel-bg)] p-10 text-center">
         <div className="mb-3 text-2xl text-[var(--text-muted)]">💧</div>
-        <p className="text-[11px] uppercase tracking-[0.15em] text-[var(--text-muted)]">No pools available yet</p>
-        <p className="mt-1 text-[10px] text-[var(--text-dim)]">Check back soon.</p>
+        <p className="text-[11px] uppercase tracking-[0.15em] text-[var(--text-secondary)]">No pools available yet</p>
+        <p className="mt-1 text-[10px] text-[var(--text-secondary)]">Check back soon.</p>
       </div>
     );
   }


### PR DESCRIPTION
## What

Follow-up to #2238, same class of issue on the **stake page**: several text elements are nearly unreadable in the dark theme.

- Empty-state subtext ("Deposit into a pool to get started", "Check back soon.") used `--text-dim` (`#2A2E3D`) — roughly **1.4:1** contrast against the dark background.
- Empty-state headings ("NO OPEN POSITIONS", "NO POOLS AVAILABLE YET"), the inactive tranche tab (SENIOR/JUNIOR), and disabled CTA labels ("DEPOSIT →", "Connect Wallet to Deposit", cooldown withdraw) used `--text-muted` (`#454B5F`) — roughly **2.2:1**, below the WCAG large-text minimum of 3:1.

## Fix

Bump the affected text to `--text-secondary` (`#7A7F96`, ~4.9:1) — readable but still clearly muted, matching the approach taken in #2238. Inactive tranche tabs now hover to full `--text` (they previously hovered to `--text-secondary`, which is now their resting state).

Deliberately **not** changed:

- The global `--text-muted` / `--text-dim` tokens — that's a design-system decision that would ripple app-wide.
- Input placeholder text (`0.00`) and fine-print pool metadata — conventionally faint, and not the readability complaint here.

## Testing

- `npx tsc --noEmit` — clean, 0 errors
- Diff is class strings only in `app/app/stake/page.tsx`; no logic changes
- Contrast figures above computed against the dark-theme background; before/after screenshot to follow in a comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated several staking page empty and disabled states to use a more consistent secondary text color.
  * Improved the appearance of inactive tranche selectors, disabled action buttons, and “no data” messages for a more polished UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->