### PR TITLE
fix(chart): repaint drawings after the price series is recreated

### DIFF
--- a/app/__tests__/components/trade/ChartDrawingOverlay.test.tsx
+++ b/app/__tests__/components/trade/ChartDrawingOverlay.test.tsx
@@ -195,6 +195,7 @@ interface HarnessProps {
   setTool?: (next: DrawingTool) => void;
   slabAddress?: string;
   series?: PriceConverter | null;
+  seriesEpoch?: number;
 }
 
 const Harness: FC<HarnessProps> = ({
@@ -207,6 +208,7 @@ const Harness: FC<HarnessProps> = ({
   setTool = () => {},
   slabAddress = SLAB_A,
   series = idSeries,
+  seriesEpoch = 0,
 }) => {
   const chartRef = useRef<IChartApi | null>(null);
   chartRef.current = chart;
@@ -226,6 +228,7 @@ const Harness: FC<HarnessProps> = ({
         tool={tool}
         setTool={setTool}
         slabAddress={slabAddress}
+        seriesEpoch={seriesEpoch}
       />
     </div>
   );
@@ -372,6 +375,24 @@ describe("ChartDrawingOverlay", () => {
       const sizeHandler = ch.subscribeSize.mock.calls[0][0];
       sizeHandler();
       expect(clearRect.mock.calls.length).toBe(initial + 3);
+    });
+
+    it("repaints when seriesEpoch bumps (price series was recreated)", () => {
+      // Regression: TradingChart's series effect does a full removeSeries +
+      // addSeries when candle data changes. The swap-time range-change redraw
+      // runs against the disposed series and leaves the canvas blank; the
+      // seriesEpoch dep must trigger one repaint against the new series.
+      const { clearRect } = stubCanvasContext();
+      const ch = fakeChart();
+      const stableDrawings = [horiz("h1", 100)];
+      const { rerender } = render(
+        <Harness chart={ch.chart} ready={true} drawings={stableDrawings} />,
+      );
+      const initial = clearRect.mock.calls.length;
+      rerender(
+        <Harness chart={ch.chart} ready={true} drawings={stableDrawings} seriesEpoch={1} />,
+      );
+      expect(clearRect.mock.calls.length).toBe(initial + 1);
     });
   });
 

--- a/app/components/trade/ChartDrawingOverlay.tsx
+++ b/app/components/trade/ChartDrawingOverlay.tsx
@@ -61,6 +61,15 @@ interface ChartDrawingOverlayProps {
   /** The slab whose drawings these are. Used to reset overlay-local
    *  selection state when the user navigates between markets. */
   slabAddress: string;
+  /** Bumped by TradingChart after each price-series remove+re-add (its
+   *  series effect fully recreates the series when candle data / style /
+   *  timeframe change). The swap fires a visible-range change while the
+   *  OLD series is already disposed — that redraw clears the canvas and
+   *  projects zero drawings — and nothing else repaints afterwards, so
+   *  committed drawings silently vanish (state and localStorage intact)
+   *  until the next pan/zoom. A dep on this counter repaints once the
+   *  NEW series is in place. */
+  seriesEpoch: number;
 }
 
 /**
@@ -103,6 +112,7 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
   tool,
   setTool,
   slabAddress,
+  seriesEpoch,
 }) => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   /** Currently selected drawing's id, or null. Overlay-local state —
@@ -516,9 +526,13 @@ export const ChartDrawingOverlay: FC<ChartDrawingOverlayProps> = ({
   // pendingP1 in the deps so the preview anchor dot appears the
   // moment the first trend click lands (without waiting for the next
   // crosshair move to repaint).
+  //
+  // seriesEpoch repaints after TradingChart recreates the price series
+  // (see the prop doc) — the swap-time redraw ran against the disposed
+  // series and left the canvas blank.
   useEffect(() => {
     redrawRef.current();
-  }, [drawings, selectedId, pendingP1]);
+  }, [drawings, selectedId, pendingP1, seriesEpoch]);
 
   // Rectangle creation: drag-driven (mouse-down inside the chart sets
   // p1, mouse-move tracks the opposite corner, mouse-up commits).

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -243,6 +243,10 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
   // hooks (useIndicatorOverlays) that need to attach series to the chart
   // — refs alone can't drive an effect since they don't trigger re-runs.
   const [chartReady, setChartReady] = useState(false);
+  // Bumped after every price-series remove+re-add so ChartDrawingOverlay
+  // repaints against the NEW series (the swap-time redraw runs against the
+  // disposed one and leaves committed drawings invisible until a pan).
+  const [seriesEpoch, setSeriesEpoch] = useState(0);
   const seriesRef = useRef<ISeriesApi<ChartSeriesKind> | null>(null);
   const volumeSeriesRef = useRef<ISeriesApi<"Histogram"> | null>(null);
   const priceLineRef = useRef<ReturnType<ISeriesApi<"Candlestick">["createPriceLine"]> | null>(null);
@@ -824,6 +828,10 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
       fitKeyRef.current = fitKey;
     }
 
+    // Signal the drawing overlay that the series it projects through was
+    // just swapped — see seriesEpoch's declaration comment.
+    setSeriesEpoch((e) => e + 1);
+
     return () => {
       chart.unsubscribeCrosshairMove(crosshairHandler);
     };
@@ -1017,6 +1025,7 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
             seriesRef={seriesRef}
             containerRef={containerRef}
             chartReady={chartReady}
+            seriesEpoch={seriesEpoch}
             drawings={drawings}
             addDrawing={addDrawing}
             deleteDrawing={deleteDrawing}


### PR DESCRIPTION
## Bug

Draw a trend line / horizontal / rectangle on the trade chart → **it disappears 3–5 seconds later**. The drawing still *exists* — localStorage keeps it, the clear-all button shows the count, pointer-mode hit-testing finds it — only the pixels are gone. Panning or zooming makes it reappear.

Reproduced deterministically in headless Chromium by sampling the overlay canvas's pixels after committing a horizontal drawing:

```
t+0.2s  painted pixels: 2348   ← line visible
t+2s    painted pixels: 2348
t+5s    painted pixels: 0      ← gone (localStorage still has the drawing)
t+10s   painted pixels: 0
after pan: 2348                ← reappears
```

## Root cause

`TradingChart`'s series effect does a **full `removeSeries` + `addSeries`** whenever candle data changes — which is every few seconds while candles poll. The swap fires a `visibleLogicalRangeChange` while the overlay's `seriesRef` still points at the just-disposed series, so that redraw clears the canvas and projects zero drawings (no throw — coordinates just come back empty). After the swap completes, nothing triggers another redraw: the overlay's redraw drivers are range/size events and drawings/selection state, none of which change. The canvas stays blank until the user pans.

## Fix

`TradingChart` bumps a `seriesEpoch` counter at the end of its series effect; `ChartDrawingOverlay` takes it as a prop and includes it in the redraw-driver effect deps — one repaint against the new series after each swap. No changes to the subscribe-once architecture or the pointer-events contract.

## Testing

- Same headless repro after the fix: **2348 px at t+0.2s, t+6s (past multiple swap cycles), and after pan** — no errors
- `ChartDrawingOverlay` suite: 65/65 pass, including a new regression test (`repaints when seriesEpoch bumps`) that fails on the old code
- `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
