### PR TITLE
fix(stake): refresh pool TVL after deposit

### DIFF
--- a/app/app/stake/page.tsx
+++ b/app/app/stake/page.tsx
@@ -1021,6 +1021,7 @@ export default function StakePage() {
   const [poolsLoading, setPoolsLoading] = useState(true);
   const [position, setPosition] = useState<UserPosition | null>(null);
   const [positionRefreshKey, setPositionRefreshKey] = useState(0);
+  const [poolsRefreshKey, setPoolsRefreshKey] = useState(0);
 
   const { connected, publicKey } = useWalletCompat();
   const { connection } = useConnectionCompat();
@@ -1041,7 +1042,7 @@ export default function StakePage() {
       }
     })();
     return () => { cancelled = true; };
-  }, []);
+  }, [poolsRefreshKey]);
 
   // Fetch user position from on-chain data when wallet connected + pools loaded
   useEffect(() => {
@@ -1080,8 +1081,15 @@ export default function StakePage() {
   }, [connected, publicKey, pools, connection, positionRefreshKey]);
 
   const handleTxSuccess = useCallback(() => {
-    // Re-fetch position after deposit/withdraw
+    // Re-fetch both the user's LP position and pool-level TVL/cap data after
+    // deposit/withdraw. Without refreshing pools, successful deposits can leave
+    // pool cards showing stale TVL until the user manually reloads.
     setPositionRefreshKey((k) => k + 1);
+    setPoolsRefreshKey((k) => k + 1);
+
+    // RPC/indexer reads can lag just after confirmation, so do one follow-up
+    // refresh to catch the settled vault balance without requiring a reload.
+    window.setTimeout(() => setPoolsRefreshKey((k) => k + 1), 2_000);
   }, []);
 
   const totalUserDeposited = position ? position.estimatedValue : connected ? 0 : null;


### PR DESCRIPTION
## Summary

This PR fixes a Stake page UX issue where pool-level TVL/cap data could remain stale after a successful deposit or withdraw until the user manually refreshed the page.

The Stake page already refreshed the user's LP position after a successful transaction, but the pool list fetched from `/api/stake/pools` was only loaded on the initial page mount. Because the pool cards read their displayed TVL from that pool list state, a successful deposit could appear completed while the pool card still showed the previous TVL value.

## Issue

When a user deposits into a stake pool:

1. The transaction succeeds.
2. The user's position state is refreshed.
3. The pool card TVL does not immediately update.
4. The updated TVL only appears after manually refreshing the page.

This can make users think the deposit did not affect the pool TVL, even though the transaction already succeeded.

## Changes

- Adds a `poolsRefreshKey` state to the Stake page.
- Re-runs the `/api/stake/pools` fetch when `poolsRefreshKey` changes.
- Updates the transaction success handler to refresh both:
  - the user's LP position
  - the pool-level TVL/cap data
- Keeps the existing on-chain position refresh behavior unchanged.
- Does not change stake transaction builders, vault logic, pool decoding, or API routes.

## Validation

- `pnpm build` passes.
- `git diff --check` passes.
- PR is scoped to one file only:
  - `app/app/stake/page.tsx`