### PR TITLE
fix(security): faucet/airdrop claim gates fail closed on database errors (GH#2216)

### DIFF
--- a/app/__tests__/api/airdrop-rate-limit-gate.test.ts
+++ b/app/__tests__/api/airdrop-rate-limit-gate.test.ts
@@ -18,7 +18,8 @@ const RATE_LIMIT_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 type ClaimGateResult =
   | { allowed: true; claimId: number }
-  | { allowed: false; nextClaimAt: string };
+  | { allowed: false; nextClaimAt: string }
+  | { allowed: false; degraded: true };
 
 /**
  * Pure logic version of tryAirdropClaimGate for unit testing.
@@ -53,8 +54,9 @@ function simulateClaimGate(params: {
     return { allowed: false, nextClaimAt: new Date(Date.now() + RATE_LIMIT_WINDOW_MS).toISOString() };
   }
 
-  // Unexpected DB error — fail open
-  return { allowed: true, claimId: -1 };
+  // GH#2216: unexpected DB error — fail CLOSED (no durable claim reservation
+  // → no server-funded transaction). Route surfaces a retryable 503.
+  return { allowed: false, degraded: true };
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
@@ -113,9 +115,12 @@ describe("GH#1588 — INSERT-as-gate rate limit for /api/airdrop", () => {
   });
 
   describe("unexpected DB error", () => {
-    it("fails open (allows claim) on unexpected DB errors to avoid blocking users", () => {
+    it("fails closed (denies claim, degraded) so a claim-table outage cannot mint unmetered (GH#2216)", () => {
       const result = simulateClaimGate({ deleteExpired: false, insertError: "other" });
-      expect(result.allowed).toBe(true);
+      expect(result.allowed).toBe(false);
+      if (!result.allowed && "degraded" in result) {
+        expect(result.degraded).toBe(true);
+      }
     });
   });
 

--- a/app/__tests__/lib/faucet-rate-gate-fail-closed.test.ts
+++ b/app/__tests__/lib/faucet-rate-gate-fail-closed.test.ts
@@ -1,0 +1,103 @@
+/**
+ * GH#2216 — tryFaucetGate must fail CLOSED on database errors.
+ *
+ * The gate's invariant: no durable claim reservation → no server-funded
+ * transaction. Previously, a Supabase outage (pre-check error, unexpected
+ * INSERT error, or a thrown exception) returned `allowed: true` with no
+ * claimId, letting requests reach the SOL-airdrop / MintTo path unmetered.
+ *
+ * These tests drive the REAL tryFaucetGate with a mock Supabase client.
+ */
+import { describe, it, expect } from "vitest";
+import { tryFaucetGate } from "@/lib/faucet-rate-gate";
+
+type SupabaseResult = { data: unknown; error: { code?: string; message: string } | null };
+
+/**
+ * Minimal Supabase mock: `results` are consumed in call order —
+ * pre-check SELECT, (DELETE), INSERT, [23505 re-SELECT].
+ * The DELETE step is auto-inserted since the gate ignores its result.
+ */
+function mockSupabase(results: SupabaseResult[]) {
+  let call = 0;
+  const withDelete: Array<SupabaseResult | "delete"> = [results[0]!, "delete", ...results.slice(1)];
+
+  const next = () => {
+    const r = withDelete[call++];
+    if (r === "delete") return { data: null, error: null };
+    return r ?? { data: null, error: null };
+  };
+
+  const chain = () => {
+    const promise = new Promise((resolve) => queueMicrotask(() => resolve(next())));
+    const handler: ProxyHandler<object> = {
+      get(_t, prop) {
+        if (prop === "then") return promise.then.bind(promise);
+        if (prop === "catch") return promise.catch.bind(promise);
+        if (prop === "finally") return promise.finally.bind(promise);
+        return () => new Proxy({}, handler);
+      },
+    };
+    return new Proxy({}, handler);
+  };
+
+  return { from: () => chain() };
+}
+
+describe("GH#2216 — tryFaucetGate fails closed on DB errors", () => {
+  it("denies (degraded) when the pre-check SELECT returns an error", async () => {
+    const supabase = mockSupabase([
+      { data: null, error: { code: "08006", message: "connection failure" } },
+    ]);
+    const gate = await tryFaucetGate(supabase, "WALLET_A", "sol");
+    expect(gate.allowed).toBe(false);
+    expect(gate.degraded).toBe(true);
+    expect(gate.claimId).toBeUndefined();
+  });
+
+  it("denies (degraded) when the gate INSERT returns an unexpected error", async () => {
+    const supabase = mockSupabase([
+      { data: null, error: null }, // pre-check: no active claim
+      { data: null, error: { code: "57014", message: "statement timeout" } }, // INSERT
+    ]);
+    const gate = await tryFaucetGate(supabase, "WALLET_A", "sol");
+    expect(gate.allowed).toBe(false);
+    expect(gate.degraded).toBe(true);
+    expect(gate.claimId).toBeUndefined();
+  });
+
+  it("denies (degraded) when the Supabase client throws", async () => {
+    const supabase = {
+      from: () => {
+        throw new Error("fetch failed");
+      },
+    };
+    const gate = await tryFaucetGate(supabase, "WALLET_A", "sol");
+    expect(gate.allowed).toBe(false);
+    expect(gate.degraded).toBe(true);
+  });
+
+  it("still allows a first-time claim when the DB is healthy (not degraded)", async () => {
+    const supabase = mockSupabase([
+      { data: null, error: null }, // pre-check: no active claim
+      { data: { id: 7, claimed_at: new Date().toISOString() }, error: null }, // INSERT wins
+    ]);
+    const gate = await tryFaucetGate(supabase, "WALLET_A", "sol");
+    expect(gate.allowed).toBe(true);
+    expect(gate.degraded).toBeUndefined();
+    expect(gate.claimId).toBe(7);
+  });
+
+  it("still returns a plain rate-limit denial (not degraded) on 23505 conflict", async () => {
+    const claimedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const supabase = mockSupabase([
+      { data: null, error: null }, // pre-check: no active claim (race)
+      { data: null, error: { code: "23505", message: "duplicate key" } }, // INSERT loses race
+      { data: { claimed_at: claimedAt }, error: null }, // re-SELECT existing row
+    ]);
+    const gate = await tryFaucetGate(supabase, "WALLET_A", "sol");
+    expect(gate.allowed).toBe(false);
+    expect(gate.degraded).toBeUndefined();
+    expect(gate.nextClaimAt).not.toBeNull();
+  });
+});

--- a/app/app/api/airdrop/route.ts
+++ b/app/app/api/airdrop/route.ts
@@ -71,19 +71,25 @@ async function tryAirdropClaimGate(
   supabase: ReturnType<typeof getServiceClient>,
   walletAddress: string,
   marketAddress: string,
-): Promise<{ allowed: boolean; nextClaimAt: string | null; claimId?: number }> {
+): Promise<{ allowed: boolean; nextClaimAt: string | null; claimId?: number; degraded?: boolean }> {
   const windowStart = new Date(Date.now() - RATE_LIMIT_WINDOW_MS).toISOString();
 
   try {
     // Pre-check (same idea as GH#1803 / tryFaucetGate): if an active claim exists,
     // deny before INSERT so a transient INSERT error cannot fail-open into the mint path.
-    const { data: activeClaim } = await supabase
+    const { data: activeClaim, error: preCheckError } = await supabase
       .from("airdrop_claims")
       .select("claimed_at")
       .eq("wallet", walletAddress)
       .eq("market_address", marketAddress)
       .gte("claimed_at", windowStart)
       .maybeSingle();
+
+    // GH#2216: a failed pre-check must not be treated as "no active claim".
+    if (preCheckError) {
+      console.warn(`[airdrop] claim gate pre-check error (code=${preCheckError.code}): ${preCheckError.message}`);
+      return { allowed: false, nextClaimAt: null, degraded: true };
+    }
 
     if (activeClaim) {
       const nextClaimAt = new Date(
@@ -124,16 +130,18 @@ async function tryAirdropClaimGate(
         return { allowed: false, nextClaimAt };
       }
 
-      // Unexpected DB error — fail open to avoid blocking users; log for alerting.
+      // GH#2216: unexpected DB error — fail CLOSED. Without a durable claim
+      // reservation the server-funded mint path must not run; callers surface
+      // this as a retryable 503 via `degraded`.
       console.warn(`[airdrop] claim gate INSERT error (code=${error.code}): ${error.message}`);
-      return { allowed: true, nextClaimAt: null };
+      return { allowed: false, nextClaimAt: null, degraded: true };
     }
 
     return { allowed: true, nextClaimAt: null, claimId: (data as { id: number; claimed_at: string } | null)?.id };
   } catch (err) {
     console.warn("[airdrop] tryAirdropClaimGate threw:", err instanceof Error ? err.message : String(err));
-    // Fail open — don't block users on unexpected errors
-    return { allowed: true, nextClaimAt: null };
+    // GH#2216: fail closed — no verified claim state, no server-funded mint.
+    return { allowed: false, nextClaimAt: null, degraded: true };
   }
 }
 
@@ -289,11 +297,19 @@ export async function POST(req: NextRequest) {
     // GH#1588: INSERT-as-gate rate limit (replaces old SELECT→INSERT TOCTOU pattern).
     // Key: slab_address (marketAddress) — immutable even after resolveServerOwnedMint
     // migrates markets.mint_address to a server-owned mirror.
-    const { allowed, nextClaimAt: rateLimitNextClaimAt, claimId } = await tryAirdropClaimGate(
+    const { allowed, nextClaimAt: rateLimitNextClaimAt, claimId, degraded } = await tryAirdropClaimGate(
       supabase,
       walletAddress,
       marketAddress,
     );
+    // GH#2216: gate could not verify/reserve a claim slot (DB unavailable).
+    // Fail closed with a retryable 503 — NOT a 429, the wallet isn't rate-limited.
+    if (degraded) {
+      return NextResponse.json(
+        { error: "Airdrop temporarily unavailable. Please retry in a few minutes.", retryable: true },
+        { status: 503 },
+      );
+    }
     if (!allowed) {
       return NextResponse.json(
         { error: "Already claimed in the last 24 hours", nextClaimAt: rateLimitNextClaimAt },

--- a/app/app/api/auto-fund/route.ts
+++ b/app/app/api/auto-fund/route.ts
@@ -75,6 +75,15 @@ export async function POST(req: NextRequest) {
     const supabase = getServiceClient();
     const gate = await tryFaucetGate(supabase, walletAddress, "auto-fund");
 
+    // GH#2216: gate could not verify/reserve a claim slot (DB unavailable).
+    // Fail closed with a retryable 503 — NOT a 429, the wallet isn't rate-limited.
+    if (gate.degraded) {
+      return NextResponse.json(
+        { error: "Auto-fund temporarily unavailable. Please retry in a few minutes.", funded: false, retryable: true },
+        { status: 503 },
+      );
+    }
+
     if (!gate.allowed) {
       return NextResponse.json(
         { error: "Already funded in the last 24 hours", funded: false, nextClaimAt: gate.nextClaimAt },

--- a/app/app/api/devnet-airdrop/route.ts
+++ b/app/app/api/devnet-airdrop/route.ts
@@ -88,19 +88,25 @@ async function tryClaimGate(
   supabase: ReturnType<typeof getServiceClient>,
   walletAddress: string,
   mintAddress: string,
-): Promise<{ allowed: boolean; retryAfterSecs: number; claimId?: number }> {
+): Promise<{ allowed: boolean; retryAfterSecs: number; claimId?: number; degraded?: boolean }> {
   const windowStart = new Date(Date.now() - RATE_LIMIT_WINDOW_MS).toISOString();
 
   try {
     // Pre-check (GH#1803-style): active claim in window → deny before INSERT so a
     // transient INSERT error cannot fail-open into the mint path for rate-limited wallets.
-    const { data: activeClaim } = await supabase
+    const { data: activeClaim, error: preCheckError } = await supabase
       .from("devnet_airdrop_claims")
       .select("claimed_at")
       .eq("wallet", walletAddress)
       .eq("mint", mintAddress)
       .gte("claimed_at", windowStart)
       .maybeSingle();
+
+    // GH#2216: a failed pre-check must not be treated as "no active claim".
+    if (preCheckError) {
+      console.warn(`[devnet-airdrop] gate pre-check error (code=${preCheckError.code}): ${preCheckError.message}`);
+      return { allowed: false, retryAfterSecs: 0, degraded: true };
+    }
 
     if (activeClaim) {
       const age = Date.now() - new Date(activeClaim.claimed_at as string).getTime();
@@ -146,14 +152,16 @@ async function tryClaimGate(
         return { allowed: false, retryAfterSecs: Math.ceil(RATE_LIMIT_WINDOW_MS / 1000) };
       }
 
-      // Unexpected DB error — fail open to avoid blocking users; capture for alerting.
+      // GH#2216: unexpected DB error — fail CLOSED. Without a durable claim
+      // reservation the server-funded mint path must not run; callers surface
+      // this as a retryable 503 via `degraded`. Capture for alerting.
       const dbErr = new Error(`[devnet-airdrop] gate INSERT failed: ${error.message}`);
       console.warn(dbErr.message);
       Sentry.captureException(dbErr, {
         tags: { endpoint: "/api/devnet-airdrop", step: "try_claim_gate" },
         extra: { supabase_code: error.code, walletAddress, mintAddress },
       });
-      return { allowed: true, retryAfterSecs: 0 };
+      return { allowed: false, retryAfterSecs: 0, degraded: true };
     }
 
     return { allowed: true, retryAfterSecs: 0, claimId: data?.id };
@@ -164,7 +172,8 @@ async function tryClaimGate(
       tags: { endpoint: "/api/devnet-airdrop", step: "try_claim_gate" },
       extra: { walletAddress, mintAddress },
     });
-    return { allowed: true, retryAfterSecs: 0 };
+    // GH#2216: fail closed — no verified claim state, no server-funded mint.
+    return { allowed: false, retryAfterSecs: 0, degraded: true };
   }
 }
 
@@ -505,7 +514,15 @@ export async function POST(req: NextRequest) {
 
     // 2. INSERT-as-gate: atomically reserve the claim slot BEFORE minting.
     //    This eliminates the TOCTOU race in the previous SELECT→UPSERT flow.
-    const { allowed, retryAfterSecs, claimId } = await tryClaimGate(supabase, walletAddress, mintAddress);
+    const { allowed, retryAfterSecs, claimId, degraded } = await tryClaimGate(supabase, walletAddress, mintAddress);
+    // GH#2216: gate could not verify/reserve a claim slot (DB unavailable).
+    // Fail closed with a retryable 503 — NOT a 429, the wallet isn't rate-limited.
+    if (degraded) {
+      return NextResponse.json(
+        { error: "Airdrop temporarily unavailable. Please retry in a few minutes.", retryable: true },
+        { status: 503 },
+      );
+    }
     if (!allowed) {
       const h = Math.floor(retryAfterSecs / 3600);
       const m = Math.floor((retryAfterSecs % 3600) / 60);

--- a/app/app/api/devnet-pre-fund/route.ts
+++ b/app/app/api/devnet-pre-fund/route.ts
@@ -263,6 +263,17 @@ export async function POST(req: NextRequest) {
     const supabaseForGate = getServiceClient();
     const fundType = `devnet-pre-fund:${mintAddress}`;
     const gate = await tryFaucetGate(supabaseForGate, walletAddress, fundType);
+    // GH#2216: gate could not verify/reserve a claim slot (DB unavailable).
+    // Fail closed with a retryable 503 — NOT a 429, the wallet isn't rate-limited.
+    if (gate.degraded) {
+      return NextResponse.json(
+        {
+          error: "Pre-fund temporarily unavailable. Please retry in a few minutes.",
+          retryable: true,
+        },
+        { status: 503 },
+      );
+    }
     if (!gate.allowed) {
       return NextResponse.json(
         {

--- a/app/app/api/faucet/route.ts
+++ b/app/app/api/faucet/route.ts
@@ -123,6 +123,19 @@ export async function POST(req: NextRequest) {
     const supabase = getServiceClient();
     const gate = await tryFaucetGate(supabase, walletAddress, type);
 
+    // GH#2216: gate could not verify/reserve a claim slot (DB unavailable).
+    // Fail closed with a retryable 503 — NOT a 429, the wallet isn't rate-limited.
+    if (gate.degraded) {
+      return NextResponse.json(
+        {
+          error: "Faucet temporarily unavailable. Please retry in a few minutes.",
+          funded: false,
+          retryable: true,
+        },
+        { status: 503 },
+      );
+    }
+
     if (!gate.allowed) {
       return NextResponse.json(
         {

--- a/app/lib/faucet-rate-gate.ts
+++ b/app/lib/faucet-rate-gate.ts
@@ -20,6 +20,13 @@ export interface GateResult {
   allowed: boolean;
   nextClaimAt: string | null;
   claimId?: number;
+  /**
+   * GH#2216: true when the gate could not reach / verify the claim table.
+   * The invariant is "no durable claim reservation → no server-funded
+   * transaction", so DB failures deny (`allowed: false`) — but callers
+   * should surface a retryable 503 rather than a misleading 429.
+   */
+  degraded?: boolean;
 }
 
 /**
@@ -45,13 +52,22 @@ export async function tryFaucetGate(supabase: any, wallet: string, fundType: str
     // The race applies to concurrent FIRST-time requests (two requests both see
     // no row and race to INSERT). For already-rate-limited wallets (active claim
     // already exists), the SELECT reliably returns the row without any race.
-    const { data: activeClaim } = await supabase
+    const { data: activeClaim, error: preCheckError } = await supabase
       .from("faucet_claims")
       .select("claimed_at")
       .eq("wallet", wallet)
       .eq("fund_type", fundType)
       .gte("claimed_at", windowStart)
       .maybeSingle();
+
+    // GH#2216: a failed pre-check must not be treated as "no active claim" —
+    // without a verified claim state we cannot reserve a slot, so deny.
+    if (preCheckError) {
+      console.warn(
+        `[faucet-gate] pre-check SELECT error (code=${preCheckError.code}): ${preCheckError.message}`,
+      );
+      return { allowed: false, nextClaimAt: null, degraded: true };
+    }
 
     if (activeClaim) {
       const nextClaimAt = new Date(
@@ -91,15 +107,19 @@ export async function tryFaucetGate(supabase: any, wallet: string, fundType: str
         return { allowed: false, nextClaimAt };
       }
 
-      // Unexpected DB error — fail open (devnet-only, don't block users)
+      // GH#2216: unexpected DB error — fail CLOSED. Proceeding here would run
+      // the server-funded path with no durable claim reservation, so a claim-
+      // table outage would allow unmetered airdrops/minting. Callers surface
+      // this as a retryable 503 via `degraded`.
       console.warn(`[faucet-gate] INSERT error (code=${error.code}): ${error.message}`);
-      return { allowed: true, nextClaimAt: null };
+      return { allowed: false, nextClaimAt: null, degraded: true };
     }
 
     return { allowed: true, nextClaimAt: null, claimId: (data as { id: number } | null)?.id };
   } catch (err) {
+    // GH#2216: thrown errors fail closed for the same reason as above.
     console.warn("[faucet-gate] threw:", err instanceof Error ? err.message : String(err));
-    return { allowed: true, nextClaimAt: null };
+    return { allowed: false, nextClaimAt: null, degraded: true };
   }
 }
 


### PR DESCRIPTION
Fixes #2216.

## Problem

The devnet funding gates returned `allowed: true` when the claim table was unreachable:

- `tryFaucetGate` (shared by `/api/faucet`, `/api/auto-fund`, `/api/devnet-pre-fund`) ignored the pre-check SELECT `error` field, explicitly failed open on unexpected INSERT errors, and failed open in its catch block.
- The route-local gates in `/api/airdrop` and `/api/devnet-airdrop` had the same three fail-open paths.

During a Supabase outage every server-funded path (SOL airdrop, ATA creation, `MintTo`) ran with no durable claim reservation -- unmetered.

## Fix

Invariant restored: **no durable claim reservation -> no server-funded transaction.**

- All three failure paths (pre-check error, unexpected INSERT error, thrown error) in all three gate implementations now deny, with a new `degraded: true` flag on the gate result.
- All five consumer routes surface a degraded gate as a retryable **503** ("temporarily unavailable") instead of a misleading "already claimed" **429**. Healthy-state behavior (allow / 23505 rate-limit denial) is unchanged.

## Testing

- New `app/__tests__/lib/faucet-rate-gate-fail-closed.test.ts` drives the real `tryFaucetGate` with a mock Supabase client: all three fail-closed paths, healthy first-claim (not degraded), healthy 23505 denial (not degraded).
- Updated the GH#1588 gate-simulation test to the fail-closed contract.
- `npx tsc --noEmit -p app/tsconfig.json` -- 0 errors; full vitest suite -- no new failures (same 13 pre-existing failures as main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
