### PR TITLE
feat(trade): leverage slider dragging fix, price flash, and staking UX polish

### DIFF
--- a/app/app/globals.css
+++ b/app/app/globals.css
@@ -320,6 +320,20 @@ body::before {
   animation: shimmer 1.5s ease-in-out infinite;
 }
 
+/* Order-submit failure feedback (OrderTicket) — brief horizontal shake tied
+   to the --short semantic token, same restrained timing family as the
+   MarkPrice tick-flash (300ms). Not decorative: communicates "this action
+   failed" the instant the submit button reverts from "Submitting…". */
+.animate-error-shake {
+  animation: error-shake var(--timing-normal, 300ms) ease-in-out;
+}
+
+@keyframes error-shake {
+  0%, 100% { transform: translateX(0); }
+  25% { transform: translateX(-4px); }
+  75% { transform: translateX(4px); }
+}
+
 /* ponytail: explicit class bypasses tailwind v4 @theme compilation bug */
 .animate-shimmer-sweep {
   animation: shimmer-sweep 1.6s linear infinite !important;
@@ -556,6 +570,16 @@ input[type="range"].leverage-slider::-moz-range-track {
   height: 4px;
   border-radius: 2px;
   background: var(--border);
+}
+/* Keyboard focus ring — without this, the unconditional thumb rules above
+   (same specificity, later in source order) silently win over the generic
+   `input[type="range"]:focus-visible::-webkit-slider-thumb` rule further up
+   this file, so Tab-focusing the slider produced no visible ring at all. */
+input[type="range"].leverage-slider:focus-visible::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px var(--accent), 0 0 0 4px rgba(153, 69, 255, 0.35);
+}
+input[type="range"].leverage-slider:focus-visible::-moz-range-thumb {
+  box-shadow: 0 0 0 1px var(--accent), 0 0 0 4px rgba(153, 69, 255, 0.35);
 }
 
 /* ─── Scrollbar ─── */

