### PR TITLE
fix(security): validate client IP extraction and stop trusting spoofable forwarding headers (GH#2218)

### DIFF
--- a/app/__tests__/lib/get-client-ip.test.ts
+++ b/app/__tests__/lib/get-client-ip.test.ts
@@ -1,0 +1,141 @@
+/**
+ * GH#2218 — hardened shared client-IP extractor.
+ *
+ * The previous implementation trusted `x-forwarded-for` / `x-real-ip`
+ * verbatim: any caller-controlled string became a rate-limit key or
+ * blocklist input. The hardened version validates every candidate as a
+ * real IPv4/IPv6 address and prefers proxy-set single-IP headers
+ * (cf-connecting-ip, x-real-ip) over the client-influenced XFF chain,
+ * mirroring the waitlist parser (lib/waitlist/client-ip.ts).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { getClientIp, isValidIp } from "@/lib/get-client-ip";
+
+function makeReq(headers: Record<string, string>) {
+  return new Request("https://example.com/api/test", { headers }) as never;
+}
+
+const ORIGINAL_DEPTH = process.env.TRUSTED_PROXY_DEPTH;
+
+beforeEach(() => {
+  delete process.env.TRUSTED_PROXY_DEPTH; // default depth = 1
+});
+
+afterEach(() => {
+  if (ORIGINAL_DEPTH === undefined) delete process.env.TRUSTED_PROXY_DEPTH;
+  else process.env.TRUSTED_PROXY_DEPTH = ORIGINAL_DEPTH;
+});
+
+describe("getClientIp header precedence", () => {
+  it("prefers cf-connecting-ip over everything else", () => {
+    const req = makeReq({
+      "cf-connecting-ip": "203.0.113.7",
+      "x-real-ip": "198.51.100.1",
+      "x-forwarded-for": "192.0.2.1, 192.0.2.2",
+    });
+    expect(getClientIp(req)).toBe("203.0.113.7");
+  });
+
+  it("prefers x-real-ip over x-forwarded-for", () => {
+    const req = makeReq({
+      "x-real-ip": "198.51.100.1",
+      "x-forwarded-for": "192.0.2.1, 192.0.2.2",
+    });
+    expect(getClientIp(req)).toBe("198.51.100.1");
+  });
+
+  it("uses the TRUSTED_PROXY_DEPTH hop of x-forwarded-for (rightmost at depth 1)", () => {
+    const req = makeReq({ "x-forwarded-for": "1.2.3.4, 5.6.7.8" });
+    expect(getClientIp(req)).toBe("5.6.7.8");
+  });
+
+  it("uses the second-to-last hop at depth 2", () => {
+    process.env.TRUSTED_PROXY_DEPTH = "2";
+    const req = makeReq({ "x-forwarded-for": "9.9.9.9, 1.2.3.4, 5.6.7.8" });
+    expect(getClientIp(req)).toBe("1.2.3.4");
+  });
+
+  it("returns unknown when no header is present", () => {
+    expect(getClientIp(makeReq({}))).toBe("unknown");
+  });
+});
+
+describe("getClientIp validation (GH#2218)", () => {
+  it("rejects a non-IP x-real-ip instead of using it as an identity key", () => {
+    const req = makeReq({ "x-real-ip": "fresh-bucket-please" });
+    expect(getClientIp(req)).toBe("unknown");
+  });
+
+  it("rejects a non-IP cf-connecting-ip and falls through to x-real-ip", () => {
+    const req = makeReq({
+      "cf-connecting-ip": "not-an-ip",
+      "x-real-ip": "198.51.100.1",
+    });
+    expect(getClientIp(req)).toBe("198.51.100.1");
+  });
+
+  it("returns unknown when the selected XFF hop is not an IP (no fallback to attacker-controlled hops)", () => {
+    const req = makeReq({ "x-forwarded-for": "6.6.6.6, garbage" });
+    expect(getClientIp(req)).toBe("unknown");
+  });
+
+  it("strips an IPv4 port suffix", () => {
+    const req = makeReq({ "x-real-ip": "192.0.2.1:443" });
+    expect(getClientIp(req)).toBe("192.0.2.1");
+  });
+
+  it("strips brackets and port from IPv6", () => {
+    const req = makeReq({ "x-real-ip": "[2001:db8::1]:443" });
+    expect(getClientIp(req)).toBe("2001:db8::1");
+  });
+
+  it("accepts a bare IPv6 address", () => {
+    const req = makeReq({ "x-real-ip": "2001:db8::1" });
+    expect(getClientIp(req)).toBe("2001:db8::1");
+  });
+});
+
+describe("getClientIp TRUSTED_PROXY_DEPTH=0 (no trusted proxy)", () => {
+  it("ignores all forwarding headers — every one is client-supplied", () => {
+    process.env.TRUSTED_PROXY_DEPTH = "0";
+    const req = makeReq({
+      "cf-connecting-ip": "203.0.113.7",
+      "x-real-ip": "198.51.100.1",
+      "x-forwarded-for": "192.0.2.1",
+    });
+    expect(getClientIp(req)).toBe("unknown");
+  });
+});
+
+describe("isValidIp", () => {
+  it.each([
+    "192.0.2.1",
+    "0.0.0.0",
+    "255.255.255.255",
+    "::1",
+    "::",
+    "2001:db8::1",
+    "2001:db8:0:0:0:0:0:1",
+    "::ffff:192.0.2.1",
+    "fe80::a:b:c:d",
+  ])("accepts %s", (ip) => {
+    expect(isValidIp(ip)).toBe(true);
+  });
+
+  it.each([
+    "",
+    "unknown",
+    "1.2.3.4.5",
+    "256.0.0.1",
+    "01.2.3.4", // octal-ambiguous leading zero
+    "1.2.3",
+    "::::::",
+    "a:b:c:d.e",
+    "1::2::3",
+    "1:2:3:4:5:6:7:8:9",
+    "g::1",
+    "192.0.2.1; DROP TABLE",
+  ])("rejects %s", (ip) => {
+    expect(isValidIp(ip)).toBe(false);
+  });
+});

--- a/app/lib/get-client-ip.ts
+++ b/app/lib/get-client-ip.ts
@@ -1,29 +1,148 @@
 /**
- * Trusted-proxy-aware client IP extractor.
+ * Trusted-proxy-aware client IP extractor (Edge Runtime compatible).
  *
- * Uses `TRUSTED_PROXY_DEPTH` to determine how many hops to peel off the
- * `x-forwarded-for` chain (rightmost hop is most-trusted). Falls back to
- * `x-real-ip` if the forwarded-for header is absent, then "unknown".
+ * Header precedence mirrors the hardened waitlist parser
+ * (`lib/waitlist/client-ip.ts`), which is the local security standard
+ * (GH#2218). Most-trustworthy first:
  *
- * Must stay in sync with app/app/api/devnet-mirror-mint/route.ts (getClientIp).
+ *   1. `cf-connecting-ip` — Cloudflare's single-IP header. Set by
+ *      Cloudflare itself and not propagated from the client in the
+ *      production CF→Vercel topology.
+ *   2. `x-real-ip` — set by Vercel (and most reverse proxies) to the
+ *      direct peer. Vercel overwrites whatever the client sent.
+ *   3. `x-forwarded-for` — comma-separated `client, proxy1, …` chain.
+ *      Only the entry appended by the innermost trusted proxy is
+ *      consulted, controlled by `TRUSTED_PROXY_DEPTH` (rightmost hop
+ *      is most-trusted). If that entry is not a syntactically valid
+ *      IP the function returns "unknown" rather than falling back to
+ *      an attacker-controlled entry further left.
+ *
+ * Every candidate is validated as a real IPv4/IPv6 address before use —
+ * a caller-controlled garbage string must never become a rate-limit key
+ * or blocklist input. This module runs in the Edge Runtime (middleware),
+ * so validation is implemented locally instead of via `node:net.isIP`.
+ *
+ * `TRUSTED_PROXY_DEPTH=0` means "no trusted proxy in front" — in that
+ * topology every forwarding header is client-supplied, so none of them
+ * are trusted and the function returns "unknown".
  */
 import type { NextRequest } from "next/server";
 
 export function getClientIp(req: NextRequest): string {
   const PROXY_DEPTH = Math.max(0, Number(process.env.TRUSTED_PROXY_DEPTH ?? 1));
-  if (PROXY_DEPTH > 0) {
-    const forwarded = req.headers.get("x-forwarded-for");
-    if (forwarded) {
-      const ips = forwarded.split(",").map((s) =>
-      s.trim()).filter(Boolean);
-      if (ips.length > 0) {
-        const idx = Math.max(0, ips.length - 
-      PROXY_DEPTH);
-        return ips[idx] ?? "unknown";
-      }
+  if (PROXY_DEPTH === 0) return "unknown";
+
+  const cfIp = checkIp(req.headers.get("cf-connecting-ip"));
+  if (cfIp) return cfIp;
+
+  const realIp = checkIp(req.headers.get("x-real-ip"));
+  if (realIp) return realIp;
+
+  const forwarded = req.headers.get("x-forwarded-for");
+  if (forwarded) {
+    const ips = forwarded.split(",").map((s) => s.trim()).filter(Boolean);
+    if (ips.length > 0) {
+      // Each proxy appends the peer it received the connection from, so
+      // with N trusted proxies the client is the Nth entry from the right.
+      const idx = Math.max(0, ips.length - PROXY_DEPTH);
+      const picked = checkIp(ips[idx] ?? null);
+      if (picked) return picked;
     }
   }
-  const realIp = req.headers.get("x-real-ip");
-  if (realIp) return realIp;
+
   return "unknown";
+}
+
+/**
+ * Normalise a raw header value and validate it as a real IPv4/IPv6
+ * address. Returns the validated address on success, `null` otherwise.
+ */
+function checkIp(raw: string | null): string | null {
+  if (!raw) return null;
+  const normalised = normaliseIp(raw.trim());
+  return isValidIp(normalised) ? normalised : null;
+}
+
+/**
+ * Strip the cruft proxies append to the raw IP — surrounding brackets
+ * on IPv6 (`[::1]:443` → `::1`), trailing `:port` on IPv4
+ * (`192.0.2.1:443` → `192.0.2.1`). Does NOT validate.
+ */
+function normaliseIp(raw: string): string {
+  if (raw.startsWith("[")) {
+    const end = raw.indexOf("]");
+    if (end > 0) return raw.slice(1, end);
+  }
+  // IPv4 with port: exactly one colon AND a dot present (IPv6 has
+  // multiple colons; bare IPv4 has none).
+  const firstColon = raw.indexOf(":");
+  if (firstColon !== -1 && raw.lastIndexOf(":") === firstColon && raw.includes(".")) {
+    return raw.slice(0, firstColon);
+  }
+  return raw;
+}
+
+/**
+ * Strict IPv4/IPv6 syntax check, Edge Runtime compatible (no `node:net`).
+ * Exported for unit tests.
+ */
+export function isValidIp(s: string): boolean {
+  return isIPv4(s) || isIPv6(s);
+}
+
+function isIPv4(s: string): boolean {
+  const parts = s.split(".");
+  if (parts.length !== 4) return false;
+  for (const p of parts) {
+    if (!/^\d{1,3}$/.test(p)) return false;
+    const n = Number(p);
+    if (n > 255) return false;
+    // Reject leading zeros ("01") — some parsers read them as octal,
+    // so "010.0.0.1" can alias a different address downstream.
+    if (p.length > 1 && p.startsWith("0")) return false;
+  }
+  return true;
+}
+
+function isIPv6(s: string): boolean {
+  if (!s.includes(":")) return false;
+  // At most one "::" (zero-compression marker).
+  const doubleColonCount = s.split("::").length - 1;
+  if (doubleColonCount > 1) return false;
+
+  const hasCompression = doubleColonCount === 1;
+  const [left, right = ""] = hasCompression ? s.split("::") : [s];
+
+  const parseGroups = (part: string): string[] | null => {
+    if (part === "") return [];
+    const groups = part.split(":");
+    // Empty group inside a side means stray ":" (e.g. ":::" or "a::b:")
+    if (groups.some((g) => g === "")) return null;
+    return groups;
+  };
+
+  const leftGroups = parseGroups(left ?? "");
+  const rightGroups = parseGroups(right);
+  if (leftGroups === null || rightGroups === null) return false;
+
+  let groupCount = 0;
+  const all = [...leftGroups, ...rightGroups];
+  for (let i = 0; i < all.length; i++) {
+    const g = all[i]!;
+    const isLast = i === all.length - 1;
+    if (isLast && g.includes(".")) {
+      // Embedded IPv4 tail (e.g. "::ffff:192.0.2.1") counts as two groups.
+      if (!isIPv4(g)) return false;
+      groupCount += 2;
+      continue;
+    }
+    if (!/^[0-9a-fA-F]{1,4}$/.test(g)) return false;
+    groupCount += 1;
+  }
+
+  if (hasCompression) {
+    // "::" must stand for at least one zero group.
+    return groupCount <= 7;
+  }
+  return groupCount === 8;
 }

--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -3,6 +3,7 @@ import type { NextRequest } from "next/server";
 import { Redis } from "@upstash/redis";
 import { Ratelimit } from "@upstash/ratelimit";
 import { BLOCKED_SLAB_ADDRESSES } from "@/lib/blocklist";
+import { getClientIp } from "@/lib/get-client-ip";
 
 // ── Rate limiter configuration ───────────────────────────────────────────────
 // Two tiers: RPC proxy gets a higher limit since Solana web3.js generates many calls per page load.
@@ -332,21 +333,15 @@ export async function middleware(request: NextRequest) {
   }
 
   // ── IP Blocklist check ─────────────────────────────────────────────────────
-  // Resolve client IP using the same proxy-depth logic as the rate limiter.
+  // Resolve client IP via the shared hardened helper (GH#2218) — validated,
+  // trusted-header-first, proxy-depth-aware. Same identity the rate limiter
+  // uses below.
+  // NOTE: depth=0 means "no proxy" — getClientIp returns "unknown" and
+  // _isBlocked("unknown") returns false, effectively disabling the
+  // Edge Runtime blocklist. The Hono ip-blocklist.ts middleware
+  // handles depth=0 correctly for the API server path.
   if (_blocklist.length > 0) {
-    const _proxyDepth = Math.max(0, Number(process.env.TRUSTED_PROXY_DEPTH ?? 1));
-    let _clientIp = "unknown";
-    // NOTE: depth=0 means "no proxy" — _clientIp stays "unknown" and
-    // _isBlocked("unknown") returns false, effectively disabling the
-    // Edge Runtime blocklist. The Hono ip-blocklist.ts middleware
-    // handles depth=0 correctly for the API server path.
-    if (_proxyDepth > 0) {
-      const _fwd = request.headers.get("x-forwarded-for");
-      if (_fwd) {
-        const _ips = _fwd.split(",").map((s) => s.trim());
-        _clientIp = _ips[Math.max(0, _ips.length - _proxyDepth)] ?? "unknown";
-      }
-    }
+    const _clientIp = getClientIp(request);
     if (_isBlocked(_clientIp)) {
       return new NextResponse(JSON.stringify({ error: "Forbidden" }), {
         status: 403,
@@ -392,21 +387,14 @@ export async function middleware(request: NextRequest) {
     return response;
   }
 
-  // Extract client IP respecting TRUSTED_PROXY_DEPTH env var.
-  // - TRUSTED_PROXY_DEPTH=0: Ignore X-Forwarded-For (direct exposure, no proxy)
-  // - TRUSTED_PROXY_DEPTH=1: One proxy layer (Vercel, Cloudflare) — use last IP
-  // - TRUSTED_PROXY_DEPTH=2: Two proxy layers — use second-to-last IP
-  // This prevents IP spoofing attacks via forged X-Forwarded-For headers.
-  const PROXY_DEPTH = Math.max(0, Number(process.env.TRUSTED_PROXY_DEPTH ?? 1));
-  let ip = "unknown";
-  if (PROXY_DEPTH > 0) {
-    const forwarded = request.headers.get("x-forwarded-for");
-    if (forwarded) {
-      const ips = forwarded.split(",").map((s) => s.trim());
-      const idx = Math.max(0, ips.length - PROXY_DEPTH);
-      ip = ips[idx] ?? "unknown";
-    }
-  }
+  // Extract client IP via the shared hardened helper (GH#2218):
+  // trusted single-IP headers (cf-connecting-ip, x-real-ip) first, then the
+  // TRUSTED_PROXY_DEPTH-selected x-forwarded-for hop, every candidate
+  // validated as a real IPv4/IPv6 address before it becomes a rate-limit key.
+  // - TRUSTED_PROXY_DEPTH=0: no trusted proxy — ignore all forwarding headers
+  // - TRUSTED_PROXY_DEPTH=1: one proxy layer (Vercel, Cloudflare) — use last IP
+  // - TRUSTED_PROXY_DEPTH=2: two proxy layers — use second-to-last IP
+  const ip = getClientIp(request);
   const isApi = request.nextUrl.pathname.startsWith("/api/");
 
   if (isApi) {


### PR DESCRIPTION
Fixes #2218.

## Problem

`getClientIp` (`app/lib/get-client-ip.ts`) and the two inline copies in `app/middleware.ts` derived rate-limit keys, blocklist inputs, and downstream identity metadata directly from `x-forwarded-for` / `x-real-ip` with no validation. Any caller whose forwarding headers reach the origin can rotate arbitrary strings into fresh rate-limit buckets and bypass IP-based controls. The repo already contained a hardened parser for the waitlist (`lib/waitlist/client-ip.ts`), so the shared primitive was weaker than the local security standard.

## Fix

- `getClientIp` now mirrors the waitlist parser's precedence: `cf-connecting-ip` -> `x-real-ip` -> `TRUSTED_PROXY_DEPTH`-selected `x-forwarded-for` hop.
- Every candidate is validated as a real IPv4/IPv6 address before it becomes an identity key. Validation is implemented locally (Edge Runtime safe -- middleware cannot use `node:net`), including port/bracket normalisation, leading-zero octet rejection, and IPv6 grammar (zero compression, embedded IPv4 tail).
- If the selected XFF hop is invalid the function returns `"unknown"` -- it does NOT fall back to attacker-controlled entries further left.
- `TRUSTED_PROXY_DEPTH=0` now means "no trusted proxy -> trust no forwarding header" instead of silently accepting raw `x-real-ip`.
- `middleware.ts` drops both duplicated inline parsers and uses the shared helper for the IP blocklist and the global API rate limiter, so every consumer shares one identity definition.

## Testing

- New `app/__tests__/lib/get-client-ip.test.ts`: header precedence, validation rejects (`fresh-bucket-please` as x-real-ip -> unknown), no XFF fallback to attacker hops, port/bracket stripping, depth semantics, isValidIp accept/reject table.
- `npx tsc --noEmit -p app/tsconfig.json` -- 0 errors.
- Full app vitest suite: no new failures (the 13 pre-existing failures in oracle-advance-phase / admin-session-security-v2 / useStuckSlabs fail identically on main).

## Residual risk (documented, out of scope)

On a direct-to-Vercel path an attacker can still supply `cf-connecting-ip` (trusted first, matching the waitlist parser's documented CF->Vercel topology assumption). Locking the origin to Cloudflare IP ranges or verifying an origin secret would close that; that is deployment configuration, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client IP detection for blocking and rate limiting, making it more reliable behind proxies.
  * Added stricter handling for malformed IP headers, reducing false matches and unsafe values.
  * Updated header priority so the most trusted client IP source is used first, with better support for IPv4, IPv6, and proxy port formats.

* **Tests**
  * Added coverage for proxy depth handling, header precedence, and IP validation edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->