### PR TITLE
fix: ignore stale market info responses on slab switch

### DIFF
--- a/app/__tests__/hooks/useMarketInfo.test.ts
+++ b/app/__tests__/hooks/useMarketInfo.test.ts
@@ -1,0 +1,107 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useMarketInfo } from "../../hooks/useMarketInfo";
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+const testState = vi.hoisted(() => ({
+  pendingBySlab: {} as Record<string, Deferred<{ data: unknown; error: null | { message: string } }>>,
+  realtimeHandler: null as null | ((payload: { new: Record<string, unknown> }) => void),
+}));
+
+vi.mock("@/lib/mock-mode", () => ({
+  isMockMode: vi.fn(() => false),
+}));
+
+vi.mock("@/lib/mock-trade-data", () => ({
+  isMockSlab: vi.fn(() => false),
+  getMockMarketInfo: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  getSupabase: vi.fn(() => {
+    const channel = {
+      on: vi.fn((_event, _filter, handler) => {
+        testState.realtimeHandler = handler;
+        return channel;
+      }),
+      subscribe: vi.fn(() => channel),
+    };
+
+    return {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn((_column: string, slabAddress: string) => ({
+            maybeSingle: vi.fn(() => testState.pendingBySlab[slabAddress].promise),
+          })),
+        })),
+      })),
+      channel: vi.fn(() => channel),
+      removeChannel: vi.fn(),
+    };
+  }),
+}));
+
+describe("useMarketInfo", () => {
+  beforeEach(() => {
+    testState.pendingBySlab = {
+      "slab-a": deferred(),
+      "slab-b": deferred(),
+    };
+    testState.realtimeHandler = null;
+  });
+
+  it("ignores stale market info responses after the active slab changes", async () => {
+    const { result, rerender } = renderHook(({ slab }) => useMarketInfo(slab), {
+      initialProps: { slab: "slab-a" },
+    });
+
+    rerender({ slab: "slab-b" });
+
+    await act(async () => {
+      testState.pendingBySlab["slab-a"].resolve({
+        data: { slab_address: "slab-a", volume_24h: 100 },
+        error: null,
+      });
+      await testState.pendingBySlab["slab-a"].promise;
+    });
+
+    expect(result.current.market).toBeNull();
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      testState.pendingBySlab["slab-b"].resolve({
+        data: { slab_address: "slab-b", volume_24h: 200 },
+        error: null,
+      });
+      await testState.pendingBySlab["slab-b"].promise;
+    });
+
+    await waitFor(() => {
+      expect(result.current.market).toMatchObject({
+        slab_address: "slab-b",
+        volume_24h: 200,
+      });
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/app/hooks/useMarketInfo.ts
+++ b/app/hooks/useMarketInfo.ts
@@ -1,41 +1,69 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+
 import { getSupabase } from "@/lib/supabase";
 import type { Database } from "@/lib/database.types";
 import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab, getMockMarketInfo } from "@/lib/mock-trade-data";
 
-type MarketWithStats = Database['public']['Views']['markets_with_stats']['Row'];
+type MarketWithStats = Database["public"]["Views"]["markets_with_stats"]["Row"];
 type SupabaseClient = ReturnType<typeof getSupabase>;
 
 export function useMarketInfo(slabAddress: string) {
   const [market, setMarket] = useState<MarketWithStats | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const requestSeqRef = useRef(0);
 
   useEffect(() => {
+    requestSeqRef.current += 1;
+    const requestSeq = requestSeqRef.current;
+    let cancelled = false;
+
+    const isCurrentRequest = () => !cancelled && requestSeqRef.current === requestSeq;
+
     setLoading(true);
     setError(null);
+    setMarket(null);
+
+    if (!slabAddress) {
+      setLoading(false);
+      return () => {
+        cancelled = true;
+      };
+    }
 
     // Mock-mode short-circuit: serves logoUrl, decimals, symbol, OI, volume
     // straight from the in-codebase mock-trade-data. Avoids a DB round-trip
     // and lets demo-shots / pitch screenshots render with correct token logos.
     if (isMockMode() && isMockSlab(slabAddress)) {
       const mock = getMockMarketInfo(slabAddress);
-      setMarket(mock as unknown as MarketWithStats);
-      setLoading(false);
-      return;
+
+      if (isCurrentRequest()) {
+        setMarket(mock as unknown as MarketWithStats);
+        setLoading(false);
+      }
+
+      return () => {
+        cancelled = true;
+      };
     }
 
     let supabase: SupabaseClient;
+
     try {
       supabase = getSupabase();
     } catch {
       // Supabase client creation can fail if env vars missing (e.g. in test env)
-      setError("Database unavailable");
-      setLoading(false);
-      return;
+      if (isCurrentRequest()) {
+        setError("Database unavailable");
+        setLoading(false);
+      }
+
+      return () => {
+        cancelled = true;
+      };
     }
 
     const sb = supabase;
@@ -47,6 +75,9 @@ export function useMarketInfo(slabAddress: string) {
           .select("*")
           .eq("slab_address", slabAddress)
           .maybeSingle();
+
+        if (!isCurrentRequest()) return;
+
         if (dbError) {
           setError(dbError.message);
         } else if (!data) {
@@ -57,27 +88,41 @@ export function useMarketInfo(slabAddress: string) {
           setError(null);
         }
       } catch (e) {
+        if (!isCurrentRequest()) return;
+
         setError(e instanceof Error ? e.message : "Failed to load market");
       } finally {
-        setLoading(false);
+        if (isCurrentRequest()) {
+          setLoading(false);
+        }
       }
     }
-    load();
+
+    void load();
 
     // Subscribe to stat updates
     const channel = sb
       .channel(`market-${slabAddress}`)
-      .on("postgres_changes", {
-        event: "UPDATE",
-        schema: "public",
-        table: "market_stats",
-        filter: `slab_address=eq.${slabAddress}`,
-      }, (payload) => {
-        setMarket((prev) => prev ? { ...prev, ...payload.new } : prev);
-      })
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "market_stats",
+          filter: `slab_address=eq.${slabAddress}`,
+        },
+        (payload) => {
+          if (!isCurrentRequest()) return;
+
+          setMarket((prev) => (prev ? { ...prev, ...payload.new } : prev));
+        },
+      )
       .subscribe();
 
-    return () => { sb.removeChannel(channel); };
+    return () => {
+      cancelled = true;
+      sb.removeChannel(channel);
+    };
   }, [slabAddress]);
 
   return { market, loading, error };


### PR DESCRIPTION
## Summary

Fixes a market UI race condition where stale `useMarketInfo()` responses could update the active market state after users switch slabs quickly.

## Root Cause

`useMarketInfo()` loaded market data asynchronously but did not guard state updates against outdated requests. If a previous slab request resolved after the user had already switched to another slab, the old response could overwrite the current market info.

## Fix

- Added request sequencing to track the latest active slab request.
- Reset market state when `slabAddress` changes.
- Ignore stale Supabase responses after slab switches.
- Guard realtime market stats updates against outdated subscriptions.
- Added a regression test for stale market info responses.

## Why this matters

The trade and market UI depends on accurate market metadata. This prevents users from seeing stale volume, OI, or market stats from a previously selected slab.

## Test Plan

- `pnpm exec vitest run __tests__/hooks/useMarketInfo.test.ts`

## Risk

Low. This change is limited to frontend market info state handling and does not change trading logic, backend APIs, or on-chain instructions.