### PR TITLE
fix: ignore stale trader stats responses on wallet switch

### DIFF
--- a/app/__tests__/hooks/useTraderStats.test.ts
+++ b/app/__tests__/hooks/useTraderStats.test.ts
@@ -1,0 +1,97 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useTraderStats } from "../../hooks/useTraderStats";
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+const testState = vi.hoisted(() => ({
+  pendingByWallet: {} as Record<string, Deferred<Response>>,
+}));
+
+function makeResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: vi.fn(async () => body),
+  } as unknown as Response;
+}
+
+describe("useTraderStats", () => {
+  beforeEach(() => {
+    testState.pendingByWallet = {
+      "wallet-a": deferred<Response>(),
+      "wallet-b": deferred<Response>(),
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        const match = url.match(/\/api\/trader\/([^/]+)\/stats/);
+        const wallet = decodeURIComponent(match?.[1] ?? "");
+
+        return testState.pendingByWallet[wallet].promise;
+      }),
+    );
+  });
+
+  it("ignores stale trader stats responses after the wallet changes", async () => {
+    const { result, rerender } = renderHook(({ wallet }) => useTraderStats(wallet), {
+      initialProps: { wallet: "wallet-a" },
+    });
+
+    rerender({ wallet: "wallet-b" });
+
+    await act(async () => {
+      testState.pendingByWallet["wallet-a"].resolve(
+        makeResponse({
+          totalTrades: 1,
+          totalVolume: 100,
+        }),
+      );
+
+      await testState.pendingByWallet["wallet-a"].promise;
+    });
+
+    expect(result.current.stats).toBeNull();
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      testState.pendingByWallet["wallet-b"].resolve(
+        makeResponse({
+          totalTrades: 2,
+          totalVolume: 200,
+        }),
+      );
+
+      await testState.pendingByWallet["wallet-b"].promise;
+    });
+
+    await waitFor(() => {
+      expect(result.current.stats).toMatchObject({
+        totalTrades: 2,
+        totalVolume: 200,
+      });
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/app/hooks/useTraderStats.ts
+++ b/app/hooks/useTraderStats.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import type { TraderStatsResponse } from "@/app/api/trader/[wallet]/stats/route";
 
 export type { TraderStatsResponse };
@@ -20,32 +20,83 @@ export function useTraderStats(wallet: string | null | undefined): UseTraderStat
   const [stats, setStats] = useState<TraderStatsResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const requestSeqRef = useRef(0);
 
-  const fetch_ = useCallback(async () => {
-    if (!wallet) {
-      setStats(null);
-      return;
-    }
-    setLoading(true);
-    setError(null);
-    try {
-      const res = await fetch(`/api/trader/${wallet}/stats`);
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error ?? `HTTP ${res.status}`);
+  const fetch_ = useCallback(
+    async (requestSeq = requestSeqRef.current) => {
+      if (!wallet) {
+        setStats(null);
+        setLoading(false);
+        return;
       }
-      const data: TraderStatsResponse = await res.json();
-      setStats(data);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load stats");
-    } finally {
-      setLoading(false);
-    }
-  }, [wallet]);
+
+      const isCurrentRequest = () => requestSeqRef.current === requestSeq;
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const res = await fetch(`/api/trader/${wallet}/stats`);
+
+        if (!isCurrentRequest()) return;
+
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+
+          if (!isCurrentRequest()) return;
+
+          throw new Error(body.error ?? `HTTP ${res.status}`);
+        }
+
+        const data: TraderStatsResponse = await res.json();
+
+        if (!isCurrentRequest()) return;
+
+        setStats(data);
+      } catch (err) {
+        if (!isCurrentRequest()) return;
+
+        setError(err instanceof Error ? err.message : "Failed to load stats");
+      } finally {
+        if (isCurrentRequest()) {
+          setLoading(false);
+        }
+      }
+    },
+    [wallet],
+  );
 
   useEffect(() => {
-    fetch_();
-  }, [fetch_]);
+    requestSeqRef.current += 1;
+    const requestSeq = requestSeqRef.current;
 
-  return { stats, loading, error, refresh: fetch_ };
+    setStats(null);
+    setError(null);
+
+    if (wallet) {
+      void fetch_(requestSeq);
+    } else {
+      setLoading(false);
+    }
+
+    return () => {
+      requestSeqRef.current += 1;
+    };
+  }, [wallet, fetch_]);
+
+  const refresh = useCallback(() => {
+    requestSeqRef.current += 1;
+    const requestSeq = requestSeqRef.current;
+
+    setStats(null);
+    setError(null);
+
+    if (wallet) {
+      void fetch_(requestSeq);
+    } else {
+      setLoading(false);
+    }
+  }, [wallet, fetch_]);
+
+  return { stats, loading, error, refresh };
 }


### PR DESCRIPTION
## Summary

Fixes a trader stats race condition where stale `useTraderStats()` responses could update the UI after the active wallet changes.

## Root Cause

`useTraderStats()` fetched trader stats asynchronously but did not guard state updates against outdated requests. If a previous wallet request resolved after the user switched wallets, stale stats could overwrite the current wallet stats.

## Fix

- Added request sequencing to track the latest active stats request.
- Ignored stale fetch responses after wallet changes.
- Reset trader stats state when the wallet changes.
- Guarded loading and error updates against outdated requests.
- Added a regression test for stale wallet response handling.

## Why this matters

The trader stats panel should only show aggregate stats for the currently active wallet. This prevents old responses from showing stale or incorrect totals after fast wallet switching.

## Test Plan

- `pnpm exec vitest run __tests__/hooks/useTraderStats.test.ts`

## Risk

Low. This change is limited to frontend trader stats state handling and does not change backend APIs, trading logic, or on-chain instructions.