### PR TITLE
fix(trade): trade-terminal UI conflict cleanup pass

### DIFF
--- a/app/app/trade/[slab]/page.tsx
+++ b/app/app/trade/[slab]/page.tsx
@@ -431,7 +431,7 @@ function TradePageInner({ slab }: { slab: string }) {
   // template strings) but nothing is placed in it.
   const gridStyle: CSSProperties = {
     gridTemplateAreas: '"MarketBar MarketBar" "Chart OrderTicket" "PositionsDock OrderTicket"',
-    gridTemplateColumns: orderBookVisible ? "minmax(0,1fr) 340px" : "minmax(0,1fr) 340px",
+    gridTemplateColumns: "minmax(0,1fr) 340px",
     gridTemplateRows: "auto minmax(0,1fr) minmax(220px,340px)",
   };
   // When the order book is visible it takes its own column between Chart and

--- a/app/components/trade/ChartDisplayMenu.tsx
+++ b/app/components/trade/ChartDisplayMenu.tsx
@@ -93,7 +93,11 @@ export const ChartDisplayMenu: FC<ChartDisplayMenuProps> = ({ prefs, onToggle })
       <div
         aria-hidden={!open || undefined}
         className={[
-          "absolute left-0 top-full z-20 mt-1 min-w-[200px] rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] py-1 shadow-[0_8px_32px_rgba(0,0,0,0.48)] transition-opacity duration-[120ms] ease-out",
+          // z-[60] so the dropdown sits above the sticky MarketInfoBar (z-30)
+          // and MobileBottomNav (z-50) — matching the sibling ChartIndicatorMenu.
+          // At z-20 it was painting behind the sticky market bar when the chart
+          // header scrolled up beneath it on mobile.
+          "absolute left-0 top-full z-[60] mt-1 min-w-[200px] rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] py-1 shadow-[0_8px_32px_rgba(0,0,0,0.48)] transition-opacity duration-[120ms] ease-out",
           open ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none",
         ].join(" ")}
       >

--- a/app/components/trade/ChartStyleMenu.tsx
+++ b/app/components/trade/ChartStyleMenu.tsx
@@ -94,7 +94,11 @@ export const ChartStyleMenu: FC<ChartStyleMenuProps> = ({ value, onChange }) => 
         role="listbox"
         aria-hidden={!open || undefined}
         className={[
-          "absolute left-0 top-full z-20 mt-1 min-w-[180px] rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] py-1 shadow-[0_8px_32px_rgba(0,0,0,0.48)] transition-opacity duration-[120ms] ease-out",
+          // z-[60] so the dropdown sits above the sticky MarketInfoBar (z-30)
+          // and MobileBottomNav (z-50) — matching the sibling ChartIndicatorMenu.
+          // At z-20 it was painting behind the sticky market bar when the chart
+          // header scrolled up beneath it on mobile.
+          "absolute left-0 top-full z-[60] mt-1 min-w-[180px] rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] py-1 shadow-[0_8px_32px_rgba(0,0,0,0.48)] transition-opacity duration-[120ms] ease-out",
           open ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none",
         ].join(" ")}
       >

--- a/app/components/trade/ClosePositionModal.tsx
+++ b/app/components/trade/ClosePositionModal.tsx
@@ -4,6 +4,7 @@ import { FC, useEffect, useRef, useState, useMemo } from "react";
 import { createPortal } from "react-dom";
 import gsap from "gsap";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
 import { formatTokenAmount, formatUsdPriceE6 } from "@/lib/format";
 import { computeMarkPnl } from "@/lib/trading";
 
@@ -62,6 +63,7 @@ export const ClosePositionModal: FC<ClosePositionModalProps> = ({
   const overlayRef = useRef<HTMLDivElement>(null);
   const modalRef = useRef<HTMLDivElement>(null);
   const prefersReduced = usePrefersReducedMotion();
+  useLockBodyScroll();
   const [percent, setPercent] = useState(100);
 
   // Ref-based callback to prevent WS price ticks from replaying the GSAP animation
@@ -227,7 +229,7 @@ export const ClosePositionModal: FC<ClosePositionModalProps> = ({
             style={{
               background: `linear-gradient(to right, var(--short) 0%, var(--short) ${percent}%, rgba(255,255,255,0.03) ${percent}%, rgba(255,255,255,0.03) 100%)`,
             }}
-            className="mb-2 h-1 w-full cursor-pointer appearance-none [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:bg-[var(--short)]"
+            className="mb-2 h-1 w-full cursor-pointer appearance-none [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:bg-[var(--short)] [&::-moz-range-thumb]:h-3 [&::-moz-range-thumb]:w-3 [&::-moz-range-thumb]:appearance-none [&::-moz-range-thumb]:rounded-none [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-[var(--short)] [&::-moz-range-track]:bg-transparent"
           />
           <div className="flex gap-1">
             {PRESETS.map((p) => (

--- a/app/components/trade/SendPositionNftModal.tsx
+++ b/app/components/trade/SendPositionNftModal.tsx
@@ -5,6 +5,15 @@ import { createPortal } from "react-dom";
 import { PublicKey } from "@solana/web3.js";
 import gsap from "gsap";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
+
+/**
+ * Focusable-element selector for the focus trap. Excludes `[disabled]` controls
+ * so a disabled boundary element can't break the Tab-wrap — same selector the
+ * other trade modals (ClosePositionModal / TradeConfirmationModal) use.
+ */
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 interface SendPositionNftModalProps {
   /** Human summary of the position being transferred — e.g. "LONG 0.3507 SOL" */
@@ -37,6 +46,7 @@ export const SendPositionNftModal: FC<SendPositionNftModalProps> = ({
   const overlayRef = useRef<HTMLDivElement>(null);
   const modalRef = useRef<HTMLDivElement>(null);
   const prefersReduced = usePrefersReducedMotion();
+  useLockBodyScroll();
 
   const [destInput, setDestInput] = useState("");
   const [acknowledged, setAcknowledged] = useState(false);
@@ -45,14 +55,39 @@ export const SendPositionNftModal: FC<SendPositionNftModalProps> = ({
   const pubkeyInvalid = destInput.length > 0 && !parsedDest;
   const canConfirm = parsedDest !== null && acknowledged && !loading;
 
-  // Trap Escape to cancel, match the other modals
+  // Trap Escape + Tab, match the other modals (ClosePositionModal /
+  // TradeConfirmationModal). Without the Tab-wrap, focus escaped the dialog
+  // into the page behind it.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && !loading) onCancel();
+      if (e.key === "Escape" && !loading) {
+        onCancel();
+        return;
+      }
+      if (e.key === "Tab" && modalRef.current) {
+        const items = modalRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+        if (items.length === 0) return;
+        const first = items[0];
+        const last = items[items.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
     };
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
   }, [onCancel, loading]);
+
+  // Move initial focus inside the dialog on open (APG dialog pattern) so Tab
+  // starts trapped — runs once on mount, regardless of reduced-motion.
+  useEffect(() => {
+    const first = modalRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)[0];
+    first?.focus();
+  }, []);
 
   // Enter/scale animation matching ClosePositionModal
   useEffect(() => {

--- a/app/components/trade/TradeConfirmationModal.tsx
+++ b/app/components/trade/TradeConfirmationModal.tsx
@@ -4,6 +4,7 @@ import { FC, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import gsap from "gsap";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
 import { formatLeverage, ORDER_LEVERAGE_LABEL, RISK_LEVERAGE_LABEL } from "@/lib/leverage-display";
 import { formatTokenAmount } from "@/lib/format";
 
@@ -62,6 +63,7 @@ export const TradeConfirmationModal: FC<TradeConfirmationModalProps> = ({
   const overlayRef = useRef<HTMLDivElement>(null);
   const modalRef = useRef<HTMLDivElement>(null);
   const prefersReduced = usePrefersReducedMotion();
+  useLockBodyScroll();
   // Local submit guard: a fast double-click on "Confirm Trade" would otherwise
   // fire onConfirm twice, surfacing a confusing "Trade already in progress"
   // banner. Latch on first click, disable the button, and only unlatch if the

--- a/app/components/trade/WarmupExplainerModal.tsx
+++ b/app/components/trade/WarmupExplainerModal.tsx
@@ -4,6 +4,7 @@ import { FC, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import gsap from "gsap";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
 
 interface WarmupExplainerModalProps {
   onClose: () => void;
@@ -15,6 +16,7 @@ export const WarmupExplainerModal: FC<WarmupExplainerModalProps> = ({
   const overlayRef = useRef<HTMLDivElement>(null);
   const modalRef = useRef<HTMLDivElement>(null);
   const prefersReduced = usePrefersReducedMotion();
+  useLockBodyScroll();
 
   // Keep the onClose callback in a ref so the mount effect never re-runs on parent
   // re-renders. Trade-page parents re-render frequently (countdown ticks, WS price

--- a/app/hooks/useLockBodyScroll.ts
+++ b/app/hooks/useLockBodyScroll.ts
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+
+/**
+ * Locks background page scroll while a modal/overlay is mounted, restoring the
+ * previous value on unmount. Extracts the inline pattern `MobileOrderSheet`
+ * (app/trade/[slab]/page.tsx) already uses so every portaled trade-page dialog
+ * behaves the same way — without this, wheel/trackpad scrolling over a modal's
+ * dim backdrop scrolls the trade page underneath it.
+ *
+ * Deliberately simple (save + restore, no ref-count): the trade page never
+ * stacks two of these dialogs at once, so nested locks aren't a concern here.
+ */
+export function useLockBodyScroll(): void {
+  useEffect(() => {
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, []);
+}


### PR DESCRIPTION
Closes #2279
Closes #2280
Closes #2281
Closes #2282
Closes #2283

## What & why

Frontend-only, devnet-safe cleanup pass on the trade page. **No behavior changes to trading, on-chain calls, or the price feed.** Five self-contained UI/visual-conflict fixes found in a static audit of `app/components/trade/**` + the trade page.

### 1. Firefox: close-slider thumb is the wrong color (#2279)
`ClosePositionModal`'s close-amount slider only overrode the **WebKit** thumb, so on Firefox it fell through to the base accent (**purple**) thumb in `globals.css` while Chrome showed the intended danger-**red** thumb. Added matching `::-moz-range-thumb` / `::-moz-range-track` overrides so both engines render the red 12px thumb.
- `components/trade/ClosePositionModal.tsx`

### 2. Chart Style/Display menus rendered behind the sticky market bar (#2280)
`MarketInfoBar` is `sticky top-0 z-30`. `ChartStyleMenu` and `ChartDisplayMenu` opened their dropdowns at **z-20**, so on mobile — where the chart header scrolls up under the sticky bar — the dropdown painted **behind** the market bar. The sibling `ChartIndicatorMenu` already uses `z-[60]`; the other two never got the same fix. Bumped both to `z-[60]` (above the market bar and `MobileBottomNav`), unifying the three sibling chart menus on one tier.
- `components/trade/ChartStyleMenu.tsx`, `components/trade/ChartDisplayMenu.tsx`

### 3. Background scrolled behind open trade modals (#2281)
Only `MobileOrderSheet` locked body scroll; the portaled trade modals didn't, so wheel/trackpad over the dim backdrop scrolled the page underneath. Extracted that inline pattern into a shared `useLockBodyScroll` hook and applied it to `TradeConfirmationModal`, `ClosePositionModal`, `SendPositionNftModal`, `WarmupExplainerModal`.
- new `hooks/useLockBodyScroll.ts` + the four modals

### 4. `SendPositionNftModal` had no focus trap (#2282)
It handled `Escape` but Tab / Shift+Tab escaped into the page behind it. Added the same Tab-wrap + initial-focus pattern #2240 gave `ClosePositionModal` / `TradeConfirmationModal` (this modal is reachable from the trade rail via `PositionNftPanel`).
- `components/trade/SendPositionNftModal.tsx`

### 5. Dead ternary in the desktop grid template (#2283)
`gridTemplateColumns: orderBookVisible ? "minmax(0,1fr) 340px" : "minmax(0,1fr) 340px"` — identical branches. Collapsed to the single value (the real orderbook-column swap happens in the `if (orderBookVisible)` block below).
- `app/trade/[slab]/page.tsx`

## Testing
- `npx tsc --noEmit` — no new errors (only the pre-existing `vitest.config.ts` vite-version conflict, unrelated and untouched — same one noted in #2251).
- `npx vitest run` — no new failures: the failing suites (`useTrade`, `OpenInterestCard`, stake hooks, …) fail identically on the clean `playground` baseline before this change.
- Changes are additive CSS + a11y + a no-op cleanup; nothing alters trade/price/on-chain paths.

## Follow-ups (tracked separately, not in this PR)
Found in the same audit, left out because each changes displayed values or is higher-risk:
- #2284 — `PositionPanel` appears unused on the trade page (superseded by `PositionsDock`); candidate for removal like `TradeForm`/`PositionsTable` in #2240.
- #2285 — `ClosePositionModal`'s `tradingFeeBps` is never passed by callers, so the fee row never renders and "Est. Receive" overstates.
- #2286 — modal scrims / z-index vary across the six modals; unify behind a shared `<Modal>` primitive.