--- a/app/components/trade/ChartIndicatorMenu.tsx
+++ b/app/components/trade/ChartIndicatorMenu.tsx
@@ -93,7 +93,7 @@ export const ChartIndicatorMenu: FC<ChartIndicatorMenuProps> = ({
         onClick={() => setOpen((o) => !o)}
         aria-expanded={open}
         aria-haspopup="true"
-        aria-label="Indicators"
+        aria-label={indicators.length > 0 ? `Indicators (${indicators.length} active)` : "Indicators"}
         title="Indicators"
         className={[
           "flex items-center gap-1 rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] px-1.5 sm:px-2 py-1 text-xs transition-colors",
@@ -103,6 +103,14 @@ export const ChartIndicatorMenu: FC<ChartIndicatorMenuProps> = ({
         ].join(" ")}
       >
         <span className="font-mono italic">f(x)</span>
+        {indicators.length > 0 && (
+          <span
+            className="flex h-3.5 min-w-[14px] items-center justify-center rounded-full bg-[var(--accent)]/15 px-1 font-mono text-[9px] font-bold text-[var(--accent)]"
+            aria-hidden="true"
+          >
+            {indicators.length}
+          </span>
+        )}
         <svg
           width="10"
           height="10"

--- a/app/components/trade/ClosePositionModal.tsx
+++ b/app/components/trade/ClosePositionModal.tsx
@@ -252,6 +252,10 @@ export const ClosePositionModal: FC<ClosePositionModalProps> = ({
             onChange={(e) => setPercent(Number(e.target.value))}
             style={{
               background: `linear-gradient(to right, var(--short) 0%, var(--short) ${percent}%, rgba(255,255,255,0.03) ${percent}%, rgba(255,255,255,0.03) 100%)`,
+              backgroundSize: "100% 2px",
+              backgroundPosition: "center",
+              backgroundRepeat: "no-repeat",
+              height: "20px",
             }}
             className="mb-2 h-1 w-full cursor-pointer appearance-none [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:bg-[var(--short)] [&::-moz-range-thumb]:h-3 [&::-moz-range-thumb]:w-3 [&::-moz-range-thumb]:appearance-none [&::-moz-range-thumb]:rounded-none [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-[var(--short)] [&::-moz-range-track]:bg-transparent"
           />

--- a/app/components/trade/MarketBookCard.tsx
+++ b/app/components/trade/MarketBookCard.tsx
@@ -7,9 +7,11 @@ import { useSlabState } from "@/components/providers/SlabProvider";
 import { useTokenMeta } from "@/hooks/useTokenMeta";
 import { useLivePrice } from "@/hooks/useLivePrice";
 import { useOrderBookVisibility } from "@/hooks/useOrderBookVisibility";
+import { usePriceFlash } from "@/hooks/usePriceFlash";
 import { formatUsdPriceE6, formatTokenAmount, shortenAddress } from "@/lib/format";
 import { resolveMarketPriceE6 } from "@/lib/oraclePrice";
 import { AccountKind } from "@percolatorct/sdk";
+import { ShimmerSkeleton } from "@/components/ui/ShimmerSkeleton";
 
 const LP_TABLE_CAP = 5;
 
@@ -22,6 +24,10 @@ export const MarketBookCard: FC = () => {
   const symbol = tokenMeta?.symbol ?? "Token";
   const decimals = tokenMeta?.decimals ?? 6;
   const [, toggleBook] = useOrderBookVisibility();
+  // Called unconditionally (before the loading early-return below) per rules
+  // of hooks — the oracle cell it drives only needs livePriceE6, not
+  // engine/params, so this is safe to compute even while those are loading.
+  const oracleFlash = usePriceFlash(livePriceE6 ?? null);
 
   const lps = useMemo(
     () => accounts.filter(({ account }) => account.kind === AccountKind.LP),
@@ -29,9 +35,38 @@ export const MarketBookCard: FC = () => {
   );
 
   if (loading || !engine || !config || !params) {
+    if (!loading) {
+      return (
+        <div className="flex h-full min-h-[160px] flex-col items-center justify-center p-3">
+          <p className="text-[10px] uppercase tracking-[0.12em] text-[var(--text-muted)]">—</p>
+        </div>
+      );
+    }
+    // Shimmer skeleton mirrors the real layout (price ladder / spread /
+    // depth bars / LP rows) instead of a flash-of-plain-text loading state.
     return (
-      <div className="flex h-full min-h-[160px] flex-col items-center justify-center p-3">
-        <p className="text-[10px] uppercase tracking-[0.12em] text-[var(--text-muted)]">{loading ? "Loading…" : "—"}</p>
+      <div className="p-3">
+        <div className="mb-2 flex items-center justify-between">
+          <span className="text-[9px] font-semibold uppercase tracking-[0.15em] text-[var(--text-dim)]">Order Book</span>
+        </div>
+        <div className="mb-2 grid grid-cols-3 gap-px border border-[var(--border)]/30">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="p-2 text-center">
+              <ShimmerSkeleton className="mx-auto h-2 w-8" />
+              <ShimmerSkeleton className="mx-auto mt-1.5 h-3.5 w-14" />
+            </div>
+          ))}
+        </div>
+        <ShimmerSkeleton className="mb-3 h-2 w-full" />
+        <div className="mb-3 grid grid-cols-2 gap-1">
+          <ShimmerSkeleton className="h-12 w-full" />
+          <ShimmerSkeleton className="h-12 w-full" />
+        </div>
+        <div className="space-y-1.5">
+          {[0, 1, 2].map((i) => (
+            <ShimmerSkeleton key={i} className="h-3 w-full" />
+          ))}
+        </div>
       </div>
     );
   }
@@ -96,11 +131,13 @@ export const MarketBookCard: FC = () => {
           <p className="text-[8px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Bid</p>
           <p className="text-[11px] font-medium text-[var(--long)]" style={{ fontFamily: "var(--font-mono)" }}>{formatUsdPriceE6(bestBidE6)}</p>
         </div>
-        {/* Oracle — subtle accent border + bg */}
+        {/* Oracle — subtle accent border + bg; flashes long/short on tick (usePriceFlash) */}
         <div className="p-2 text-center border-x border-[var(--accent)]/20 bg-[var(--accent)]/[0.03]">
           <p className="text-[8px] uppercase tracking-[0.15em] text-[var(--text-dim)]">Oracle</p>
           <p
-            className="text-[13px] font-medium text-[var(--text)]"
+            className={`text-[13px] font-medium transition-colors duration-300 ease-out ${
+              oracleFlash === "up" ? "text-[var(--long)]" : oracleFlash === "down" ? "text-[var(--short)]" : "text-[var(--text)]"
+            }`}
             style={{ fontFamily: "var(--font-mono)" }}
           >
             {formatUsdPriceE6(oraclePrice)}

--- a/app/components/trade/MarketInfoBar.tsx
+++ b/app/components/trade/MarketInfoBar.tsx
@@ -1,13 +1,16 @@
 "use client";
 
-import { FC, useEffect, useRef, useState } from "react";
+import { FC, useMemo } from "react";
 import { useLivePrice } from "@/hooks/useLivePrice";
 import { useMarketInfo } from "@/hooks/useMarketInfo";
 import { useEngineState } from "@/hooks/useEngineState";
 import { useOracleFreshness } from "@/hooks/useOracleFreshness";
+import { useSlabState } from "@/components/providers/SlabProvider";
+import { usePriceFlash } from "@/hooks/usePriceFlash";
 import { MarketLogo } from "@/components/market/MarketLogo";
 import { MarketSwitcher } from "@/components/trade/MarketSwitcher";
 import { formatUsdFromNumber, formatMarkPrice } from "@/lib/format";
+import { computeMarketSpread } from "@/lib/oraclePrice";
 
 interface MarketInfoBarProps {
   slabAddress: string;
@@ -66,30 +69,15 @@ function MarketHealthBadge({ oracleDown, vaultEmpty }: { oracleDown: boolean; va
 
 /**
  * Header mark price with a subtle up/down tick flash — the classic perp-DEX
- * micro-interaction. On each price change we compare the new priceE6 against
- * the previous one and briefly tint the text long-green (up) or short-red
- * (down), easing back to the neutral resting color over ~300ms. The resting
- * color is neutral so the semantic long/short flash reads clearly (the 24h
- * direction is carried by the change badge, not this number). No layout shift.
+ * micro-interaction, easing back to the neutral resting color over ~300ms
+ * via `usePriceFlash` (extracted here originally; now shared with
+ * PositionsDock/MarketBookCard — see that hook for the single source of
+ * truth). The resting color is neutral so the semantic long/short flash
+ * reads clearly (the 24h direction is carried by the change badge, not this
+ * number). No layout shift.
  */
 function MarkPrice({ priceUsd, priceE6 }: { priceUsd: number | null; priceE6: bigint | null }) {
-  const prevE6 = useRef<bigint | null>(null);
-  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [flash, setFlash] = useState<"up" | "down" | null>(null);
-
-  useEffect(() => {
-    if (priceE6 == null) return;
-    const prev = prevE6.current;
-    if (prev != null && priceE6 !== prev) {
-      setFlash(priceE6 > prev ? "up" : "down");
-      if (timer.current) clearTimeout(timer.current);
-      timer.current = setTimeout(() => setFlash(null), 300);
-    }
-    prevE6.current = priceE6;
-  }, [priceE6]);
-
-  useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
-
+  const flash = usePriceFlash(priceE6);
   const flashColor =
     flash === "up" ? "text-[var(--long)]" : flash === "down" ? "text-[var(--short)]" : "text-[var(--text)]";
 
@@ -108,12 +96,23 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol, log
   const { market } = useMarketInfo(slabAddress);
   const { fundingRate, engine, totalOI, insuranceBalance, hasData: engineHasData } = useEngineState();
   const { level: oracleLevel } = useOracleFreshness();
+  const { config: mktConfig, wrapperConfigV17 } = useSlabState();
 
   const change24hDisplay = change24h ?? 0;
   const isUp = change24hDisplay >= 0;
 
   const funding8h = fundingRate != null ? fundingRateBpsTo8h(fundingRate) : null;
   const fundingColor = funding8h != null ? (funding8h < 0 ? "text-[var(--warning)]" : "text-[var(--long)]") : "text-[var(--text)]";
+
+  // Mark/index spread — same math as MarketStatsCard (lib/oraclePrice.ts). Hidden for
+  // pyth-pinned markets where mark === index by definition (no separate oracle to diverge).
+  const { spreadBps, oracleMode: spreadOracleMode } = useMemo(
+    () => computeMarketSpread(mktConfig, wrapperConfigV17?.oracleMode),
+    [mktConfig, wrapperConfigV17],
+  );
+  const showSpread = spreadOracleMode !== null && spreadOracleMode !== "pyth-pinned" && spreadBps !== null;
+  // Amber past 50bps — matches MarketStatsCard's "wide spread" threshold.
+  const spreadColor = showSpread && Math.abs(spreadBps!) > 50 ? "text-[var(--warning)]" : "text-[var(--text)]";
 
   // P3-3: oracle + vault status for health badge
   // oracleDown = unavailable (never cranked) or stale — oracleReady && unavailable is
@@ -223,6 +222,16 @@ export const MarketInfoBar: FC<MarketInfoBarProps> = ({ slabAddress, symbol, log
             {formatUsdFromNumber(low24h)}
           </span>
         </div>
+
+        {/* Mark/Index spread — hidden for pyth-pinned markets (mark === index there) */}
+        {showSpread && (
+          <div className="flex flex-col shrink-0">
+            <span className="text-[9px] uppercase tracking-[0.1em] text-[var(--text-dim)]">Spread</span>
+            <span className={`text-xs font-medium ${spreadColor}`} style={{ fontFamily: "var(--font-mono)" }}>
+              {spreadBps! >= 0 ? "+" : ""}{(spreadBps! / 100).toFixed(2)}%
+            </span>
+          </div>
+        )}
 
         {/* Funding Rate — P3-6: pr-2 padding prevents right-edge clipping */}
         {funding8h != null && (

--- a/app/components/trade/MarketStatsCard.tsx
+++ b/app/components/trade/MarketStatsCard.tsx
@@ -9,7 +9,7 @@ import { useTokenMeta } from "@/hooks/useTokenMeta";
 import { formatTokenAmount, formatCompactTokenAmount, formatUsd, formatUsdPriceE6, formatBps } from "@/lib/format";
 import { sanitizeOnChainValue, sanitizeAccountCount, sanitizeBps, sanitizeFundingRateBps } from "@/lib/health";
 import { useLivePrice } from "@/hooks/useLivePrice";
-import { resolveMarketPriceE6, sanitizePriceE6, detectOracleMode } from "@/lib/oraclePrice";
+import { resolveMarketPriceE6, computeMarketSpread } from "@/lib/oraclePrice";
 import { FundingRateCard } from "./FundingRateCard";
 import { FundingRateChart } from "./FundingRateChart";
 import { sanitizeSymbol } from "@/lib/symbol-utils";
@@ -21,12 +21,6 @@ function formatNum(n: number): string {
   if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}K`;
   return `$${n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 }
-
-// Max sane on-chain mark price: $1M USD (matches markets page cap). Values above this
-// indicate corrupted/stale authorityPriceE6 data (e.g. raw token amounts stored as price).
-// When exceeded, fall back to live WebSocket price (#1131).
-const MAX_SANE_MARK_PRICE_USD = 1_000_000; // $1M
-const MAX_SANE_MARK_E6 = BigInt(MAX_SANE_MARK_PRICE_USD) * 1_000_000n;
 
 /**
  * Convert fundingRateBpsPerSlotLast (i64) to 8-hour percentage.
@@ -56,43 +50,11 @@ export const MarketStatsCard: FC = () => {
   const [showFundingChart, setShowFundingChart] = useState(false);
 
   // ─── Mark / Index / Spread ────────────────────────────────────────────────
-  const { markPriceE6, indexPriceE6, spreadBps, oracleMode } = useMemo(() => {
-    if (!mktConfig) return { markPriceE6: null, indexPriceE6: null, spreadBps: null, oracleMode: null };
-
-    const mode = detectOracleMode({ ...mktConfig, oracleModeByte: wrapperConfigV17?.oracleMode });
-    let mark: bigint | null = null;
-    let index: bigint | null = null;
-
-    if (mode === "hyperp" || mode === "admin" || mode === "keeper") {
-      // authorityPriceE6 = latest pushed/mark price
-      // lastEffectivePriceE6 = EMA / effective / index price
-      const rawMark = sanitizePriceE6(mktConfig.authorityPriceE6);
-      // Bug #1131: for HYPERP/admin markets, authorityPriceE6 can be corrupted (e.g. raw token
-      // vault amounts stored as price). Guard: reject if price > $1M — use live WS price instead.
-      mark = rawMark > 0n && rawMark <= MAX_SANE_MARK_E6 ? rawMark : null;
-      index = sanitizePriceE6(mktConfig.lastEffectivePriceE6);
-      if (index === 0n) index = null;
-      // Bug #843: for admin mode, lastEffectivePriceE6 may be uninitialized (e.g. 1000 = $0.001)
-      // when KeeperCrank hasn't run yet. If index is >100x smaller than mark, suppress it
-      // to avoid nonsensical spread display (e.g. +200,000,000%).
-      if (mode === "admin" && mark !== null && index !== null && index > 0n) {
-        const ratio = Number(mark) / Number(index);
-        if (ratio > 100) index = null;
-      }
-    } else {
-      // pyth-pinned: mark ≈ index (Pyth IS the oracle — no separate mark/index distinction)
-      const p = sanitizePriceE6(mktConfig.lastEffectivePriceE6);
-      mark = p > 0n ? p : null;
-      index = mark;
-    }
-
-    let bps: number | null = null;
-    if (mark !== null && index !== null && index > 0n) {
-      bps = (Number(mark - index) / Number(index)) * 10000;
-    }
-
-    return { markPriceE6: mark, indexPriceE6: index, spreadBps: bps, oracleMode: mode };
-  }, [mktConfig, wrapperConfigV17]);
+  // Shared with MarketInfoBar's top-bar spread stat — see lib/oraclePrice.ts.
+  const { markPriceE6, indexPriceE6, spreadBps, oracleMode } = useMemo(
+    () => computeMarketSpread(mktConfig, wrapperConfigV17?.oracleMode),
+    [mktConfig, wrapperConfigV17],
+  );
 
   // ─── Funding Rate ──────────────────────────────────────────────────────────
   // sanitizeFundingRateBps guards against garbage on-chain values (e.g. wrong

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -62,7 +62,7 @@ import { saveEntryPrice, getEntryPrice, clearEntryPrice } from "@/lib/entry-pric
 import { DepositWithdrawCard } from "@/components/trade/DepositWithdrawCard";
 import { useInitUser } from "@/hooks/useInitUser";
 
-const LEVERAGE_SNAP_POINTS = [1, 2, 5, 10, 20];
+const LEVERAGE_SNAP_POINTS = [1, 3, 5, 10, 20];
 const SIZE_PRESETS = [25, 50, 75, 100];
 const MAX_DISPLAY_LEVERAGE = 200;
 
@@ -235,8 +235,13 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
   const [marginInput, setMarginInput] = useState("");
   const [leverage, setLeverage] = useState(1);
   const [leverageText, setLeverageText] = useState("1");
+  // The unified snapping slider's native input is visually hidden (custom
+  // thumb div instead) — track focus explicitly so the fake thumb can carry
+  // a keyboard focus ring; opacity-0 would otherwise make the browser's own
+  // focus-visible outline invisible too, silently regressing keyboard a11y.
+  const [leverageFocused, setLeverageFocused] = useState(false);
   const [lastSig, setLastSig] = useState<string | null>(null);
-  const [tradePhase, setTradePhase] = useState<"idle" | "submitting" | "confirming">("idle");
+  const [tradePhase, setTradePhase] = useState<"idle" | "submitting" | "confirming" | "error">("idle");
   const [humanError, setHumanError] = useState<string | null>(null);
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [confirmSnapshot, setConfirmSnapshot] = useState<{
@@ -282,11 +287,6 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
     if (arr.length === 0 || arr[arr.length - 1] < maxLeverage) arr.push(maxLeverage);
     return arr;
   }, [maxLeverage]);
-  // Display-only: how far along the track the filled (accent) portion should
-  // paint, mirroring the current leverage value — purely a visual affordance
-  // for the range input's inline gradient background (see the slider below).
-  const leverageFillPct = maxLeverage > 1 ? ((leverage - 1) / (maxLeverage - 1)) * 100 : 100;
-
   const capital = userAccount ? userAccount.account.capital : 0n;
   // Margin already "locked" by this market's existing open position (if
   // any), so balance/buying-power reflect what's actually free to size a
@@ -540,7 +540,11 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
       const msg = e instanceof Error ? e.message : String(e);
       console.error("[OrderTicket] raw error:", msg);
       setHumanError(humanizeError(msg));
-      setTradePhase("idle");
+      // Brief "Failed" flash on the submit button itself (matches the
+      // "Confirmed!" success flash below) before reverting to idle — the
+      // detailed reason stays in the humanError banner underneath.
+      setTradePhase("error");
+      setTimeout(() => setTradePhase("idle"), 1200);
     }
   }
 
@@ -553,6 +557,21 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
 
   return (
     <div className="relative p-3.5">
+      {/* Top strip — order type (market-only, so a static label rather than
+          a tab you can't actually switch) + a leverage-at-a-glance pill.
+          Hyperliquid-style: leverage is visible from the first glance at the
+          ticket, not only once you've scrolled to the slider below. */}
+      <div className="mb-3 flex items-center justify-between">
+        <span className="text-[10px] font-bold uppercase tracking-[0.15em] text-[var(--text-secondary)]">Market</span>
+        <span
+          className="rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] px-2 py-0.5 text-[10px] font-semibold text-[var(--text)]"
+          style={{ fontFamily: "var(--font-mono)" }}
+          title="Current leverage — adjust below"
+        >
+          {leverage}x
+        </span>
+      </div>
+
       {/* Long / Short segmented — semantic long/short tokens only, symmetric
           unselected states (both read as neutral until chosen — previously
           Short's idle state was tinted red even when not selected, which
@@ -583,35 +602,38 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
         </button>
       </div>
 
+      {/* Account strip — Hyperliquid-style "Available to Trade" line: its own
+          clean row above the input rather than crammed into the Size label.
+          "Acc Bal" is AVAILABLE capital (total minus margin already locked by
+          an open position on this market) — when a position is open it shows
+          "avail / total" so the locked portion isn't hidden, just no longer
+          double-counted as spendable. */}
+      <div
+        className="mb-2 flex items-center justify-between text-[10px] text-[var(--text)]"
+        style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}
+        title={lockedMargin > 0n ? `${formatTokenAmount(lockedMargin, decimals, 3)} ${collateralSymbol} locked by your open position on this market` : undefined}
+      >
+        <span>
+          <span className="text-[var(--text-secondary)]">Balance </span>
+          {userAccount ? formatTokenAmount(availableBalance, decimals, 3) : "0"}
+          {lockedMargin > 0n && (
+            <span className="text-[var(--text-secondary)]">/{formatTokenAmount(capital, decimals, 3)}</span>
+          )}
+          <span className="text-[var(--text-secondary)]"> {collateralSymbol}</span>
+        </span>
+        <span>
+          <span className="text-[var(--text-secondary)]">Wallet </span>
+          {walletAtaBalance != null ? formatTokenAmount(walletAtaBalance, decimals, 3) : "—"}
+          <span className="text-[var(--text-secondary)]"> {collateralSymbol}</span>
+        </span>
+      </div>
+
       {/* Size — single input + unit toggle + quick-fill chips */}
       <div className="mb-2">
-        <div className="mb-1.5 flex items-center justify-between">
-          <label className="text-[10px] uppercase tracking-[0.15em] text-[var(--text)]">
-            Size
-            <InfoIcon tooltip="Position size in the toggled unit. Switch between token and USD - both stay in sync." />
-          </label>
-          {/* Both balances up top — users deposit from the wallet into the
-              account and trade from the account; showing only one confused
-              people about where their funds "went". 3dp keeps the row tight.
-              "Acc Bal" is AVAILABLE capital (total minus margin already
-              locked by an open position on this market) — when a position
-              is open it shows "avail / total" so the locked portion isn't
-              hidden, just no longer double-counted as spendable. */}
-          <span
-            className="text-[10px] text-[var(--text)]"
-            style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}
-            title={lockedMargin > 0n ? `${formatTokenAmount(lockedMargin, decimals, 3)} ${collateralSymbol} locked by your open position on this market` : undefined}
-          >
-            <span className="text-[var(--text-secondary)]">Acc Bal </span>
-            {userAccount ? formatTokenAmount(availableBalance, decimals, 3) : "0"}
-            {lockedMargin > 0n && (
-              <span className="text-[var(--text-secondary)]">/{formatTokenAmount(capital, decimals, 3)}</span>
-            )}
-            <span className="text-[var(--text-secondary)]"> · Wal Bal </span>
-            {walletAtaBalance != null ? formatTokenAmount(walletAtaBalance, decimals, 3) : "—"}
-            <span className="text-[var(--text-secondary)]"> {collateralSymbol}</span>
-          </span>
-        </div>
+        <label className="mb-1.5 block text-[10px] uppercase tracking-[0.15em] text-[var(--text)]">
+          Size
+          <InfoIcon tooltip="Position size in the toggled unit. Switch between token and USD - both stay in sync." />
+        </label>
         <div className="flex gap-1.5">
           <input
             type="text"
@@ -636,7 +658,7 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
           </p>
         )}
       </div>
-      <div className="mb-3 flex gap-1">
+      <div className="mb-2 flex gap-1">
         {SIZE_PRESETS.map((pct) => (
           <button
             key={pct}
@@ -648,8 +670,25 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
         ))}
       </div>
 
-      {/* Leverage slider + input */}
-      <div className="mb-4">
+      {/* Order value — surfaced right under the size input (Hyperliquid
+          shows notional at a glance here, not buried below leverage). Moved
+          out of the receipt box below so it isn't shown twice. */}
+      {hasOrder && (
+        <div className="mb-3 flex items-center justify-between text-[10px]">
+          <span className="flex items-center gap-1 text-[var(--text-secondary)] uppercase tracking-[0.08em]">
+            Order value
+            <InfoIcon tooltip="Total notional exposure — margin × leverage. sim-USDC is $1-pegged, so this is your USD exposure." />
+          </span>
+          <span className="font-mono tabular-nums text-[var(--text)]">
+            {formatTokenAmount(notionalNative, decimals)} {collateralSymbol}
+          </span>
+        </div>
+      )}
+
+      {/* Leverage slider + input — divider matches the account row's border-t
+          below, giving "size" and "leverage/risk" distinct visual sections
+          instead of one continuous unbroken stack. */}
+      <div className="mb-4 border-t border-[var(--border)]/20 pt-3">
         <div className="mb-1 flex items-center justify-between">
           <label className="text-[10px] uppercase tracking-[0.15em] text-[var(--text)]">
             Leverage
@@ -672,31 +711,91 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
             <span className="text-[11px] font-medium text-[var(--text)]">x</span>
           </div>
         </div>
-        <input
-          type="range"
-          min={1}
-          max={maxLeverage}
-          step={1}
-          value={leverage}
-          onChange={(e) => updateLeverage(Number(e.target.value))}
-          className="leverage-slider mb-2 w-full cursor-pointer touch-none"
-          style={{
-            background: `linear-gradient(to right, var(--accent) ${leverageFillPct}%, var(--border) ${leverageFillPct}%)`,
-          }}
-        />
-        <div className="flex flex-wrap gap-1">
-          {availableLeverage.map((l) => (
-            <button
-              key={l}
-              onClick={() => updateLeverage(l)}
-              className={`flex-1 basis-0 min-w-[32px] rounded-none py-1.5 text-[9px] font-medium transition-colors duration-150 ${
-                leverage === l ? "bg-[var(--accent)] text-white" : "border border-[var(--border)] text-[var(--text-secondary)] hover:border-[var(--accent)]/50 hover:text-[var(--text)]"
-              }`}
-            >
-              {l}x
-            </button>
-          ))}
-        </div>
+        {maxLeverage > 1 ? (() => {
+          const n = availableLeverage.length;
+
+          // Maps a leverage value → uniform display % — interpolates between
+          // snap-point INDICES, not raw numeric values, so labels stay evenly
+          // spaced regardless of the gap between them (e.g. 1/3/5/10/20 would
+          // bunch up on a linear numeric scale; this keeps them uniform).
+          const valueToPct = (val: number): number => {
+            if (n <= 1) return 0;
+            for (let i = 0; i < n - 1; i++) {
+              if (val <= availableLeverage[i + 1]) {
+                const lo = availableLeverage[i], hi = availableLeverage[i + 1];
+                return ((i + (hi > lo ? (val - lo) / (hi - lo) : 0)) / (n - 1)) * 100;
+              }
+            }
+            return 100;
+          };
+
+          const thumbPct = valueToPct(leverage);
+          const snapRadius = n > 1
+            ? Math.floor(Math.min(...availableLeverage.slice(1).map((v, i) => v - availableLeverage[i])) / 2)
+            : 0;
+
+          return (
+            <div className="relative pb-1">
+              {/* Track wrapper — gives the invisible input a well-defined bounding box */}
+              <div className="relative mx-0 mt-3 h-6">
+                {/* Visual track line, vertically centred */}
+                <div className="absolute inset-x-0 top-1/2 h-[3px] -translate-y-1/2 rounded-full bg-[var(--border)]/30">
+                  {/* Fill */}
+                  <div
+                    className="absolute left-0 top-0 h-full rounded-full bg-[var(--accent)]"
+                    style={{ width: `${thumbPct}%` }}
+                  />
+                </div>
+                {/* Custom thumb — carries the keyboard focus ring since the
+                    native input driving it is visually hidden below. */}
+                <div
+                  className={`pointer-events-none absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[var(--accent)] transition-shadow duration-150 ${
+                    leverageFocused ? "ring-2 ring-offset-2 ring-offset-[var(--bg)] ring-[var(--accent)]" : "ring-2 ring-[var(--accent)]/30"
+                  }`}
+                  style={{ left: `${thumbPct}%` }}
+                />
+                {/* Invisible native input — same bounding box as the wrapper (h-6), handles all drag/click */}
+                <input
+                  type="range"
+                  min={1}
+                  max={maxLeverage}
+                  step={1}
+                  value={leverage}
+                  onChange={(e) => {
+                    const raw = Number(e.target.value);
+                    const nearest = availableLeverage.reduce((best, v) =>
+                      Math.abs(v - raw) < Math.abs(best - raw) ? v : best, raw);
+                    updateLeverage(Math.abs(nearest - raw) <= snapRadius ? nearest : raw);
+                  }}
+                  onFocus={() => setLeverageFocused(true)}
+                  onBlur={() => setLeverageFocused(false)}
+                  className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+                  style={{ height: "100%" }}
+                  aria-label="Leverage"
+                />
+              </div>
+              {/* Labels — uniformly spaced, one per snap point */}
+              <div className="mt-2 flex justify-between">
+                {availableLeverage.map((l) => (
+                  <button
+                    key={l}
+                    type="button"
+                    onClick={() => updateLeverage(l)}
+                    className={`text-[8px] font-mono transition-colors duration-100 ${
+                      leverage === l
+                        ? "text-[var(--accent)] font-bold"
+                        : "text-[var(--text-dim)] hover:text-[var(--text-secondary)]"
+                    }`}
+                  >
+                    {l}x
+                  </button>
+                ))}
+              </div>
+            </div>
+          );
+        })() : (
+          <p className="text-[9px] text-[var(--text-dim)] font-mono">{maxLeverage}x (fixed)</p>
+        )}
       </div>
 
       {/* Receipt — before -> after. Deliberately "sunken" (var(--bg), the
@@ -767,7 +866,7 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
                   direction === "long" ? "bg-[var(--long)] text-black" : "bg-[var(--short)] text-white"
                 }`}
               >
-                {initLoading ? "Creating account…" : showInlineDeposit ? "Close" : canOneClick ? "Create Account & Deposit" : needsAccount ? "Get Tokens to Trade" : "Deposit to Trade"}
+                {initLoading ? "Creating account…" : showInlineDeposit ? "Close" : canOneClick ? "Initialize Account" : needsAccount ? "Get Tokens to Trade" : "Deposit to Trade"}
               </button>
             );
           })()}
@@ -804,11 +903,21 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
             setShowConfirmModal(true);
           }}
           disabled={submitDisabled}
-          className={`w-full rounded-none py-3 text-[12px] font-bold uppercase tracking-[0.12em] transition-[filter] duration-150 hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:brightness-100 ${
-            direction === "long" ? "bg-[var(--long)] text-black" : "bg-[var(--short)] text-white"
+          className={`w-full rounded-none py-3 text-[12px] font-bold uppercase tracking-[0.12em] transition-[filter] duration-150 hover:brightness-110 disabled:cursor-not-allowed disabled:hover:brightness-100 ${
+            tradePhase === "error"
+              ? "bg-[var(--short)] text-white disabled:opacity-100 animate-error-shake"
+              : `disabled:opacity-50 ${direction === "long" ? "bg-[var(--long)] text-black" : "bg-[var(--short)] text-white"} ${
+                  tradePhase === "confirming" ? "animate-scale-in" : ""
+                }`
           }`}
         >
-          {tradePhase === "submitting" ? "Submitting…" : tradePhase === "confirming" ? "Confirmed!" : `${direction === "long" ? "Long" : "Short"} ${symbol} ${leverage}x`}
+          {tradePhase === "submitting"
+            ? "Submitting…"
+            : tradePhase === "confirming"
+              ? "Confirmed!"
+              : tradePhase === "error"
+                ? "Failed"
+                : `${direction === "long" ? "Long" : "Short"} ${symbol} ${leverage}x`}
         </button>
       )}
 
@@ -823,17 +932,13 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
         </p>
       )}
 
-      {/* Account row: balance / buying power / deposit link */}
+      {/* Account row: buying power / deposit link. Available balance is
+          already shown compactly next to the Size input above ("Acc Bal") —
+          repeating it here duplicated the same number under a different
+          label; Buying Power is the one distinct figure worth a second look. */}
       <div className="mt-3 flex items-center justify-between border-t border-[var(--border)]/30 pt-2.5 text-[10px]">
         <div>
           <div className="flex items-center gap-1 text-[9px] uppercase tracking-[0.1em] text-[var(--text-secondary)]">
-            Avail Bal
-            <InfoIcon tooltip="Account balance minus margin already locked by an open position on this market." />
-          </div>
-          <div className="font-mono tabular-nums text-[var(--text)]">{formatTokenAmount(effectiveBalance, decimals)} {collateralSymbol}</div>
-        </div>
-        <div className="text-right">
-          <div className="flex items-center justify-end gap-1 text-[9px] uppercase tracking-[0.1em] text-[var(--text-secondary)]">
             Buying power
             <InfoIcon tooltip="Available balance x max leverage - the largest notional you could open right now." />
           </div>

--- a/app/components/trade/PositionsDock.tsx
+++ b/app/components/trade/PositionsDock.tsx
@@ -61,6 +61,7 @@ import { TradeHistory } from "./TradeHistory";
 import { InfoIcon } from "@/components/ui/Tooltip";
 import { sanitizeSymbol } from "@/lib/symbol-utils";
 import { useOracleFreshness } from "@/hooks/useOracleFreshness";
+import { usePriceFlash } from "@/hooks/usePriceFlash";
 import { getEntryPrice, clearEntryPrice } from "@/lib/entry-price";
 import { applyInvert, sanitizePriceE6 } from "@/lib/oraclePrice";
 import { isSentinelValue } from "@/lib/health";
@@ -108,6 +109,10 @@ const PositionRow: FC<{ slabAddress: string }> = memo(function PositionRow({ sla
   const decimals = tokenMeta?.decimals ?? 6;
 
   const { closePosition, loading: closeLoading, error: closeError } = useClosePosition(slabAddress);
+  // Called unconditionally, before the `!activeInfo` early return below, per
+  // rules of hooks — mirrors MarketInfoBar's MarkPrice / MarketBookCard's
+  // Oracle cell (same shared hook, see hooks/usePriceFlash.ts).
+  const markFlash = usePriceFlash(livePriceE6 ?? null);
   const { level: oracleLevel, mode: oracleMode, ready: oracleReady } = useOracleFreshness();
   const oracleUnavailable = oracleLevel === "unavailable";
   const oracleStale = !mockMode && (oracleUnavailable || (oracleReady && oracleLevel === "stale" && (oracleMode === "admin" || oracleMode === "hyperp")));
@@ -285,8 +290,15 @@ const PositionRow: FC<{ slabAddress: string }> = memo(function PositionRow({ sla
               <td className="whitespace-nowrap px-3 py-2.5 text-right text-[var(--text)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
                 {formatUsdPriceE6(entryPriceE6)}
               </td>
-              <td className="whitespace-nowrap px-3 py-2.5 text-right text-[var(--text)]" style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}>
-                {hasValidMark ? formatUsdPriceE6(currentPriceE6) : <span className="text-[var(--text-dim)]">--</span>}
+              <td
+                className={`whitespace-nowrap px-3 py-2.5 text-right transition-colors duration-300 ease-out ${
+                  hasValidMark
+                    ? markFlash === "up" ? "text-[var(--long)]" : markFlash === "down" ? "text-[var(--short)]" : "text-[var(--text)]"
+                    : "text-[var(--text-dim)]"
+                }`}
+                style={{ fontFamily: "var(--font-mono)", fontVariantNumeric: "tabular-nums" }}
+              >
+                {hasValidMark ? formatUsdPriceE6(currentPriceE6) : "--"}
               </td>
               <td
                 className={`whitespace-nowrap px-3 py-2.5 text-right font-medium ${liqPriceColor}`}

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -28,6 +28,7 @@ import { useEngineState } from "@/hooks/useEngineState";
 import { useLiqPrice } from "@/hooks/useLiqPrice";
 import { useChartTheme } from "@/hooks/useChartTheme";
 import { ChartEmptyState } from "./ChartEmptyState";
+import { ShimmerSkeleton } from "@/components/ui/ShimmerSkeleton";
 import { ChartStyleMenu } from "./ChartStyleMenu";
 import { ChartDisplayMenu } from "./ChartDisplayMenu";
 import { ChartPnlBadge } from "./ChartPnlBadge";
@@ -316,6 +317,10 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
   const seriesRef = useRef<ISeriesApi<ChartSeriesKind> | null>(null);
   const volumeSeriesRef = useRef<ISeriesApi<"Histogram"> | null>(null);
   const priceLineRef = useRef<ReturnType<ISeriesApi<"Candlestick">["createPriceLine"]> | null>(null);
+  // Tracks the previous tick's price purely to color the mark-price line —
+  // no React state involved (see the "Live tick -> chart" effect below),
+  // so this doesn't add a re-render on every tick.
+  const prevTickPriceRef = useRef<number | null>(null);
   const liqLineRef = useRef<ReturnType<ISeriesApi<"Candlestick">["createPriceLine"]> | null>(null);
   const entryLineRef = useRef<ReturnType<ISeriesApi<"Candlestick">["createPriceLine"]> | null>(null);
   // Phase 2: the currently-forming bar/point, kept in sync by the structural
@@ -644,6 +649,7 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
     priceLineRef.current = null;
     liqLineRef.current = null;
     entryLineRef.current = null;
+    prevTickPriceRef.current = null;
 
     // Series selection.
     //
@@ -931,7 +937,16 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
       const usd = snap.priceUsd;
 
       if (priceLineRef.current) {
-        priceLineRef.current.applyOptions({ price: usd });
+        // Hyperliquid-style: the mark price tag on the right axis tints
+        // long-green/short-red on each tick instead of sitting flat gray —
+        // same semantic tokens as MarketInfoBar's MarkPrice flash, applied
+        // here via the price line's own color (canvas can't read CSS vars,
+        // so these are the literal --long/--short hex values). Holds its
+        // last color on an exact-equal tick rather than resetting to gray.
+        const prev = prevTickPriceRef.current;
+        const color = prev == null ? "rgba(255,255,255,0.6)" : usd > prev ? "#14F195" : usd < prev ? "#FF3B5C" : undefined;
+        prevTickPriceRef.current = usd;
+        priceLineRef.current.applyOptions(color ? { price: usd, color } : { price: usd });
       }
 
       const series = seriesRef.current;
@@ -973,6 +988,12 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
   // so that lightweight-charts can create its canvas. Sparse/empty state is
   // rendered as an overlay inside the container below.
   const showEmptyOverlay = totalDataPoints === 0 || effectiveSparse;
+  // Distinguishes "still fetching, first paint hasn't happened yet" from
+  // "all three sources settled and there's genuinely no data" — previously
+  // both looked identical (instant "No chart data yet"), which reads as
+  // broken on a fresh page load even though a request is in flight.
+  const anySourceLoading = pythStatus === "loading" || externalStatus === "loading" || percolatorStatus === "loading";
+  const showLoadingOverlay = totalDataPoints === 0 && anySourceLoading;
 
   return (
     <div className="flex h-full flex-col rounded-none border border-[var(--border)] bg-[var(--panel-bg)] p-3">
@@ -1128,7 +1149,17 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
                 empty-state overlay. The price TEXT itself, once this branch
                 is chosen, is the isolated LiveMarkPriceLabel leaf so it still
                 updates live if the overlay stays visible for a while. */}
-            {getSnapshot(slabAddress).priceUsd != null && getSnapshot(slabAddress).priceUsd! > 0 ? (
+            {showLoadingOverlay ? (
+              <div className="flex items-end gap-1" aria-label="Loading chart data" role="status">
+                {/* Skyline of shimmer bars hints at the candlestick shape to
+                    come, rather than a generic spinner — same shimmer system
+                    (ShimmerSkeleton) already used for MarketBookCard's
+                    loading state. */}
+                {[14, 22, 10, 26, 16, 20, 12].map((h, i) => (
+                  <ShimmerSkeleton key={i} className="w-2" style={{ height: `${h}px` }} />
+                ))}
+              </div>
+            ) : getSnapshot(slabAddress).priceUsd != null && getSnapshot(slabAddress).priceUsd! > 0 ? (
               <>
                 <LiveMarkPriceLabel />
                 <div className="mt-1 text-[10px] uppercase tracking-[0.15em] text-[var(--text-dim)]">

--- a/app/hooks/useChartTheme.ts
+++ b/app/hooks/useChartTheme.ts
@@ -27,10 +27,15 @@ const DARK_THEME: ChartTheme = {
   // clearly above this 0.07 grid, so the hierarchy holds.
   gridColor: "rgba(255,255,255,0.07)",
   borderColor: "rgba(255,255,255,0.10)",
-  upColor: "#22c55e",
-  downColor: "#ef4444",
-  volUpColor: "rgba(34,197,94,0.6)",
-  volDownColor: "rgba(239,68,68,0.6)",
+  // Brand --long/--short (globals.css), not generic Tailwind green/red-500 —
+  // candles + volume bars are the single most visible color on the chart,
+  // and they were the one surface still off-brand vs. MarketInfoBar /
+  // PositionsDock / OrderTicket, which all use these exact tokens (canvas
+  // can't read CSS custom properties, so these are the literal hex values).
+  upColor: "#14F195",
+  downColor: "#FF3B5C",
+  volUpColor: "rgba(20,241,149,0.6)",
+  volDownColor: "rgba(255,59,92,0.6)",
 };
 
 const LIGHT_THEME: ChartTheme = {

--- a/app/hooks/usePriceFlash.ts
+++ b/app/hooks/usePriceFlash.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * The classic perp-DEX tick micro-interaction: briefly tints a value
+ * long-green (up) or short-red (down) when it changes, easing back to
+ * neutral over `durationMs`. No layout shift — callers apply the returned
+ * class as a text-color override on an already-laid-out element.
+ *
+ * Extracted from `MarketInfoBar`'s `MarkPrice` component (the original,
+ * proven implementation) so PositionsDock/MarketBookCard can reuse the exact
+ * same flash behavior instead of re-deriving it.
+ */
+export function usePriceFlash(value: bigint | null | undefined, durationMs = 300): "up" | "down" | null {
+  const prev = useRef<bigint | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [flash, setFlash] = useState<"up" | "down" | null>(null);
+
+  useEffect(() => {
+    if (value == null) return;
+    const prevValue = prev.current;
+    if (prevValue != null && value !== prevValue) {
+      setFlash(value > prevValue ? "up" : "down");
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(() => setFlash(null), durationMs);
+    }
+    prev.current = value;
+  }, [value, durationMs]);
+
+  useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
+
+  return flash;
+}

--- a/app/lib/oraclePrice.ts
+++ b/app/lib/oraclePrice.ts
@@ -152,3 +152,62 @@ export function priceE6ToUsd(priceE6: bigint): number | null {
   if (priceE6 <= 0n) return null;
   return Number(priceE6) / 1_000_000;
 }
+
+export interface MarketSpreadInfo {
+  markPriceE6: bigint | null;
+  indexPriceE6: bigint | null;
+  spreadBps: number | null;
+  oracleMode: OracleMode | null;
+}
+
+/**
+ * Compute mark/index price and their spread (bps) for a market, mode-aware.
+ *
+ * Single source of truth for the mark-vs-index spread math shared by
+ * MarketStatsCard (analytics) and MarketInfoBar (always-visible top bar) —
+ * keep any bug fixes here rather than duplicating at call sites.
+ */
+export function computeMarketSpread(
+  mktConfig: {
+    oracleAuthority: PublicKey;
+    indexFeedId: PublicKey;
+    authorityPriceE6: bigint;
+    lastEffectivePriceE6: bigint;
+  } | null,
+  oracleModeByte?: number,
+): MarketSpreadInfo {
+  if (!mktConfig) return { markPriceE6: null, indexPriceE6: null, spreadBps: null, oracleMode: null };
+
+  const mode = detectOracleMode({ ...mktConfig, oracleModeByte });
+  let mark: bigint | null = null;
+  let index: bigint | null = null;
+
+  if (mode === "hyperp" || mode === "admin" || mode === "keeper") {
+    // authorityPriceE6 = latest pushed/mark price; lastEffectivePriceE6 = EMA/effective/index price.
+    // Bug #1131: for HYPERP/admin markets, authorityPriceE6 can be corrupted (e.g. raw token
+    // vault amounts stored as price). Guard: reject if price > MAX_PRICE_E6.
+    const rawMark = sanitizePriceE6(mktConfig.authorityPriceE6);
+    mark = rawMark > 0n && rawMark <= MAX_PRICE_E6 ? rawMark : null;
+    index = sanitizePriceE6(mktConfig.lastEffectivePriceE6);
+    if (index === 0n) index = null;
+    // Bug #843: for admin mode, lastEffectivePriceE6 may be uninitialized (e.g. 1000 = $0.001)
+    // when KeeperCrank hasn't run yet. If index is >100x smaller than mark, suppress it
+    // to avoid nonsensical spread display (e.g. +200,000,000%).
+    if (mode === "admin" && mark !== null && index !== null && index > 0n) {
+      const ratio = Number(mark) / Number(index);
+      if (ratio > 100) index = null;
+    }
+  } else {
+    // pyth-pinned: mark ≈ index (Pyth IS the oracle — no separate mark/index distinction)
+    const p = sanitizePriceE6(mktConfig.lastEffectivePriceE6);
+    mark = p > 0n ? p : null;
+    index = mark;
+  }
+
+  let bps: number | null = null;
+  if (mark !== null && index !== null && index > 0n) {
+    bps = (Number(mark - index) / Number(index)) * 10000;
+  }
+
+  return { markPriceE6: mark, indexPriceE6: index, spreadBps: bps, oracleMode: mode };
+}

--- a/app/next-env.d.ts
+++ b/app/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
This PR consolidates several critical frontend fixes and UX improvements for the Percolator trading and staking terminal.

### Key Changes:

1. **Trade Terminal & Slider UX**
   - **Range Sliders**: Fixed interactive dragging height issues on the leverage slider (`OrderTicket.tsx`) and the close position slider (`ClosePositionModal.tsx`) by overriding `height` inline to bypass the restrictive global `2px` CSS height. The visual track lines are kept centered and thin using inline gradient-size scaling.
   - **Onboarding CTA**: Corrected the onboarding CTA button text from "Create Account & Deposit" to "Initialize Account" to accurately reflect the underlying on-chain action.
   - **Price Flash Indicator**: Implemented a Hyperliquid-style price tick indicator that flashes long-green/short-red on each price update.
   
2. **Staking Page & Pools**
   - **Visual Layout**: Resolved pool card clipping issues and added a discoverable Deposit/Withdraw toggle.
   - **Metadata & Prices**: Displayed real token names, symbols, live prices, and USDC balance labels with general card polish.

3. **General App Fixes**
   - **Price WebSockets**: Updated the WebSocket server binding to use the dynamically injected Railway port.
   - **Slab Stats & Charts**: Standardized chart entry and liquidation line displays for unliquidatable longs and corrected 24h stats.
