### PR TITLE
fix(trade): liq line on chart for v17 + ∞ for unliquidatable longs

### DIFF
--- a/app/components/trade/PositionPanel.tsx
+++ b/app/components/trade/PositionPanel.tsx
@@ -291,7 +291,12 @@ export const PositionPanel: FC<{ slabAddress: string }> = ({ slabAddress }) => {
     return Math.abs(Number(currentPriceE6) - Number(liqPriceE6)) / Number(currentPriceE6);
   })();
 
+  // Long-side clamp: liq at/below $0 with a resolved entry = cannot be
+  // liquidated by price (excess collateral) — a SAFE state, not a warning.
+  const liqUnliquidatable = liqPriceE6 <= 0n && entryPriceE6 > 0n && account.positionSize !== 0n;
+
   const liqPriceColor = (() => {
+    if (liqUnliquidatable) return "text-[var(--text-secondary)]";
     if (liqPriceE6 <= 0n || !hasValidMark || currentPriceE6 <= 0n) return "text-[var(--warning)]";
     if (liqDistPct < 0.05) return "text-[var(--short)]";   // <5% — critical red
     if (liqDistPct < 0.10) return "text-[var(--warning)]"; // <10% — amber
@@ -531,8 +536,12 @@ export const PositionPanel: FC<{ slabAddress: string }> = ({ slabAddress }) => {
               </div>
               <div className="flex items-center justify-between py-1.5">
                 <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text)]">Liq. Price</span>
-                <span className={`text-[11px] font-medium ${liqPriceColor}`} style={{ fontFamily: "var(--font-mono)" }}>
-                  {formatLiqPrice(liqPriceE6)}
+                <span
+                  className={`text-[11px] font-medium ${liqPriceColor}`}
+                  style={{ fontFamily: "var(--font-mono)" }}
+                  title={liqUnliquidatable ? "No liquidation price — collateral exceeds position notional; cannot be liquidated by price" : undefined}
+                >
+                  {formatLiqPrice(liqPriceE6, { hasPosition: liqUnliquidatable })}
                 </span>
               </div>
               <div className="flex items-center justify-between py-1.5">

--- a/app/components/trade/PositionsDock.tsx
+++ b/app/components/trade/PositionsDock.tsx
@@ -174,8 +174,12 @@ const PositionRow: FC<{ slabAddress: string }> = memo(function PositionRow({ sla
   const pnlIsCapped = hasValidMark && pnlTokens > 0n && payableCapacity > 0n && pnlTokens > payableCapacity;
 
   const liqPriceE6 = computeLiqPrice(entryPriceE6, account.capital, account.positionSize, maintenanceBps);
+  // Long-side clamp: liq at/below $0 with a live position = cannot be
+  // liquidated by price (excess collateral) — formatLiqPrice renders "∞".
+  const liqUnliquidatable = liqPriceE6 <= 0n && entryPriceE6 > 0n && account.positionSize !== 0n;
   const liqPriceColor = (() => {
-    if (liqPriceE6 <= 0n) return "text-[var(--text-muted)]";
+    if (liqUnliquidatable) return "text-[var(--text-secondary)]";
+    if (liqPriceE6 <= 0n) return "text-[var(--text-secondary)]";
     if (!hasValidMark || currentPriceE6 <= 0n) return "text-[var(--warning)]";
     const distPct = Math.abs(Number(currentPriceE6) - Number(liqPriceE6)) / Number(currentPriceE6);
     if (distPct < 0.05) return "text-[var(--short)]";
@@ -247,8 +251,12 @@ const PositionRow: FC<{ slabAddress: string }> = memo(function PositionRow({ sla
               <td className="whitespace-nowrap px-3 py-2.5 text-right text-[var(--text)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
                 {hasValidMark ? formatUsdPriceE6(currentPriceE6) : <span className="text-[var(--text-dim)]">--</span>}
               </td>
-              <td className={`whitespace-nowrap px-3 py-2.5 text-right font-medium ${liqPriceColor}`} style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
-                {formatLiqPrice(liqPriceE6)}
+              <td
+                className={`whitespace-nowrap px-3 py-2.5 text-right font-medium ${liqPriceColor}`}
+                style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}
+                title={liqUnliquidatable ? "No liquidation price — collateral exceeds position notional; cannot be liquidated by price" : undefined}
+              >
+                {formatLiqPrice(liqPriceE6, { hasPosition: liqUnliquidatable })}
               </td>
               <td className={`whitespace-nowrap px-3 py-2.5 text-right ${hasValidMark ? pnlColor : "text-[var(--text-dim)]"}`} style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
                 {hasValidMark ? (

--- a/app/hooks/useLiqPrice.ts
+++ b/app/hooks/useLiqPrice.ts
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { useUserAccount } from "@/hooks/useUserAccount";
 import { useSlabState } from "@/components/providers/SlabProvider";
 import { computeLiqPrice } from "@/lib/trading";
+import { getEntryPrice } from "@/lib/entry-price";
 
 /**
  * Phase 2: Returns the liquidation price (as bigint e6) for the current user's
@@ -12,7 +13,7 @@ import { computeLiqPrice } from "@/lib/trading";
  */
 export function useLiqPrice(): bigint | null {
   const realUserAccount = useUserAccount();
-  const { params } = useSlabState();
+  const { params, slabAddress } = useSlabState();
 
   return useMemo(() => {
     if (!realUserAccount) return null;
@@ -20,21 +21,26 @@ export function useLiqPrice(): bigint | null {
     if (account.positionSize === 0n) return null;
 
     // v17 (and NFT-wrapped v12) accounts do not store an entry price on-chain
-    // (entryPrice === 0n). computeLiqPrice needs a non-zero entry to produce a
-    // real number — without it, it returns 0n, which a consumer could otherwise
-    // misread as "liquidation at $0.00". Surface it as null ("no liq price
-    // available") instead. The position panels (PositionPanel / PositionsTable /
-    // AccountRiskSidebar) resolve the entry from the live mark for a usable
-    // figure; this hook only feeds the chart's liq overlay, which correctly
-    // hides the line when the value is null.
-    if (account.entryPrice === 0n) return null;
+    // (entryPrice === 0n) — every v17 position used to bail out here, so the
+    // chart's "Liquidation Price" display toggle never drew anything. Resolve
+    // the entry the same way ChartPnlBadge does: fall back to the client-side
+    // entry saved at trade-open time (lib/entry-price). Still null when
+    // neither source has it (e.g. a transferred-in position NFT) — the chart
+    // correctly hides the line for null.
+    const rawEntryPrice = account.entryPrice ?? 0n;
+    const entryPrice =
+      rawEntryPrice > 0n ? rawEntryPrice : getEntryPrice(slabAddress, realUserAccount.idx);
+    if (entryPrice <= 0n) return null;
 
     const maintenanceBps = params?.maintenanceMarginBps ?? 500n;
-    return computeLiqPrice(
-      account.entryPrice,
+    const liq = computeLiqPrice(
+      entryPrice,
       account.capital,
       account.positionSize,
       maintenanceBps,
     );
-  }, [realUserAccount, params]);
+    // Long-side clamp (liq at/below $0): the position cannot be liquidated by
+    // price, so there is genuinely no line to draw.
+    return liq > 0n ? liq : null;
+  }, [realUserAccount, params, slabAddress]);
 }

--- a/app/lib/format.ts
+++ b/app/lib/format.ts
@@ -155,10 +155,22 @@ export function formatMarkPrice(priceUsd: number | null | undefined, fallback = 
  * Returns "∞" when the position is unliquidatable (liqPrice === max u64),
  * "-" when zero/null, otherwise delegates to formatUsd.
  */
-export function formatLiqPrice(liqPriceE6: bigint | null | undefined): string {
+export function formatLiqPrice(
+  liqPriceE6: bigint | null | undefined,
+  opts?: {
+    /** Pass true when an open position with a resolved entry produced this
+     *  value. computeLiqPrice clamps a LONG's liq price to 0n when it falls
+     *  at/below $0 — the position holds more collateral than its notional
+     *  and cannot be liquidated by price. That's the same semantics as the
+     *  short-side u64::MAX sentinel, so with hasPosition it renders "∞"
+     *  instead of being conflated with "no data" ("N/A"). */
+    hasPosition?: boolean;
+  },
+): string {
   if (liqPriceE6 == null) return "N/A";
-  // 0n = no liq price (no position open, or position not yet priced). Show "N/A".
-  if (liqPriceE6 <= 0n) return "N/A";
+  // 0n = no liq price (no position / entry unresolved) — unless hasPosition
+  // says this is the long-side unliquidatable clamp (see opts doc).
+  if (liqPriceE6 <= 0n) return opts?.hasPosition ? "∞" : "N/A";
   // Sentinel = max u64: position is so overcollateralized it cannot be liquidated.
   if (liqPriceE6 >= LIQ_PRICE_UNLIQUIDATABLE) return "∞";
   return formatUsd(liqPriceE6);


### PR DESCRIPTION
## Bugs

User report: turning on **Display → Liquidation Price** draws nothing on the chart, and the positions dock shows **N/A** for LIQ. PRICE — with an open LONG position.

Two distinct causes:

**1. The chart's liq line never drew on v17 markets.** `useLiqPrice` bails when `account.entryPrice === 0n` — which is *every* v17 position, since v17 doesn't store entry price on-chain. Every other consumer (`ChartPnlBadge`, `PositionsDock`, `AccountRiskSidebar`) already falls back to the client-side entry saved at trade-open time; this hook was the one holdout. Fixed with the same `getEntryPrice` fallback. Still `null` (line hidden) when neither source has an entry — e.g. a transferred-in position NFT.

**2. Unliquidatable longs render "N/A" instead of "∞".** `computeLiqPrice` clamps a long's liq price to `0n` when it lands at/below $0 — i.e. collateral exceeds the position's notional and the position **cannot be liquidated by price** (the reporting user held a ~$550 1× long against ~$10k account capital: liq ≈ $0.246 − $4.25 < 0). The short-side equivalent (u64::MAX sentinel) already renders "∞", but the long-side clamp was conflated with "no data" → "N/A". Worse, `PositionPanel` painted this **safe** state warning-amber.

`formatLiqPrice` gains an opt-in `hasPosition` flag (backward-compatible); `PositionsDock` and `PositionPanel` pass it when the clamp fires with a live position + resolved entry, render **∞** in a calm secondary color with a tooltip ("collateral exceeds position notional; cannot be liquidated by price"). This matches `AccountRiskSidebar`, which already says "Unliquidatable" for the same state. The chart hook returns `null` for the clamp — no line to draw is the correct rendering there.

## Testing

- `npx tsc --noEmit` clean
- `format.test.ts` + `format-extended.test.ts`: 131/131 pass (new param is opt-in; all existing call sites unchanged in behavior)
- Arithmetic verified against the reported position (liq < $0 at 1× overcollateralized; real line at 2×+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
