### PR TITLE
fix: reset live price state when switching trade markets

### DIFF
--- a/app/__tests__/hooks/useLivePrice.test.ts
+++ b/app/__tests__/hooks/useLivePrice.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useLivePrice } from "../../hooks/useLivePrice";
+
+const testState = vi.hoisted(() => ({
+  slabAddress: "slab-a" as string | null,
+  marketByKey: {} as Record<string, any>,
+}));
+
+vi.mock("@/components/providers/SlabProvider", () => ({
+  useSlabState: vi.fn(() => ({
+    slabAddress: testState.slabAddress,
+    config: null,
+  })),
+}));
+
+vi.mock("@/lib/config", () => ({
+  getBackendUrl: () => "",
+}));
+
+vi.mock("@/lib/oraclePrice", () => ({
+  applyInvert: (price: bigint) => price,
+  resolveMarketPriceE6: () => 0n,
+  sanitizePriceE6: (price: bigint) => price,
+}));
+
+vi.mock("swr", () => ({
+  default: vi.fn((key: string | null) => ({
+    data: key ? testState.marketByKey[key] : undefined,
+  })),
+}));
+
+describe("useLivePrice", () => {
+  beforeEach(() => {
+    testState.slabAddress = "slab-a";
+    testState.marketByKey = {
+      "/api/markets/slab-a": {
+        market: {
+          last_price: 42,
+        },
+      },
+    };
+  });
+
+  it("clears previous market price when the active slab changes", async () => {
+    const { result, rerender } = renderHook(() => useLivePrice());
+
+    await waitFor(() => {
+      expect(result.current.priceUsd).toBe(42);
+      expect(result.current.priceE6).toBe(42_000_000n);
+    });
+
+    testState.slabAddress = "slab-b";
+    testState.marketByKey = {};
+
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.priceUsd).toBeNull();
+      expect(result.current.priceE6).toBeNull();
+      expect(result.current.price).toBeNull();
+    });
+
+    expect(result.current.loading).toBe(true);
+  });
+});

--- a/app/hooks/useLivePrice.ts
+++ b/app/hooks/useLivePrice.ts
@@ -84,6 +84,24 @@ interface PriceState {
   loading: boolean;
 }
 
+interface InternalPriceState extends PriceState {
+  slabAddress: string | null;
+}
+
+function emptyPriceState(slabAddress: string | null): InternalPriceState {
+  return {
+    price: null,
+    priceUsd: null,
+    priceE6: null,
+    change24h: null,
+    high24h: null,
+    low24h: null,
+    loading: Boolean(slabAddress),
+    slabAddress,
+  };
+}
+
+
 type PricesApiJson = {
   stats?: { change24h?: number; high24h?: string; low24h?: string } | null;
 };
