### PR TITLE
feat(trade): market switcher dropdown in the info bar

### DIFF
--- a/app/components/trade/MarketInfoBar.tsx
+++ b/app/components/trade/MarketInfoBar.tsx
@@ -6,6 +6,7 @@ import { useMarketInfo } from "@/hooks/useMarketInfo";
 import { useEngineState } from "@/hooks/useEngineState";
 import { useOracleFreshness } from "@/hooks/useOracleFreshness";
 import { MarketLogo } from "@/components/market/MarketLogo";
+import { MarketSwitcher } from "@/components/trade/MarketSwitcher";
 import { formatUsdFromNumber, formatMarkPrice } from "@/lib/format";
 
 interface MarketInfoBarProps {
@@ -143,14 +144,8 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol, log
       data-testid="market-info-bar"
       className="sticky top-0 z-30 w-full border-b border-[var(--border)] bg-[var(--bg)]/95 backdrop-blur-sm px-4 py-3 flex items-center gap-5 overflow-x-auto whitespace-nowrap scrollbar-none"
     >
-      {/* Symbol + Logo */}
-      <div className="flex items-center gap-2 shrink-0">
-        <MarketLogo logoUrl={logoUrl} mintAddress={mintAddress} symbol={symbol} size="sm" />
-        <span className="text-sm font-bold text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>
-          {symbol}/USD
-          <span className="ml-1.5 text-[9px] font-normal uppercase tracking-[0.12em] text-[var(--text-dim)]">PERP</span>
-        </span>
-      </div>
+      {/* Symbol + Logo — now a dropdown market switcher (top markets + search) */}
+      <MarketSwitcher slabAddress={slabAddress} symbol={symbol} logoUrl={logoUrl} mintAddress={mintAddress} />
 
       <span className="h-6 w-px bg-[var(--border)] shrink-0" />
 

--- a/app/components/trade/MarketSwitcher.tsx
+++ b/app/components/trade/MarketSwitcher.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useRouter } from "next/navigation";
+import { useAllMarketStats } from "@/hooks/useAllMarketStats";
+import { MarketLogo } from "@/components/market/MarketLogo";
+
+interface MarketSwitcherProps {
+  slabAddress: string;
+  symbol: string;
+  logoUrl?: string | null;
+  mintAddress?: string | null;
+}
+
+interface SwitcherRow {
+  slab: string;
+  symbol: string;
+  name: string | null;
+  priceUsd: number | null;
+  oiUsd: number;
+}
+
+/**
+ * The market title in the info bar, upgraded from a static label to a
+ * switcher: click → dropdown with the top markets by open interest and a
+ * search box, so switching markets doesn't require a round-trip through
+ * /markets.
+ *
+ * Positioning: the info bar is an `overflow-x-auto` scroll container (clips
+ * absolute children — the original Share dropdown bug, #2268) AND has
+ * `backdrop-blur`, whose backdrop-filter makes the bar the containing block
+ * for position:fixed descendants too — a fixed panel rendered inline gets
+ * re-anchored to the bar and clipped all the same. The panel is therefore
+ * PORTALED to document.body and placed from the trigger's
+ * boundingClientRect, clamped to the viewport.
+ */
+export const MarketSwitcher: FC<MarketSwitcherProps> = ({ slabAddress, symbol, logoUrl, mintAddress }) => {
+  const router = useRouter();
+  const { statsMap } = useAllMarketStats();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [panelPos, setPanelPos] = useState<{ left: number; top: number } | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const PANEL_W = 300;
+
+  const openPanel = useCallback(() => {
+    const rect = triggerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    // Clamp inside the viewport; drop below the trigger.
+    const left = Math.max(8, Math.min(rect.left, window.innerWidth - PANEL_W - 8));
+    setPanelPos({ left, top: rect.bottom + 6 });
+    setQuery("");
+    setOpen(true);
+  }, []);
+
+  // Focus the search box as soon as the panel mounts.
+  useEffect(() => {
+    if (open) inputRef.current?.focus();
+  }, [open]);
+
+  // Outside click / Escape close.
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      const t = e.target as Node;
+      if (panelRef.current?.contains(t) || triggerRef.current?.contains(t)) return;
+      setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const allMarkets = useMemo<SwitcherRow[]>(() => {
+    const rows: SwitcherRow[] = [];
+    for (const [slab, m] of statsMap) {
+      if (!m?.symbol) continue;
+      // Ranking score only: raw OI atoms × price. Playground markets share
+      // 6-decimal collateral, so cross-market ordering is sound; the exact
+      // USD figure is never displayed here.
+      const oiScore =
+        (typeof m.total_open_interest === "number" ? m.total_open_interest : 0) *
+        (typeof m.last_price === "number" ? m.last_price : 0);
+      rows.push({
+        slab,
+        symbol: String(m.symbol),
+        name: (m.name as string | null) ?? null,
+        priceUsd: typeof m.last_price === "number" ? m.last_price : null,
+        oiUsd: oiScore,
+      });
+    }
+    rows.sort((a, b) => b.oiUsd - a.oiUsd || a.symbol.localeCompare(b.symbol));
+    return rows;
+  }, [statsMap]);
+
+  const q = query.trim().toLowerCase();
+  const results = useMemo<SwitcherRow[]>(() => {
+    if (!q) return allMarkets.slice(0, 3); // top by OI when not searching
+    return allMarkets
+      .filter(
+        (r) =>
+          r.symbol.toLowerCase().includes(q) ||
+          (r.name ?? "").toLowerCase().includes(q) ||
+          r.slab.toLowerCase().startsWith(q),
+      )
+      .slice(0, 8);
+  }, [allMarkets, q]);
+
+  const goTo = useCallback(
+    (slab: string) => {
+      setOpen(false);
+      if (slab !== slabAddress) router.push(`/trade/${slab}`);
+    },
+    [router, slabAddress],
+  );
+
+  const fmtPrice = (p: number | null) =>
+    p == null ? "—" : p >= 1 ? `$${p.toFixed(2)}` : `$${p.toPrecision(4)}`;
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => (open ? setOpen(false) : openPanel())}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        title="Switch market"
+        className="group flex shrink-0 items-center gap-2 rounded-sm px-1 py-0.5 transition-colors hover:bg-[var(--bg-elevated)]"
+      >
+        <MarketLogo logoUrl={logoUrl} mintAddress={mintAddress} symbol={symbol} size="sm" />
+        <span className="text-sm font-bold text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>
+          {symbol}/USD
+          <span className="ml-1.5 text-[9px] font-normal uppercase tracking-[0.12em] text-[var(--text-secondary)]">PERP</span>
+        </span>
+        <span
+          aria-hidden="true"
+          className={`text-[9px] text-[var(--text-secondary)] transition-transform duration-150 group-hover:text-[var(--text)] ${open ? "rotate-180" : ""}`}
+        >
+          ▼
+        </span>
+      </button>
+
+      {open && panelPos && typeof document !== "undefined" && createPortal(
+        <div
+          ref={panelRef}
+          role="listbox"
+          aria-label="Switch market"
+          className="fixed z-50 border border-[var(--border)] bg-[var(--bg-elevated)]/95 shadow-xl backdrop-blur-sm"
+          style={{ left: panelPos.left, top: panelPos.top, width: PANEL_W }}
+        >
+          {/* Search */}
+          <div className="border-b border-[var(--border)]/60 p-2">
+            <input
+              ref={inputRef}
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && results.length > 0) goTo(results[0].slab);
+              }}
+              placeholder="Search markets…"
+              className="w-full rounded-none border border-[var(--border)]/40 bg-[var(--bg)] px-2 py-1.5 text-[12px] text-[var(--text)] placeholder-[var(--text-muted)] focus:border-[var(--accent)]/50 focus:outline-none focus:ring-1 focus:ring-[var(--accent)]/20"
+              style={{ fontFamily: "var(--font-mono)" }}
+            />
+          </div>
+
+          {/* Section label */}
+          <div className="px-3 pb-1 pt-2 text-[9px] font-medium uppercase tracking-[0.18em] text-[var(--text-secondary)]">
+            {q ? "Results" : "Top markets"}
+          </div>
+
+          {/* Rows */}
+          <div className="max-h-72 overflow-y-auto pb-1">
+            {results.length === 0 && (
+              <p className="px-3 py-3 text-[11px] text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-mono)" }}>
+                No markets match &quot;{query.trim()}&quot;
+              </p>
+            )}
+            {results.map((r) => {
+              const isCurrent = r.slab === slabAddress;
+              return (
+                <button
+                  key={r.slab}
+                  type="button"
+                  role="option"
+                  aria-selected={isCurrent}
+                  onClick={() => goTo(r.slab)}
+                  className={`flex w-full items-center justify-between gap-2 px-3 py-2 text-left transition-colors hover:bg-[var(--bg-surface)] ${
+                    isCurrent ? "bg-[var(--accent)]/[0.06]" : ""
+                  }`}
+                >
+                  <span className="min-w-0">
+                    <span className={`block truncate text-[12px] font-bold ${isCurrent ? "text-[var(--accent)]" : "text-[var(--text)]"}`} style={{ fontFamily: "var(--font-mono)" }}>
+                      {r.symbol}/USD
+                      {isCurrent && <span className="ml-1.5 text-[8px] font-normal uppercase tracking-[0.12em] text-[var(--accent)]">current</span>}
+                    </span>
+                    {r.name && (
+                      <span className="block truncate text-[10px] text-[var(--text-secondary)]">{r.name}</span>
+                    )}
+                  </span>
+                  <span className="shrink-0 text-[11px] tabular-nums text-[var(--text-secondary)]" style={{ fontFamily: "var(--font-mono)" }}>
+                    {fmtPrice(r.priceUsd)}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+
+          {/* All markets link */}
+          <a
+            href="/markets"
+            className="block border-t border-[var(--border)]/60 px-3 py-2 text-[10px] uppercase tracking-[0.12em] text-[var(--text-secondary)] transition-colors hover:text-[var(--accent)]"
+          >
+            All markets →
+          </a>
+        </div>,
+        document.body,
+      )}
+    </>
+  );
+};


