### PR TITLE
fix(analytics): brighten near-invisible dim/muted text

### DIFF
--- a/app/app/analytics/[slab]/page.tsx
+++ b/app/app/analytics/[slab]/page.tsx
@@ -31,7 +31,7 @@ import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <div className="rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80">
-      <div className="border-b border-[var(--border)]/40 px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-dim)]">
+      <div className="border-b border-[var(--border)]/40 px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.15em] text-[var(--text-secondary)]">
         {title}
       </div>
       <div className="p-3">{children}</div>

--- a/app/components/market/InsuranceDashboard.tsx
+++ b/app/components/market/InsuranceDashboard.tsx
@@ -141,7 +141,7 @@ export const InsuranceDashboard: FC<{ slabAddress: string }> = ({
 
   // Calculate health status
   const healthStatus = useMemo(() => {
-    if (!insuranceData) return { color: "text-[var(--text-muted)]", dotColor: "bg-[var(--text-muted)]", label: "Unknown", borderColor: "border-[var(--border)]", bgColor: "bg-transparent" };
+    if (!insuranceData) return { color: "text-[var(--text-secondary)]", dotColor: "bg-[var(--text-muted)]", label: "Unknown", borderColor: "border-[var(--border)]", bgColor: "bg-transparent" };
 
     const ratio = insuranceData.coverageRatio ?? 0;
 
@@ -176,7 +176,7 @@ export const InsuranceDashboard: FC<{ slabAddress: string }> = ({
     return (
       <div className="rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 p-3">
         <div className="flex items-center justify-between">
-          <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">
+          <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-secondary)]">
             Insurance Fund
           </span>
           <div className="h-4 w-16 animate-pulse rounded-none bg-[var(--border)]" />
@@ -189,10 +189,10 @@ export const InsuranceDashboard: FC<{ slabAddress: string }> = ({
     return (
       <div className="rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 p-3">
         <div className="flex items-center justify-between">
-          <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">
+          <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-secondary)]">
             Insurance Fund
           </span>
-          <span className="text-[10px] text-[var(--text-dim)]">No data available</span>
+          <span className="text-[10px] text-[var(--text-secondary)]">No data available</span>
         </div>
       </div>
     );
@@ -207,7 +207,7 @@ export const InsuranceDashboard: FC<{ slabAddress: string }> = ({
         {/* Header row: label + balance */}
         <div className="mb-1.5 flex items-baseline justify-between">
           <div className="flex items-center gap-1">
-            <span className="text-[9px] font-bold uppercase tracking-[0.15em] text-[var(--text-dim)]">
+            <span className="text-[9px] font-bold uppercase tracking-[0.15em] text-[var(--text-secondary)]">
               Insurance Fund
             </span>
             <InfoIcon tooltip="Safety net that protects LPs from bankruptcy during extreme market events." />
@@ -228,7 +228,7 @@ export const InsuranceDashboard: FC<{ slabAddress: string }> = ({
 
         {/* Fee Revenue row */}
         <div className="mb-1.5 flex items-baseline justify-between">
-          <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">Fee Revenue</span>
+          <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-secondary)]">Fee Revenue</span>
           <div className="flex items-baseline gap-1">
             <span className="text-[11px] font-medium text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-mono)" }}>
               ${feeRevenueUsd}
@@ -247,7 +247,7 @@ export const InsuranceDashboard: FC<{ slabAddress: string }> = ({
               <span className={healthStatus.color}>{healthStatus.label}</span>
             </span>
             {insuranceData.coverageRatio != null && typeof insuranceData.coverageRatio === "number" && (
-              <span className="text-[9px] text-[var(--text-dim)]">
+              <span className="text-[9px] text-[var(--text-secondary)]">
                 {insuranceData.coverageRatio.toFixed(1)}x coverage
               </span>
             )}
@@ -257,7 +257,7 @@ export const InsuranceDashboard: FC<{ slabAddress: string }> = ({
         {/* 7-day mini chart */}
         <div className="rounded-none border border-[var(--border)]/30 bg-[var(--bg-elevated)] px-1.5 py-1">
           <div className="mb-0.5 flex items-center justify-between">
-            <span className="text-[8px] uppercase tracking-[0.1em] text-[var(--text-dim)]">7d Trend</span>
+            <span className="text-[8px] uppercase tracking-[0.1em] text-[var(--text-secondary)]">7d Trend</span>
             {insuranceData.historicalBalance && insuranceData.historicalBalance.length > 1 && insuranceData.historicalBalance[0].balance > 0 && (
               <span className="text-[9px] text-[var(--long)]" style={{ fontFamily: "var(--font-mono)" }}>
                 +{((insuranceData.historicalBalance[insuranceData.historicalBalance.length - 1].balance / insuranceData.historicalBalance[0].balance - 1) * 100).toFixed(1)}%
@@ -280,7 +280,7 @@ export const InsuranceDashboard: FC<{ slabAddress: string }> = ({
               })}
             </div>
           ) : (
-            <div className="flex h-6 items-center justify-center text-[9px] text-[var(--text-dim)]">No data</div>
+            <div className="flex h-6 items-center justify-center text-[9px] text-[var(--text-secondary)]">No data</div>
           )}
         </div>
 

--- a/app/components/market/OpenInterestCard.tsx
+++ b/app/components/market/OpenInterestCard.tsx
@@ -116,7 +116,7 @@ export const OpenInterestCard: FC<{ slabAddress: string }> = ({
           shortPct: 50,
           imbalancePct: 0,
           imbalanceLabel: "Balanced",
-          imbalanceColor: "text-[var(--text-muted)]",
+          imbalanceColor: "text-[var(--text-secondary)]",
           oiUtilPct: 0,
           oiUtilColor: "var(--accent)",
         };
@@ -141,7 +141,7 @@ export const OpenInterestCard: FC<{ slabAddress: string }> = ({
         "var(--short)";                             // red — near capacity
 
       let label = "Balanced";
-      let color = "text-[var(--text-muted)]";
+      let color = "text-[var(--text-secondary)]";
 
       if (Math.abs(imbalance) < 5) {
         label = "Balanced";
@@ -179,7 +179,7 @@ export const OpenInterestCard: FC<{ slabAddress: string }> = ({
     return (
       <div className="rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 p-3">
         <div className="flex items-center justify-between">
-          <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">
+          <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-secondary)]">
             Open Interest
           </span>
           <div className="h-4 w-16 animate-pulse rounded-none bg-[var(--border)]" />
@@ -192,10 +192,10 @@ export const OpenInterestCard: FC<{ slabAddress: string }> = ({
     return (
       <div className="rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 p-3">
         <div className="flex items-center justify-between">
-          <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">
+          <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-secondary)]">
             Open Interest
           </span>
-          <span className="text-[10px] text-[var(--text-dim)]">No data available</span>
+          <span className="text-[10px] text-[var(--text-secondary)]">No data available</span>
         </div>
       </div>
     );
@@ -212,7 +212,7 @@ export const OpenInterestCard: FC<{ slabAddress: string }> = ({
       {/* Header row: label + total OI value */}
       <div className="mb-1.5 flex items-baseline justify-between">
         <div className="flex items-center gap-1">
-          <span className="text-[9px] font-bold uppercase tracking-[0.15em] text-[var(--text-dim)]">
+          <span className="text-[9px] font-bold uppercase tracking-[0.15em] text-[var(--text-secondary)]">
             Open Interest
           </span>
           <InfoIcon tooltip="Total notional value of all open positions in the market." />
@@ -228,7 +228,7 @@ export const OpenInterestCard: FC<{ slabAddress: string }> = ({
       {/* OI Utilization bar with label */}
       <div className="mb-1.5">
         <div className="mb-1 flex items-center justify-between">
-          <span className="text-[9px] uppercase tracking-[0.04em] text-[var(--text-dim)]">
+          <span className="text-[9px] uppercase tracking-[0.04em] text-[var(--text-secondary)]">
             OI Utilization
           </span>
           <span
@@ -250,7 +250,7 @@ export const OpenInterestCard: FC<{ slabAddress: string }> = ({
       <div className="mb-1.5 space-y-1">
         <div>
           <div className="mb-0.5 flex items-center justify-between">
-            <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">Long</span>
+            <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-secondary)]">Long</span>
             <span className="text-[10px] font-medium text-[var(--long)]" style={{ fontFamily: "var(--font-mono)" }}>
               ${longOiUsd} ({longPct.toFixed(1)}%)
             </span>
@@ -261,7 +261,7 @@ export const OpenInterestCard: FC<{ slabAddress: string }> = ({
         </div>
         <div>
           <div className="mb-0.5 flex items-center justify-between">
-            <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">Short</span>
+            <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-secondary)]">Short</span>
             <span className="text-[10px] font-medium text-[var(--short)]" style={{ fontFamily: "var(--font-mono)" }}>
               ${shortOiUsd} ({shortPct.toFixed(1)}%)
             </span>
@@ -275,28 +275,28 @@ export const OpenInterestCard: FC<{ slabAddress: string }> = ({
       {/* Imbalance + LP Net — compact two-column row */}
       <div className="mb-1.5 grid grid-cols-2 gap-1">
         <div className="rounded-none border-l-2 border-l-[var(--border)] bg-[var(--bg-elevated)] px-1.5 py-1">
-          <div className="text-[8px] uppercase tracking-[0.1em] text-[var(--text-dim)]">Imbalance</div>
+          <div className="text-[8px] uppercase tracking-[0.1em] text-[var(--text-secondary)]">Imbalance</div>
           <div className={`text-[11px] font-bold ${imbalanceColor}`} style={{ fontFamily: "var(--font-mono)" }}>
             {imbalancePct >= 0 ? "+" : ""}{imbalancePct.toFixed(1)}%
           </div>
-          <div className="text-[8px] text-[var(--text-dim)]">{imbalanceLabel}</div>
+          <div className="text-[8px] text-[var(--text-secondary)]">{imbalanceLabel}</div>
         </div>
         <div className="rounded-none border border-[var(--border)]/30 bg-[var(--bg)] px-1.5 py-1">
           <div className="flex items-center gap-0.5">
-            <span className="text-[8px] uppercase tracking-[0.1em] text-[var(--text-dim)]">LP Net</span>
+            <span className="text-[8px] uppercase tracking-[0.1em] text-[var(--text-secondary)]">LP Net</span>
             <InfoIcon tooltip="The aggregate position LPs must hold to balance trader positions. Drives funding rates." />
           </div>
           <div className={`text-[11px] font-bold ${lpDirection === "long" ? "text-[var(--long)]" : "text-[var(--short)]"}`} style={{ fontFamily: "var(--font-mono)" }}>
             {lpNetUsd}
           </div>
-          <div className="text-[8px] text-[var(--text-dim)]">({lpDirection})</div>
+          <div className="text-[8px] text-[var(--text-secondary)]">({lpDirection})</div>
         </div>
       </div>
 
       {/* 24h OI mini chart */}
       <div className="rounded-none border border-[var(--border)]/30 bg-[var(--bg-elevated)] px-1.5 py-1">
         <div className="mb-0.5 flex items-center justify-between">
-          <span className="text-[8px] uppercase tracking-[0.1em] text-[var(--text-dim)]">24h OI</span>
+          <span className="text-[8px] uppercase tracking-[0.1em] text-[var(--text-secondary)]">24h OI</span>
           {oiData.historicalOi && oiData.historicalOi.length > 1 && oiData.historicalOi[0].totalOi > 0 && (
             <span className="text-[9px] text-[var(--accent)]" style={{ fontFamily: "var(--font-mono)" }}>
               {((oiData.historicalOi[oiData.historicalOi.length - 1].totalOi / oiData.historicalOi[0].totalOi - 1) * 100) >= 0 ? "+" : ""}
@@ -323,7 +323,7 @@ export const OpenInterestCard: FC<{ slabAddress: string }> = ({
             })}
           </div>
         ) : (
-          <div className="flex h-8 items-center justify-center text-[9px] text-[var(--text-dim)]">No data</div>
+          <div className="flex h-8 items-center justify-center text-[9px] text-[var(--text-secondary)]">No data</div>
         )}
       </div>
 

--- a/app/components/trade/AccountsCard.tsx
+++ b/app/components/trade/AccountsCard.tsx
@@ -110,7 +110,7 @@ export const AccountsCard: FC = () => {
     return sorted;
   }, [tab, openPositions, idleAccounts, leaderboard, sortKey, sortDir]);
 
-  if (loading) return <div className="relative rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 p-3"><p className="text-[10px] text-[var(--text-muted)]">Loading...</p></div>;
+  if (loading) return <div className="relative rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 p-3"><p className="text-[10px] text-[var(--text-secondary)]">Loading...</p></div>;
 
   const tabs: { key: Tab; label: string; count: number }[] = [
     { key: "open", label: "Open", count: openPositions.length },
@@ -172,11 +172,11 @@ export const AccountsCard: FC = () => {
                 const absPos = row.positionSize < 0n ? -row.positionSize : row.positionSize;
                 return (
                   <tr key={row.idx} className="border-b border-[var(--border)]/20 transition-colors hover:bg-[var(--accent)]/[0.03]">
-                    <td className="whitespace-nowrap px-2 py-1.5 text-left text-[var(--text-dim)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>{i + 1}</td>
+                    <td className="whitespace-nowrap px-2 py-1.5 text-left text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>{i + 1}</td>
                     <td className="whitespace-nowrap px-2 py-1.5 text-left text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>{shortenAddress(row.owner)}</td>
                     {isOpenLike && (
                       <td className="whitespace-nowrap px-2 py-1.5 text-left">
-                        {row.direction === "IDLE" ? <span className="text-[var(--text-dim)]">-</span> : (
+                        {row.direction === "IDLE" ? <span className="text-[var(--text-secondary)]">-</span> : (
                           <span className={`text-[9px] font-bold ${
                             row.direction === "LONG" ? "text-[var(--long)]" : "text-[var(--short)]"
                           }`}>{row.direction}</span>
@@ -184,7 +184,7 @@ export const AccountsCard: FC = () => {
                       </td>
                     )}
                     {isOpenLike && (
-                      <td className={`whitespace-nowrap px-2 py-1.5 text-right ${row.positionSize > 0n ? "text-[var(--long)]" : row.positionSize < 0n ? "text-[var(--short)]" : "text-[var(--text-dim)]"}`} style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
+                      <td className={`whitespace-nowrap px-2 py-1.5 text-right ${row.positionSize > 0n ? "text-[var(--long)]" : row.positionSize < 0n ? "text-[var(--short)]" : "text-[var(--text-secondary)]"}`} style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
                         {row.positionSize !== 0n ? formatTokenAmount(absPos, decimals) : "-"}
                       </td>
                     )}
@@ -201,7 +201,7 @@ export const AccountsCard: FC = () => {
                         ) : "-"}
                       </td>
                     )}
-                    <td className={`whitespace-nowrap px-2 py-1.5 text-right ${row.pnl > 0n ? "text-[var(--long)]" : row.pnl < 0n ? "text-[var(--short)]" : "text-[var(--text-dim)]"}`} style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
+                    <td className={`whitespace-nowrap px-2 py-1.5 text-right ${row.pnl > 0n ? "text-[var(--long)]" : row.pnl < 0n ? "text-[var(--short)]" : "text-[var(--text-secondary)]"}`} style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
                       {formatPnl(row.pnl, decimals)}
                     </td>
                     <td className="whitespace-nowrap px-2 py-1.5 text-right text-[var(--text)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>{formatTokenAmount(row.capital, decimals)}</td>

--- a/app/components/trade/AdlLeaderboard.tsx
+++ b/app/components/trade/AdlLeaderboard.tsx
@@ -117,7 +117,7 @@ export const AdlLeaderboard: FC<Props> = ({ slabAddress }) => {
       <div className="rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 p-3">
         <div className="flex items-center gap-2">
           <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-[var(--text-dim)]" />
-          <span className="text-[10px] text-[var(--text-dim)]">Loading ADL rankings…</span>
+          <span className="text-[10px] text-[var(--text-secondary)]">Loading ADL rankings…</span>
         </div>
       </div>
     );
@@ -128,7 +128,7 @@ export const AdlLeaderboard: FC<Props> = ({ slabAddress }) => {
     return (
       <div className="rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 p-3">
         <div className="flex items-center gap-1.5">
-          <span className="text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-dim)]">ADL Rankings</span>
+          <span className="text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-secondary)]">ADL Rankings</span>
         </div>
         <p className="mt-1.5 text-[10px] text-[var(--short)]">{error ?? "No data"}</p>
       </div>
@@ -164,7 +164,7 @@ export const AdlLeaderboard: FC<Props> = ({ slabAddress }) => {
       {/* ── Header ── */}
       <div className="mb-2.5 flex items-center justify-between">
         <div className="flex items-center gap-1.5">
-          <span className="text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-dim)]">
+          <span className="text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-secondary)]">
             ADL Rankings
           </span>
           <InfoIcon tooltip="Auto-Deleverage leaderboard. Top profitable positions are candidates for forced reduction when insurance is depleted or PnL cap is exceeded." />
@@ -188,7 +188,7 @@ export const AdlLeaderboard: FC<Props> = ({ slabAddress }) => {
       <div className="mb-2.5 rounded-none border border-[var(--border)]/30 bg-[var(--bg-elevated)] p-2">
         <div className="mb-1 flex items-center justify-between">
           <div className="flex items-center gap-1">
-            <span className="text-[9px] font-bold uppercase tracking-[0.1em] text-[var(--text-dim)]">
+            <span className="text-[9px] font-bold uppercase tracking-[0.1em] text-[var(--text-secondary)]">
               Insurance Utilization
             </span>
             <InfoIcon tooltip="How much of the insurance fund has been consumed. ADL triggers at ≥80%." />
@@ -223,13 +223,13 @@ export const AdlLeaderboard: FC<Props> = ({ slabAddress }) => {
       {/* ── Rankings table ── */}
       {adlNeeded ? (
         rankings.length === 0 ? (
-          <p className="text-[10px] text-[var(--text-dim)]">
+          <p className="text-[10px] text-[var(--text-secondary)]">
             ADL triggered but no profitable positions to rank.
           </p>
         ) : (
           <>
             <div className="mb-1.5 flex items-center gap-1">
-              <span className="text-[9px] font-bold uppercase tracking-[0.1em] text-[var(--text-dim)]">
+              <span className="text-[9px] font-bold uppercase tracking-[0.1em] text-[var(--text-secondary)]">
                 Position Rankings
               </span>
               <InfoIcon tooltip="Positions ranked by PnL%. Rank #1 is deleveraged first. Highlighted rows are near-trigger." />
@@ -238,11 +238,11 @@ export const AdlLeaderboard: FC<Props> = ({ slabAddress }) => {
               <table className="w-full border-collapse text-[9px] font-mono">
                 <thead>
                   <tr className="border-b border-[var(--border)]/40">
-                    <th className="pb-1 text-left font-semibold uppercase tracking-[0.08em] text-[var(--text-dim)] pr-2">#</th>
-                    <th className="pb-1 text-left font-semibold uppercase tracking-[0.08em] text-[var(--text-dim)] pr-2">Slot</th>
-                    <th className="pb-1 text-right font-semibold uppercase tracking-[0.08em] text-[var(--text-dim)] pr-2">PnL%</th>
-                    <th className="pb-1 text-right font-semibold uppercase tracking-[0.08em] text-[var(--text-dim)] pr-2">Unr. PnL</th>
-                    <th className="pb-1 text-right font-semibold uppercase tracking-[0.08em] text-[var(--text-dim)]">Capital</th>
+                    <th className="pb-1 text-left font-semibold uppercase tracking-[0.08em] text-[var(--text-secondary)] pr-2">#</th>
+                    <th className="pb-1 text-left font-semibold uppercase tracking-[0.08em] text-[var(--text-secondary)] pr-2">Slot</th>
+                    <th className="pb-1 text-right font-semibold uppercase tracking-[0.08em] text-[var(--text-secondary)] pr-2">PnL%</th>
+                    <th className="pb-1 text-right font-semibold uppercase tracking-[0.08em] text-[var(--text-secondary)] pr-2">Unr. PnL</th>
+                    <th className="pb-1 text-right font-semibold uppercase tracking-[0.08em] text-[var(--text-secondary)]">Capital</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -267,7 +267,7 @@ export const AdlLeaderboard: FC<Props> = ({ slabAddress }) => {
                             <span className="ml-0.5 text-[var(--short)] text-[8px]">⚠</span>
                           )}
                         </td>
-                        <td className="py-0.5 pr-2 text-[var(--text-dim)]">{pos.idx}</td>
+                        <td className="py-0.5 pr-2 text-[var(--text-secondary)]">{pos.idx}</td>
                         <td className="py-0.5 pr-2 text-right font-bold text-[var(--long)]">
                           {fmtPct(pos.pnlPctMillionths)}
                         </td>
@@ -283,7 +283,7 @@ export const AdlLeaderboard: FC<Props> = ({ slabAddress }) => {
                 </tbody>
               </table>
               {rankings.length > 20 && (
-                <p className="mt-1 text-[9px] text-[var(--text-dim)] text-right">
+                <p className="mt-1 text-[9px] text-[var(--text-secondary)] text-right">
                   +{rankings.length - 20} more positions
                 </p>
               )}
@@ -292,7 +292,7 @@ export const AdlLeaderboard: FC<Props> = ({ slabAddress }) => {
         )
       ) : (
         <div className="rounded-none border border-[var(--border)]/30 bg-[var(--bg-elevated)] px-3 py-2">
-          <p className="text-[10px] text-[var(--text-dim)]">
+          <p className="text-[10px] text-[var(--text-secondary)]">
             ADL is not active. No positions are at risk of auto-deleveraging.
           </p>
         </div>
@@ -300,7 +300,7 @@ export const AdlLeaderboard: FC<Props> = ({ slabAddress }) => {
 
       {/* ── Last updated ── */}
       {lastUpdated && (
-        <p className="mt-2 text-right text-[8px] text-[var(--text-dim)]">
+        <p className="mt-2 text-right text-[8px] text-[var(--text-secondary)]">
           Updated {lastUpdated.toLocaleTimeString()}
         </p>
       )}
@@ -337,7 +337,7 @@ function TriggerBadge({
       <span
         className={[
           "text-[8px] font-semibold uppercase tracking-[0.06em] leading-tight",
-          active ? "text-[var(--short)]" : "text-[var(--text-dim)]",
+          active ? "text-[var(--short)]" : "text-[var(--text-secondary)]",
         ].join(" ")}
       >
         {label}
@@ -358,7 +358,7 @@ function StatRow({
 }) {
   return (
     <div className="flex flex-col gap-0.5">
-      <span className="text-[8px] uppercase tracking-[0.08em] text-[var(--text-dim)]">{label}</span>
+      <span className="text-[8px] uppercase tracking-[0.08em] text-[var(--text-secondary)]">{label}</span>
       <span className={`font-mono text-[10px] font-bold ${valueClass}`}>{value}</span>
     </div>
   );

--- a/app/components/trade/CrankHealthCard.tsx
+++ b/app/components/trade/CrankHealthCard.tsx
@@ -27,7 +27,7 @@ export const CrankHealthCard: FC = () => {
   if (loading || !engine) {
     return (
       <div className="rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 p-2">
-        <span className="text-[10px] text-[var(--text-dim)]">{loading ? "Loading..." : "Not available on v17 markets yet"}</span>
+        <span className="text-[10px] text-[var(--text-secondary)]">{loading ? "Loading..." : "Not available on v17 markets yet"}</span>
       </div>
     );
   }
@@ -64,7 +64,7 @@ export const CrankHealthCard: FC = () => {
     <div className="rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 p-2">
       <div className="mb-1.5 flex items-center justify-between">
         <div className="flex items-center gap-1">
-          <span className="text-[8px] uppercase tracking-[0.15em] text-[var(--text-dim)]">
+          <span className="text-[8px] uppercase tracking-[0.15em] text-[var(--text-secondary)]">
             Crank Health
           </span>
           <InfoIcon tooltip="The crank processes funding accrual, liquidation checks, and position updates every slot" />
@@ -77,7 +77,7 @@ export const CrankHealthCard: FC = () => {
 
       {/* Staleness progress bar */}
       <div className="mb-1.5">
-        <div className="mb-1 flex items-center justify-between text-[9px] text-[var(--text-dim)]">
+        <div className="mb-1 flex items-center justify-between text-[9px] text-[var(--text-secondary)]">
           <span>Last update: {secondsBehind}s ago ({slotsBehind.toLocaleString()} slots)</span>
           <span>Max: {maxStaleness.toLocaleString()} slots</span>
         </div>
@@ -92,7 +92,7 @@ export const CrankHealthCard: FC = () => {
       {/* Stats */}
       <div className="grid grid-cols-2 gap-px">
         <div className="px-1.5 py-1 border-b border-r border-[var(--border)]/20 last:border-r-0 [&:nth-child(2n)]:border-r-0 [&:nth-last-child(-n+2)]:border-b-0">
-          <span className="text-[8px] uppercase tracking-[0.15em] text-[var(--text-dim)]">
+          <span className="text-[8px] uppercase tracking-[0.15em] text-[var(--text-secondary)]">
             Lifetime Liquidations
           </span>
           <p className="text-[11px] font-medium text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>
@@ -100,7 +100,7 @@ export const CrankHealthCard: FC = () => {
           </p>
         </div>
         <div className="px-1.5 py-1 border-b border-r border-[var(--border)]/20 last:border-r-0 [&:nth-child(2n)]:border-r-0 [&:nth-last-child(-n+2)]:border-b-0">
-          <span className="text-[8px] uppercase tracking-[0.15em] text-[var(--text-dim)]">
+          <span className="text-[8px] uppercase tracking-[0.15em] text-[var(--text-secondary)]">
             Force Closes
           </span>
           <p className="text-[11px] font-medium text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>

--- a/app/components/trade/EngineHealthCard.tsx
+++ b/app/components/trade/EngineHealthCard.tsx
@@ -159,7 +159,7 @@ export const EngineHealthCard: FC = () => {
       <div className="grid grid-cols-3 gap-px">
         {metrics.map((m) => (
           <div key={m.label} className="px-1.5 py-1 border-b border-r border-[var(--border)]/20 last:border-r-0 [&:nth-child(3n)]:border-r-0 [&:nth-last-child(-n+3)]:border-b-0">
-            <p className="text-[8px] uppercase tracking-[0.15em] text-[var(--text-dim)]">{m.label}</p>
+            <p className="text-[8px] uppercase tracking-[0.15em] text-[var(--text-secondary)]">{m.label}</p>
             <p className="text-[11px] font-medium text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>{m.value}</p>
           </div>
         ))}

--- a/app/components/trade/LiquidationAnalytics.tsx
+++ b/app/components/trade/LiquidationAnalytics.tsx
@@ -29,14 +29,14 @@ export const LiquidationAnalytics: FC = () => {
   if (loading) {
     return (
       <div className="rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 p-3">
-        <span className="text-[10px] text-[var(--text-dim)]">Loading...</span>
+        <span className="text-[10px] text-[var(--text-secondary)]">Loading...</span>
       </div>
     );
   }
   if (!hasData) {
     return (
       <div className="rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 p-3">
-        <span className="text-[10px] text-[var(--text-dim)]">No liquidation data for this market</span>
+        <span className="text-[10px] text-[var(--text-secondary)]">No liquidation data for this market</span>
       </div>
     );
   }
@@ -64,7 +64,7 @@ export const LiquidationAnalytics: FC = () => {
   let coverageText: string;
   if (coveragePercent == null) {
     dotColor = "bg-[var(--text-dim)]";
-    textColor = "text-[var(--text-dim)]";
+    textColor = "text-[var(--text-secondary)]";
     coverageText = "—";
   } else if (coveragePercent === Infinity || coveragePercent > 100) {
     dotColor = "bg-[var(--long)]";
@@ -90,7 +90,7 @@ export const LiquidationAnalytics: FC = () => {
   return (
     <div className="rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 p-3">
       <div className="mb-3 flex items-center gap-1">
-        <span className="text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-dim)]">
+        <span className="text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-secondary)]">
           Liquidation Analytics
         </span>
         <InfoIcon tooltip="Liquidation metrics and insurance coverage for this market" />
@@ -100,7 +100,7 @@ export const LiquidationAnalytics: FC = () => {
         {stats.map((s) => (
           <div key={s.label} className="flex flex-col">
             <div className="mb-1 flex items-center gap-1">
-              <span className="text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-dim)]">{s.label}</span>
+              <span className="text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-secondary)]">{s.label}</span>
               <InfoIcon tooltip={s.tip} />
             </div>
             <span className="text-sm font-bold text-[var(--text)] font-mono">{s.value}</span>
@@ -111,7 +111,7 @@ export const LiquidationAnalytics: FC = () => {
       <div className="rounded-none border border-[var(--border)]/30 bg-[var(--bg-elevated)] p-2">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-1">
-            <span className="text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-dim)]">Insurance Coverage</span>
+            <span className="text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-secondary)]">Insurance Coverage</span>
             <InfoIcon tooltip="Insurance balance as % of open interest. Green = >100%, Yellow = 10-100%, Red = <10%" />
           </div>
           <div className="flex items-center gap-2">
@@ -119,7 +119,7 @@ export const LiquidationAnalytics: FC = () => {
             <span className={`text-sm font-bold font-mono ${textColor}`}>{coverageText}</span>
           </div>
         </div>
-        <div className="mt-1 flex items-center justify-between text-[9px] text-[var(--text-dim)]">
+        <div className="mt-1 flex items-center justify-between text-[9px] text-[var(--text-secondary)]">
           <span>Insurance: {insuranceBalance != null ? fmtCompact(insuranceBalance) : "—"}</span>
           <span>OI: {totalOI != null ? fmtCompact(totalOI) : "—"}</span>
         </div>

--- a/app/components/trade/MarketStatsCard.tsx
+++ b/app/components/trade/MarketStatsCard.tsx
@@ -155,12 +155,12 @@ export const MarketStatsCard: FC = () => {
   })();
   // Color spread amber if abs spread > 0.5% (50 bps)
   const spreadColor = (() => {
-    if (!showSpread || spreadBps === null) return "text-[var(--text-dim)]";
+    if (!showSpread || spreadBps === null) return "text-[var(--text-secondary)]";
     const absBps = Math.abs(spreadBps);
     if (absBps > 50) return "text-amber-400";
     if (spreadAbs !== null && spreadAbs > 0n) return "text-[var(--long)]";
     if (spreadAbs !== null && spreadAbs < 0n) return "text-[var(--short)]";
-    return "text-[var(--text-dim)]";
+    return "text-[var(--text-secondary)]";
   })();
 
   // Funding rate display: "+0.0081%/8h" — consistent with MarketInfoBar label
@@ -168,12 +168,12 @@ export const MarketStatsCard: FC = () => {
     ? `${fundingHourlyPct >= 0 ? "+" : ""}${fundingHourlyPct.toFixed(4)}%/8h`
     : "—";
   const fundingColor = fundingHourlyPct === null
-    ? "text-[var(--text-dim)]"
+    ? "text-[var(--text-secondary)]"
     : fundingHourlyPct > 0
       ? "text-[var(--short)]" // longs pay shorts → short favorable
       : fundingHourlyPct < 0
         ? "text-[var(--long)]" // shorts pay longs → long favorable
-        : "text-[var(--text-dim)]";
+        : "text-[var(--text-secondary)]";
 
   type StatCell = {
     label: string;

--- a/app/components/trade/SystemCapitalCard.tsx
+++ b/app/components/trade/SystemCapitalCard.tsx
@@ -31,14 +31,14 @@ export const SystemCapitalCard: FC = () => {
   if (loading) {
     return (
       <div className="rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 p-3">
-        <span className="text-[10px] text-[var(--text-dim)]">Loading...</span>
+        <span className="text-[10px] text-[var(--text-secondary)]">Loading...</span>
       </div>
     );
   }
   if (!hasData) {
     return (
       <div className="rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 p-3">
-        <span className="text-[10px] text-[var(--text-dim)]">No capital data for this market</span>
+        <span className="text-[10px] text-[var(--text-secondary)]">No capital data for this market</span>
       </div>
     );
   }
@@ -125,7 +125,7 @@ export const SystemCapitalCard: FC = () => {
   return (
     <div className="rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 p-3">
       <div className="mb-3 flex items-center gap-1">
-        <span className="text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-dim)]">
+        <span className="text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-secondary)]">
           System Capital
         </span>
         <InfoIcon tooltip="Aggregate capital metrics from the on-chain risk engine" />
@@ -135,7 +135,7 @@ export const SystemCapitalCard: FC = () => {
         {stats.map((s) => (
           <div key={s.label} className="flex flex-col">
             <div className="mb-1 flex items-center gap-1">
-              <span className="text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-dim)]">{s.label}</span>
+              <span className="text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-secondary)]">{s.label}</span>
               <InfoIcon tooltip={s.tip} />
             </div>
             <span className={`text-sm font-bold font-mono ${s.color || "text-[var(--text)]"}`}>{s.value}</span>
@@ -146,20 +146,20 @@ export const SystemCapitalCard: FC = () => {
       {/* LP Exposure Section */}
       <div className="rounded-none border border-[var(--border)]/30 bg-[var(--bg-elevated)] p-2">
         <div className="mb-2 flex items-center gap-1">
-          <span className="text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-dim)]">LP Exposure</span>
+          <span className="text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-secondary)]">LP Exposure</span>
           <InfoIcon tooltip="LP position aggregates - net exposure drives funding rates, concentration shows whale risk" />
         </div>
         <div className="grid grid-cols-3 gap-2">
           <div className="flex flex-col">
-            <span className="text-[9px] text-[var(--text-dim)]">Net</span>
+            <span className="text-[9px] text-[var(--text-secondary)]">Net</span>
             <span className={`text-xs font-bold font-mono ${engine ? netLpColor : "text-[var(--text)]"}`}>{engine ? fmtCompact(netLp) : "—"}</span>
           </div>
           <div className="flex flex-col">
-            <span className="text-[9px] text-[var(--text-dim)]">Total</span>
+            <span className="text-[9px] text-[var(--text-secondary)]">Total</span>
             <span className="text-xs font-bold font-mono text-[var(--text)]">{engine ? fmtCompact(lpSum) : "—"}</span>
           </div>
           <div className="flex flex-col">
-            <span className="text-[9px] text-[var(--text-dim)]">Concentration</span>
+            <span className="text-[9px] text-[var(--text-secondary)]">Concentration</span>
             <span className={`text-xs font-bold font-mono ${engine && lpConcentration > 80 ? "text-[var(--short)]" : "text-[var(--text)]"}`}>
               {engine ? `${lpConcentration.toFixed(1)}%` : "—"}
             </span>


### PR DESCRIPTION
## What

Fourth page in the contrast series (#2238 create wizard, #2258 stake, #2259 dashboard — all merged): the **market analytics route** (`/analytics/[slab]`) renders nearly all of its text in the two lowest-contrast tokens:

- `--text-dim` (`#2A2E3D`, ~**1.4:1** against the dark background): section headers, stat labels, table column headers, and footnotes across all nine cards — 67 occurrences
- `--text-muted` (`#454B5F`, ~**2.2:1**): a handful more

Both are below the WCAG large-text minimum of 3:1.

## Fix

Same treatment as the three merged PRs: bump to `--text-secondary` (`#7A7F96`, ~4.9:1 — readable, still clearly muted). 72 class-string swaps across the page shell and its nine cards (EngineHealth, CrankHealth, OpenInterest, Insurance, Liquidations, SystemCapital, AdlLeaderboard, Accounts, MarketStats). All nine components render only on this route, so no other page changes appearance.

Text colors only — no layout, hover-chain, or logic changes (none of these files had hover-to-secondary chains or opacity-suffixed variants).

## Testing

- `npx tsc --noEmit` — clean
- Diff mechanically verified: every changed line is a `text-[var(--text-*)]` class swap
- Headless-browser check on `/analytics/<JUP slab>`: renders with zero page errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
