### PR TITLE
feat(chart): draggable position/PnL badge stack + readable labels

### DIFF
--- a/app/components/trade/ChartPnlBadge.tsx
+++ b/app/components/trade/ChartPnlBadge.tsx
@@ -57,11 +57,13 @@ export const ChartPnlBadge: FC<ChartPnlBadgeProps> = ({ slabAddress }) => {
 
   const { display, sign } = formatPnl(pnlUsd, roe);
   const colorClass =
-    sign === "positive" ? "text-green-400" : sign === "negative" ? "text-red-400" : "text-[var(--text-dim)]";
+    sign === "positive" ? "text-green-400" : sign === "negative" ? "text-red-400" : "text-[var(--text-secondary)]";
 
+  // Positioning is owned by DraggableChartBadges in TradingChart — this chip
+  // stacks under PositionSummary and drags with it as one unit.
   return (
-    <div className="absolute top-10 right-2 z-10 flex items-center gap-1.5 rounded-none border border-[var(--border)]/60 bg-[var(--bg)]/90 px-2 py-1 backdrop-blur-sm">
-      <span className="text-[9px] font-bold uppercase tracking-[0.12em] text-[var(--text-dim)]">PnL</span>
+    <div className="flex items-center gap-1.5 rounded-none border border-[var(--border)]/60 bg-[var(--bg)]/90 px-2 py-1 backdrop-blur-sm">
+      <span className="text-[9px] font-bold uppercase tracking-[0.12em] text-[var(--text-secondary)]">PnL</span>
       <span className={`text-[10px] font-mono ${colorClass}`}>{display}</span>
     </div>
   );

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -127,9 +127,75 @@ function PositionSummary({ slabAddress }: PositionSummaryProps) {
   const dirColor = isLong ? "text-green-400" : "text-red-400";
 
   return (
-    <div className="absolute top-2 right-2 z-10 flex items-center gap-1.5 rounded-none border border-[var(--border)]/60 bg-[var(--bg)]/90 px-2 py-1 backdrop-blur-sm">
+    <div className="flex items-center gap-1.5 rounded-none border border-[var(--border)]/60 bg-[var(--bg)]/90 px-2 py-1 backdrop-blur-sm">
       <span className={`text-[9px] font-bold uppercase tracking-[0.12em] ${dirColor}`}>{direction}</span>
-      <span className="text-[9px] text-[var(--text-dim)]">position open</span>
+      <span className="text-[9px] text-[var(--text-secondary)]">position open</span>
+    </div>
+  );
+}
+
+/** Draggable stack for the position + PnL badges.
+ *
+ *  The badges default to the chart's top-right, exactly where the price axis
+ *  labels and recent candles live — they routinely cover the very data the
+ *  user is watching. This wrapper keeps them as ONE unit (they always move
+ *  together) and lets the user drag the pair anywhere inside the chart.
+ *  Position is chart-local state: it resets to top-right on market switch,
+ *  which is the sane default for a fresh layout.
+ *
+ *  Pointer events (not mouse) so touch dragging works; the container uses
+ *  touch-none while dragging targets it so the browser doesn't hijack the
+ *  gesture for scrolling. Children keep their own pointer handlers (none —
+ *  the badges are display-only), so a drag can start anywhere on the stack. */
+function DraggableChartBadges({ children }: { children: React.ReactNode }) {
+  const elRef = useRef<HTMLDivElement | null>(null);
+  // null → default CSS position (top-right). Set on first drag.
+  const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
+  const dragRef = useRef<{ startX: number; startY: number; baseX: number; baseY: number } | null>(null);
+
+  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    const el = elRef.current;
+    const parent = el?.offsetParent as HTMLElement | null;
+    if (!el || !parent) return;
+    const rect = el.getBoundingClientRect();
+    const prect = parent.getBoundingClientRect();
+    dragRef.current = {
+      startX: e.clientX,
+      startY: e.clientY,
+      baseX: rect.left - prect.left,
+      baseY: rect.top - prect.top,
+    };
+    el.setPointerCapture(e.pointerId);
+  };
+
+  const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    const d = dragRef.current;
+    const el = elRef.current;
+    const parent = el?.offsetParent as HTMLElement | null;
+    if (!d || !el || !parent) return;
+    // Clamp inside the chart container so the badges can't be lost off-canvas.
+    const x = Math.max(0, Math.min(d.baseX + (e.clientX - d.startX), parent.clientWidth - el.offsetWidth));
+    const y = Math.max(0, Math.min(d.baseY + (e.clientY - d.startY), parent.clientHeight - el.offsetHeight));
+    setPos({ x, y });
+  };
+
+  const endDrag = (e: React.PointerEvent<HTMLDivElement>) => {
+    dragRef.current = null;
+    elRef.current?.releasePointerCapture(e.pointerId);
+  };
+
+  return (
+    <div
+      ref={elRef}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+      title="Drag to move"
+      className="absolute z-10 flex cursor-grab touch-none select-none flex-col items-end gap-1 active:cursor-grabbing"
+      style={pos ? { left: pos.x, top: pos.y } : { top: 8, right: 8 }}
+    >
+      {children}
     </div>
   );
 }
@@ -1136,8 +1202,12 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
           </div>
         )}
 
-        {overlayPrefs.position && <PositionSummary slabAddress={slabAddress} />}
-        {overlayPrefs.pnl && <ChartPnlBadge slabAddress={slabAddress} />}
+        {(overlayPrefs.position || overlayPrefs.pnl) && (
+          <DraggableChartBadges>
+            {overlayPrefs.position && <PositionSummary slabAddress={slabAddress} />}
+            {overlayPrefs.pnl && <ChartPnlBadge slabAddress={slabAddress} />}
+          </DraggableChartBadges>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## What

The floating position + PnL badges on the trade chart had two problems:

1. **They cover the data you're watching.** Hard-coded to the chart's top-right — right on top of the price axis labels and the most recent candles — with no way to move them.
2. **Their labels were near-invisible** — "position open" and "PnL" rendered in `--text-dim` (~1.4:1 contrast).

## Fix

- **`DraggableChartBadges`** wrapper: both badges now render as **one stack** that drags as a unit anywhere inside the chart. Pointer events (touch works), `touch-none` so mobile browsers don't hijack the gesture, position clamped to the chart container so the stack can't be dragged off-canvas, grab/grabbing cursors + a "Drag to move" title for discoverability. Chart-local state — resets to top-right on market switch.
- The badges lose their individual `absolute top-N right-2` positioning; the wrapper owns placement, so the pair can never drift apart.
- Labels bumped `--text-dim` → `--text-secondary` (both badges plus the flat-PnL color fallback).

## Testing

- `npx tsc --noEmit` clean
- **Headless-browser drag test** (mock mode, real pointer events): stack found at `(1083, 236)`, dragged to `(773, 474)` in one gesture, dimensions unchanged (badges stayed together), zero page errors
- Clamping verified by construction (drag math clamps to `offsetParent` bounds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
