### PR TITLE
fix(dashboard): brighten near-invisible dim/muted text

### DIFF
--- a/app/app/dashboard/page.tsx
+++ b/app/app/dashboard/page.tsx
@@ -77,7 +77,7 @@ export default function DashboardPage() {
             className="text-xl font-medium tracking-[-0.01em] text-[var(--text)] sm:text-2xl"
             style={{ fontFamily: "var(--font-heading)" }}
           >
-            <span className="font-normal text-[var(--text-muted)]">Trader </span>Dashboard
+            <span className="font-normal text-[var(--text-secondary)]">Trader </span>Dashboard
           </h1>
           <p className="mt-2 mb-8 text-[13px] text-[var(--text-secondary)]">
             Your personal command centre for trading on Percolator
@@ -129,7 +129,7 @@ export default function DashboardPage() {
               className="text-xl font-medium tracking-[-0.01em] text-[var(--text)] sm:text-2xl"
               style={{ fontFamily: "var(--font-heading)" }}
             >
-              <span className="font-normal text-[var(--text-muted)]">Trader </span>Dashboard
+              <span className="font-normal text-[var(--text-secondary)]">Trader </span>Dashboard
             </h1>
           </div>
         </ScrollReveal>
@@ -202,7 +202,7 @@ export default function DashboardPage() {
                   "rounded-sm px-2 py-2 text-center text-[10px] font-bold transition-all",
                   mobileTab === tab.key
                     ? "bg-[var(--accent)]/15 text-[var(--accent)]"
-                    : "text-[var(--text-muted)]",
+                    : "text-[var(--text-secondary)]",
                 ].join(" ")}
               >
                 <span className="block text-sm">{tab.icon}</span>

--- a/app/components/dashboard/DashboardHeader.tsx
+++ b/app/components/dashboard/DashboardHeader.tsx
@@ -58,7 +58,7 @@ export function DashboardHeader() {
       {/* Right: Stats */}
       <div className="flex flex-wrap items-center gap-6">
         <div className="text-right">
-          <p className="text-[8px] font-medium uppercase tracking-[0.2em] text-[var(--text-dim)]">
+          <p className="text-[8px] font-medium uppercase tracking-[0.2em] text-[var(--text-secondary)]">
             Portfolio Value
           </p>
           <p
@@ -79,7 +79,7 @@ export function DashboardHeader() {
         <div className="h-6 w-px bg-[var(--border)]" />
 
         <div className="text-right">
-          <p className="text-[8px] font-medium uppercase tracking-[0.2em] text-[var(--text-dim)]">
+          <p className="text-[8px] font-medium uppercase tracking-[0.2em] text-[var(--text-secondary)]">
             Active Positions
           </p>
           <p

--- a/app/components/dashboard/FundingRates.tsx
+++ b/app/components/dashboard/FundingRates.tsx
@@ -48,17 +48,17 @@ export function FundingRates() {
       {/* Header */}
       <div className="flex items-center justify-between border-b border-[var(--border)] px-5 py-4">
         <div className="flex items-center gap-2">
-          <p className="text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-dim)]">
+          <p className="text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-secondary)]">
             Funding Rates
           </p>
           <span
-            className="cursor-help text-[10px] text-[var(--text-dim)] transition-colors hover:text-[var(--text-secondary)]"
+            className="cursor-help text-[10px] text-[var(--text-secondary)] transition-colors hover:text-[var(--text)]"
             title="Continuous funding: positive rate = longs pay shorts, negative = shorts pay longs. Shown as % per hour."
           >
             ⓘ
           </span>
         </div>
-        <span className="text-[9px] text-[var(--text-dim)]">% / hr</span>
+        <span className="text-[9px] text-[var(--text-secondary)]">% / hr</span>
       </div>
 
       {/* Content */}
@@ -72,8 +72,8 @@ export function FundingRates() {
         </div>
       ) : active.length === 0 ? (
         <div className="px-5 py-8 text-center">
-          <p className="text-[11px] text-[var(--text-muted)]">No active funding rates</p>
-          <p className="mt-1 text-[9px] text-[var(--text-dim)]">
+          <p className="text-[11px] text-[var(--text-secondary)]">No active funding rates</p>
+          <p className="mt-1 text-[9px] text-[var(--text-secondary)]">
             Rates appear once markets have open positions
           </p>
         </div>

--- a/app/components/dashboard/PnlChart.tsx
+++ b/app/components/dashboard/PnlChart.tsx
@@ -26,7 +26,7 @@ export function PnlChart() {
     <div className="border border-[var(--border)] bg-[var(--panel-bg)]">
       {/* Header */}
       <div className="flex items-center justify-between border-b border-[var(--border)] px-5 py-4">
-        <p className="text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-dim)]">
+        <p className="text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-secondary)]">
           Portfolio PnL
         </p>
         <div className="flex gap-1">
@@ -37,7 +37,7 @@ export function PnlChart() {
               className={`px-2 py-0.5 text-[9px] font-medium transition-colors ${
                 range === r
                   ? "bg-[var(--accent)]/10 text-[var(--accent)]"
-                  : "text-[var(--text-dim)] hover:text-[var(--text-secondary)]"
+                  : "text-[var(--text-secondary)] hover:text-[var(--text)]"
               }`}
             >
               {r}
@@ -49,11 +49,11 @@ export function PnlChart() {
       {/* Chart area */}
       <div className="flex h-[200px] items-center justify-center px-5">
         {loading ? (
-          <p className="text-[11px] text-[var(--text-muted)]">Loading...</p>
+          <p className="text-[11px] text-[var(--text-secondary)]">Loading...</p>
         ) : !hasData ? (
           <div className="text-center">
-            <p className="text-[11px] text-[var(--text-muted)]">No positions yet</p>
-            <p className="mt-1 text-[9px] text-[var(--text-dim)]">Open a trade to see your PnL</p>
+            <p className="text-[11px] text-[var(--text-secondary)]">No positions yet</p>
+            <p className="mt-1 text-[9px] text-[var(--text-secondary)]">Open a trade to see your PnL</p>
           </div>
         ) : (
           <div className="text-center">
@@ -61,7 +61,7 @@ export function PnlChart() {
                style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
               {isPositive ? "+" : ""}${Math.abs(pnlFloat).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
             </p>
-            <p className="mt-1 text-[9px] text-[var(--text-dim)]">
+            <p className="mt-1 text-[9px] text-[var(--text-secondary)]">
               Across {positions.length} position{positions.length !== 1 ? "s" : ""} • Historical chart coming soon
             </p>
           </div>

--- a/app/components/dashboard/PositionSummary.tsx
+++ b/app/components/dashboard/PositionSummary.tsx
@@ -93,7 +93,7 @@ function PositionCard({ pos, symbol, decimals = 6 }: { pos: PortfolioPosition; s
                 </span>
               </>
             ) : (
-              <span className="text-[11px] font-bold text-[var(--text-dim)]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
+              <span className="text-[11px] font-bold text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
                 --
               </span>
             )}
@@ -103,25 +103,25 @@ function PositionCard({ pos, symbol, decimals = 6 }: { pos: PortfolioPosition; s
         {/* Row 2: Key metrics */}
         <div className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 text-[10px]">
           <div>
-            <span className="text-[var(--text-dim)]">Size: </span>
+            <span className="text-[var(--text-secondary)]">Size: </span>
             <span className="text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
               {formatTokenAmount(sizeAbs, decimals)}
             </span>
           </div>
           <div>
-            <span className="text-[var(--text-dim)]">Entry: </span>
+            <span className="text-[var(--text-secondary)]">Entry: </span>
             <span className="text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
               {pos.account?.entryPrice != null ? formatUsdPriceE6(pos.account.entryPrice) : "—"}
             </span>
           </div>
           <div>
-            <span className="text-[var(--text-dim)]">Mark: </span>
+            <span className="text-[var(--text-secondary)]">Mark: </span>
             <span className="text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-jetbrains-mono)" }}>
               {pos.oraclePriceE6 > 0n ? formatUsdPriceE6(pos.oraclePriceE6) : "—"}
             </span>
           </div>
           <div>
-            <span className="text-[var(--text-dim)]">Liq: </span>
+            <span className="text-[var(--text-secondary)]">Liq: </span>
             <span
               className={`${
                 severity === "danger" ? "font-semibold text-[var(--short)]" : severity === "warning" ? "text-[var(--warning)]" : "text-[var(--text-secondary)]"
@@ -136,7 +136,7 @@ function PositionCard({ pos, symbol, decimals = 6 }: { pos: PortfolioPosition; s
         {/* Margin health bar */}
         {hasPosition && pos.liquidationDistancePct < 100 && (
           <div className="mt-2">
-            <div className="flex items-center justify-between text-[8px] text-[var(--text-dim)]">
+            <div className="flex items-center justify-between text-[8px] text-[var(--text-secondary)]">
               <span>Margin Health</span>
               <span
                 className={
@@ -144,7 +144,7 @@ function PositionCard({ pos, symbol, decimals = 6 }: { pos: PortfolioPosition; s
                     ? "font-bold text-[var(--short)]"
                     : severity === "warning"
                     ? "font-bold text-[var(--warning)]"
-                    : "text-[var(--text-muted)]"
+                    : "text-[var(--text-secondary)]"
                 }
               >
                 {pos.liquidationDistancePct.toFixed(0)}%
@@ -186,10 +186,10 @@ export function PositionSummary() {
       {/* Header */}
       <div className="flex items-center justify-between border-b border-[var(--border)] px-5 py-4">
         <div className="flex items-center gap-2">
-          <p className="text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-dim)]">
+          <p className="text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-secondary)]">
             Open Positions
           </p>
-          <span className="text-[9px] font-bold text-[var(--text-muted)]">
+          <span className="text-[9px] font-bold text-[var(--text-secondary)]">
             ({positions.length})
           </span>
           {positions.length > 0 && (
@@ -210,7 +210,7 @@ export function PositionSummary() {
           <div className="flex h-full flex-col items-center justify-center p-6 text-center">
             <div className="mb-3 text-2xl opacity-30">📊</div>
             <p className="text-[13px] font-medium text-[var(--text-secondary)]">No open positions</p>
-            <p className="mt-1 text-[11px] text-[var(--text-muted)]">Start trading →</p>
+            <p className="mt-1 text-[11px] text-[var(--text-secondary)]">Start trading →</p>
             <Link href="/markets" className="mt-3">
               <GlowButton>Browse Markets</GlowButton>
             </Link>

--- a/app/components/dashboard/ProtocolStatsBar.tsx
+++ b/app/components/dashboard/ProtocolStatsBar.tsx
@@ -157,13 +157,13 @@ export function ProtocolStatsBar() {
       label: "24h Volume",
       value: loading ? null : formatUsd(stats?.volume24h ?? 0),
       live: true,
-      color: (stats?.volume24h ?? 0) > 0 ? "text-[var(--long)]" : "text-[var(--text-muted)]",
+      color: (stats?.volume24h ?? 0) > 0 ? "text-[var(--long)]" : "text-[var(--text-secondary)]",
     },
     {
       label: "Open Interest",
       value: loading ? null : formatUsd(stats?.openInterest ?? 0),
       live: false,
-      color: (stats?.openInterest ?? 0) > 0 ? "text-[var(--text)]" : "text-[var(--text-muted)]",
+      color: (stats?.openInterest ?? 0) > 0 ? "text-[var(--text)]" : "text-[var(--text-secondary)]",
     },
     {
       label: "Active Markets",
@@ -182,7 +182,7 @@ export function ProtocolStatsBar() {
         >
           <div className="flex items-center gap-1.5">
             {item.live && <Pulse />}
-            <span className="text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-dim)]">
+            <span className="text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-secondary)]">
               {item.label}
             </span>
           </div>

--- a/app/components/dashboard/StatsBar.tsx
+++ b/app/components/dashboard/StatsBar.tsx
@@ -30,7 +30,7 @@ export function StatsBar() {
       label: "Today's PnL",
       value: "--",
       sub: "Last 24h",
-      color: "text-[var(--text-muted)]",
+      color: "text-[var(--text-secondary)]",
     },
     {
       label: "Win Rate",
@@ -53,7 +53,7 @@ export function StatsBar() {
           key={card.label}
           className="bg-[var(--panel-bg)] p-5 transition-all duration-200 hover:bg-[var(--bg-elevated)] hover:translate-y-[-1px]"
         >
-          <p className="mb-2 text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-dim)]">
+          <p className="mb-2 text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-secondary)]">
             {card.label}
           </p>
           <p
@@ -62,7 +62,7 @@ export function StatsBar() {
           >
             {card.value}
           </p>
-          <p className="mt-0.5 text-[10px] text-[var(--text-muted)]">{card.sub}</p>
+          <p className="mt-0.5 text-[10px] text-[var(--text-secondary)]">{card.sub}</p>
         </div>
       ))}
     </div>

--- a/app/components/dashboard/TradeHistory.tsx
+++ b/app/components/dashboard/TradeHistory.tsx
@@ -111,12 +111,12 @@ export function TradeHistory() {
     return (
       <div className="flex flex-col border border-[var(--border)] bg-[var(--panel-bg)]">
         <div className="px-5 py-4 border-b border-[var(--border)]">
-          <p className="text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-dim)]">
+          <p className="text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-secondary)]">
             Trade History
           </p>
         </div>
         <div className="flex flex-col items-center justify-center py-12">
-          <p className="text-[13px] text-[var(--text-dim)]">Connect wallet to view trades</p>
+          <p className="text-[13px] text-[var(--text-secondary)]">Connect wallet to view trades</p>
         </div>
       </div>
     );
@@ -126,13 +126,13 @@ export function TradeHistory() {
     <div className="flex flex-col border border-[var(--border)] bg-[var(--panel-bg)]">
       {/* Header */}
       <div className="flex items-center justify-between border-b border-[var(--border)] px-5 py-4">
-        <p className="text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-dim)]">
+        <p className="text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-secondary)]">
           Trade History
         </p>
         <button
           onClick={handleExportCsv}
           disabled={filtered.length === 0}
-          className="rounded-sm border border-[var(--border)] px-3 py-1 text-[10px] text-[var(--text-muted)] transition-all hover:border-[var(--accent)]/30 hover:text-[var(--text-secondary)] disabled:opacity-30"
+          className="rounded-sm border border-[var(--border)] px-3 py-1 text-[10px] text-[var(--text-secondary)] transition-all hover:border-[var(--accent)]/30 hover:text-[var(--text)] disabled:opacity-30"
         >
           Export CSV
         </button>
@@ -171,8 +171,8 @@ export function TradeHistory() {
           </div>
         ) : filtered.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-12">
-            <p className="text-[13px] text-[var(--text-dim)]">No trades yet</p>
-            <p className="mt-1 text-[10px] text-[var(--text-dim)]/60">
+            <p className="text-[13px] text-[var(--text-secondary)]">No trades yet</p>
+            <p className="mt-1 text-[10px] text-[var(--text-secondary)]">
               Your executed trades will appear here once the trade indexer has processed them.
             </p>
             {(process.env.NEXT_PUBLIC_DEFAULT_NETWORK ?? process.env.NEXT_PUBLIC_SOLANA_NETWORK) === "devnet" && (
@@ -184,7 +184,7 @@ export function TradeHistory() {
         ) : (
           <table className="w-full">
             <thead>
-              <tr className="border-b border-[var(--border)] text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">
+              <tr className="border-b border-[var(--border)] text-[9px] font-medium uppercase tracking-[0.15em] text-[var(--text-secondary)]">
                 <th className="px-4 py-3 text-left">Time</th>
                 <th className="px-3 py-3 text-left">Market</th>
                 <th className="px-3 py-3 text-left">Side</th>
@@ -237,7 +237,7 @@ export function TradeHistory() {
                     {formatUsdFromNumber(trade.price)}
                   </td>
                   <td
-                    className="px-3 py-2.5 text-right text-[var(--text-muted)]"
+                    className="px-3 py-2.5 text-right text-[var(--text-secondary)]"
                     style={{ fontFamily: "var(--font-jetbrains-mono)" }}
                   >
                     {formatUsd(trade.fee)}
@@ -248,7 +248,7 @@ export function TradeHistory() {
                         href={explorerTxUrl(trade.tx_signature)}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="text-[var(--text-dim)] transition-colors hover:text-[var(--accent)]"
+                        className="text-[var(--text-secondary)] transition-colors hover:text-[var(--accent)]"
                         title="View on Solana Explorer"
                       >
                         ↗
@@ -270,12 +270,12 @@ export function TradeHistory() {
           <button
             onClick={() => setPage((p) => Math.max(1, p - 1))}
             disabled={page === 1}
-            className="rounded-sm border border-[var(--border)] px-3 py-1 text-[10px] text-[var(--text-muted)] transition-all hover:border-[var(--accent)]/30 hover:text-[var(--text-secondary)] disabled:opacity-30"
+            className="rounded-sm border border-[var(--border)] px-3 py-1 text-[10px] text-[var(--text-secondary)] transition-all hover:border-[var(--accent)]/30 hover:text-[var(--text)] disabled:opacity-30"
           >
             ← Prev
           </button>
           <span
-            className="text-[10px] text-[var(--text-muted)]"
+            className="text-[10px] text-[var(--text-secondary)]"
             style={{ fontFamily: "var(--font-jetbrains-mono)" }}
           >
             Page {page} of {totalPages}
@@ -283,7 +283,7 @@ export function TradeHistory() {
           <button
             onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
             disabled={page === totalPages}
-            className="rounded-sm border border-[var(--border)] px-3 py-1 text-[10px] text-[var(--text-muted)] transition-all hover:border-[var(--accent)]/30 hover:text-[var(--text-secondary)] disabled:opacity-30"
+            className="rounded-sm border border-[var(--border)] px-3 py-1 text-[10px] text-[var(--text-secondary)] transition-all hover:border-[var(--accent)]/30 hover:text-[var(--text)] disabled:opacity-30"
           >
             Next →
           </button>

--- a/app/components/dashboard/Watchlist.tsx
+++ b/app/components/dashboard/Watchlist.tsx
@@ -43,19 +43,19 @@ export function Watchlist() {
   return (
     <div className="border border-[var(--border)] bg-[var(--panel-bg)]">
       <div className="flex items-center justify-between border-b border-[var(--border)] px-5 py-4">
-        <p className="text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-dim)]">
+        <p className="text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-secondary)]">
           Markets
         </p>
-        <Link href="/markets" className="text-[10px] text-[var(--text-dim)] transition-colors hover:text-[var(--accent)]">
+        <Link href="/markets" className="text-[10px] text-[var(--text-secondary)] transition-colors hover:text-[var(--accent)]">
           View All →
         </Link>
       </div>
 
       <div className="max-h-[280px] overflow-y-auto">
         {loading ? (
-          <div className="px-4 py-6 text-center text-[10px] text-[var(--text-muted)]">Loading markets...</div>
+          <div className="px-4 py-6 text-center text-[10px] text-[var(--text-secondary)]">Loading markets...</div>
         ) : markets.length === 0 ? (
-          <div className="px-4 py-6 text-center text-[10px] text-[var(--text-muted)]">No markets found</div>
+          <div className="px-4 py-6 text-center text-[10px] text-[var(--text-secondary)]">No markets found</div>
         ) : (
           markets.slice(0, 10).map((m) => (
             <Link
@@ -67,10 +67,10 @@ export function Watchlist() {
                 {m.symbol ? `${m.symbol}-PERP` : `${m.slab_address.slice(0, 6)}…`}
               </span>
               <div className="flex-1 text-right">
-                <p className="text-[9px] text-[var(--text-muted)]">
+                <p className="text-[9px] text-[var(--text-secondary)]">
                   Vol: {m.volume_24h_usd != null && m.volume_24h_usd > 0 ? formatCompact(m.volume_24h_usd) : "--"}
                 </p>
-                <p className="text-[9px] text-[var(--text-dim)]">
+                <p className="text-[9px] text-[var(--text-secondary)]">
                   OI: {m.total_open_interest_usd != null && m.total_open_interest_usd > 0 ? formatCompact(m.total_open_interest_usd) : "--"}
                 </p>
               </div>


### PR DESCRIPTION
## What

Third in the contrast series (#2238 create wizard, #2258 stake page): the **trader dashboard** is rendered almost entirely in the two lowest-contrast text tokens and is hard to read in the dark theme.

- `--text-dim` (`#2A2E3D`, ~**1.4:1** against the dark background): panel headers ("PORTFOLIO PNL", "OPEN POSITIONS", "TRADE HISTORY", "FUNDING RATES", "WATCHLIST"), empty-state subtext ("Open a trade to see your PnL"), position data labels (Size / Entry / Mark / Liq), trade-table column headers, inactive timeframe toggles (24H / 30D / ALL), "Connect wallet to view trades", "No trades yet".
- `--text-muted` (`#454B5F`, ~**2.2:1**): empty-state headings ("No positions yet"), "Start trading →", stat sublabels, pagination controls, inactive mobile tabs, the "Trader" half of the page heading, zero-value stat colors.

Both sit below the WCAG large-text minimum of 3:1.

## Fix

Text colors only — 50 class-string swaps across 9 files, no layout or logic changes:

- `text-[var(--text-dim)]` and `text-[var(--text-muted)]` → `text-[var(--text-secondary)]` (`#7A7F96`, ~4.9:1 — readable, still clearly muted)
- Elements that hovered dim → secondary now hover secondary → full `--text`, keeping the hover affordance
- One `text-[var(--text-dim)]/60` (TradeHistory empty-state hint) gets the same bump with the extra opacity dropped

Global `--text-dim` / `--text-muted` tokens are deliberately untouched — changing those is an app-wide design decision.

## Testing

- `npx tsc --noEmit` — clean, 0 errors
- Verified the diff contains only `text-[var(--text*` class changes (no other lines touched)
- Contrast figures computed against the dark-theme background

🤖 Generated with [Claude Code](https://claude.com/claude-code)
