### PR TITLE
feat(trade): one-click trading, TP/SL chart lines, risk gauges, snapping leverage slider

### DIFF
--- a/app/components/trade/MarketBookCard.tsx
+++ b/app/components/trade/MarketBookCard.tsx
@@ -92,7 +92,9 @@ export const MarketBookCard: FC = () => {
       {/* 2.1: Price ladder — bigger fonts (Click to auto-populate Order Ticket) */}
       <div className="mb-2 grid grid-cols-3 gap-px border border-[var(--border)]/30">
         {/* Bid */}
-        <div
+        <button
+          type="button"
+          aria-label="Long at Bid price"
           onClick={() => {
             const event = new CustomEvent("percolator-book-click", {
               detail: { price: Number(bestBidE6) / 1e6, type: "bid" }
@@ -100,13 +102,15 @@ export const MarketBookCard: FC = () => {
             window.dispatchEvent(event);
           }}
           title="Click to Long at Bid price"
-          className="bg-[var(--bg)] p-2 text-center cursor-pointer hover:bg-[var(--long)]/[0.08] transition-colors duration-150 active:scale-98 select-none"
+          className="bg-[var(--bg)] p-2 text-center cursor-pointer hover:bg-[var(--long)]/[0.08] transition-colors duration-150 active:scale-98 select-none focus-visible:ring-1 focus-visible:ring-[var(--long)]/40"
         >
           <p className="text-[8px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Bid</p>
           <p className="text-[11px] font-medium text-[var(--long)]" style={{ fontFamily: "var(--font-mono)" }}>{formatUsdPriceE6(bestBidE6)}</p>
-        </div>
+        </button>
         {/* Oracle — subtle accent border + bg */}
-        <div
+        <button
+          type="button"
+          aria-label="Populate order at Oracle price"
           onClick={() => {
             const event = new CustomEvent("percolator-book-click", {
               detail: { price: Number(oraclePrice) / 1e6, type: "oracle" }
@@ -114,7 +118,7 @@ export const MarketBookCard: FC = () => {
             window.dispatchEvent(event);
           }}
           title="Click to populate Oracle price"
-          className="p-2 text-center border-x border-[var(--accent)]/20 bg-[var(--accent)]/[0.03] cursor-pointer hover:bg-[var(--accent)]/[0.08] transition-colors duration-150 active:scale-98 select-none"
+          className="p-2 text-center border-x border-[var(--accent)]/20 bg-[var(--accent)]/[0.03] cursor-pointer hover:bg-[var(--accent)]/[0.08] transition-colors duration-150 active:scale-98 select-none focus-visible:ring-1 focus-visible:ring-[var(--accent)]/40"
         >
           <p className="text-[8px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Oracle</p>
           <p
@@ -123,9 +127,11 @@ export const MarketBookCard: FC = () => {
           >
             {formatUsdPriceE6(oraclePrice)}
           </p>
-        </div>
+        </button>
         {/* Ask */}
-        <div
+        <button
+          type="button"
+          aria-label="Short at Ask price"
           onClick={() => {
             const event = new CustomEvent("percolator-book-click", {
               detail: { price: Number(bestAskE6) / 1e6, type: "ask" }
@@ -133,11 +139,11 @@ export const MarketBookCard: FC = () => {
             window.dispatchEvent(event);
           }}
           title="Click to Short at Ask price"
-          className="bg-[var(--bg)] p-2 text-center cursor-pointer hover:bg-[var(--short)]/[0.08] transition-colors duration-150 active:scale-98 select-none"
+          className="bg-[var(--bg)] p-2 text-center cursor-pointer hover:bg-[var(--short)]/[0.08] transition-colors duration-150 active:scale-98 select-none focus-visible:ring-1 focus-visible:ring-[var(--short)]/40"
         >
           <p className="text-[8px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Ask</p>
           <p className="text-[11px] font-medium text-[var(--short)]" style={{ fontFamily: "var(--font-mono)" }}>{formatUsdPriceE6(bestAskE6)}</p>
-        </div>
+        </button>
       </div>
 
       {/* 2.2: Spread row */}

--- a/app/components/trade/MarketBookCard.tsx
+++ b/app/components/trade/MarketBookCard.tsx
@@ -89,15 +89,33 @@ export const MarketBookCard: FC = () => {
         </button>
       </div>
 
-      {/* 2.1: Price ladder — bigger fonts */}
+      {/* 2.1: Price ladder — bigger fonts (Click to auto-populate Order Ticket) */}
       <div className="mb-2 grid grid-cols-3 gap-px border border-[var(--border)]/30">
         {/* Bid */}
-        <div className="bg-[var(--bg)] p-2 text-center">
+        <div
+          onClick={() => {
+            const event = new CustomEvent("percolator-book-click", {
+              detail: { price: Number(bestBidE6) / 1e6, type: "bid" }
+            });
+            window.dispatchEvent(event);
+          }}
+          title="Click to Long at Bid price"
+          className="bg-[var(--bg)] p-2 text-center cursor-pointer hover:bg-[var(--long)]/[0.08] transition-colors duration-150 active:scale-98 select-none"
+        >
           <p className="text-[8px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Bid</p>
           <p className="text-[11px] font-medium text-[var(--long)]" style={{ fontFamily: "var(--font-mono)" }}>{formatUsdPriceE6(bestBidE6)}</p>
         </div>
         {/* Oracle — subtle accent border + bg */}
-        <div className="p-2 text-center border-x border-[var(--accent)]/20 bg-[var(--accent)]/[0.03]">
+        <div
+          onClick={() => {
+            const event = new CustomEvent("percolator-book-click", {
+              detail: { price: Number(oraclePrice) / 1e6, type: "oracle" }
+            });
+            window.dispatchEvent(event);
+          }}
+          title="Click to populate Oracle price"
+          className="p-2 text-center border-x border-[var(--accent)]/20 bg-[var(--accent)]/[0.03] cursor-pointer hover:bg-[var(--accent)]/[0.08] transition-colors duration-150 active:scale-98 select-none"
+        >
           <p className="text-[8px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Oracle</p>
           <p
             className="text-[13px] font-medium text-[var(--text)]"
@@ -107,7 +125,16 @@ export const MarketBookCard: FC = () => {
           </p>
         </div>
         {/* Ask */}
-        <div className="bg-[var(--bg)] p-2 text-center">
+        <div
+          onClick={() => {
+            const event = new CustomEvent("percolator-book-click", {
+              detail: { price: Number(bestAskE6) / 1e6, type: "ask" }
+            });
+            window.dispatchEvent(event);
+          }}
+          title="Click to Short at Ask price"
+          className="bg-[var(--bg)] p-2 text-center cursor-pointer hover:bg-[var(--short)]/[0.08] transition-colors duration-150 active:scale-98 select-none"
+        >
           <p className="text-[8px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Ask</p>
           <p className="text-[11px] font-medium text-[var(--short)]" style={{ fontFamily: "var(--font-mono)" }}>{formatUsdPriceE6(bestAskE6)}</p>
         </div>

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -751,45 +751,59 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
             <span className="text-[11px] font-medium text-[var(--text)]">x</span>
           </div>
         </div>
-        {/* Unified snapping slider — steps are indices into availableLeverage */}
-        {availableLeverage.length > 1 && (() => {
-          const snapIdx = availableLeverage.indexOf(leverage) !== -1
-            ? availableLeverage.indexOf(leverage)
-            : availableLeverage.reduce((best, val, i) =>
-                Math.abs(val - leverage) < Math.abs(availableLeverage[best] - leverage) ? i : best, 0);
-          const fillPct = availableLeverage.length > 1 ? (snapIdx / (availableLeverage.length - 1)) * 100 : 0;
+        {/* Unified continuous slider with snapping tick marks */}
+        {maxLeverage > 1 && (() => {
+          // Snap magnitude: snap if within half the smallest gap between adjacent snap points
+          const snapRadius = availableLeverage.length > 1
+            ? Math.floor(Math.min(...availableLeverage.slice(1).map((v, i) => v - availableLeverage[i])) / 2)
+            : 0;
+
+          const handleChange = (raw: number) => {
+            if (snapRadius > 0) {
+              const nearest = availableLeverage.reduce((best, v) =>
+                Math.abs(v - raw) < Math.abs(best - raw) ? v : best, raw);
+              if (Math.abs(nearest - raw) <= snapRadius) {
+                updateLeverage(nearest);
+                return;
+              }
+            }
+            updateLeverage(raw);
+          };
+
+          const fillPct = maxLeverage > 1 ? ((leverage - 1) / (maxLeverage - 1)) * 100 : 0;
+
           return (
-            <div className="relative px-0 pb-5">
-              {/* Track + filled portion */}
-              <div className="relative h-[3px] rounded-full bg-[var(--border)]/30 mt-3">
+            <div className="relative pb-5">
+              {/* Visual track */}
+              <div className="relative h-[3px] rounded-full bg-[var(--border)]/30 mt-3 mx-0">
+                {/* Filled portion */}
                 <div
-                  className="absolute left-0 top-0 h-full rounded-full bg-[var(--accent)] transition-[width] duration-75"
+                  className="absolute left-0 top-0 h-full rounded-full bg-[var(--accent)]"
                   style={{ width: `${fillPct}%` }}
                 />
-                {/* Tick marks */}
-                {availableLeverage.map((l, i) => {
-                  const pct = availableLeverage.length > 1 ? (i / (availableLeverage.length - 1)) * 100 : 0;
+                {/* Snap point tick marks — purely visual, also clickable */}
+                {availableLeverage.map((l) => {
+                  const pct = maxLeverage > 1 ? ((l - 1) / (maxLeverage - 1)) * 100 : 0;
                   const isActive = leverage >= l;
+                  const isCurrent = leverage === l;
                   return (
                     <button
                       key={l}
                       type="button"
                       aria-label={`Set leverage to ${l}x`}
                       onClick={() => updateLeverage(l)}
-                      className="absolute top-1/2 -translate-x-1/2 -translate-y-1/2 group"
+                      className="absolute top-1/2 -translate-x-1/2 -translate-y-1/2 group z-10"
                       style={{ left: `${pct}%` }}
                     >
-                      {/* Tick dot */}
-                      <span className={`block h-2.5 w-2.5 rounded-full border-2 transition-colors duration-100 ${
-                        leverage === l
-                          ? "border-[var(--accent)] bg-[var(--accent)] scale-125"
+                      <span className={`block rounded-full border-2 transition-all duration-100 ${
+                        isCurrent
+                          ? "h-3 w-3 border-[var(--accent)] bg-[var(--accent)]"
                           : isActive
-                            ? "border-[var(--accent)] bg-[var(--accent)]/30 group-hover:bg-[var(--accent)]/60"
-                            : "border-[var(--border)] bg-[var(--panel-bg)] group-hover:border-[var(--accent)]/50"
+                            ? "h-2.5 w-2.5 border-[var(--accent)] bg-[var(--accent)]/40 group-hover:bg-[var(--accent)]/70"
+                            : "h-2.5 w-2.5 border-[var(--border)] bg-[var(--panel-bg)] group-hover:border-[var(--accent)]/60"
                       }`} />
-                      {/* Label below */}
-                      <span className={`absolute top-3.5 left-1/2 -translate-x-1/2 text-[8px] whitespace-nowrap font-mono transition-colors duration-100 ${
-                        leverage === l ? "text-[var(--accent)] font-bold" : "text-[var(--text-dim)] group-hover:text-[var(--text-secondary)]"
+                      <span className={`absolute top-3.5 left-1/2 -translate-x-1/2 whitespace-nowrap text-[8px] font-mono transition-colors duration-100 ${
+                        isCurrent ? "text-[var(--accent)] font-bold" : "text-[var(--text-dim)] group-hover:text-[var(--text-secondary)]"
                       }`}>
                         {l}x
                       </span>
@@ -797,24 +811,24 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
                   );
                 })}
               </div>
-              {/* Invisible range input overlaid for drag behaviour */}
+              {/* Full-range input overlay — continuous, step 1 */}
               <input
                 type="range"
-                min={0}
-                max={availableLeverage.length - 1}
+                min={1}
+                max={maxLeverage}
                 step={1}
-                value={snapIdx}
-                onChange={(e) => updateLeverage(availableLeverage[Number(e.target.value)])}
-                className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+                value={leverage}
+                onChange={(e) => handleChange(Number(e.target.value))}
+                className="absolute inset-0 w-full h-full opacity-0 cursor-pointer z-20"
                 aria-label="Leverage"
               />
             </div>
           );
         })()}
-        {/* Fallback for single-leverage markets */}
-        {availableLeverage.length === 1 && (
-          <p className="text-[9px] text-[var(--text-dim)] font-mono">{availableLeverage[0]}x (fixed)</p>
+        {maxLeverage <= 1 && (
+          <p className="text-[9px] text-[var(--text-dim)] font-mono">{maxLeverage}x (fixed)</p>
         )}
+
       </div>
 
 

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -753,51 +753,52 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
         </div>
         {maxLeverage > 1 ? (
           <>
-            <input
-              type="range"
-              min={1}
-              max={maxLeverage}
-              step={1}
-              value={leverage}
-              onChange={(e) => {
-                const raw = Number(e.target.value);
-                // Magnetic snap: if within half the smallest inter-point gap, snap
-                const nearest = availableLeverage.reduce((best, v) =>
-                  Math.abs(v - raw) < Math.abs(best - raw) ? v : best, raw);
-                const snapRadius = availableLeverage.length > 1
-                  ? Math.floor(Math.min(...availableLeverage.slice(1).map((v, i) => v - availableLeverage[i])) / 2)
-                  : 0;
-                updateLeverage(Math.abs(nearest - raw) <= snapRadius ? nearest : raw);
-              }}
-              className="leverage-slider w-full cursor-pointer"
-              style={{
-                background: `linear-gradient(to right, var(--accent) ${
-                  maxLeverage > 1 ? ((leverage - 1) / (maxLeverage - 1)) * 100 : 0
-                }%, var(--border) ${
-                  maxLeverage > 1 ? ((leverage - 1) / (maxLeverage - 1)) * 100 : 0
-                }%)`,
-              }}
-              aria-label="Leverage"
-            />
-            {/* Snap-point labels — uniformly spaced reference */}
-            <div className="mt-1 flex justify-between">
-              {availableLeverage.map((l) => (
-                <button
-                  key={l}
-                  type="button"
-                  onClick={() => updateLeverage(l)}
-                  className={`text-[8px] font-mono transition-colors duration-100 ${
-                    leverage === l
-                      ? "text-[var(--accent)] font-bold"
-                      : "text-[var(--text-dim)] hover:text-[var(--text-secondary)]"
-                  }`}
-                >
-                  {l}x
-                </button>
-              ))}
-            </div>
+            {(() => {
+              const n = availableLeverage.length;
+              // Find closest snap index to current leverage (for when text input sets a between-point value)
+              const snapIdx = availableLeverage.reduce(
+                (best, v, i) => Math.abs(v - leverage) < Math.abs(availableLeverage[best] - leverage) ? i : best,
+                0,
+              );
+              const fillPct = n > 1 ? (snapIdx / (n - 1)) * 100 : 0;
+              return (
+                <>
+                  <input
+                    type="range"
+                    min={0}
+                    max={n - 1}
+                    step={1}
+                    value={snapIdx}
+                    onChange={(e) => updateLeverage(availableLeverage[Number(e.target.value)])}
+                    className="leverage-slider w-full cursor-pointer"
+                    style={{
+                      background: `linear-gradient(to right, var(--accent) ${fillPct}%, var(--border) ${fillPct}%)`,
+                    }}
+                    aria-label="Leverage"
+                  />
+                  {/* Labels uniformly spaced — one per snap point, aligns with slider steps */}
+                  <div className="mt-1 flex justify-between">
+                    {availableLeverage.map((l) => (
+                      <button
+                        key={l}
+                        type="button"
+                        onClick={() => updateLeverage(l)}
+                        className={`text-[8px] font-mono transition-colors duration-100 ${
+                          leverage === l
+                            ? "text-[var(--accent)] font-bold"
+                            : "text-[var(--text-dim)] hover:text-[var(--text-secondary)]"
+                        }`}
+                      >
+                        {l}x
+                      </button>
+                    ))}
+                  </div>
+                </>
+              );
+            })()}
           </>
         ) : (
+
           <p className="text-[9px] text-[var(--text-dim)] font-mono">{maxLeverage}x (fixed)</p>
         )}
       </div>

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -755,17 +755,17 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
         </div>
       </div>
 
-      {/* TP/SL Simulation HUD (Horizontal scrollable chips) */}
+      {/* TP/SL Simulation HUD (Bloomberg-style High-Info 2x2 Grid) */}
       {hasOrder && priceUsd && priceUsd > 0 && (
         <div className="mb-3">
-          <p className="mb-1 text-[8px] uppercase tracking-[0.15em] text-[var(--text-secondary)] font-medium">TP/SL Exit Projections</p>
-          <div className="flex gap-1.5 overflow-x-auto pb-1 scrollbar-thin select-none">
+          <p className="mb-1.5 text-[8px] uppercase tracking-[0.15em] text-[var(--text-secondary)] font-medium">TP/SL Exit Projections</p>
+          <div className="grid grid-cols-2 gap-1.5 select-none">
             {(() => {
               const targets = [
-                { type: "tp", roi: 0.5, label: "TP +50%", colorClass: "text-emerald-400 border-emerald-500/20 bg-emerald-500/5" },
-                { type: "tp", roi: 1.0, label: "TP +100%", colorClass: "text-emerald-400 border-emerald-500/20 bg-emerald-500/5 font-medium" },
-                { type: "sl", roi: -0.25, label: "SL -25%", colorClass: "text-red-400 border-red-500/20 bg-red-500/5" },
-                { type: "sl", roi: -0.5, label: "SL -50%", colorClass: "text-red-400 border-red-500/20 bg-red-500/5 font-medium" },
+                { type: "tp", roi: 0.5, label: "TP +50%", colorClass: "border-emerald-500/20 bg-emerald-500/[0.02]", textClass: "text-emerald-400" },
+                { type: "tp", roi: 1.0, label: "TP +100%", colorClass: "border-emerald-500/20 bg-emerald-500/[0.02]", textClass: "text-emerald-400" },
+                { type: "sl", roi: -0.25, label: "SL -25%", colorClass: "border-red-500/20 bg-red-500/[0.02]", textClass: "text-red-400" },
+                { type: "sl", roi: -0.5, label: "SL -50%", colorClass: "border-red-500/20 bg-red-500/[0.02]", textClass: "text-red-400" },
               ];
 
               return targets.map((t, idx) => {
@@ -777,14 +777,27 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
                 const pnlAmt = marginAmt * t.roi;
                 const pnlSign = pnlAmt > 0 ? "+" : "";
 
+                // Percentage price move required to hit target
+                const priceMovePct = (t.roi / leverage) * 100;
+                const priceMoveSign = priceMovePct > 0 ? "+" : "";
+
                 return (
                   <div
                     key={idx}
-                    className={`flex-shrink-0 flex items-center gap-1.5 px-2 py-1 rounded-sm border text-[9px] font-mono whitespace-nowrap ${t.colorClass}`}
+                    className={`rounded-sm border p-1.5 flex flex-col justify-between ${t.colorClass}`}
                   >
-                    <span className="opacity-90">{t.label}:</span>
-                    <span className="font-semibold text-[var(--text)]">${targetExitPrice.toFixed(targetExitPrice < 0.01 ? 6 : targetExitPrice < 1 ? 4 : 2)}</span>
-                    <span className="opacity-70">({pnlSign}{pnlAmt.toFixed(2)} {collateralSymbol})</span>
+                    <div className="flex items-center justify-between text-[8px] uppercase tracking-[0.05em] text-[var(--text-secondary)]">
+                      <span>{t.label}</span>
+                      <span className={t.textClass}>{priceMoveSign}{priceMovePct.toFixed(1)}%</span>
+                    </div>
+                    <div className="mt-1 flex items-baseline justify-between">
+                      <span className="text-[11px] font-bold font-mono text-[var(--text)]">
+                        ${targetExitPrice.toFixed(targetExitPrice < 0.01 ? 6 : targetExitPrice < 1 ? 4 : 2)}
+                      </span>
+                      <span className="text-[8px] font-mono text-[var(--text-dim)]">
+                        {pnlSign}{pnlAmt.toFixed(2)} {collateralSymbol}
+                      </span>
+                    </div>
                   </div>
                 );
               });

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -751,57 +751,81 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
             <span className="text-[11px] font-medium text-[var(--text)]">x</span>
           </div>
         </div>
-        {maxLeverage > 1 ? (
-          <>
-            {(() => {
-              const n = availableLeverage.length;
-              // Find closest snap index to current leverage (for when text input sets a between-point value)
-              const snapIdx = availableLeverage.reduce(
-                (best, v, i) => Math.abs(v - leverage) < Math.abs(availableLeverage[best] - leverage) ? i : best,
-                0,
-              );
-              const fillPct = n > 1 ? (snapIdx / (n - 1)) * 100 : 0;
-              return (
-                <>
-                  <input
-                    type="range"
-                    min={0}
-                    max={n - 1}
-                    step={1}
-                    value={snapIdx}
-                    onChange={(e) => updateLeverage(availableLeverage[Number(e.target.value)])}
-                    className="leverage-slider w-full cursor-pointer"
-                    style={{
-                      background: `linear-gradient(to right, var(--accent) ${fillPct}%, var(--border) ${fillPct}%)`,
-                    }}
-                    aria-label="Leverage"
-                  />
-                  {/* Labels uniformly spaced — one per snap point, aligns with slider steps */}
-                  <div className="mt-1 flex justify-between">
-                    {availableLeverage.map((l) => (
-                      <button
-                        key={l}
-                        type="button"
-                        onClick={() => updateLeverage(l)}
-                        className={`text-[8px] font-mono transition-colors duration-100 ${
-                          leverage === l
-                            ? "text-[var(--accent)] font-bold"
-                            : "text-[var(--text-dim)] hover:text-[var(--text-secondary)]"
-                        }`}
-                      >
-                        {l}x
-                      </button>
-                    ))}
-                  </div>
-                </>
-              );
-            })()}
-          </>
-        ) : (
+        {maxLeverage > 1 ? (() => {
+          const n = availableLeverage.length;
 
+          // Maps a leverage value → uniform display % (interpolates between snap-point indices)
+          const valueToPct = (val: number): number => {
+            if (n <= 1) return 0;
+            for (let i = 0; i < n - 1; i++) {
+              if (val <= availableLeverage[i + 1]) {
+                const lo = availableLeverage[i], hi = availableLeverage[i + 1];
+                return ((i + (hi > lo ? (val - lo) / (hi - lo) : 0)) / (n - 1)) * 100;
+              }
+            }
+            return 100;
+          };
+
+          const thumbPct = valueToPct(leverage);
+          const snapRadius = n > 1
+            ? Math.floor(Math.min(...availableLeverage.slice(1).map((v, i) => v - availableLeverage[i])) / 2)
+            : 0;
+
+          return (
+            <div className="relative pt-1 pb-1">
+              {/* Custom visual track — 3px tall */}
+              <div className="relative mx-0 h-[3px] rounded-full bg-[var(--border)]/30 mt-2">
+                {/* Fill */}
+                <div
+                  className="absolute left-0 top-0 h-full rounded-full bg-[var(--accent)]"
+                  style={{ width: `${thumbPct}%` }}
+                />
+                {/* Custom thumb — follows valueToPct, not the native linear position */}
+                <div
+                  className="pointer-events-none absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[var(--accent)] ring-2 ring-[var(--accent)]/30"
+                  style={{ left: `${thumbPct}%` }}
+                />
+              </div>
+              {/* Invisible native input — full value range, handles all drag/click */}
+              <input
+                type="range"
+                min={1}
+                max={maxLeverage}
+                step={1}
+                value={leverage}
+                onChange={(e) => {
+                  const raw = Number(e.target.value);
+                  const nearest = availableLeverage.reduce((best, v) =>
+                    Math.abs(v - raw) < Math.abs(best - raw) ? v : best, raw);
+                  updateLeverage(Math.abs(nearest - raw) <= snapRadius ? nearest : raw);
+                }}
+                className="absolute inset-x-0 top-0 h-full w-full cursor-pointer opacity-0"
+                aria-label="Leverage"
+              />
+              {/* Labels — uniformly spaced, one per snap point */}
+              <div className="mt-2 flex justify-between">
+                {availableLeverage.map((l) => (
+                  <button
+                    key={l}
+                    type="button"
+                    onClick={() => updateLeverage(l)}
+                    className={`text-[8px] font-mono transition-colors duration-100 ${
+                      leverage === l
+                        ? "text-[var(--accent)] font-bold"
+                        : "text-[var(--text-dim)] hover:text-[var(--text-secondary)]"
+                    }`}
+                  >
+                    {l}x
+                  </button>
+                ))}
+              </div>
+            </div>
+          );
+        })() : (
           <p className="text-[9px] text-[var(--text-dim)] font-mono">{maxLeverage}x (fixed)</p>
         )}
       </div>
+
 
 
 

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -247,6 +247,40 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
     worstFillPriceE6: bigint;
   } | null>(null);
   const [showInlineDeposit, setShowInlineDeposit] = useState(false);
+  const [oneClickEnabled, setOneClickEnabled] = useState(false);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const val = localStorage.getItem("percolator-one-click-trading");
+      if (val === "true") setOneClickEnabled(true);
+    }
+  }, []);
+
+  const handleOneClickToggle = (val: boolean) => {
+    setOneClickEnabled(val);
+    if (typeof window !== "undefined") {
+      localStorage.setItem("percolator-one-click-trading", val ? "true" : "false");
+    }
+  };
+
+  // Keyboard shortcuts: Shift+L for Long, Shift+S for Short
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (document.activeElement?.tagName === "INPUT" || document.activeElement?.tagName === "TEXTAREA") {
+        return;
+      }
+      if (e.shiftKey && e.key.toUpperCase() === "L") {
+        e.preventDefault();
+        setDirection("long");
+      } else if (e.shiftKey && e.key.toUpperCase() === "S") {
+        e.preventDefault();
+        setDirection("short");
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
   // Which tab the inline card opens on. Clicking the active trigger closes the
   // card; clicking the other trigger switches its tab in place.
   const [inlineDepositMode, setInlineDepositMode] = useState<"deposit" | "withdraw">("deposit");
@@ -428,6 +462,28 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
     },
     [effectiveBalance, decimals, leverage, priceUsd, sizeUnit],
   );
+
+  // Listen to order book price clicks to auto-calculate/populate size input
+  useEffect(() => {
+    const handleBookClick = (e: Event) => {
+      const customEvt = e as CustomEvent<{ price: number; type: "bid" | "ask" | "oracle" }>;
+      const clickPrice = customEvt.detail.price;
+      const type = customEvt.detail.type;
+
+      if (type === "bid") setDirection("long");
+      if (type === "ask") setDirection("short");
+
+      if (clickPrice > 0 && effectiveBalance > 0n) {
+        const balNum = Number(effectiveBalance) / Math.pow(10, decimals);
+        const maxNotionalUsd = balNum * leverage;
+        const val = sizeUnit === "token" ? (maxNotionalUsd / clickPrice).toFixed(6) : maxNotionalUsd.toFixed(2);
+        setSizeInput(val);
+        recomputeFromSize(val, sizeUnit, leverage);
+      }
+    };
+    window.addEventListener("percolator-book-click", handleBookClick);
+    return () => window.removeEventListener("percolator-book-click", handleBookClick);
+  }, [effectiveBalance, decimals, leverage, sizeUnit, recomputeFromSize]);
 
   const marginNative = marginInput ? parsePercToNative(marginInput, decimals) : 0n;
   const notionalNative = marginNative * BigInt(leverage);
@@ -726,6 +782,53 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
             after={`${formatTokenAmount(afterMargin, decimals)} ${collateralSymbol}`}
             tooltip="Margin reserved from your account balance to back this position — not a deposit, so your balance after opening is lower, not higher."
           />
+          {afterLiqPrice > 0n && (
+            <div className="flex items-center justify-between py-1 text-[10px]">
+              <span className="flex items-center gap-1 text-[var(--text-secondary)] uppercase tracking-[0.08em]">
+                Risk Level
+                <InfoIcon tooltip="The estimated risk of liquidation based on the distance between the oracle price and your liquidation price." />
+              </span>
+              {(() => {
+                const mark = livePriceE6 ?? oracleE6;
+                const liq = afterLiqPrice;
+                if (mark <= 0n || liq <= 0n) return <span className="text-[var(--text-dim)] font-mono">N/A</span>;
+                const pct = mark > 0n ? Math.abs(Number(mark - liq)) / Number(mark) : 0;
+                
+                let label = "Low";
+                let colorClass = "text-emerald-400 border-emerald-400/30 bg-emerald-400/5";
+                let barColor = "bg-emerald-400";
+                let barPct = Math.min(100, Math.max(0, (pct / 0.4) * 100)); // 40%+ is 100% green
+                
+                if (pct < 0.05) {
+                  label = "Critical";
+                  colorClass = "text-red-500 border-red-500/30 bg-red-500/5 font-bold animate-pulse";
+                  barColor = "bg-red-500";
+                  barPct = Math.min(100, Math.max(0, (pct / 0.4) * 100));
+                } else if (pct < 0.15) {
+                  label = "High";
+                  colorClass = "text-red-400 border-red-400/30 bg-red-400/5";
+                  barColor = "bg-red-400";
+                  barPct = Math.min(100, Math.max(0, (pct / 0.4) * 100));
+                } else if (pct < 0.30) {
+                  label = "Medium";
+                  colorClass = "text-amber-400 border-amber-400/30 bg-amber-400/5";
+                  barColor = "bg-amber-400";
+                  barPct = Math.min(100, Math.max(0, (pct / 0.4) * 100));
+                }
+                
+                return (
+                  <div className="flex items-center gap-2">
+                    <div className="h-1.5 w-12 bg-[var(--border)]/20 overflow-hidden rounded-sm hidden xs:block">
+                      <div className={`h-full ${barColor}`} style={{ width: `${barPct}%` }} />
+                    </div>
+                    <span className={`px-1.5 py-0.5 rounded-sm border text-[9px] font-medium uppercase tracking-[0.05em] ${colorClass}`}>
+                      {label}
+                    </span>
+                  </div>
+                );
+              })()}
+            </div>
+          )}
         </div>
       )}
 
@@ -734,6 +837,21 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
         <div className="mb-3 rounded-none border border-[var(--warning)]/30 bg-[var(--warning)]/5 p-2.5">
           <p className="text-[9px] font-bold uppercase tracking-[0.15em] text-[var(--warning)]">{blockingIssue.title}</p>
           <p className="mt-1 text-[9px] leading-relaxed text-[var(--text-secondary)]">{blockingIssue.message}</p>
+        </div>
+      )}
+
+      {/* One-click trading option */}
+      {connected && !needsAccount && !needsDeposit && (
+        <div className="mb-3 flex items-center justify-between">
+          <label className="flex items-center gap-1.5 cursor-pointer text-[10px] text-[var(--text-secondary)] uppercase tracking-[0.08em]">
+            <input
+              type="checkbox"
+              checked={oneClickEnabled}
+              onChange={(e) => handleOneClickToggle(e.target.checked)}
+              className="accent-[var(--accent)]"
+            />
+            One-Click Trading
+          </label>
         </div>
       )}
 
@@ -794,14 +912,18 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
             } catch {
               worstFillPriceE6 = 0n;
             }
-            setConfirmSnapshot({
-              positionSize,
-              marginNative,
-              estimatedLiqPrice: afterLiqPrice,
-              tradingFee: fee,
-              worstFillPriceE6,
-            });
-            setShowConfirmModal(true);
+            if (oneClickEnabled) {
+              handleTrade(positionSize);
+            } else {
+              setConfirmSnapshot({
+                positionSize,
+                marginNative,
+                estimatedLiqPrice: afterLiqPrice,
+                tradingFee: fee,
+                worstFillPriceE6,
+              });
+              setShowConfirmModal(true);
+            }
           }}
           disabled={submitDisabled}
           className={`w-full rounded-none py-3 text-[12px] font-bold uppercase tracking-[0.12em] transition-[filter] duration-150 hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:brightness-100 ${

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -62,7 +62,7 @@ import { saveEntryPrice, getEntryPrice, clearEntryPrice } from "@/lib/entry-pric
 import { DepositWithdrawCard } from "@/components/trade/DepositWithdrawCard";
 import { useInitUser } from "@/hooks/useInitUser";
 
-const LEVERAGE_SNAP_POINTS = [1, 2, 5, 10, 20];
+const LEVERAGE_SNAP_POINTS = [1, 3, 5, 10, 20];
 const SIZE_PRESETS = [25, 50, 75, 100];
 const MAX_DISPLAY_LEVERAGE = 200;
 

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -565,6 +565,8 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
   const needsAccount = connected && !userAccount;
   const needsDeposit = connected && userAccount && capital === 0n;
 
+  // snapshotSize must be UNSIGNED (magnitude only). Direction sign is applied
+  // internally: `direction === "short" ? -effectiveSize : effectiveSize`.
   async function handleTrade(snapshotSize?: bigint) {
     const effectiveSize = snapshotSize ?? positionSize;
     if (!marginInput || !userAccount || effectiveSize <= 0n || exceedsBalance) return;
@@ -820,27 +822,25 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
                 const liq = afterLiqPrice;
                 if (mark <= 0n || liq <= 0n) return <span className="text-[var(--text-dim)] font-mono">N/A</span>;
                 const pct = mark > 0n ? Math.abs(Number(mark - liq)) / Number(mark) : 0;
-                
+                // barPct: distance-to-liq as a 0–100 gauge (40%+ distance = 100% "safe")
+                const barPct = Math.min(100, Math.max(0, (pct / 0.4) * 100));
+
                 let label = "Low";
                 let colorClass = "text-emerald-400 border-emerald-400/30 bg-emerald-400/5";
                 let barColor = "bg-emerald-400";
-                let barPct = Math.min(100, Math.max(0, (pct / 0.4) * 100)); // 40%+ is 100% green
-                
+
                 if (pct < 0.05) {
                   label = "Critical";
                   colorClass = "text-red-500 border-red-500/30 bg-red-500/5 font-bold animate-pulse";
                   barColor = "bg-red-500";
-                  barPct = Math.min(100, Math.max(0, (pct / 0.4) * 100));
                 } else if (pct < 0.15) {
                   label = "High";
                   colorClass = "text-red-400 border-red-400/30 bg-red-400/5";
                   barColor = "bg-red-400";
-                  barPct = Math.min(100, Math.max(0, (pct / 0.4) * 100));
                 } else if (pct < 0.30) {
                   label = "Medium";
                   colorClass = "text-amber-400 border-amber-400/30 bg-amber-400/5";
                   barColor = "bg-amber-400";
-                  barPct = Math.min(100, Math.max(0, (pct / 0.4) * 100));
                 }
                 
                 return (
@@ -870,8 +870,9 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
       {/* One-click trading option */}
       {connected && !needsAccount && !needsDeposit && (
         <div className="mb-3 flex items-center justify-between">
-          <label className="flex items-center gap-1.5 cursor-pointer text-[10px] text-[var(--text-secondary)] uppercase tracking-[0.08em]">
+          <label htmlFor="one-click-trade" className="flex items-center gap-1.5 cursor-pointer text-[10px] text-[var(--text-secondary)] uppercase tracking-[0.08em]">
             <input
+              id="one-click-trade"
               type="checkbox"
               checked={oneClickEnabled}
               onChange={(e) => handleOneClickToggle(e.target.checked)}

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -521,6 +521,31 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
     slippageBoundE6 = 0n;
   }
 
+  // Dispatch pending TP/SL price projections to TradingChart
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    if (!hasOrder || !priceUsd || priceUsd <= 0 || leverage <= 0) {
+      window.dispatchEvent(new CustomEvent("percolator-pending-tpsl", {
+        detail: { hasOrder: false, tp50: null, tp100: null, sl25: null, sl50: null }
+      }));
+      return;
+    }
+
+    const entryNum = Number(estEntry) / 1e6;
+    
+    // Math formulas:
+    // TP +50%: targetExitPrice = entryNum * (1 + 0.5 / leverage)
+    const tp50 = direction === "long" ? entryNum * (1 + 0.5 / leverage) : entryNum * (1 - 0.5 / leverage);
+    const tp100 = direction === "long" ? entryNum * (1 + 1.0 / leverage) : entryNum * (1 - 1.0 / leverage);
+    const sl25 = direction === "long" ? entryNum * (1 - 0.25 / leverage) : entryNum * (1 + 0.25 / leverage);
+    const sl50 = direction === "long" ? entryNum * (1 - 0.5 / leverage) : entryNum * (1 + 0.5 / leverage);
+
+    window.dispatchEvent(new CustomEvent("percolator-pending-tpsl", {
+      detail: { hasOrder: true, tp50, tp100, sl25, sl50 }
+    }));
+  }, [hasOrder, estEntry, leverage, direction, priceUsd]);
+
   // ── Validation (single banner, priority-ordered) ──
   const validationIssues = buildValidationIssues({
     marketPaused: !!header?.paused,
@@ -755,56 +780,7 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
         </div>
       </div>
 
-      {/* TP/SL Simulation HUD (Bloomberg-style High-Info 2x2 Grid) */}
-      {hasOrder && priceUsd && priceUsd > 0 && (
-        <div className="mb-3">
-          <p className="mb-1.5 text-[8px] uppercase tracking-[0.15em] text-[var(--text-secondary)] font-medium">TP/SL Exit Projections</p>
-          <div className="grid grid-cols-2 gap-1.5 select-none">
-            {(() => {
-              const targets = [
-                { type: "tp", roi: 0.5, label: "TP +50%", colorClass: "border-emerald-500/20 bg-emerald-500/[0.02]", textClass: "text-emerald-400" },
-                { type: "tp", roi: 1.0, label: "TP +100%", colorClass: "border-emerald-500/20 bg-emerald-500/[0.02]", textClass: "text-emerald-400" },
-                { type: "sl", roi: -0.25, label: "SL -25%", colorClass: "border-red-500/20 bg-red-500/[0.02]", textClass: "text-red-400" },
-                { type: "sl", roi: -0.5, label: "SL -50%", colorClass: "border-red-500/20 bg-red-500/[0.02]", textClass: "text-red-400" },
-              ];
 
-              return targets.map((t, idx) => {
-                const entryNum = Number(estEntry) / 1e6;
-                const factor = t.roi / leverage;
-                const targetExitPrice = direction === "long" ? entryNum * (1 + factor) : entryNum * (1 - factor);
-                
-                const marginAmt = Number(marginNative) / Math.pow(10, decimals);
-                const pnlAmt = marginAmt * t.roi;
-                const pnlSign = pnlAmt > 0 ? "+" : "";
-
-                // Percentage price move required to hit target
-                const priceMovePct = (t.roi / leverage) * 100;
-                const priceMoveSign = priceMovePct > 0 ? "+" : "";
-
-                return (
-                  <div
-                    key={idx}
-                    className={`rounded-sm border p-1.5 flex flex-col justify-between ${t.colorClass}`}
-                  >
-                    <div className="flex items-center justify-between text-[8px] uppercase tracking-[0.05em] text-[var(--text-secondary)]">
-                      <span>{t.label}</span>
-                      <span className={t.textClass}>{priceMoveSign}{priceMovePct.toFixed(1)}%</span>
-                    </div>
-                    <div className="mt-1 flex items-baseline justify-between">
-                      <span className="text-[11px] font-bold font-mono text-[var(--text)]">
-                        ${targetExitPrice.toFixed(targetExitPrice < 0.01 ? 6 : targetExitPrice < 1 ? 4 : 2)}
-                      </span>
-                      <span className="text-[8px] font-mono text-[var(--text-dim)]">
-                        {pnlSign}{pnlAmt.toFixed(2)} {collateralSymbol}
-                      </span>
-                    </div>
-                  </div>
-                );
-              });
-            })()}
-          </div>
-        </div>
-      )}
 
       {/* Receipt — before -> after. Deliberately "sunken" (var(--bg), the
           page-level darkness, rather than an elevated surface) so it reads

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -751,102 +751,57 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
             <span className="text-[11px] font-medium text-[var(--text)]">x</span>
           </div>
         </div>
-        {/* Unified continuous slider — tick marks uniformly spaced, magnetic snap */}
-        {maxLeverage > 1 && (() => {
-          const n = availableLeverage.length;
-
-          // Snap within half the smallest gap between adjacent snap points
-          const snapRadius = n > 1
-            ? Math.floor(Math.min(...availableLeverage.slice(1).map((v, i) => v - availableLeverage[i])) / 2)
-            : 0;
-
-          const handleChange = (raw: number) => {
-            if (snapRadius > 0) {
-              const nearest = availableLeverage.reduce((best, v) =>
-                Math.abs(v - raw) < Math.abs(best - raw) ? v : best, raw);
-              if (Math.abs(nearest - raw) <= snapRadius) {
-                updateLeverage(nearest);
-                return;
-              }
-            }
-            updateLeverage(raw);
-          };
-
-          // Map a leverage value → uniform display %, interpolating between snap-point indices
-          const valueToPct = (val: number): number => {
-            if (n <= 1) return 0;
-            for (let i = 0; i < n - 1; i++) {
-              if (val <= availableLeverage[i + 1]) {
-                const lo = availableLeverage[i];
-                const hi = availableLeverage[i + 1];
-                const segFrac = hi > lo ? (val - lo) / (hi - lo) : 0;
-                return ((i + segFrac) / (n - 1)) * 100;
-              }
-            }
-            return 100;
-          };
-
-          const fillPct = valueToPct(leverage);
-
-          return (
-            <div className="relative pb-5">
-              {/* Visual track */}
-              <div className="relative h-[3px] rounded-full bg-[var(--border)]/30 mt-3">
-                {/* Filled portion — width tracks index-space position */}
-                <div
-                  className="absolute left-0 top-0 h-full rounded-full bg-[var(--accent)]"
-                  style={{ width: `${fillPct}%` }}
-                />
-                {/* Uniformly spaced tick marks */}
-                {availableLeverage.map((l, i) => {
-                  const pct = n > 1 ? (i / (n - 1)) * 100 : 0;
-                  const isActive = leverage >= l;
-                  const isCurrent = leverage === l;
-                  return (
-                    <button
-                      key={l}
-                      type="button"
-                      aria-label={`Set leverage to ${l}x`}
-                      onClick={() => updateLeverage(l)}
-                      className="absolute top-1/2 -translate-x-1/2 -translate-y-1/2 group z-10"
-                      style={{ left: `${pct}%` }}
-                    >
-                      <span className={`block rounded-full border-2 transition-all duration-100 ${
-                        isCurrent
-                          ? "h-3 w-3 border-[var(--accent)] bg-[var(--accent)]"
-                          : isActive
-                            ? "h-2.5 w-2.5 border-[var(--accent)] bg-[var(--accent)]/40 group-hover:bg-[var(--accent)]/70"
-                            : "h-2.5 w-2.5 border-[var(--border)] bg-[var(--panel-bg)] group-hover:border-[var(--accent)]/60"
-                      }`} />
-                      <span className={`absolute top-3.5 left-1/2 -translate-x-1/2 whitespace-nowrap text-[8px] font-mono transition-colors duration-100 ${
-                        isCurrent ? "text-[var(--accent)] font-bold" : "text-[var(--text-dim)] group-hover:text-[var(--text-secondary)]"
-                      }`}>
-                        {l}x
-                      </span>
-                    </button>
-                  );
-                })}
-              </div>
-              {/* Full-range input overlay — continuous, step 1 */}
-              <input
-                type="range"
-                min={1}
-                max={maxLeverage}
-                step={1}
-                value={leverage}
-                onChange={(e) => handleChange(Number(e.target.value))}
-                className="absolute inset-0 w-full h-full opacity-0 cursor-pointer z-20"
-                aria-label="Leverage"
-              />
+        {maxLeverage > 1 ? (
+          <>
+            <input
+              type="range"
+              min={1}
+              max={maxLeverage}
+              step={1}
+              value={leverage}
+              onChange={(e) => {
+                const raw = Number(e.target.value);
+                // Magnetic snap: if within half the smallest inter-point gap, snap
+                const nearest = availableLeverage.reduce((best, v) =>
+                  Math.abs(v - raw) < Math.abs(best - raw) ? v : best, raw);
+                const snapRadius = availableLeverage.length > 1
+                  ? Math.floor(Math.min(...availableLeverage.slice(1).map((v, i) => v - availableLeverage[i])) / 2)
+                  : 0;
+                updateLeverage(Math.abs(nearest - raw) <= snapRadius ? nearest : raw);
+              }}
+              className="leverage-slider w-full cursor-pointer"
+              style={{
+                background: `linear-gradient(to right, var(--accent) ${
+                  maxLeverage > 1 ? ((leverage - 1) / (maxLeverage - 1)) * 100 : 0
+                }%, var(--border) ${
+                  maxLeverage > 1 ? ((leverage - 1) / (maxLeverage - 1)) * 100 : 0
+                }%)`,
+              }}
+              aria-label="Leverage"
+            />
+            {/* Snap-point labels — uniformly spaced reference */}
+            <div className="mt-1 flex justify-between">
+              {availableLeverage.map((l) => (
+                <button
+                  key={l}
+                  type="button"
+                  onClick={() => updateLeverage(l)}
+                  className={`text-[8px] font-mono transition-colors duration-100 ${
+                    leverage === l
+                      ? "text-[var(--accent)] font-bold"
+                      : "text-[var(--text-dim)] hover:text-[var(--text-secondary)]"
+                  }`}
+                >
+                  {l}x
+                </button>
+              ))}
             </div>
-
-          );
-        })()}
-        {maxLeverage <= 1 && (
+          </>
+        ) : (
           <p className="text-[9px] text-[var(--text-dim)] font-mono">{maxLeverage}x (fixed)</p>
         )}
-
       </div>
+
 
 
 

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -751,10 +751,12 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
             <span className="text-[11px] font-medium text-[var(--text)]">x</span>
           </div>
         </div>
-        {/* Unified continuous slider with snapping tick marks */}
+        {/* Unified continuous slider — tick marks uniformly spaced, magnetic snap */}
         {maxLeverage > 1 && (() => {
-          // Snap magnitude: snap if within half the smallest gap between adjacent snap points
-          const snapRadius = availableLeverage.length > 1
+          const n = availableLeverage.length;
+
+          // Snap within half the smallest gap between adjacent snap points
+          const snapRadius = n > 1
             ? Math.floor(Math.min(...availableLeverage.slice(1).map((v, i) => v - availableLeverage[i])) / 2)
             : 0;
 
@@ -770,20 +772,34 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
             updateLeverage(raw);
           };
 
-          const fillPct = maxLeverage > 1 ? ((leverage - 1) / (maxLeverage - 1)) * 100 : 0;
+          // Map a leverage value → uniform display %, interpolating between snap-point indices
+          const valueToPct = (val: number): number => {
+            if (n <= 1) return 0;
+            for (let i = 0; i < n - 1; i++) {
+              if (val <= availableLeverage[i + 1]) {
+                const lo = availableLeverage[i];
+                const hi = availableLeverage[i + 1];
+                const segFrac = hi > lo ? (val - lo) / (hi - lo) : 0;
+                return ((i + segFrac) / (n - 1)) * 100;
+              }
+            }
+            return 100;
+          };
+
+          const fillPct = valueToPct(leverage);
 
           return (
             <div className="relative pb-5">
               {/* Visual track */}
-              <div className="relative h-[3px] rounded-full bg-[var(--border)]/30 mt-3 mx-0">
-                {/* Filled portion */}
+              <div className="relative h-[3px] rounded-full bg-[var(--border)]/30 mt-3">
+                {/* Filled portion — width tracks index-space position */}
                 <div
                   className="absolute left-0 top-0 h-full rounded-full bg-[var(--accent)]"
                   style={{ width: `${fillPct}%` }}
                 />
-                {/* Snap point tick marks — purely visual, also clickable */}
-                {availableLeverage.map((l) => {
-                  const pct = maxLeverage > 1 ? ((l - 1) / (maxLeverage - 1)) * 100 : 0;
+                {/* Uniformly spaced tick marks */}
+                {availableLeverage.map((l, i) => {
+                  const pct = n > 1 ? (i / (n - 1)) * 100 : 0;
                   const isActive = leverage >= l;
                   const isCurrent = leverage === l;
                   return (
@@ -823,6 +839,7 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
                 aria-label="Leverage"
               />
             </div>
+
           );
         })()}
         {maxLeverage <= 1 && (

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -316,10 +316,6 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
     if (arr.length === 0 || arr[arr.length - 1] < maxLeverage) arr.push(maxLeverage);
     return arr;
   }, [maxLeverage]);
-  // Display-only: how far along the track the filled (accent) portion should
-  // paint, mirroring the current leverage value — purely a visual affordance
-  // for the range input's inline gradient background (see the slider below).
-  const leverageFillPct = maxLeverage > 1 ? ((leverage - 1) / (maxLeverage - 1)) * 100 : 100;
 
   const capital = userAccount ? userAccount.account.capital : 0n;
   // Margin already "locked" by this market's existing open position (if
@@ -731,9 +727,9 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
         ))}
       </div>
 
-      {/* Leverage slider + input */}
+      {/* Leverage — unified snapping slider with tick marks */}
       <div className="mb-4">
-        <div className="mb-1 flex items-center justify-between">
+        <div className="mb-2 flex items-center justify-between">
           <label className="text-[10px] uppercase tracking-[0.15em] text-[var(--text)]">
             Leverage
             <InfoIcon tooltip="The multiplier used to size this order. On-chain margin params are the authoritative cap." />
@@ -755,32 +751,72 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
             <span className="text-[11px] font-medium text-[var(--text)]">x</span>
           </div>
         </div>
-        <input
-          type="range"
-          min={1}
-          max={maxLeverage}
-          step={1}
-          value={leverage}
-          onChange={(e) => updateLeverage(Number(e.target.value))}
-          className="leverage-slider mb-2 w-full cursor-pointer touch-none"
-          style={{
-            background: `linear-gradient(to right, var(--accent) ${leverageFillPct}%, var(--border) ${leverageFillPct}%)`,
-          }}
-        />
-        <div className="flex flex-wrap gap-1">
-          {availableLeverage.map((l) => (
-            <button
-              key={l}
-              onClick={() => updateLeverage(l)}
-              className={`flex-1 basis-0 min-w-[32px] rounded-none py-1.5 text-[9px] font-medium transition-colors duration-150 ${
-                leverage === l ? "bg-[var(--accent)] text-white" : "border border-[var(--border)] text-[var(--text-secondary)] hover:border-[var(--accent)]/50 hover:text-[var(--text)]"
-              }`}
-            >
-              {l}x
-            </button>
-          ))}
-        </div>
+        {/* Unified snapping slider — steps are indices into availableLeverage */}
+        {availableLeverage.length > 1 && (() => {
+          const snapIdx = availableLeverage.indexOf(leverage) !== -1
+            ? availableLeverage.indexOf(leverage)
+            : availableLeverage.reduce((best, val, i) =>
+                Math.abs(val - leverage) < Math.abs(availableLeverage[best] - leverage) ? i : best, 0);
+          const fillPct = availableLeverage.length > 1 ? (snapIdx / (availableLeverage.length - 1)) * 100 : 0;
+          return (
+            <div className="relative px-0 pb-5">
+              {/* Track + filled portion */}
+              <div className="relative h-[3px] rounded-full bg-[var(--border)]/30 mt-3">
+                <div
+                  className="absolute left-0 top-0 h-full rounded-full bg-[var(--accent)] transition-[width] duration-75"
+                  style={{ width: `${fillPct}%` }}
+                />
+                {/* Tick marks */}
+                {availableLeverage.map((l, i) => {
+                  const pct = availableLeverage.length > 1 ? (i / (availableLeverage.length - 1)) * 100 : 0;
+                  const isActive = leverage >= l;
+                  return (
+                    <button
+                      key={l}
+                      type="button"
+                      aria-label={`Set leverage to ${l}x`}
+                      onClick={() => updateLeverage(l)}
+                      className="absolute top-1/2 -translate-x-1/2 -translate-y-1/2 group"
+                      style={{ left: `${pct}%` }}
+                    >
+                      {/* Tick dot */}
+                      <span className={`block h-2.5 w-2.5 rounded-full border-2 transition-colors duration-100 ${
+                        leverage === l
+                          ? "border-[var(--accent)] bg-[var(--accent)] scale-125"
+                          : isActive
+                            ? "border-[var(--accent)] bg-[var(--accent)]/30 group-hover:bg-[var(--accent)]/60"
+                            : "border-[var(--border)] bg-[var(--panel-bg)] group-hover:border-[var(--accent)]/50"
+                      }`} />
+                      {/* Label below */}
+                      <span className={`absolute top-3.5 left-1/2 -translate-x-1/2 text-[8px] whitespace-nowrap font-mono transition-colors duration-100 ${
+                        leverage === l ? "text-[var(--accent)] font-bold" : "text-[var(--text-dim)] group-hover:text-[var(--text-secondary)]"
+                      }`}>
+                        {l}x
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+              {/* Invisible range input overlaid for drag behaviour */}
+              <input
+                type="range"
+                min={0}
+                max={availableLeverage.length - 1}
+                step={1}
+                value={snapIdx}
+                onChange={(e) => updateLeverage(availableLeverage[Number(e.target.value)])}
+                className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+                aria-label="Leverage"
+              />
+            </div>
+          );
+        })()}
+        {/* Fallback for single-leverage markets */}
+        {availableLeverage.length === 1 && (
+          <p className="text-[9px] text-[var(--text-dim)] font-mono">{availableLeverage[0]}x (fixed)</p>
+        )}
       </div>
+
 
 
 

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -755,6 +755,44 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
         </div>
       </div>
 
+      {/* TP/SL Simulation HUD (Horizontal scrollable chips) */}
+      {hasOrder && priceUsd && priceUsd > 0 && (
+        <div className="mb-3">
+          <p className="mb-1 text-[8px] uppercase tracking-[0.15em] text-[var(--text-secondary)] font-medium">TP/SL Exit Projections</p>
+          <div className="flex gap-1.5 overflow-x-auto pb-1 scrollbar-thin select-none">
+            {(() => {
+              const targets = [
+                { type: "tp", roi: 0.5, label: "TP +50%", colorClass: "text-emerald-400 border-emerald-500/20 bg-emerald-500/5" },
+                { type: "tp", roi: 1.0, label: "TP +100%", colorClass: "text-emerald-400 border-emerald-500/20 bg-emerald-500/5 font-medium" },
+                { type: "sl", roi: -0.25, label: "SL -25%", colorClass: "text-red-400 border-red-500/20 bg-red-500/5" },
+                { type: "sl", roi: -0.5, label: "SL -50%", colorClass: "text-red-400 border-red-500/20 bg-red-500/5 font-medium" },
+              ];
+
+              return targets.map((t, idx) => {
+                const entryNum = Number(estEntry) / 1e6;
+                const factor = t.roi / leverage;
+                const targetExitPrice = direction === "long" ? entryNum * (1 + factor) : entryNum * (1 - factor);
+                
+                const marginAmt = Number(marginNative) / Math.pow(10, decimals);
+                const pnlAmt = marginAmt * t.roi;
+                const pnlSign = pnlAmt > 0 ? "+" : "";
+
+                return (
+                  <div
+                    key={idx}
+                    className={`flex-shrink-0 flex items-center gap-1.5 px-2 py-1 rounded-sm border text-[9px] font-mono whitespace-nowrap ${t.colorClass}`}
+                  >
+                    <span className="opacity-90">{t.label}:</span>
+                    <span className="font-semibold text-[var(--text)]">${targetExitPrice.toFixed(targetExitPrice < 0.01 ? 6 : targetExitPrice < 1 ? 4 : 2)}</span>
+                    <span className="opacity-70">({pnlSign}{pnlAmt.toFixed(2)} {collateralSymbol})</span>
+                  </div>
+                );
+              });
+            })()}
+          </div>
+        </div>
+      )}
+
       {/* Receipt — before -> after. Deliberately "sunken" (var(--bg), the
           page-level darkness, rather than an elevated surface) so it reads
           as an inset readout inside the ticket panel — a small depth cue

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -772,36 +772,39 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
             : 0;
 
           return (
-            <div className="relative pt-1 pb-1">
-              {/* Custom visual track — 3px tall */}
-              <div className="relative mx-0 h-[3px] rounded-full bg-[var(--border)]/30 mt-2">
-                {/* Fill */}
-                <div
-                  className="absolute left-0 top-0 h-full rounded-full bg-[var(--accent)]"
-                  style={{ width: `${thumbPct}%` }}
-                />
-                {/* Custom thumb — follows valueToPct, not the native linear position */}
+            <div className="relative pb-1">
+              {/* Track wrapper — gives the invisible input a well-defined bounding box */}
+              <div className="relative mx-0 mt-3 h-6">
+                {/* Visual track line, vertically centred */}
+                <div className="absolute inset-x-0 top-1/2 h-[3px] -translate-y-1/2 rounded-full bg-[var(--border)]/30">
+                  {/* Fill */}
+                  <div
+                    className="absolute left-0 top-0 h-full rounded-full bg-[var(--accent)]"
+                    style={{ width: `${thumbPct}%` }}
+                  />
+                </div>
+                {/* Custom thumb */}
                 <div
                   className="pointer-events-none absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[var(--accent)] ring-2 ring-[var(--accent)]/30"
                   style={{ left: `${thumbPct}%` }}
                 />
+                {/* Invisible native input — same bounding box as the wrapper (h-6), handles all drag/click */}
+                <input
+                  type="range"
+                  min={1}
+                  max={maxLeverage}
+                  step={1}
+                  value={leverage}
+                  onChange={(e) => {
+                    const raw = Number(e.target.value);
+                    const nearest = availableLeverage.reduce((best, v) =>
+                      Math.abs(v - raw) < Math.abs(best - raw) ? v : best, raw);
+                    updateLeverage(Math.abs(nearest - raw) <= snapRadius ? nearest : raw);
+                  }}
+                  className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+                  aria-label="Leverage"
+                />
               </div>
-              {/* Invisible native input — full value range, handles all drag/click */}
-              <input
-                type="range"
-                min={1}
-                max={maxLeverage}
-                step={1}
-                value={leverage}
-                onChange={(e) => {
-                  const raw = Number(e.target.value);
-                  const nearest = availableLeverage.reduce((best, v) =>
-                    Math.abs(v - raw) < Math.abs(best - raw) ? v : best, raw);
-                  updateLeverage(Math.abs(nearest - raw) <= snapRadius ? nearest : raw);
-                }}
-                className="absolute inset-x-0 top-0 h-full w-full cursor-pointer opacity-0"
-                aria-label="Leverage"
-              />
               {/* Labels — uniformly spaced, one per snap point */}
               <div className="mt-2 flex justify-between">
                 {availableLeverage.map((l) => (

--- a/app/components/trade/PositionsDock.tsx
+++ b/app/components/trade/PositionsDock.tsx
@@ -289,11 +289,33 @@ const PositionRow: FC<{ slabAddress: string }> = memo(function PositionRow({ sla
                 {hasValidMark ? formatUsdPriceE6(currentPriceE6) : <span className="text-[var(--text-dim)]">--</span>}
               </td>
               <td
-                className={`whitespace-nowrap px-3 py-2.5 text-right font-medium ${liqPriceColor}`}
+                className="whitespace-nowrap px-3 py-2.5 text-right font-medium"
                 style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}
                 title={liqUnliquidatable ? "No liquidation price — collateral exceeds position notional; cannot be liquidated by price" : undefined}
               >
-                {formatLiqPrice(liqPriceE6, { hasPosition: liqUnliquidatable })}
+                <div className={liqPriceColor}>{formatLiqPrice(liqPriceE6, { hasPosition: liqUnliquidatable })}</div>
+                {liqPriceE6 > 0n && !liqUnliquidatable && hasValidMark && (
+                  (() => {
+                    const pct = currentPriceE6 > 0n ? Math.abs(Number(currentPriceE6 - liqPriceE6)) / Number(currentPriceE6) : 0;
+                    let riskLabel = "Low Risk";
+                    let riskColor = "text-emerald-400";
+                    if (pct < 0.05) {
+                      riskLabel = "Critical";
+                      riskColor = "text-red-500 font-bold animate-pulse";
+                    } else if (pct < 0.15) {
+                      riskLabel = "High Risk";
+                      riskColor = "text-red-400";
+                    } else if (pct < 0.30) {
+                      riskLabel = "Med Risk";
+                      riskColor = "text-amber-400";
+                    }
+                    return (
+                      <div className={`text-[8px] uppercase tracking-[0.05em] mt-0.5 ${riskColor}`}>
+                        {riskLabel}
+                      </div>
+                    );
+                  })()
+                )}
               </td>
               <td className={`whitespace-nowrap px-3 py-2.5 text-right ${hasValidMark ? pnlColor : "text-[var(--text-dim)]"}`} style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
                 {hasValidMark ? (

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -640,7 +640,12 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
     const chart = chartRef.current;
     if (!chart) return;
 
-    // Remove old series
+    // Null pending TP/SL line refs before removeSeries so in-flight
+    // handlePendingTpSl events can't attempt removePriceLine on the wrong series.
+    pendingTp50LineRef.current = null;
+    pendingTp100LineRef.current = null;
+    pendingSl25LineRef.current = null;
+    pendingSl50LineRef.current = null;
     if (seriesRef.current) {
       chart.removeSeries(seriesRef.current);
       seriesRef.current = null;
@@ -984,7 +989,9 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
 
       const { hasOrder, tp50, tp100, sl25, sl50 } = customEvt.detail;
 
-      const clearLine = (ref: React.MutableRefObject<any>) => {
+      type PriceLine = ReturnType<ISeriesApi<"Candlestick">["createPriceLine"]>;
+
+      const clearLine = (ref: React.MutableRefObject<PriceLine | null>) => {
         if (ref.current) {
           try {
             s.removePriceLine(ref.current);
@@ -1001,9 +1008,18 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
         return;
       }
 
-      const updateOrCreateLine = (ref: React.MutableRefObject<any>, price: number | null, title: string, color: string) => {
-        clearLine(ref);
+      const updateOrCreateLine = (
+        ref: React.MutableRefObject<PriceLine | null>,
+        price: number | null,
+        title: string,
+        color: string,
+      ) => {
         if (price != null && price > 0) {
+          if (ref.current) {
+            // Cheap update — avoids flicker of remove+recreate on every tick
+            ref.current.applyOptions({ price });
+            return;
+          }
           ref.current = s.createPriceLine({
             price,
             color,
@@ -1012,6 +1028,8 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
             axisLabelVisible: true,
             title,
           });
+        } else {
+          clearLine(ref);
         }
       };
 

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -318,6 +318,10 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
   const priceLineRef = useRef<ReturnType<ISeriesApi<"Candlestick">["createPriceLine"]> | null>(null);
   const liqLineRef = useRef<ReturnType<ISeriesApi<"Candlestick">["createPriceLine"]> | null>(null);
   const entryLineRef = useRef<ReturnType<ISeriesApi<"Candlestick">["createPriceLine"]> | null>(null);
+  const pendingTp50LineRef = useRef<ReturnType<ISeriesApi<"Candlestick">["createPriceLine"]> | null>(null);
+  const pendingTp100LineRef = useRef<ReturnType<ISeriesApi<"Candlestick">["createPriceLine"]> | null>(null);
+  const pendingSl25LineRef = useRef<ReturnType<ISeriesApi<"Candlestick">["createPriceLine"]> | null>(null);
+  const pendingSl50LineRef = useRef<ReturnType<ISeriesApi<"Candlestick">["createPriceLine"]> | null>(null);
   // Phase 2: the currently-forming bar/point, kept in sync by the structural
   // series effect (on every setData) and merged into by live ticks (on
   // every price-store notification) via series.update() — never setData().
@@ -590,6 +594,10 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
       priceLineRef.current = null;
       liqLineRef.current = null;
       entryLineRef.current = null;
+      pendingTp50LineRef.current = null;
+      pendingTp100LineRef.current = null;
+      pendingSl25LineRef.current = null;
+      pendingSl50LineRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -644,6 +652,10 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
     priceLineRef.current = null;
     liqLineRef.current = null;
     entryLineRef.current = null;
+    pendingTp50LineRef.current = null;
+    pendingTp100LineRef.current = null;
+    pendingSl25LineRef.current = null;
+    pendingSl50LineRef.current = null;
 
     // Series selection.
     //
@@ -955,6 +967,65 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
       finishSpan();
     });
   }, [slabAddress]);
+
+  // Listen to order ticket pending TP/SL exit price projections and draw price lines on the chart
+  useEffect(() => {
+    const handlePendingTpSl = (e: Event) => {
+      const customEvt = e as CustomEvent<{
+        hasOrder: boolean;
+        tp50: number | null;
+        tp100: number | null;
+        sl25: number | null;
+        sl50: number | null;
+      }>;
+      
+      const s = seriesRef.current;
+      if (!s) return;
+
+      const { hasOrder, tp50, tp100, sl25, sl50 } = customEvt.detail;
+
+      const clearLine = (ref: React.MutableRefObject<any>) => {
+        if (ref.current) {
+          try {
+            s.removePriceLine(ref.current);
+          } catch {}
+          ref.current = null;
+        }
+      };
+
+      if (!hasOrder || overlayPrefs.entry === false) {
+        clearLine(pendingTp50LineRef);
+        clearLine(pendingTp100LineRef);
+        clearLine(pendingSl25LineRef);
+        clearLine(pendingSl50LineRef);
+        return;
+      }
+
+      const updateOrCreateLine = (ref: React.MutableRefObject<any>, price: number | null, title: string, color: string) => {
+        clearLine(ref);
+        if (price != null && price > 0) {
+          ref.current = s.createPriceLine({
+            price,
+            color,
+            lineWidth: 1,
+            lineStyle: LineStyle.Dotted,
+            axisLabelVisible: true,
+            title,
+          });
+        }
+      };
+
+      updateOrCreateLine(pendingTp50LineRef, tp50, "TP +50%", "#10b981");
+      updateOrCreateLine(pendingTp100LineRef, tp100, "TP +100%", "#059669");
+      updateOrCreateLine(pendingSl25LineRef, sl25, "SL -25%", "#f87171");
+      updateOrCreateLine(pendingSl50LineRef, sl50, "SL -50%", "#ef4444");
+    };
+
+    window.addEventListener("percolator-pending-tpsl", handlePendingTpSl);
+    return () => {
+      window.removeEventListener("percolator-pending-tpsl", handlePendingTpSl);
+    };
+  }, [overlayPrefs.entry]);
 
   // Header % change is ALWAYS trailing 24 h vs current — the industry
   // convention users expect, independent of what timeframe/zoom they picked.


### PR DESCRIPTION
## Summary

A focused, additive trading UX pass on the four trade-panel components. No breaking changes to existing business logic, hooks, or the data layer.

---

## Changes

### One-Click Trading
- Persistent toggle stored in `localStorage` — bypasses the confirmation modal and submits immediately.
- Global keyboard shortcuts: `Shift+L` sets Long, `Shift+S` sets Short. Both are input-focus-aware and do not fire when the cursor is inside a text field.

### TP/SL Price Lines on Chart
- `OrderTicket` dispatches a `percolator-pending-tpsl` custom window event whenever pending order parameters change (entry price, leverage, direction).
- `TradingChart` subscribes to this event and draws four `lightweight-charts` price lines (TP +50%, TP +100%, SL -25%, SL -50%) directly on the active series.
- Lines use `applyOptions({ price })` for in-place updates — avoids the remove + recreate cycle that caused flicker on every tick.
- Lines are cleared on form reset and the line refs are explicitly nulled before `removeSeries()` to close a timing race window.

### Liquidation Risk Gauge
- Dynamic risk level (Low / Medium / High / Critical) shown as a colour-coded labelled bar in both the pre-trade receipt (`OrderTicket`) and the open positions table (`PositionsDock`).
- Derived from the percentage distance between mark price and estimated liquidation price.

### Unified Snapping Leverage Slider
- Replaces the old slider + separate button row.
- Custom visual thumb positioned in **uniform index-space** (`valueToPct` interpolator) so that snap-point labels and the thumb always align, regardless of the numeric spread between leverage values.
- The underlying native `<input type="range">` spans the full `1–maxLeverage` range so any integer (e.g. 3x, 7x) is reachable by dragging.
- Magnetic snap: if the drag value falls within half the smallest inter-point gap it snaps to the nearest labelled point.
- Configurable via the `LEVERAGE_SNAP_POINTS` constant (`[1, 3, 5, 10, 20]` by default).

### Order Book Click-to-Fill
- Clicking Bid / Oracle / Ask cells in `MarketBookCard` dispatches a `percolator-book-click` event that pre-fills the price field in `OrderTicket`.

---

## Code Quality (Audit Fixes)

- `barPct` clamp de-duplicated (was computed four times identically inside the if-chain).
- `React.MutableRefObject<any>` replaced with a typed `PriceLine` alias derived from `ISeriesApi`.
- Clickable `<div>` Bid/Ask/Oracle cells converted to `<button type="button">` with `aria-label` and `focus-visible` ring (WCAG 2.1 SC 4.1.2).
- One-click checkbox now has explicit `htmlFor` / `id` pairing.
- `handleTrade` size-parameter contract documented (unsigned magnitude; direction sign applied internally).

---

## Files Changed

| File | What changed |
|------|-------------|
| `app/components/trade/OrderTicket.tsx` | One-click, hotkeys, TP/SL dispatch, risk gauge, leverage slider |
| `app/components/trade/TradingChart.tsx` | TP/SL price line subscriber, series-swap race fix, typed refs |
| `app/components/trade/MarketBookCard.tsx` | Click-to-fill events, `<div>` → `<button>` |
| `app/components/trade/PositionsDock.tsx` | Risk level badge per open position row |

---

## Testing Checklist

- [x] One-click toggle persists across page reload
- [ ] `Shift+L` / `Shift+S` switch direction; no effect when a text input is focused
- [ ] TP/SL lines appear on chart when a valid order is configured; clear on form reset
- [ ] Leverage slider: thumb and labels stay aligned at all snap points; intermediate values (e.g. 3x, 7x) reachable by dragging; text input accepts arbitrary values
- [ ] Bid/Ask/Oracle cells are keyboard-navigable (Tab + Enter triggers fill)
- [ ] No regression on the standard confirmation modal flow when one-click is off

---

> **Note**: The pre-existing `vitest.config.ts` type conflict (Rolldown / Rollup `PluginContextMeta` mismatch) is unrelated to this branch and should be resolved separately.
