### PR TITLE
fix(app): silence three recurring dev-console errors

### DIFF
--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -86,10 +86,15 @@ export const metadata: Metadata = {
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const nonce = (await headers()).get("x-nonce") ?? undefined;
   return (
-    <html lang="en" suppressHydrationWarning className={`${geistMono.variable} ${spaceGrotesk.variable} ${jetbrainsMono.variable} ${outfit.variable}`}>
+    <html lang="en" suppressHydrationWarning data-scroll-behavior="smooth" className={`${geistMono.variable} ${spaceGrotesk.variable} ${jetbrainsMono.variable} ${outfit.variable}`}>
       <head>
+        {/* suppressHydrationWarning: browsers blank the nonce content attribute after
+            parsing (nonce hiding), so React's hydration diff always sees nonce="" vs
+            the server value and logs a mismatch error on every load. The nonce itself
+            still applies — only the noisy warning is suppressed. */}
         <script
           nonce={nonce}
+          suppressHydrationWarning
           dangerouslySetInnerHTML={{
             __html: `
               try {

--- a/app/components/providers/WalletAdapterProviderClient.tsx
+++ b/app/components/providers/WalletAdapterProviderClient.tsx
@@ -17,7 +17,7 @@ import {
   ConnectionProvider,
   WalletProvider as SolanaWalletProvider,
 } from "@solana/wallet-adapter-react";
-import { PhantomWalletAdapter, SolflareWalletAdapter } from "@solana/wallet-adapter-wallets";
+import { SolflareWalletAdapter } from "@solana/wallet-adapter-wallets";
 import { getConfig } from "@/lib/config";
 
 interface Props {
@@ -31,10 +31,11 @@ export const WalletAdapterProviderClient: FC<Props> = ({ children }) => {
 
   const wallets = useMemo(
     () => [
-      // These are "legacy" adapters that auto-detect the extension. If the user has
-      // a Wallet Standard implementation (modern Phantom / Solflare / Backpack) it
-      // will be picked up by the WalletProvider via the standard adapter bridge too.
-      new PhantomWalletAdapter(),
+      // Legacy adapter that auto-detects the extension. Wallet Standard wallets
+      // (modern Phantom / Solflare / Backpack) self-register via the standard
+      // adapter bridge. Phantom's legacy adapter is intentionally omitted — Phantom
+      // is always Standard-compliant now and double-registering logs a console
+      // warning ("Phantom was registered as a Standard Wallet…") on every load.
       new SolflareWalletAdapter(),
     ],
     [],


### PR DESCRIPTION
## What

Three recurring dev-console errors/warnings, observed in a real browsing session (counts per session):

1. **13× React hydration mismatch** — the inline theme `<script>` in the root layout gets `nonce={nonce}`, but browsers deliberately blank the nonce content attribute after parsing ("nonce hiding"), so React's hydration diff always sees `nonce=""` vs the server value and logs a full error with component stack on every page load.
   **Fix:** `suppressHydrationWarning` on that one `<script>` element. The CSP nonce still applies (it's read at parse time); only the false-positive warning is suppressed.

2. **12× "Phantom was registered as a Standard Wallet. The Wallet Adapter for Phantom can be removed from your app."** — modern Phantom self-registers via the Wallet Standard, so the legacy `PhantomWalletAdapter` double-registers.
   **Fix:** drop the legacy Phantom adapter (matches the adapter's own guidance; the production branch already removed it in the WalletProvider rewrite). The Solflare legacy adapter is kept for its no-extension install-link affordance.

3. **8× Next.js smooth-scroll notice** — `globals.css` sets `scroll-behavior: smooth` on `<html>`, and Next 16 asks for `data-scroll-behavior="smooth"` on the `<html>` element to manage scroll during route transitions.
   **Fix:** add the attribute.

## Why base = `playground`

Targets the playground app on the `playground` branch. Items 1 and 3 also exist on `main`'s layout — happy to open a twin PR there if useful.

## Testing

- `npx tsc --noEmit` — clean
- Headless-browser console capture on `/` (Playwright chromium, local dev server): hydration error and scroll notice **gone**, zero page errors
- Phantom warning requires the extension so it can't be reproduced headless; the change follows the wallet-adapter's own deprecation message
- No logic changes: one attribute on `<html>`, one attribute + comment on the theme script, one adapter removed from the wallets array

🤖 Generated with [Claude Code](https://claude.com/claude-code)