@@ -98,19 +116,17 @@ type MarketApiJson = { market?: { last_price?: number | null } };
  *
  */
 export function useLivePrice(): PriceState {
-  const [state, setState] = useState<PriceState>({
-    price: null,
-    priceUsd: null,
-    priceE6: null,
-    change24h: null,
-    high24h: null,
-    low24h: null,
-    loading: true,
-  });
+  const [state, setState] = useState<InternalPriceState>(() => emptyPriceState(null));
 
   const { config: mktConfig, slabAddress } = useSlabState();
   // Use the slab address from SlabProvider context — works for both /trade/[slab] and ?market= URLs
   const slabAddr = slabAddress || null;
+  const dbRawE6Ref = useRef<bigint | null>(null);
+
+  useEffect(() => {
+    dbRawE6Ref.current = null;
+    setState(emptyPriceState(slabAddr));
+  }, [slabAddr]);
 
   const pricesKey = slabAddr ? `/api/prices/${slabAddr}` : null;
   const { data: pricesJson } = useSWR<PricesApiJson>(pricesKey, livePriceJsonFetcher, SWR_REST_OPTS);
@@ -121,13 +137,11 @@ export function useLivePrice(): PriceState {
   // Merge 24h stats from deduped REST
   useEffect(() => {
     if (!pricesJson?.stats) return;
-    setState((prev) => ({
-      ...prev,
-      change24h: pricesJson.stats?.change24h ?? null,
+    setState((prev) => ({ ...prev, slabAddress: slabAddr, change24h: pricesJson.stats?.change24h ?? null,
       high24h: pricesJson.stats?.high24h ? Number(pricesJson.stats.high24h) / 1_000_000 : null,
       low24h: pricesJson.stats?.low24h ? Number(pricesJson.stats.low24h) / 1_000_000 : null,
     }));
-  }, [pricesJson]);
+  }, [pricesJson, slabAddr]);
 
   // PERC-1232: DB last_price display-only fallback (deduped REST)
   // GH#1990: The DB stores raw (non-inverted) oracle price. For inverted markets
@@ -137,7 +151,6 @@ export function useLivePrice(): PriceState {
   //
   // CR fix: track dbRawE6 separately so re-runs recompute when mktConfig?.invert
   // arrives after the initial render (avoids stale invert on first DB-fallback paint).
-  const dbRawE6Ref = useRef<bigint | null>(null);
   useEffect(() => {
     const dbPrice = marketJson?.market?.last_price;
     if (dbPrice == null || dbPrice <= 0) return;
@@ -156,7 +169,7 @@ export function useLivePrice(): PriceState {
         // Price already correct — no update needed
         return prev;
       }
-      return { ...prev, price: usd, priceUsd: usd, priceE6: e6, loading: false };
+      return { ...prev, price: usd, priceUsd: usd, priceE6: e6, loading: false, slabAddress: slabAddr };
     });
   }, [marketJson, mktConfig?.invert]);
 
@@ -170,7 +183,7 @@ export function useLivePrice(): PriceState {
     const usd = Number(onChainE6) / 1_000_000;
     setState((prev) => {
       if (prev.price !== null) return prev;
-      return { ...prev, price: usd, priceUsd: usd, priceE6: onChainE6, loading: false };
+      return { ...prev, price: usd, priceUsd: usd, priceE6: onChainE6, loading: false, slabAddress: slabAddr };
     });
   }, [mktConfig]);
 
@@ -190,7 +203,7 @@ export function useLivePrice(): PriceState {
   useEffect(() => {
     mountedRef.current = true;
     // Only set loading if we don't already have a price
-    setState((prev) => (prev.price !== null ? prev : { ...prev, loading: true }));
+    setState((prev) => (prev.slabAddress === slabAddr && prev.price !== null ? prev : emptyPriceState(slabAddr)));
 
     if (!slabAddr) return;
 
@@ -281,7 +294,7 @@ export function useLivePrice(): PriceState {
                 change24h: prev.change24h,
                 high24h: prev.high24h !== null ? Math.max(prev.high24h, usd) : usd,
                 low24h: prev.low24h !== null ? Math.min(prev.low24h, usd) : usd,
-                loading: false,
+                loading: false, slabAddress: slabAddr,
               }));
             }
           } else if (isLegacy) {
@@ -305,7 +318,7 @@ export function useLivePrice(): PriceState {
                 change24h: prev.change24h,
                 high24h: prev.high24h !== null ? Math.max(prev.high24h, usd) : usd,
                 low24h: prev.low24h !== null ? Math.min(prev.low24h, usd) : usd,
-                loading: false,
+                loading: false, slabAddress: slabAddr,
               }));
             }
           }
@@ -371,5 +384,5 @@ export function useLivePrice(): PriceState {
     };
   }, [slabAddr]);
 
-  return state;
+  return state.slabAddress === slabAddr ? state : emptyPriceState(slabAddr);
 }


### PR DESCRIPTION
## Summary

Fixes a trading UI issue where `useLivePrice()` could continue exposing the previous market's price after the active slab changes.

When users switch trade markets, the hook now immediately clears stale live price data and only returns price state that belongs to the currently active slab.

## Root Cause

`useLivePrice()` stored the latest live price in local React state, but that state was not associated with the slab/market it came from.

Because of that, after switching from one market to another, the hook could briefly return a non-null price from the previous market until the new REST, on-chain, or WebSocket price arrived.

## Fix

- Added an internal `slabAddress` owner field to the live price state.
- Added `emptyPriceState()` to reset price data safely.
- Reset live price state whenever `slabAddr` changes.
- Tagged REST fallback, on-chain fallback, and WebSocket price updates with the active slab address.
- Added a final guard so the hook never returns price state from a previous slab.
- Added a regression test covering market switch behavior.

## Why this matters

The trade page and trade form depend on live market price data for display and trade previews. Clearing stale price state prevents users from briefly seeing or using the previous market's price after switching markets.

## Test Plan

- `pnpm exec vitest run __tests__/hooks/useLivePrice.test.ts`

## Risk

Low. This change is limited to frontend live price state ownership and reset behavior. It does not change on-chain instructions, backend APIs, or trade execution logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Live price values now reset correctly when switching between slabs, preventing old price data from briefly appearing.
  * Price loading and fallback values are now more reliable, with stale data cleared when the active market changes.
  * Updated behavior helps ensure displayed USD and E6 price values stay in sync with the currently selected slab.

* **Tests**
  * Added coverage for live price updates and state resets when the active slab changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->