### PR DESCRIPTION
## What

Switching markets currently requires a round-trip through `/markets`. This turns the market title in the trade page's info bar into a **market switcher**:

- Click `SOL-PERP/USD ▾` → dropdown with a **search box** (auto-focused) and the **top 3 markets by open interest** (symbol, name, price per row)
- Type to search **all** markets by symbol, name, or slab address — `Enter` jumps to the first match, `Esc`/outside-click closes
- Current market is highlighted with a "current" tag when it appears in results
- "All markets →" footer link keeps the full browser page one click away
- Data comes from the existing `useAllMarketStats` SWR cache (no new fetches; 30s shared poll)

Styled to the terminal theme: mono uppercase section labels, `--border`/`--bg-elevated` panel, no new colors.

## The rendering trap (why the panel is portaled)

The info bar is an `overflow-x-auto` scroll container **and** has `backdrop-blur`. The first clips absolutely-positioned children (the invisible-Share-dropdown bug fixed in #2268); the second is nastier — `backdrop-filter` establishes a **containing block for `position: fixed` descendants**, so even a fixed-position panel rendered inline gets re-anchored into the bar and clipped. Reproduced both failure modes during development.

The panel is therefore rendered via `createPortal(document.body)` with viewport-clamped coordinates from the trigger's rect — immune to both. Comment in the component documents the trap for the next dropdown someone adds to this bar.

## Testing (headless Chromium against the dev server)

- Panel opens with 3 top-OI rows; screenshot-verified clean layering over the chart
- Search "tru" → filters to TRUMP-PERP; `Enter` navigates to `/trade/Az9jz…`
- Outside click closes; zero page errors
- `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
