### PR TITLE
fix: clear token metadata on mint switch

### DIFF
--- a/app/__tests__/hooks/useTokenMeta.test.ts
+++ b/app/__tests__/hooks/useTokenMeta.test.ts
@@ -1,0 +1,116 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { PublicKey } from "@solana/web3.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useTokenMeta } from "../../hooks/useTokenMeta";
+
+type TokenMetaFixture = {
+  symbol: string;
+  name: string;
+  decimals: number;
+};
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+const testState = vi.hoisted(() => ({
+  stableConnection: {},
+  pendingByMint: {} as Record<string, Deferred<TokenMetaFixture>>,
+}));
+
+vi.mock("@/hooks/useWalletCompat", () => ({
+  useConnectionCompat: vi.fn(() => ({
+    connection: testState.stableConnection,
+  })),
+}));
+
+vi.mock("@/lib/mock-trade-data", () => ({
+  getMockSymbol: vi.fn(() => null),
+}));
+
+vi.mock("@/lib/tokenMeta", () => ({
+  fetchTokenMeta: vi.fn((_connection: unknown, mint: PublicKey) => {
+    const pending = testState.pendingByMint[mint.toBase58()];
+
+    if (!pending) {
+      throw new Error(`Unexpected mint ${mint.toBase58()}`);
+    }
+
+    return pending.promise;
+  }),
+}));
+
+describe("useTokenMeta", () => {
+  const mintA = new PublicKey("11111111111111111111111111111111");
+  const mintB = new PublicKey("So11111111111111111111111111111111111111112");
+
+  beforeEach(() => {
+    testState.pendingByMint = {
+      [mintA.toBase58()]: deferred<TokenMetaFixture>(),
+      [mintB.toBase58()]: deferred<TokenMetaFixture>(),
+    };
+  });
+
+  it("clears previous token metadata while loading a new mint", async () => {
+    const { result, rerender } = renderHook(({ mint }) => useTokenMeta(mint), {
+      initialProps: { mint: mintA },
+    });
+
+    await act(async () => {
+      testState.pendingByMint[mintA.toBase58()].resolve({
+        symbol: "AAA",
+        name: "Token A",
+        decimals: 6,
+      });
+
+      await testState.pendingByMint[mintA.toBase58()].promise;
+    });
+
+    await waitFor(() => {
+      expect(result.current).toMatchObject({
+        symbol: "AAA",
+        name: "Token A",
+        decimals: 6,
+      });
+    });
+
+    rerender({ mint: mintB });
+
+    await waitFor(() => {
+      expect(result.current).toBeNull();
+    });
+
+    await act(async () => {
+      testState.pendingByMint[mintB.toBase58()].resolve({
+        symbol: "BBB",
+        name: "Token B",
+        decimals: 9,
+      });
+
+      await testState.pendingByMint[mintB.toBase58()].promise;
+    });
+
+    await waitFor(() => {
+      expect(result.current).toMatchObject({
+        symbol: "BBB",
+        name: "Token B",
+        decimals: 9,
+      });
+    });
+  });
+});

--- a/app/hooks/useTokenMeta.ts
+++ b/app/hooks/useTokenMeta.ts
@@ -20,6 +20,9 @@ export function useTokenMeta(mint: PublicKey | null): TokenMeta | null {
       return;
     }
 
+    // Clear previous token metadata immediately while loading a new mint.
+    setMeta(null);
+
     // Check if this mint belongs to a mock slab (design testing)
     const mintStr = mint.toBase58();
     const mockSym = getMockSymbol(mintStr);


### PR DESCRIPTION
## Summary

Fixes a token metadata UI issue where `useTokenMeta()` could keep showing metadata from the previous mint while a new mint is loading.

## Root Cause

`useTokenMeta()` only cleared metadata when `mint` was null. When switching directly from one mint to another, the previous token metadata could remain visible until the new `fetchTokenMeta()` request resolved.

## Fix

- Clear previous token metadata immediately when a new mint starts loading.
- Keep the existing cancellation guard for stale metadata fetches.
- Added a regression test covering mint switch behavior.

## Why this matters

Trade and market UI components depend on token metadata for symbols, names, and decimals. Clearing stale metadata prevents users from briefly seeing token information from the previous market/mint.

## Test Plan

- `pnpm exec vitest run __tests__/hooks/useTokenMeta.test.ts`

## Risk

Low. This change is limited to frontend token metadata state handling and does not change backend APIs, trading logic, or on-chain instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Metadata now clears immediately when switching between tokens, preventing stale token details from briefly appearing during loading.
* **Tests**
  * Added coverage for token metadata loading behavior, including switching between mints and verifying the state resets before new data loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->