### PR TITLE
fix: hide max balance while earn panel loads

### DIFF
--- a/app/__tests__/components/earn/DepositWithdrawPanel.test.tsx
+++ b/app/__tests__/components/earn/DepositWithdrawPanel.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { DepositWithdrawPanel } from "../../../components/earn/DepositWithdrawPanel";
+
+vi.mock("@/hooks/useWalletCompat", () => ({
+  useWalletCompat: vi.fn(() => ({
+    connected: true,
+  })),
+}));
+
+vi.mock("@/components/ui/GlowButton", () => ({
+  GlowButton: ({
+    children,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    disabled?: boolean;
+  }) => <button disabled={disabled}>{children}</button>,
+}));
+
+const defaultProps = {
+  userBalance: 0n,
+  userLpBalance: 0n,
+  vaultBalance: 0n,
+  lpSupply: 0n,
+  decimals: 6,
+  collateralSymbol: "USDC",
+  loading: false,
+  cooldownElapsed: true,
+  onDeposit: vi.fn(async () => undefined),
+  onWithdraw: vi.fn(async () => undefined),
+};
+
+describe("DepositWithdrawPanel", () => {
+  it("does not show a zero max deposit balance while loading", () => {
+    const { rerender } = render(
+      <DepositWithdrawPanel
+        {...defaultProps}
+        loading={true}
+        userBalance={0n}
+      />,
+    );
+
+    expect(screen.getByText(/Max:\s*—\s*USDC/)).toBeInTheDocument();
+    expect(screen.queryByText(/Max:\s*0\s*USDC/)).not.toBeInTheDocument();
+
+    rerender(
+      <DepositWithdrawPanel
+        {...defaultProps}
+        loading={false}
+        userBalance={16_000_000_000n}
+      />,
+    );
+
+    expect(screen.getByText(/Max:\s*16000\s*USDC/)).toBeInTheDocument();
+  });
+});

--- a/app/components/earn/DepositWithdrawPanel.tsx
+++ b/app/components/earn/DepositWithdrawPanel.tsx
@@ -98,17 +98,22 @@ export function DepositWithdrawPanel({
     return formatRaw(raw, decimals);
   }, [tab, userBalance, userLpBalance, decimals]);
 
+  const displayMaxAmount = loading ? '—' : maxAmount;
+
   const handleSetMax = useCallback(() => {
+    if (loading) return;
     setAmount(maxAmount);
-  }, [maxAmount]);
+  }, [loading, maxAmount]);
 
   const handleSetPercent = useCallback(
     (pct: number) => {
+      if (loading) return;
+
       const raw = tab === 'deposit' ? userBalance : userLpBalance;
       const partial = (raw * BigInt(pct)) / 100n;
       setAmount(formatRaw(partial, decimals));
     },
-    [tab, userBalance, userLpBalance, decimals],
+    [loading, tab, userBalance, userLpBalance, decimals],
   );
 
   const handleSubmit = useCallback(async () => {
@@ -144,6 +149,7 @@ export function DepositWithdrawPanel({
 
   // Validation
   const isValid = useMemo(() => {
+    if (loading) return false;
     if (rawAmount <= 0n) return false;
     if (tab === 'deposit' && rawAmount > userBalance) return false;
     if (tab === 'withdraw') {
@@ -151,7 +157,7 @@ export function DepositWithdrawPanel({
       if (!cooldownElapsed) return false;
     }
     return true;
-  }, [rawAmount, tab, userBalance, userLpBalance, cooldownElapsed]);
+  }, [loading, rawAmount, tab, userBalance, userLpBalance, cooldownElapsed]);
 
   if (!connected) {
     return (
@@ -203,7 +209,7 @@ export function DepositWithdrawPanel({
               onClick={handleSetMax}
               className="text-[10px] text-[var(--accent)] hover:text-[var(--accent)]/80 transition-colors"
             >
-              Max: {maxAmount} {tab === 'deposit' ? collateralSymbol : 'LP'}
+              Max: {displayMaxAmount} {tab === 'deposit' ? collateralSymbol : 'LP'}
             </button>
           </div>
 


### PR DESCRIPTION
## Summary

Fixes an Earn page UI issue where the deposit panel could briefly show `Max: 0 USDC` while the user's balance was still loading.

## Root Cause

`DepositWithdrawPanel` received a `loading` prop, but the displayed max balance was still derived directly from `userBalance` or `userLpBalance`.

Because those balances default to `0n` before the async stake pool/user balance state finishes loading, the UI could show a misleading `Max: 0 USDC` after page load or refresh.

## Fix

- Show `Max: — USDC` while the panel is loading.
- Prevent Max and percentage shortcuts from setting an amount while loading.
- Mark the form invalid while loading.
- Added a regression test to ensure the panel does not show a false zero max balance during loading.

## Test Plan

- `pnpm exec vitest run __tests__/components/earn/DepositWithdrawPanel.test.tsx`

## Risk

Low. This change is limited to frontend Earn panel display state and does not change staking instructions, backend APIs, or transaction construction.