### PR TITLE
fix: ignore stale trade history responses on wallet switch

### DIFF
--- a/app/__tests__/hooks/useTradeHistory.test.ts
+++ b/app/__tests__/hooks/useTradeHistory.test.ts
@@ -1,0 +1,96 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useTradeHistory } from "../../hooks/useTradeHistory";
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+const testState = vi.hoisted(() => ({
+  pendingByWallet: {} as Record<string, Deferred<Response>>,
+}));
+
+function makeResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: vi.fn(async () => body),
+  } as unknown as Response;
+}
+
+describe("useTradeHistory", () => {
+  beforeEach(() => {
+    testState.pendingByWallet = {
+      "wallet-a": deferred<Response>(),
+      "wallet-b": deferred<Response>(),
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        const match = url.match(/\/api\/trader\/([^/]+)\/trades/);
+        const wallet = decodeURIComponent(match?.[1] ?? "");
+
+        return testState.pendingByWallet[wallet].promise;
+      }),
+    );
+  });
+
+  it("ignores stale trade history responses after the wallet changes", async () => {
+    const { result, rerender } = renderHook(({ wallet }) => useTradeHistory({ wallet, limit: 10 }), {
+      initialProps: { wallet: "wallet-a" },
+    });
+
+    rerender({ wallet: "wallet-b" });
+
+    await act(async () => {
+      testState.pendingByWallet["wallet-a"].resolve(
+        makeResponse({
+          total: 1,
+          trades: [{ signature: "old-wallet-trade" }],
+        }),
+      );
+
+      await testState.pendingByWallet["wallet-a"].promise;
+    });
+
+    expect(result.current.trades).toEqual([]);
+    expect(result.current.total).toBe(0);
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      testState.pendingByWallet["wallet-b"].resolve(
+        makeResponse({
+          total: 1,
+          trades: [{ signature: "current-wallet-trade" }],
+        }),
+      );
+
+      await testState.pendingByWallet["wallet-b"].promise;
+    });
+
+    await waitFor(() => {
+      expect(result.current.trades).toEqual([{ signature: "current-wallet-trade" }]);
+    });
+
+    expect(result.current.total).toBe(1);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/app/hooks/useTradeHistory.ts
+++ b/app/hooks/useTradeHistory.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import type { TraderTradeEntry } from "@/app/api/trader/[wallet]/trades/route";
 
 export interface UseTradeHistoryOptions {
@@ -33,10 +33,14 @@ export function useTradeHistory({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [offset, setOffset] = useState(0);
+  const requestSeqRef = useRef(0);
 
   const fetchPage = useCallback(
-    async (currentOffset: number, append: boolean) => {
+    async (currentOffset: number, append: boolean, requestSeq = requestSeqRef.current) => {
       if (!wallet) return;
+
+      const isCurrentRequest = () => requestSeqRef.current === requestSeq;
+
       setLoading(true);
       setError(null);
 
@@ -45,52 +49,84 @@ export function useTradeHistory({
           limit: String(limit),
           offset: String(currentOffset),
         });
+
         if (slabFilter) params.set("slab", slabFilter);
 
         const res = await fetch(`/api/trader/${wallet}/trades?${params}`);
+
+        if (!isCurrentRequest()) return;
+
         if (!res.ok) {
           const body = await res.json().catch(() => ({}));
+
+          if (!isCurrentRequest()) return;
+
           throw new Error(body.error ?? `HTTP ${res.status}`);
         }
+
         const data = await res.json();
 
+        if (!isCurrentRequest()) return;
+
         setTotal(data.total ?? 0);
-        setTrades((prev) =>
-          append ? [...prev, ...(data.trades ?? [])] : (data.trades ?? []),
-        );
+        setTrades((prev) => (append ? [...prev, ...(data.trades ?? [])] : (data.trades ?? [])));
         setOffset(currentOffset);
       } catch (err) {
+        if (!isCurrentRequest()) return;
+
         setError(err instanceof Error ? err.message : "Failed to load history");
       } finally {
-        setLoading(false);
+        if (isCurrentRequest()) {
+          setLoading(false);
+        }
       }
     },
     [wallet, limit, slabFilter],
   );
 
-  // Initial load / wallet change
+  // Initial load / wallet or market-filter change
   useEffect(() => {
+    requestSeqRef.current += 1;
+    const requestSeq = requestSeqRef.current;
+
     setTrades([]);
     setTotal(0);
     setOffset(0);
+    setError(null);
+
     if (wallet) {
-      fetchPage(0, false);
+      fetchPage(0, false, requestSeq);
+    } else {
+      setLoading(false);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [wallet, slabFilter]);
+
+    return () => {
+      requestSeqRef.current += 1;
+    };
+  }, [wallet, slabFilter, fetchPage]);
 
   const loadMore = useCallback(() => {
     const nextOffset = offset + limit;
+
     if (nextOffset < total) {
-      fetchPage(nextOffset, true);
+      fetchPage(nextOffset, true, requestSeqRef.current);
     }
   }, [offset, limit, total, fetchPage]);
 
   const refresh = useCallback(() => {
+    requestSeqRef.current += 1;
+    const requestSeq = requestSeqRef.current;
+
     setTrades([]);
     setTotal(0);
     setOffset(0);
-    if (wallet) fetchPage(0, false);
+    setError(null);
+
+    if (wallet) {
+      fetchPage(0, false, requestSeq);
+    } else {
+      setLoading(false);
+    }
   }, [wallet, fetchPage]);
 
   const hasMore = trades.length < total;


### PR DESCRIPTION
## Summary

Fixes a trade history race condition where stale `useTradeHistory()` responses could update the UI after the active wallet or market filter changes.

## Root Cause

`useTradeHistory()` fetches trade history asynchronously but did not guard state updates against outdated requests. If a previous request resolved after the wallet or slab filter changed, stale results could overwrite or append to the current trade history state.

## Fix

- Added request sequencing to track the latest active trade history request.
- Ignored stale fetch responses after wallet or market-filter changes.
- Reset trade history state when wallet or slab filter changes.
- Guarded loading and error updates against outdated requests.
- Added a regression test for stale wallet response handling.

## Why this matters

The user trade history UI should only show trades for the currently selected wallet and market context. This prevents old responses from showing stale or incorrect trade history after fast navigation or filter changes.

## Test Plan

- `pnpm exec vitest run __tests__/hooks/useTradeHistory.test.ts`

## Risk

Low. This change is limited to frontend trade history state handling and does not change backend APIs, trading logic, or on-chain instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed trade history loading so slower, older requests no longer overwrite newer wallet data.
  * Improved pagination and refresh behavior to keep trades, totals, and loading state consistent when switching wallets or reloading quickly.

* **Tests**
  * Added coverage for trade history request ordering to verify stale responses are ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->