### PR TITLE
fix: reset stake withdraw state on pool switch

### DIFF
--- a/app/__tests__/hooks/useStakeWithdrawByPool.reset-state.test.ts
+++ b/app/__tests__/hooks/useStakeWithdrawByPool.reset-state.test.ts
@@ -1,0 +1,48 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useStakeWithdrawByPool } from "../../hooks/useStakeWithdrawByPool";
+
+vi.mock("@/hooks/useWalletCompat", () => ({
+  useConnectionCompat: vi.fn(() => ({
+    connection: {},
+  })),
+  useWalletCompat: vi.fn(() => ({
+    publicKey: null,
+    signTransaction: null,
+  })),
+}));
+
+describe("useStakeWithdrawByPool reset state", () => {
+  it("clears stale withdraw error when the selected pool changes", async () => {
+    const { result, rerender } = renderHook(
+      ({ slabAddress, collateralMint }) =>
+        useStakeWithdrawByPool({ slabAddress, collateralMint }),
+      {
+        initialProps: {
+          slabAddress: "slab-a",
+          collateralMint: "mint-a",
+        },
+      },
+    );
+
+    await act(async () => {
+      await expect(result.current.withdraw(1n)).rejects.toThrow("Wallet not connected");
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toBe("Wallet not connected");
+      expect(result.current.loading).toBe(false);
+    });
+
+    rerender({
+      slabAddress: "slab-b",
+      collateralMint: "mint-b",
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toBeNull();
+      expect(result.current.loading).toBe(false);
+    });
+  });
+});

--- a/app/hooks/useStakeWithdrawByPool.ts
+++ b/app/hooks/useStakeWithdrawByPool.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { PublicKey, TransactionInstruction } from '@solana/web3.js';
 import { useWalletCompat, useConnectionCompat } from '@/hooks/useWalletCompat';
 import {
@@ -50,6 +50,15 @@ export function useStakeWithdrawByPool({ slabAddress, collateralMint }: StakeWit
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inflightRef = useRef(false);
+
+  // Reset UI state when the selected pool changes so stale loading/error
+  // indicators from a previous pool don't bleed into the new pool context.
+  // Do not touch inflightRef.current — the in-flight guard must stay intact
+  // until the withdrawal's finally block clears it.
+  useEffect(() => {
+    setError(null);
+    setLoading(false);
+  }, [slabAddress, collateralMint]);
 
   const withdraw = useCallback(
     async (lpAmount: bigint) => {


### PR DESCRIPTION
## Summary

Fixes a staking UI issue where the withdraw hook could keep showing stale loading or error state after the selected stake pool changes.

## Root Cause

`useStakeWithdrawByPool()` keeps local `loading` and `error` state, but did not reset those values when `slabAddress` or `collateralMint` changed.

Because of that, a withdraw error or loading state from a previous pool could remain visible after the user switched to another pool.

## Fix

- Reset withdraw `error` and `loading` when the selected pool changes.
- Keep the existing `inflightRef` guard intact so active withdraw protection is not weakened.
- Added a focused regression test for pool-switch reset behavior.
- Verified the existing withdraw hook test suite still passes.

## Test Plan

- `pnpm exec vitest run __tests__/hooks/useStakeWithdrawByPool.reset-state.test.ts`
- `pnpm exec vitest run __tests__/hooks/useStakeWithdrawByPool.test.ts`

## Risk

Low. This change is limited to frontend withdraw state handling and does not change staking instructions, backend APIs, or transaction construction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reset withdrawal error and loading state when switching to a different pool, preventing stale messages from carrying over.
  * Improved the withdrawal flow so the UI reflects the current pool more accurately after changes.
* **Tests**
  * Added coverage for pool changes to confirm previous withdrawal errors are cleared and loading state resets as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->