### PR TITLE
fix(trade): crank before v17 withdraw with an open position

### DIFF
--- a/app/components/trade/DepositWithdrawCard.tsx
+++ b/app/components/trade/DepositWithdrawCard.tsx
@@ -289,8 +289,14 @@ export const DepositWithdrawCard: FC<DepositWithdrawCardProps> = ({ slabAddress,
       </div>
 
       {mode === "withdraw" && hasOpenPosition && (
-        <div className="mb-2 border border-[var(--warning)]/20 bg-[var(--warning)]/[0.04] p-2">
+        <div className="mb-2 border border-[var(--warning)]/20 bg-[var(--warning)]/[0.04] p-2 space-y-1">
           <p className="text-[10px] text-[var(--warning)]">⚠ Withdrawing margin with an open position may trigger liquidation</p>
+          <p className="text-[10px] text-[var(--text-secondary)]">
+            Part of your balance is locked as margin backing the position — the
+            program rejects withdrawals that would under-collateralize it, so
+            the full balance (MAX) may not be withdrawable until the position
+            is closed.
+          </p>
         </div>
       )}
 

--- a/app/hooks/useWithdraw.ts
+++ b/app/hooks/useWithdraw.ts
@@ -9,6 +9,7 @@ import {
   CrankAction,
   ACCOUNTS_WITHDRAW_COLLATERAL,
   ACCOUNTS_KEEPER_CRANK,
+  ACCOUNTS_PERMISSIONLESS_CRANK_BASE,
   buildAccountMetas,
   WELL_KNOWN,
   buildIx,
@@ -95,6 +96,8 @@ export function useWithdraw(slabAddress: string) {
         } catch { /* fall through — layout detection best-effort */ }
 
         const isV17 = slabDataForLayout ? isV17Account(slabDataForLayout) : false;
+        // Set when the v17 path prepends a crank — bumps the CU budget below.
+        let v17CrankIncluded = false;
 
         if (isV17) {
           // ── v17 withdraw path ─────────────────────────────────────────────
@@ -150,9 +153,11 @@ export function useWithdraw(slabAddress: string) {
           // with "insufficient margin" if the withdrawal would under-collateralize
           // the open position). This check never blocks a valid withdrawal; it only
           // catches the unambiguous "more than the whole account" case early.
+          let hasActiveLegs = false;
           if (portfolioData) {
             try {
               const portfolio = parsePortfolioV17(portfolioData);
+              hasActiveLegs = portfolio.legs.some((l) => l.active);
               if (params.amount > portfolio.capital) {
                 throw new Error(
                   "Withdrawal amount exceeds your account balance. Reduce the amount and try again.",
@@ -167,6 +172,30 @@ export function useWithdraw(slabAddress: string) {
                 throw checkErr;
               }
             }
+          }
+
+          // With an OPEN POSITION the program must value the portfolio at fresh
+          // state before releasing margin — a standalone withdraw rejects with
+          // StaleData (code 19) unless something cranked recently. Trades solve
+          // this by prepending PermissionlessCrank(FeeSweep) in the same tx
+          // (see useTrade), which is why "close, then withdraw" worked while a
+          // plain withdraw said "market data is stale". Mirror the trade flow
+          // exactly: crank only when the portfolio has active legs (cranking an
+          // empty portfolio returns EngineNonProgress 0x16 and aborts the tx).
+          if (hasActiveLegs && portfolioPk) {
+            v17CrankIncluded = true;
+            const crankKeys = buildAccountMetas(ACCOUNTS_PERMISSIONLESS_CRANK_BASE, [
+              wallet.publicKey, slabPk, portfolioPk,
+            ]);
+            // For Pyth mode, append oracle feed account as tail (same as useTrade)
+            if (!useAdminOracle) {
+              crankKeys.push({ pubkey: oracleAccount, isSigner: false, isWritable: false });
+            }
+            instructions.push(buildIx({
+              programId,
+              keys: crankKeys,
+              data: encodePermissionlessCrank({ action: CrankAction.FeeSweep, assetIndex: 0, nowSlot: 0n, closeQ: 0n, feeBps: 0n, recoveryReason: 0 }),
+            }));
           }
 
           instructions.push(buildIx({
@@ -205,7 +234,9 @@ export function useWithdraw(slabAddress: string) {
           }));
         }
 
-        const sig = await sendTx({ connection, wallet, instructions, computeUnits: 300_000 });
+        // 600k CU when the v17 crank rides along (matches useTrade's
+        // crank+trade budget); all pre-existing paths keep the original 300k.
+        const sig = await sendTx({ connection, wallet, instructions, computeUnits: v17CrankIncluded ? 600_000 : 300_000 });
         // Force immediate slab re-read so balance updates without waiting for the next poll.
         refreshSlab();
         setTimeout(() => refreshSlab(), 2000);


### PR DESCRIPTION
## Bug

Withdrawing while holding an **open position** on a v17 market fails every time with *"Market data is stale — a fresh price/crank is needed"* (program error 19). Close the position and the same withdrawal succeeds immediately.

That symptom pair is the tell: the v17 `Withdraw` path is built standalone — the code even says so (*"crank is NOT prepended (v17 Withdraw is standalone)"*) — but with an open position the program must value the portfolio at fresh state before releasing margin, so a standalone withdraw rejects with `StaleData` unless something happened to crank recently. **Trades never hit this because `useTrade` prepends `PermissionlessCrank(FeeSweep)` in the same transaction** — which is also why "close, then withdraw" works: the close just cranked.

## Fix

Mirror the trade flow exactly in `useWithdraw`'s v17 path:

- Prepend the same `PermissionlessCrank(FeeSweep)` instruction — same encoder args, same `ACCOUNTS_PERMISSIONLESS_CRANK_BASE` metas (`[owner, market, portfolio]`), same conditional Pyth oracle tail — **only when the portfolio has active legs** (same guard as `useTrade`: cranking an empty portfolio returns `EngineNonProgress` and would abort the tx). The legs check parses the portfolio buffer the hook already fetched — zero extra RPC.
- CU budget 600k when the crank rides along (matches `useTrade`'s crank+trade budget); every pre-existing path keeps 300k.
- v12 path untouched (it always prepended a crank).

Also extends the withdraw card's open-position warning: part of the balance is locked as margin, so MAX may exceed what's withdrawable until the position closes. (With staleness out of the way, an over-withdraw now surfaces the program's real answer — error 49, "Insufficient margin" — instead of the stale red herring.)

## Safety / verification

- The added instruction is permissionless and touches **no token accounts** — it cannot move funds; worst case the tx reverts atomically as before
- `npx tsc --noEmit` clean
- `useWithdraw` suite: **zero new failures** — 3 failed / 21 passed both with and without this change (those 3 are the pre-existing breakage on the branch tip, see the note in #2261)
- End-to-end (wallet-signed) verification performed on the playground by the reporting user: withdraw-with-open-position previously failed with the stale error and now needs re-testing post-fix — flagged to them; the instruction construction is line-for-line the one every successful trade already sends

🤖 Generated with [Claude Code](https://claude.com/claude-code)
