### PR TITLE
fix(trade): brighten confirm-trade modal labels

### DIFF
--- a/app/components/trade/TradeConfirmationModal.tsx
+++ b/app/components/trade/TradeConfirmationModal.tsx
@@ -190,7 +190,7 @@ export const TradeConfirmationModal: FC<TradeConfirmationModalProps> = ({
           </h2>
           <button
             onClick={onCancel}
-            className="text-[var(--text-muted)] transition-colors hover:text-[var(--text)]"
+            className="text-[var(--text-secondary)] transition-colors hover:text-[var(--text)]"
             aria-label="Close"
           >
             <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -216,42 +216,42 @@ export const TradeConfirmationModal: FC<TradeConfirmationModalProps> = ({
         {/* Trade details */}
         <div className="mb-6 space-y-2 text-xs">
           <div className="flex justify-between">
-            <span className="text-[var(--text-dim)]">Position Size:</span>
+            <span className="text-[var(--text-secondary)]">Position Size:</span>
             <span className="font-mono font-medium text-[var(--text)]">
               {formatTokenAmount(positionSize, decimals)} {symbol}
             </span>
           </div>
           <div className="flex justify-between">
-            <span className="text-[var(--text-dim)]">Margin Required:</span>
+            <span className="text-[var(--text-secondary)]">Margin Required:</span>
             <span className="font-mono font-medium text-[var(--text)]">
               {formatTokenAmount(margin, decimals)} {settleSymbol}
             </span>
           </div>
           <div className="flex justify-between">
-            <span className="text-[var(--text-dim)]">{ORDER_LEVERAGE_LABEL}:</span>
+            <span className="text-[var(--text-secondary)]">{ORDER_LEVERAGE_LABEL}:</span>
             <span className="font-mono font-medium text-[var(--text)]">{formatLeverage(leverage)}</span>
           </div>
           {riskLeverage !== null && (
             <div className="flex justify-between">
-              <span className="text-[var(--text-dim)]">{RISK_LEVERAGE_LABEL}:</span>
+              <span className="text-[var(--text-secondary)]">{RISK_LEVERAGE_LABEL}:</span>
               <span className="font-mono font-medium text-[var(--text-secondary)]">{formatLeverage(riskLeverage)}</span>
             </div>
           )}
           <div className="flex justify-between">
-            <span className="text-[var(--text-dim)]">Trading Fee:</span>
+            <span className="text-[var(--text-secondary)]">Trading Fee:</span>
             <span className="font-mono font-medium text-[var(--text)]">
               {formatTokenAmount(tradingFee, decimals)} {settleSymbol}
             </span>
           </div>
           <div className="flex justify-between border-t border-[var(--border)]/30 pt-2">
-            <span className="text-[var(--text-dim)]">Est. Liquidation Price:</span>
+            <span className="text-[var(--text-secondary)]">Est. Liquidation Price:</span>
             <span className="font-mono font-medium text-[var(--short)]">
               {estimatedLiqPrice <= 0n ? "N/A" : `$${formatTokenAmount(estimatedLiqPrice, 6)}`}
             </span>
           </div>
           {worstFillPriceE6 != null && worstFillPriceE6 > 0n && (
             <div className="flex justify-between">
-              <span className="text-[var(--text-dim)]">
+              <span className="text-[var(--text-secondary)]">
                 {direction === "long" ? "Max Fill Price:" : "Min Fill Price:"}
               </span>
               <span className="font-mono font-medium text-[var(--text)]">


### PR DESCRIPTION
Continues the merged contrast series (#2238/#2258/#2259/#2267/#2271): the trade **confirmation modal** rendered every row label (Position Size, Margin Required, Order Lev., Risk Lev., Trading Fee, Est. Liquidation Price, Max Fill Price) in \--text-dim\ (~1.4:1 in dark theme) — the least readable text in the app at the exact moment a user commits funds. All bumped to \--text-secondary\ (~4.9:1); the close button moves muted→secondary, keeping its hover-to-full-text. Text-color classes only, 8 swaps, no logic. \	sc\ clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)