### PR TITLE
fix(api): 24h high/low/change without the indexer; real v17 slab stats

### DIFF
--- a/app/app/api/markets/[slab]/route.ts
+++ b/app/app/api/markets/[slab]/route.ts
@@ -7,6 +7,7 @@ import { isBlockedSlab } from "@/lib/blocklist";
 import * as Sentry from "@sentry/nextjs";
 import {
   parseWrapperConfigV17,
+  parseMarketGroupV17OI,
   isV17Account,
   V17_HEADER_LEN,
 } from "@percolatorct/sdk";
@@ -46,6 +47,16 @@ async function onChainSlabFallback(slab: string): Promise<NextResponse> {
     const markPriceUsd = markPriceRaw > 0n ? Number(markPriceRaw) / 1_000_000 : null;
     const playgroundMeta = PLAYGROUND_SLAB_META[slab];
 
+    // Live engine stats from the same raw bytes (mirrors the list route's
+    // v17 enrichment). Degrades to zeros if the parse throws.
+    let oiLong = 0, oiShort = 0, insurance = 0;
+    try {
+      const oi = parseMarketGroupV17OI(data);
+      oiLong = Number(oi.totalLongOiQ);
+      oiShort = Number(oi.totalShortOiQ);
+      insurance = Number(oi.insuranceBalance);
+    } catch { /* stats stay zeroed */ }
+
     const market = {
       slab_address: slab,
       program_id: info.owner.toBase58(),
@@ -64,21 +75,25 @@ async function onChainSlabFallback(slab: string): Promise<NextResponse> {
       last_price: markPriceUsd,
       mark_price: markPriceUsd,
       index_price: null,
-      volume_24h: 0,
+      // Volume needs the trade-tape indexer — null ("no data"), NOT 0.
+      // MarketInfoBar renders null as "—"; a hard $0 reads as "market is dead".
+      volume_24h: null,
       trade_count_24h: 0,
-      open_interest_long: 0,
-      open_interest_short: 0,
-      total_open_interest: 0,
-      total_open_interest_usd: 0,
-      insurance_fund: 0,
-      insurance_balance: 0,
+      open_interest_long: oiLong,
+      open_interest_short: oiShort,
+      total_open_interest: oiLong + oiShort,
+      total_open_interest_usd: markPriceUsd != null ? ((oiLong + oiShort) / 1_000_000) * markPriceUsd : 0,
+      insurance_fund: insurance,
+      insurance_balance: insurance,
       total_accounts: 0,
       funding_rate: null,
       net_lp_pos: 0,
       lp_sum_abs: 0,
-      c_tot: 0,
-      volume_24h_usd: 0,
-      vault_balance: 0,
+      // Unknown on v17 (no cheap on-chain source) — null, not 0, to avoid the
+      // phantom-OI vault guard downstream (same rationale as the list route).
+      c_tot: null,
+      volume_24h_usd: null,
+      vault_balance: null,
     };
 
     return NextResponse.json(

--- a/app/app/api/prices/[slab]/route.ts
+++ b/app/app/api/prices/[slab]/route.ts
@@ -1,11 +1,55 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getBackendUrl } from "@/lib/config";
 import { validateSlabParam } from "@/lib/route-validators";
+import { PLAYGROUND_SLAB_META } from "@/lib/playground-slab-meta";
 import * as Sentry from "@sentry/nextjs";
 
 export const dynamic = "force-dynamic";
 
 const NO_STORE = { "Cache-Control": "private, no-store" } as const;
+
+/** Pyth Benchmarks — same public source /api/chart/pyth proxies for chart
+ *  history. Used as the 24h-stats fallback when the indexer backend is not
+ *  running (local playground, and the hosted playground deploy): without it
+ *  this route 502s every 10s and 24H HIGH / 24H LOW render as dashes forever. */
+const PYTH_BASE = "https://benchmarks.pyth.network/v1/shims/tradingview/history";
+
+type Stats24h = { change24h: number; high24h: string; low24h: string };
+
+/** Compute 24h stats from Pyth Benchmarks hourly bars for a playground slab.
+ *  Returns null when the slab has no playground meta or Pyth has no data —
+ *  callers then respond `{ stats: null }` (dashes in the UI, no error spam). */
+async function pythStatsFallback(slab: string): Promise<Stats24h | null> {
+  const meta = PLAYGROUND_SLAB_META[slab];
+  if (!meta) return null;
+  // "JUP-PERP" → "Crypto.JUP/USD". Guard the base so only sane symbols reach Pyth.
+  const base = meta.symbol.split("-")[0];
+  if (!/^[A-Z0-9]{2,10}$/.test(base)) return null;
+
+  const to = Math.floor(Date.now() / 1000);
+  const from = to - 86_400;
+  const url = `${PYTH_BASE}?symbol=${encodeURIComponent(`Crypto.${base}/USD`)}&resolution=60&from=${from}&to=${to}`;
+  const res = await fetch(url, {
+    headers: { "User-Agent": "percolator-prices-proxy/1.0" },
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) return null;
+  const data = (await res.json()) as { s?: string; o?: number[]; h?: number[]; l?: number[]; c?: number[] };
+  if (data.s !== "ok" || !data.o?.length || !data.h?.length || !data.l?.length || !data.c?.length) return null;
+
+  const high = Math.max(...data.h);
+  const low = Math.min(...data.l);
+  const first = data.o[0];
+  const last = data.c[data.c.length - 1];
+  if (!Number.isFinite(high) || !Number.isFinite(low) || !Number.isFinite(first) || first <= 0) return null;
+
+  const toE6Str = (v: number) => BigInt(Math.round(v * 1_000_000)).toString();
+  return {
+    change24h: ((last - first) / first) * 100,
+    high24h: toE6Str(high),
+    low24h: toE6Str(low),
+  };
+}
 
 /**
  * GET /api/prices/[slab]
@@ -38,27 +82,31 @@ export async function GET(
     }
     const validSlab = validation.slab;
 
-    const backendUrl = getBackendUrl();
-
-    const res = await fetch(`${backendUrl}/prices/${validSlab}`, {
-      headers: { "Content-Type": "application/json" },
-      signal: AbortSignal.timeout(5000),
-    });
-
-    if (!res.ok) {
-      return NextResponse.json(
-        { error: `Backend returned ${res.status}` },
-        { status: res.status, headers: NO_STORE },
-      );
+    // Primary: indexer backend oracle-price history. Absent on the local /
+    // hosted playground — any failure falls through to the Pyth fallback
+    // instead of 502ing (this endpoint is polled every 10s by useLivePrice).
+    // getBackendUrl() THROWS when NEXT_PUBLIC_API_URL is unset (the documented
+    // playground config), so it must be inside this try too.
+    let prices: Array<{ price_e6: string; timestamp: number }> = [];
+    try {
+      const backendUrl = getBackendUrl();
+      const res = await fetch(`${backendUrl}/prices/${validSlab}`, {
+        headers: { "Content-Type": "application/json" },
+        signal: AbortSignal.timeout(5000),
+      });
+      if (res.ok) {
+        const data = await res.json() as {
+          prices?: Array<{ price_e6: string; timestamp: number }>;
+        };
+        prices = data.prices ?? [];
+      }
+    } catch {
+      /* backend unreachable — use the Pyth fallback below */
     }
 
-    const data = await res.json() as {
-      prices?: Array<{ price_e6: string; timestamp: number }>;
-    };
-
-    const prices = data.prices ?? [];
     if (prices.length === 0) {
-      return NextResponse.json({ stats: null }, { headers: NO_STORE });
+      const stats = await pythStatsFallback(validSlab).catch(() => null);
+      return NextResponse.json({ stats }, { headers: NO_STORE });
     }
 
     // Prices are sorted desc (newest first). Find entries within last 24h.


### PR DESCRIPTION
## Bug

The trade page's market info bar shows **dashes for 24H HIGH / 24H LOW**, **0.00%** for the daily change, and a misleading **$0** for VOL 24H — on the local playground and on https://percolator-playground.vercel.app alike.

Root causes:

1. **`/api/prices/[slab]` 502s on every poll** (useLivePrice hits it every 10s). Two stacked problems: `getBackendUrl()` *throws* when `NEXT_PUBLIC_API_URL` is unset — which is the documented playground configuration — and even when set there's no indexer backend to proxy to.
2. **`/api/markets/[slab]`'s v17 fallback hardcodes zeros** for volume/OI/insurance, so the bar renders "$0" volume (reads as "dead market") and downstream consumers get fake zeros.

## Fix

**Pyth Benchmarks fallback for 24h stats.** `/api/prices/[slab]` now tries the indexer backend first (unchanged when it exists), and on any failure computes `high24h` / `low24h` / `change24h` from 24 hourly Pyth bars — the same free public source `/api/chart/pyth` already proxies for chart history, resolved via `PLAYGROUND_SLAB_META` (symbol whitelist-guarded). Non-playground slabs return `{ stats: null }` (dashes, no 502 spam every 10s).

**Real v17 stats on the single-market route.** Mirrors #2265's list-route enrichment: parse OI + insurance with `parseMarketGroupV17OI` from the raw bytes the route already fetched. `volume_24h`, `c_tot`, `vault_balance` become `null` (unknown ≠ zero): the info bar renders null volume as **—** instead of "$0", and a hard-zero `c_tot` trips the phantom-OI vault guard downstream.

Volume itself still needs the trade-tape indexer — there's no honest on-chain source for it, so "—" is the correct rendering until that exists.

## Verification (live dev server)

- `/api/prices/<SOL slab>`: was 502 → now `{ change24h: +0.23, high24h: "82346965", low24h: "79648109" }`
- `/api/markets/<SOL slab>`: real OI (159.79) + insurance (129.43), `volume_24h: null`
- Headless-browser check of the trade page info bar: `+0.32% | VOL 24H — | OPEN INTEREST $160 | 24H HIGH $82.346965 | 24H LOW $79.648109`
- `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
