### PR TITLE
fix(trade): brighten receipt/footer labels; 3dp balances in deposit card

### DIFF
--- a/app/components/trade/DepositWithdrawCard.tsx
+++ b/app/components/trade/DepositWithdrawCard.tsx
@@ -80,10 +80,10 @@ export const DepositWithdrawCard: FC<DepositWithdrawCardProps> = ({ slabAddress,
     const hasTokens = walletBalance !== null && walletBalance > 0n;
     return (
       <div className="relative rounded-none border border-[var(--border)]/50 bg-[var(--bg)]/80 p-3">
-        <p className="mb-1 text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Create Account</p>
+        <p className="mb-1 text-[10px] uppercase tracking-[0.15em] text-[var(--text-secondary)]">Create Account</p>
         {walletBalance !== null && (
-          <p className="mb-2 text-[10px] text-[var(--text-dim)]" style={{ fontFamily: "var(--font-mono)" }}>
-            Wallet: {formatTokenAmount(walletBalance, decimals)} {symbol}
+          <p className="mb-2 text-[10px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-mono)" }}>
+            Wallet: {formatTokenAmount(walletBalance, decimals, 3)} {symbol}
           </p>
         )}
         {!hasTokens && (
@@ -137,7 +137,7 @@ export const DepositWithdrawCard: FC<DepositWithdrawCardProps> = ({ slabAddress,
           </>
         )}
         {initError && <p className="mt-2 text-[10px] text-[var(--short)]">{initError}</p>}
-        {lastSig && <p className="mt-2 text-[10px] text-[var(--text-dim)]" style={{ fontFamily: "var(--font-mono)" }}>Tx: {lastSig.slice(0, 12)}...</p>}
+        {lastSig && <p className="mt-2 text-[10px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-mono)" }}>Tx: {lastSig.slice(0, 12)}...</p>}
       </div>
     );
   }
