### PR TITLE
fix(markets): live prices + real v17 OI/insurance on the markets list

### DIFF
--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Connection, PublicKey } from "@solana/web3.js";
 import { validateNumericParam } from "@/lib/route-validators";
-import { parseHeader, parseConfig, discoverMarkets, type DiscoveredMarket, isV17Account, parseWrapperConfigV17, parseAssetOracleProfileV17, V17_HEADER_LEN, V17_WRAPPER_CONFIG_LEN } from "@percolatorct/sdk";
+import { parseHeader, parseConfig, discoverMarkets, type DiscoveredMarket, isV17Account, parseWrapperConfigV17, parseAssetOracleProfileV17, parseMarketGroupV17OI, type V17MarketGroupOI, V17_HEADER_LEN, V17_WRAPPER_CONFIG_LEN } from "@percolatorct/sdk";
 import { getServiceClient, getServerNetwork } from "@/lib/supabase";
 import { getConfig, getRpcEndpoint } from "@/lib/config";
 import { PLAYGROUND_SLAB_META } from "@/lib/playground-slab-meta";
@@ -263,7 +263,7 @@ function numericOrNull(v: unknown): number | null {
  * For v17 markets, configV17 carries all config fields.
  * For v12 slabs, config has the fields; engine/params hold stats.
  */
-function discoveredToApiRow(m: DiscoveredMarket): Record<string, unknown> {
+function discoveredToApiRow(m: DiscoveredMarket, v17Oi?: V17MarketGroupOI): Record<string, unknown> {
   const slabAddress = m.slabAddress.toBase58();
   const programId = m.programId.toBase58();
 
@@ -272,6 +272,13 @@ function discoveredToApiRow(m: DiscoveredMarket): Record<string, unknown> {
     const markPriceRaw = cfg.markEwmaE6;
     const markPriceUsd = markPriceRaw > 0n ? Number(markPriceRaw) / 1_000_000 : null;
     const playgroundMeta = PLAYGROUND_SLAB_META[slabAddress];
+    // Live engine stats parsed from the raw market-group bytes (see the extra
+    // getMultipleAccountsInfo read in discoverMarketsOnChain). undefined when
+    // that read failed — fields then keep the previous zeroed placeholders.
+    const oiLong = v17Oi ? Number(v17Oi.totalLongOiQ) : 0;
+    const oiShort = v17Oi ? Number(v17Oi.totalShortOiQ) : 0;
+    const totalOi = oiLong + oiShort;
+    const insurance = v17Oi ? Number(v17Oi.insuranceBalance) : 0;
     return {
       slab_address: slabAddress,
       program_id: programId,
@@ -293,19 +300,23 @@ function discoveredToApiRow(m: DiscoveredMarket): Record<string, unknown> {
       index_price: null,
       volume_24h: 0,
       trade_count_24h: 0,
-      open_interest_long: 0,
-      open_interest_short: 0,
-      total_open_interest: 0,
-      total_open_interest_usd: 0,
-      insurance_fund: 0,
-      insurance_balance: 0,
+      open_interest_long: oiLong,
+      open_interest_short: oiShort,
+      total_open_interest: totalOi,
+      total_open_interest_usd: markPriceUsd != null ? (totalOi / 1_000_000) * markPriceUsd : 0,
+      insurance_fund: insurance,
+      insurance_balance: insurance,
       total_accounts: 0,
       funding_rate: null,
       net_lp_pos: 0,
       lp_sum_abs: 0,
-      c_tot: 0,
+      // Unknown on v17 (no cheap on-chain source for vault/capital yet) —
+      // null, NOT 0. A hard 0 here trips the phantom-OI vault guard
+      // (MIN_VAULT_FOR_OI) and health logic downstream; null reads as
+      // "no data" and degrades gracefully.
+      c_tot: null,
       volume_24h_usd: 0,
-      vault_balance: 0,
+      vault_balance: null,
     };
   }
 
@@ -364,14 +375,37 @@ async function discoverMarketsOnChain(): Promise<Record<string, unknown>[]> {
     if (found.length === 0) return [];
 
     const seen = new Set<string>();
-    return found
-      .filter(m => {
-        const key = m.slabAddress.toBase58();
-        if (seen.has(key)) return false;
-        seen.add(key);
-        return true;
-      })
-      .map(discoveredToApiRow);
+    const unique = found.filter(m => {
+      const key = m.slabAddress.toBase58();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+
+    // Enrich v17 rows with live OI + insurance parsed from the raw account
+    // bytes (discoverMarkets returns parsed configs only, not raws) — one
+    // batched RPC read for all v17 slabs. Degrades gracefully: on failure the
+    // rows keep zeroed stats, which is exactly the pre-enrichment behavior.
+    const v17Stats = new Map<string, V17MarketGroupOI>();
+    const v17Markets = unique.filter((m) => m.configV17);
+    // getMultipleAccountsInfo caps at 100 accounts per call — chunk the reads.
+    const CHUNK = 100;
+    for (let start = 0; start < v17Markets.length; start += CHUNK) {
+      const chunk = v17Markets.slice(start, start + CHUNK);
+      try {
+        const infos = await connection.getMultipleAccountsInfo(chunk.map((m) => m.slabAddress));
+        infos.forEach((info, i) => {
+          if (!info?.data) return;
+          const data = new Uint8Array(info.data);
+          if (!isV17Account(data)) return;
+          v17Stats.set(chunk[i].slabAddress.toBase58(), parseMarketGroupV17OI(data));
+        });
+      } catch {
+        /* this chunk's stats stay zeroed */
+      }
+    }
+
+    return unique.map((m) => discoveredToApiRow(m, v17Stats.get(m.slabAddress.toBase58())));
   } catch {
     return [];
   }

--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useMemo, useRef, Suspense } from "react";
+import { useEffect, useState, useMemo, useRef, useCallback, useSyncExternalStore, Suspense, type FC } from "react";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -23,6 +23,7 @@ import { useAllMarketStats } from "@/hooks/useAllMarketStats";
 import { MarketLogo } from "@/components/market/MarketLogo";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
 import { detectOracleMode, resolveMarketPriceE6, priceE6ToUsd, sanitizePriceE6, applyInvert } from "@/lib/oraclePrice";
+import { subscribeSlab, getSnapshot } from "@/lib/priceStore/priceStore";
 import { formatStatValue } from "@/lib/format";
 import { MIN_VAULT_FOR_OI } from "@/lib/phantom-oi";
 
@@ -78,6 +79,19 @@ function resolveDiscoveredPriceE6(oc: DiscoveredMarket): bigint {
   if (!oc.config?.indexFeedId) return 0n;
   return resolveMarketPriceE6(oc.config);
 }
+
+/** Live-ticking price cell. Subscribes this row's slab to the shared price
+ *  store (the same WS feed the trade page ticks off), so list prices move in
+ *  real time instead of freezing at the discovery/stats snapshot. Falls back
+ *  to the static snapshot price until the first tick arrives — markets the
+ *  feed doesn't stream (or no WS configured) keep the previous behavior.
+ *  Isolated as a component so ticks re-render only this cell, not the list. */
+const LiveRowPrice: FC<{ slab: string; fallback: number | null }> = ({ slab, fallback }) => {
+  const subscribe = useCallback((cb: () => void) => subscribeSlab(slab, cb), [slab]);
+  const getSnap = useCallback(() => getSnapshot(slab).priceUsd, [slab]);
+  const live = useSyncExternalStore(subscribe, getSnap, () => null);
+  return <>{formatUsdFromNumber(live ?? fallback)}</>;
+};
 
 function isPlaceholderMarketSymbol(sym: string | null | undefined, addresses: Array<string | null | undefined>): boolean {
   if (!sym) return true;
@@ -264,9 +278,12 @@ function MarketsPageInner() {
       // Derive from oracle_mode field (canonical); fall back to oracle_authority presence for
       // old rows that predate the oracle_mode column (migration 035).
       // "hyperp" markets use on-chain DEX pool — NOT admin-controlled.
-      // "admin" and "keeper" are both admin/auth-mark price sources — show price controls.
+      // "keeper" (AUTH_MARK) is an automated keeper service — NOT manual admin
+      // entry; excluding it matches the on-chain branch above (which never
+      // badges keeper markets MANUAL). Only true "admin" (manual push) rows
+      // should show the manual badge.
       const isAdminOracle = stats.oracle_mode != null
-        ? stats.oracle_mode !== "hyperp" && stats.oracle_mode !== "pyth"
+        ? stats.oracle_mode !== "hyperp" && stats.oracle_mode !== "pyth" && stats.oracle_mode !== "keeper"
         : (stats.oracle_authority != null && stats.oracle_authority !== "");
       result.push({
         slabAddress: slabAddr,
@@ -1048,7 +1065,7 @@ function MarketsPageInner() {
                       </div>
                       <div className="text-right truncate">
                         <span className="text-sm text-[var(--text)] tabular-nums" style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>
-                          {formatUsdFromNumber(lastPrice)}
+                          <LiveRowPrice slab={m.slabAddress} fallback={lastPrice} />
                         </span>
                       </div>
                       <div className="hidden sm:block text-right text-sm text-[var(--text-secondary)] truncate tabular-nums" style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>{oiDisplay}</div>


### PR DESCRIPTION
## Bugs (all reproduce on https://percolator-playground.vercel.app/markets)

Follow-up to #2261. The markets list shows the five playground markets, but the data is dead:

1. **Prices are frozen.** The list renders a one-shot snapshot (Supabase `last_price` / on-chain mark at discovery time) and never subscribes to the live price feed — rows sit at the same number indefinitely while the trade page ticks.
2. **OI and Insurance always show "—".** `/api/markets`' `discoveredToApiRow` hardcodes `total_open_interest: 0, insurance_balance: 0, …` for every v17 market (the deployed API returns literal zeros for all five markets, `curl`-verifiable).
3. **Keeper markets wear a MANUAL badge.** The stats-branch `isAdminOracle` rule predates the keeper oracle mode — it only excludes `hyperp`/`pyth`, so automated AUTH_MARK markets get badged as manually-priced. (The on-chain branch already excludes keeper, so the badge flickered depending on which data source won.)

## Fixes

- **Live prices:** new `LiveRowPrice` cell — subscribes each row's slab to the shared price store (the exact feed the trade page uses), falls back to the static snapshot until the first tick. Isolated as a component so ticks re-render one cell, not the list. Markets the feed doesn't stream keep today's behavior.
- **Real v17 stats:** discovery in `/api/markets` now does a chunked `getMultipleAccountsInfo` pass (RPC caps at 100 accounts — discovery finds ~122 v17 groups, so chunking is required, and the unchunked call fails with `-32602`) and parses OI + insurance with `parseMarketGroupV17OI` — the same SDK parser `useEngineState` uses on the trade page. `c_tot`/`vault_balance` become `null` (unknown on v17) instead of `0`, because a hard zero trips the phantom-OI vault guard (`MIN_VAULT_FOR_OI`) and misclassifies health.
- **Badge:** stats-branch `isAdminOracle` excludes `"keeper"`, matching the on-chain branch's rule.

## Result (headless Chromium against local dev server)

```
before: $0.246227 frozen | OI — | INS — | badge MANUAL | health Empty
after:  price ticks ($0.244876 → $0.244866 between samples)
        JUP  OI 100.00  INS 29.47
        SOL  OI 30.10   INS 38.06
        no MANUAL badge on keeper markets, zero page errors
```

Health now computes from real OI/insurance. Note: v17 rows with open interest read "Low Liq" because capital (`c_tot`) has no cheap on-chain source yet — that's the honest rendering of "capital unknown", and it upgrades automatically if a capital source is added later. Volume stays "—" without the external indexer (expected).

## Testing

- `npx tsc --noEmit` clean
- Markets/stats API suites: 128/128 pass
- Headless-browser verification as above (two timed samples + error capture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
