### PR TITLE
style(design-system): modernize typography, panel depth, and sizing floor

### DIFF
--- a/app/app/globals.css
+++ b/app/app/globals.css
@@ -7,7 +7,7 @@
   --bg: #0A0A0F;
   --bg-elevated: #0F1018;
   --bg-surface: #141820;
-  --panel-bg: #0D0E15;
+  --panel-bg: rgba(13, 14, 21, 0.75);
   --border: #1C1F2E;
   --border-subtle: #14161F;
   --border-hover: #2A2E42;
@@ -114,7 +114,7 @@
   --bg:           #F8F8FC;
   --bg-elevated:  #FFFFFF;
   --bg-surface:   #F2F2F8;
-  --panel-bg:     #FAFAFD;
+  --panel-bg:     rgba(250, 250, 253, 0.85);
 
   /* Borders */
   --border:        #E0E0EC;
@@ -199,10 +199,10 @@ html {
   --color-theme-nav-text: var(--text);
   --color-theme-panel: var(--panel-bg);
 
-  --font-sans: var(--font-jetbrains-mono), var(--font-geist-mono), monospace;
+  --font-sans: var(--font-jakarta), var(--font-outfit), var(--font-space-grotesk), system-ui;
   --font-mono: var(--font-jetbrains-mono), var(--font-geist-mono), monospace;
   --font-display: var(--font-outfit), var(--font-space-grotesk), system-ui;
-  --font-heading: var(--font-jetbrains-mono), var(--font-geist-mono), monospace;
+  --font-heading: var(--font-jakarta), var(--font-outfit), var(--font-space-grotesk), system-ui;
 
   /* Custom Animations & Keyframes for Tailwind v4 */
   --animate-shimmer-sweep: shimmer-sweep 1.6s cubic-bezier(0.4, 0, 0.2, 1) infinite;
@@ -377,6 +377,8 @@ body::before {
 /* ─── HUD Corner Brackets (cards) ─── */
 .hud-corners {
   position: relative;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
 }
 .hud-corners::before {
   content: "";
@@ -1169,6 +1171,39 @@ input[type="range"].leverage-slider:focus-visible::-moz-range-thumb {
 
 /* ─── Button Component Layer ─── */
 @layer components {
+  /* ─── Typography Scales ─── */
+  .label-small {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--text-secondary);
+  }
+  @media (min-width: 640px) {
+    .label-small {
+      font-size: 11px;
+    }
+  }
+
+  .label-caption {
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--text-secondary);
+  }
+
+  .heading-page {
+    font-family: var(--font-display);
+    font-size: 1.5rem; /* 24px */
+    font-weight: 500;
+    letter-spacing: -0.01em;
+    color: var(--text);
+  }
+  @media (min-width: 640px) {
+    .heading-page {
+      font-size: 1.875rem; /* 30px */
+    }
+  }
+
   .btn {
     display: inline-flex;
     align-items: center;
@@ -1290,6 +1325,26 @@ input[type="range"].leverage-slider:focus-visible::-moz-range-thumb {
     box-shadow: var(--btn-disabled-shadow) !important;
     cursor: var(--btn-disabled-cursor);
     pointer-events: none;
+  }
+
+  /* Global Inputs Focus Glow */
+  input[type="text"],
+  input[type="number"],
+  input[type="password"],
+  input[type="email"],
+  textarea,
+  select {
+    transition: border-color var(--timing-fast) ease, box-shadow var(--timing-fast) ease;
+  }
+  input[type="text"]:focus-visible,
+  input[type="number"]:focus-visible,
+  input[type="password"]:focus-visible,
+  input[type="email"]:focus-visible,
+  textarea:focus-visible,
+  select:focus-visible {
+    border-color: rgba(153, 69, 255, 0.5) !important;
+    box-shadow: 0 0 0 2px rgba(153, 69, 255, 0.15) !important;
+    outline: none !important;
   }
 }
 

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -2,7 +2,7 @@ import "@/lib/polyfills";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { Geist_Mono } from "next/font/google";
-import { Space_Grotesk, JetBrains_Mono, Outfit } from "next/font/google";
+import { Space_Grotesk, JetBrains_Mono, Outfit, Plus_Jakarta_Sans } from "next/font/google";
 import "./globals.css";
 import { Providers } from "./providers";
 import { Header } from "@/components/layout/Header";
@@ -30,6 +30,7 @@ const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"]
 const spaceGrotesk = Space_Grotesk({ variable: "--font-space-grotesk", subsets: ["latin"], weight: ["400", "500", "600", "700"], display: "swap" });
 const jetbrainsMono = JetBrains_Mono({ variable: "--font-jetbrains-mono", subsets: ["latin"], weight: ["400", "500", "600", "700"], display: "swap" });
 const outfit = Outfit({ variable: "--font-outfit", subsets: ["latin"], weight: ["400", "500", "600", "700"], display: "swap" });
+const plusJakartaSans = Plus_Jakarta_Sans({ variable: "--font-jakarta", subsets: ["latin"], weight: ["400", "500", "600", "700", "800"], display: "swap" });
 
 // PERC-695 (bug bounty — CSP static nonce): Force dynamic rendering so each request
 // generates a fresh layout render with the new per-request nonce from middleware.
@@ -86,7 +87,7 @@ export const metadata: Metadata = {
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const nonce = (await headers()).get("x-nonce") ?? undefined;
   return (
-    <html lang="en" suppressHydrationWarning data-scroll-behavior="smooth" className={`${geistMono.variable} ${spaceGrotesk.variable} ${jetbrainsMono.variable} ${outfit.variable}`}>
+    <html lang="en" suppressHydrationWarning data-scroll-behavior="smooth" className={`${geistMono.variable} ${spaceGrotesk.variable} ${jetbrainsMono.variable} ${outfit.variable} ${plusJakartaSans.variable}`}>
       <head>
         {/* suppressHydrationWarning: browsers blank the nonce content attribute after
             parsing (nonce hiding), so React's hydration diff always sees nonce="" vs

--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -637,8 +637,8 @@ function MarketsPageInner() {
               <div className="mb-2 text-[10px] font-medium uppercase tracking-[0.25em] text-[var(--accent)]/60">
                 // browse
               </div>
-              <h1 className="text-xl font-medium tracking-[-0.01em] text-[var(--text)] sm:text-2xl" style={{ fontFamily: "var(--font-heading)" }}>
-                <span className="font-normal text-[var(--text)]">All </span>Markets
+              <h1 className="heading-page">
+                <span className="font-normal">All </span>Markets
               </h1>
               <p className="mt-2 text-[13px] text-[var(--text-secondary)]">perpetual futures, pick your poison.</p>
             </div>

--- a/app/components/trade/MarketInfoBar.tsx
+++ b/app/components/trade/MarketInfoBar.tsx
@@ -203,7 +203,7 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol, log
       <div className="flex flex-1 items-center gap-5 min-w-0">
         {/* Volume 24h */}
         <div className="flex flex-col shrink-0">
-          <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">Vol 24h</span>
+          <span className="label-small">Vol 24h</span>
           <span
             className={`text-xs font-medium ${volume == null ? "text-[var(--text-dim)]" : "text-[var(--text)]"}`}
             style={{ fontFamily: "var(--font-mono)" }}
@@ -214,7 +214,7 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol, log
 
         {/* OI */}
         <div className="flex flex-col shrink-0">
-          <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">Open Interest</span>
+          <span className="label-small">Open Interest</span>
           <span className="text-xs font-medium text-[var(--text)]" style={{ fontFamily: "var(--font-mono)" }}>
             {formatCompact(oi as number)}
           </span>
@@ -222,7 +222,7 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol, log
 
         {/* 5.6: 24h High */}
         <div className="flex flex-col shrink-0">
-          <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">24h High</span>
+          <span className="label-small">24h High</span>
           <span className="text-xs font-medium text-[var(--long)]" style={{ fontFamily: "var(--font-mono)" }}>
             {formatUsdFromNumber(high24h)}
           </span>
@@ -230,7 +230,7 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol, log
 
         {/* 5.6: 24h Low */}
         <div className="flex flex-col shrink-0">
-          <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">24h Low</span>
+          <span className="label-small">24h Low</span>
           <span className="text-xs font-medium text-[var(--short)]" style={{ fontFamily: "var(--font-mono)" }}>
             {formatUsdFromNumber(low24h)}
           </span>
@@ -249,7 +249,7 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol, log
         {/* Funding Rate — P3-6: pr-2 padding prevents right-edge clipping */}
         {funding8h != null && (
           <div className="flex flex-col shrink-0 pr-2">
-            <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">Funding / 8h</span>
+            <span className="label-small">Funding / 8h</span>
             <span className={`text-xs font-semibold ${fundingColor}`} style={{ fontFamily: "var(--font-mono)" }}>
               {funding8h >= 0 ? "+" : ""}{funding8h.toFixed(4)}%
             </span>

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -881,8 +881,8 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
       {/* Single validation banner (highest-priority issue only) */}
       {blockingIssue && (
         <div className="mb-3 rounded-none border border-[var(--warning)]/30 bg-[var(--warning)]/5 p-2.5">
-          <p className="text-[9px] font-bold uppercase tracking-[0.15em] text-[var(--warning)]">{blockingIssue.title}</p>
-          <p className="mt-1 text-[9px] leading-relaxed text-[var(--text-secondary)]">{blockingIssue.message}</p>
+          <p className="label-small !text-[var(--warning)]">{blockingIssue.title}</p>
+          <p className="mt-1 label-caption">{blockingIssue.message}</p>
         </div>
       )}
 
@@ -988,7 +988,7 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
           label; Buying Power is the one distinct figure worth a second look. */}
       <div className="mt-3 flex items-center justify-between border-t border-[var(--border)]/30 pt-2.5 text-[10px]">
         <div>
-          <div className="flex items-center gap-1 text-[9px] uppercase tracking-[0.1em] text-[var(--text-secondary)]">
+          <div className="flex items-center gap-1 label-small">
             Buying power
             <InfoIcon tooltip="Available balance x max leverage - the largest notional you could open right now." />
           </div>


### PR DESCRIPTION
## Design System & UX Modernization (Restructured)

Following developer feedback, this PR has been updated to **exclude the primary CTA color revert** (keeping the sky-blue \#0ea5e9\ main CTA color as intended to differentiate actions). It now focuses solely on typography scale, layout depth, and sizing floor improvements:

### 1. Typography & Sizing Floor
*   **Plus Jakarta Sans:** Imported from Google Fonts in [layout.tsx](file:///c:/Users/PC/Documents/antigravity/brave-hubble/percolator-launch/app/app/layout.tsx) and mapped to \--font-sans\ and \--font-heading\ for body copy, form fields, and page titles.
*   **Typographic Utility Classes:** Defined \.label-small\, \.label-caption\, and \.heading-page\ inside [globals.css](file:///c:/Users/PC/Documents/antigravity/brave-hubble/percolator-launch/app/app/globals.css) to replace inline custom text tags and establish a consistent 10px-11px sizing floor for small labels.
*   **Monospace Role:** Retained \JetBrains Mono\ strictly for tabular data, balances, price feeds, hashes, and charts to keep numbers from shifting.

### 2. Glassmorphic Card Depth
*   **Translucent Backgrounds:** Configured \--panel-bg\ with light transparency (\gba(13, 14, 21, 0.75)\ for dark, \gba(250, 250, 253, 0.85)\ for light).
*   **Card Blur:** Added \ackdrop-filter: blur(12px)\ to \.hud-corners\ globally to make cards and dashboards feel layered.

### 3. Interactive Polish
*   **Input Focus Halos:** Standardized border colors and added a soft purple glow on text, number, and select inputs when focused.

### Verification Done
*   Verified computed styles on \http://localhost:3000/\ and verified that headings scale correctly (from 24px on mobile to 30px on desktop) and body font-family computes to \Plus Jakarta Sans\.