### PR TITLE
feat(trade): USD-default size input + both balances in the ticket header

### DIFF
--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -213,7 +213,9 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
   const [orderType, setOrderType] = useState<"market" | "limit">("market");
   const [limitPriceInput, setLimitPriceInput] = useState("");
   const [direction, setDirection] = useState<"long" | "short">("long");
-  const [sizeUnit, setSizeUnit] = useState<"token" | "usd">("token");
+  // USD is the default sizing unit — traders think in dollar notional first;
+  // the chip next to the input switches to token units for those who don't.
+  const [sizeUnit, setSizeUnit] = useState<"token" | "usd">("usd");
   const [sizeInput, setSizeInput] = useState("");
   const [marginInput, setMarginInput] = useState("");
   const [leverage, setLeverage] = useState(1);
@@ -544,8 +546,15 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
             Size
             <InfoIcon tooltip="Position size in the toggled unit. Switch between token and USD - both stay in sync." />
           </label>
+          {/* Both balances up top — users deposit from the wallet into the
+              account and trade from the account; showing only one confused
+              people about where their funds "went". 3dp keeps the row tight. */}
           <span className="text-[10px] text-[var(--text)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
-            Account Bal: {userAccount ? formatTokenAmount(capital, decimals) : "0"} {collateralSymbol}
+            <span className="text-[var(--text-secondary)]">Acc Bal </span>
+            {userAccount ? formatTokenAmount(capital, decimals, 3) : "0"}
+            <span className="text-[var(--text-secondary)]"> · Wal Bal </span>
+            {walletAtaBalance != null ? formatTokenAmount(walletAtaBalance, decimals, 3) : "—"}
+            <span className="text-[var(--text-secondary)]"> {collateralSymbol}</span>
           </span>
         </div>
         <div className="flex gap-1.5">


### PR DESCRIPTION
## What

Two order-ticket UX papercuts on the trade page:

**1. Size input now defaults to USD.** It defaulted to token units (`SOL-PERP`), but traders think in dollar notional first. The unit chip next to the input still toggles back to token sizing — only the default changed (placeholder becomes `$0.00`, quick-fill % chips and margin math already handle both units).

**2. Both balances in the ticket header.** The row above the size input showed only `Account Bal`. Users who deposit from their wallet into the trading account couldn't see the wallet side without opening the deposit card — funds seemed to "disappear". Now:

```
SIZE ⓘ            Acc Bal 199.459 · Wal Bal 9984.593 USDC
```

Compact labels and max 3 decimals (via `formatTokenAmount`'s existing `maxDisplayDecimals` param) keep it on one line; `Wal Bal` shows `—` until the ATA loads.

## Testing

- `npx tsc --noEmit` clean
- `useTrade` suite passes (16/16)
- Headless-browser check: `$0.00` placeholder renders (USD default), header shows `Acc Bal 0 · Wal Bal — USDC` in a wallet-less session; screenshots from a connected devnet session to follow in a comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
