### PR TITLE
fix(trade): poll engine state while market is stale

### DIFF
--- a/app/components/trade/TradeForm.tsx
+++ b/app/components/trade/TradeForm.tsx
@@ -87,6 +87,17 @@ export const TradeForm: FC<{ slabAddress: string }> = ({ slabAddress }) => {
   const { level: oracleLevel, mode: oracleMode, ready: oracleReady } = useOracleFreshness();
   const oracleUnavailable = oracleLevel === "unavailable";
   const oracleStale = oracleUnavailable || (oracleReady && oracleLevel === "stale" && (oracleMode === "admin" || oracleMode === "hyperp"));
+
+// Keep the trade form in sync with keeper/crank updates while the market is stale.
+// The submit guard already blocks stale oracle states; this short polling window
+// refreshes the slab engine state so trading can re-enable once a fresh crank lands.
+useEffect(() => {
+  if (mockMode || (!oracleUnavailable && !oracleStale)) return;
+
+  refreshSlab();
+  const id = window.setInterval(refreshSlab, 5_000);
+  return () => window.clearInterval(id);
+}, [mockMode, oracleUnavailable, oracleStale, refreshSlab]);
   const openWalletModal = usePrivyLogin();
   const mintAddress = mktConfig?.collateralMint?.toBase58() ?? "";
   const collateralSymbol = sanitizeSymbol(tokenMeta?.symbol, mintAddress);


### PR DESCRIPTION
## Summary

This PR improves the Trade page stale-market UX by polling the slab/engine state while the market is in a stale or unavailable oracle state.

The TradeForm already blocks trade submission when oracle data is stale/unavailable, but the UI could stay in that stale state until the next normal slab refresh or until the user manually reloads the page. This change adds a focused polling window while the market is stale, so the form can automatically re-sync once a fresh crank/engine update lands.

## Changes

- Reuses the existing `refreshSlab` callback from `SlabProvider`.
- Starts polling only when `oracleUnavailable` or `oracleStale` is true.
- Stops polling automatically once the market becomes fresh again.
- Keeps the existing stale-market submit guard unchanged.
- Does not modify trade instruction building, transaction logic, collateral/deposit behavior, market parsing, or API routes.

## Validation

- `pnpm build` passes.
- `git diff --check` passes.
- Only `app/components/trade/TradeForm.tsx` is changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trade form reliability by automatically refreshing market data when oracle information is stale or unavailable.
  * Added ongoing refresh checks until the data becomes current, helping keep trading inputs up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->