@@ -210,11 +210,12 @@ export const DepositWithdrawCard: FC<DepositWithdrawCardProps> = ({ slabAddress,
       <div className="mb-3 grid grid-cols-2 gap-px border border-[var(--border)]/20">
         <div className="p-2">
           <p className="text-[9px] uppercase tracking-[0.15em] text-[var(--text-secondary)]">Account Balance</p>
-          <p className="text-sm font-medium text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>{formatTokenAmount(capital, decimals)} <span className="text-[10px] font-normal text-[var(--text-secondary)]">{symbol}</span></p>
+          {/* 3dp display only — the MAX buttons below still use full raw precision */}
+          <p className="text-sm font-medium text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>{formatTokenAmount(capital, decimals, 3)} <span className="text-[10px] font-normal text-[var(--text-secondary)]">{symbol}</span></p>
         </div>
         <div className="p-2 border-l border-[var(--border)]/20">
           <p className="text-[9px] uppercase tracking-[0.15em] text-[var(--text-secondary)]">Wallet Balance</p>
-          <p className="text-sm font-medium text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>{walletBalance !== null ? formatTokenAmount(walletBalance, decimals) : "—"} <span className="text-[10px] font-normal text-[var(--text-secondary)]">{symbol}</span></p>
+          <p className="text-sm font-medium text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>{walletBalance !== null ? formatTokenAmount(walletBalance, decimals, 3) : "—"} <span className="text-[10px] font-normal text-[var(--text-secondary)]">{symbol}</span></p>
         </div>
       </div>
       {mode === "deposit" && walletBalance !== null && walletBalance === 0n && mktConfig?.collateralMint && (
@@ -236,7 +237,7 @@ export const DepositWithdrawCard: FC<DepositWithdrawCardProps> = ({ slabAddress,
               Mint more →
             </a>
           )}
-          <p className="text-[9px] text-[var(--text-dim)] break-all" style={{ fontFamily: "var(--font-mono)" }}>
+          <p className="text-[9px] text-[var(--text-secondary)] break-all" style={{ fontFamily: "var(--font-mono)" }}>
             Mint: {mktConfig.collateralMint.toBase58()}
           </p>
         </div>

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -159,13 +159,13 @@ function DiffRow({
   const changed = before !== after;
   return (
     <div className="flex items-center justify-between py-1 text-[10px]">
-      <span className="flex items-center gap-1 text-[var(--text-dim)] uppercase tracking-[0.08em]">
+      <span className="flex items-center gap-1 text-[var(--text-secondary)] uppercase tracking-[0.08em]">
         {label}
         {tooltip && <InfoIcon tooltip={tooltip} />}
       </span>
       <span className="flex items-center gap-1 font-mono tabular-nums">
-        {changed && <span className="text-[var(--text-dim)] line-through decoration-[var(--text-dim)]/50">{before}</span>}
-        {changed && <span className="text-[var(--text-dim)]">→</span>}
+        {changed && <span className="text-[var(--text-secondary)] line-through decoration-[var(--text-secondary)]/50">{before}</span>}
+        {changed && <span className="text-[var(--text-secondary)]">→</span>}
         <span className={valueClass}>{after}</span>
       </span>
     </div>
@@ -584,7 +584,7 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
             onClick={() => setOrderType(t)}
             aria-pressed={orderType === t}
             className={`flex-1 rounded-sm py-1 text-[10px] font-medium uppercase tracking-[0.12em] transition-colors duration-150 ${
-              orderType === t ? "bg-[var(--accent)]/10 text-[var(--accent)]" : "text-[var(--text-dim)] hover:text-[var(--text-secondary)]"
+              orderType === t ? "bg-[var(--accent)]/10 text-[var(--accent)]" : "text-[var(--text-secondary)] hover:text-[var(--text)]"
             }`}
           >
             {t}
@@ -890,14 +890,14 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
       {/* Account row: balance / buying power / deposit link */}
       <div className="mt-3 flex items-center justify-between border-t border-[var(--border)]/30 pt-2.5 text-[10px]">
         <div>
-          <div className="flex items-center gap-1 text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">
+          <div className="flex items-center gap-1 text-[9px] uppercase tracking-[0.1em] text-[var(--text-secondary)]">
             Avail Bal
             <InfoIcon tooltip="Account balance minus margin already locked by an open position on this market." />
           </div>
           <div className="font-mono tabular-nums text-[var(--text)]">{formatTokenAmount(effectiveBalance, decimals)} {collateralSymbol}</div>
         </div>
         <div className="text-right">
-          <div className="flex items-center justify-end gap-1 text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">
+          <div className="flex items-center justify-end gap-1 text-[9px] uppercase tracking-[0.1em] text-[var(--text-secondary)]">
             Buying power
             <InfoIcon tooltip="Available balance x max leverage - the largest notional you could open right now." />
           </div>


### PR DESCRIPTION
## What

Contrast + formatting cleanup in the order ticket and deposit/withdraw card (continues the merged contrast series #2238/#2258/#2259/#2267):

**Trade receipt readability.** The receipt a user reads *right before committing a trade* — ENTRY, LIQ PRICE, FEES, SLIPPAGE BOUND, MARGIN REQ. labels, plus the strikethrough before-value and arrow in the before→after rows — rendered in `--text-dim` (~1.4:1 contrast in dark theme). All bumped to `--text-secondary`; before-values keep their line-through so the visual grammar is unchanged.

**Footer + tabs.** The BALANCE / BUYING POWER labels above the deposit/withdraw triggers get the same bump, and the inactive Market/Limit tab moves from dim→secondary (hovering to full `--text`), matching the merged stake-page tab treatment.

**Deposit card decimals.** Account/wallet balance readouts showed full raw precision (`9759.593028`); now capped at 3 display decimals via `formatTokenAmount`'s existing `maxDisplayDecimals` param. **Display only** — the MAX buttons still capture full raw precision for actual transaction amounts, so no dust is stranded.

Also swept the card's remaining `--text-dim` strays (Create Account label, wallet line, tx signature links, collateral mint address).

## Testing

- `npx tsc --noEmit` clean; `useTrade` suite passes
- Class-string and display-formatting changes only; no logic paths touched (verified the MAX-button raw-precision path is untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
