### PR TITLE
fix(create): user-launched markets get priced, named, and listed

### DIFF
--- a/app/__tests__/lib/dex-type.test.ts
+++ b/app/__tests__/lib/dex-type.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { normalizeDexType, KEEPER_DEX_TYPES } from "@/lib/dex-type";
+
+describe("normalizeDexType", () => {
+  it("passes through exact keeper vocabulary", () => {
+    for (const t of KEEPER_DEX_TYPES) {
+      expect(normalizeDexType(t)).toBe(t);
+    }
+  });
+
+  it("maps DexScreener raw ids to keeper vocabulary", () => {
+    // DexScreener reports these ids for pools the keeper names differently —
+    // the exact mismatch that silently orphaned wizard-launched markets.
+    expect(normalizeDexType("meteora")).toBe("meteora-dlmm");
+    expect(normalizeDexType("raydium")).toBe("raydium-clmm");
+    expect(normalizeDexType("pumpswap")).toBe("pumpswap");
+  });
+
+  it("is case- and whitespace-insensitive", () => {
+    expect(normalizeDexType(" Meteora ")).toBe("meteora-dlmm");
+    expect(normalizeDexType("RAYDIUM-CLMM")).toBe("raydium-clmm");
+    expect(normalizeDexType("PumpSwap")).toBe("pumpswap");
+  });
+
+  it("returns null for unpriceable or unknown dexes", () => {
+    expect(normalizeDexType("orca")).toBeNull();
+    expect(normalizeDexType("whirlpool")).toBeNull();
+    expect(normalizeDexType("")).toBeNull();
+    expect(normalizeDexType(null)).toBeNull();
+    expect(normalizeDexType(undefined)).toBeNull();
+  });
+});

--- a/app/app/api/markets/[slab]/route.ts
+++ b/app/app/api/markets/[slab]/route.ts
@@ -13,6 +13,7 @@ import {
 } from "@percolatorct/sdk";
 import { getRpcEndpoint } from "@/lib/config";
 import { PLAYGROUND_SLAB_META } from "@/lib/playground-slab-meta";
+import { readRegisteredMarkets } from "@/lib/playground-registered-markets";
 
 /** Success responses only — matches GET /api/markets (errors omit this to avoid caching 404/500). */
 const MARKETS_CACHE_HEADERS = {
@@ -46,6 +47,13 @@ async function onChainSlabFallback(slab: string): Promise<NextResponse> {
     const markPriceRaw = cfg.markEwmaE6;
     const markPriceUsd = markPriceRaw > 0n ? Number(markPriceRaw) / 1_000_000 : null;
     const playgroundMeta = PLAYGROUND_SLAB_META[slab];
+    // Wizard-launched markets carry their metadata in the registration Blob —
+    // without this lookup the trade page header falls back to the collateral
+    // token and renders every user-created market as "USDC/USD".
+    const registered = playgroundMeta
+      ? null
+      : (await readRegisteredMarkets().catch(() => []))
+          .find((rm) => rm.slabAddress === slab) ?? null;
 
     // Live engine stats from the same raw bytes (mirrors the list route's
     // v17 enrichment). Degrades to zeros if the parse throws.
@@ -61,14 +69,15 @@ async function onChainSlabFallback(slab: string): Promise<NextResponse> {
       slab_address: slab,
       program_id: info.owner.toBase58(),
       mint_address: cfg.collateralMint.toBase58(),
-      symbol: playgroundMeta?.symbol ?? null,
-      name: playgroundMeta?.name ?? null,
+      symbol: playgroundMeta?.symbol ?? registered?.symbol ?? null,
+      name: playgroundMeta?.name ?? registered?.label ?? null,
       decimals: 6,
       deployer: cfg.marketauth.toBase58(),
       oracle_authority: cfg.marketauth.toBase58(),
-      oracle_mode: cfg.oracleMode === 1 ? "hyperp" : "admin",
-      dex_pool_address: playgroundMeta?.dex_pool_address ?? null,
-      mainnet_ca: playgroundMeta?.mainnet_ca ?? null,
+      // Match the list route: byte 3 = AUTH_MARK (keeper), byte 1 = hyperp.
+      oracle_mode: cfg.oracleMode === 1 ? "hyperp" : cfg.oracleMode === 3 ? "keeper" : "admin",
+      dex_pool_address: playgroundMeta?.dex_pool_address ?? registered?.poolAddress ?? null,
+      mainnet_ca: playgroundMeta?.mainnet_ca ?? registered?.mainnetCA ?? null,
       created_at: null,
       stats_updated_at: null,
       is_zombie: false,

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -5,7 +5,7 @@ import { parseHeader, parseConfig, discoverMarkets, type DiscoveredMarket, isV17
 import { getServiceClient, getServerNetwork } from "@/lib/supabase";
 import { getConfig, getRpcEndpoint } from "@/lib/config";
 import { PLAYGROUND_SLAB_META } from "@/lib/playground-slab-meta";
-import { readRegisteredMarkets } from "@/lib/playground-registered-markets";
+import { readRegisteredMarkets, type RegisteredMarket } from "@/lib/playground-registered-markets";
 import { getClientIp } from "@/lib/get-client-ip";
 import { claimPlaygroundChallenge } from "@/lib/playground-nonce-store";
 import { signKeeperRequest } from "@/lib/keeper-hmac";
@@ -264,7 +264,11 @@ function numericOrNull(v: unknown): number | null {
  * For v17 markets, configV17 carries all config fields.
  * For v12 slabs, config has the fields; engine/params hold stats.
  */
-function discoveredToApiRow(m: DiscoveredMarket, v17Oi?: V17MarketGroupOI): Record<string, unknown> {
+function discoveredToApiRow(
+  m: DiscoveredMarket,
+  v17Oi?: V17MarketGroupOI,
+  registered?: RegisteredMarket,
+): Record<string, unknown> {
   const slabAddress = m.slabAddress.toBase58();
   const programId = m.programId.toBase58();
 
@@ -284,15 +288,19 @@ function discoveredToApiRow(m: DiscoveredMarket, v17Oi?: V17MarketGroupOI): Reco
       slab_address: slabAddress,
       program_id: programId,
       mint_address: cfg.collateralMint.toBase58(),
-      symbol: playgroundMeta?.symbol ?? null,
-      name: playgroundMeta?.name ?? null,
+      // Metadata: curated seeds first, then the registration Blob — wizard-
+      // launched markets live there (see keeper-register). Without this
+      // fallback a registered market passed the visibility filter but rendered
+      // symbol/name-less ("USDC/USD") on every page.
+      symbol: playgroundMeta?.symbol ?? registered?.symbol ?? null,
+      name: playgroundMeta?.name ?? registered?.label ?? null,
       decimals: 6,
       deployer: cfg.marketauth.toBase58(),
       oracle_authority: cfg.marketauth.toBase58(),
       // oracleMode: 0=admin, 1=hyperp, 3=AUTH_MARK (keeper)
       oracle_mode: cfg.oracleMode === 1 ? "hyperp" : cfg.oracleMode === 3 ? "keeper" : "admin",
-      dex_pool_address: playgroundMeta?.dex_pool_address ?? null,
-      mainnet_ca: playgroundMeta?.mainnet_ca ?? null,
+      dex_pool_address: playgroundMeta?.dex_pool_address ?? registered?.poolAddress ?? null,
+      mainnet_ca: playgroundMeta?.mainnet_ca ?? registered?.mainnetCA ?? null,
       created_at: null,
       stats_updated_at: null,
       is_zombie: false,
@@ -360,7 +368,12 @@ function discoveredToApiRow(m: DiscoveredMarket, v17Oi?: V17MarketGroupOI): Reco
  *
  * Returns [] on any failure; callers must degrade gracefully.
  */
-async function discoverMarketsOnChain(): Promise<Record<string, unknown>[]> {
+async function discoverMarketsOnChain(
+  /** Registration-Blob entries keyed by slab — supplies symbol/name/pool
+   *  metadata for wizard-launched markets (curated seeds come from
+   *  PLAYGROUND_SLAB_META). Optional so a Blob outage never blocks discovery. */
+  registeredBySlab?: Map<string, RegisteredMarket>,
+): Promise<Record<string, unknown>[]> {
   const cfg = getConfig();
   if (cfg.network !== "devnet") return [];
 
@@ -406,7 +419,10 @@ async function discoverMarketsOnChain(): Promise<Record<string, unknown>[]> {
       }
     }
 
-    return unique.map((m) => discoveredToApiRow(m, v17Stats.get(m.slabAddress.toBase58())));
+    return unique.map((m) => {
+      const slab = m.slabAddress.toBase58();
+      return discoveredToApiRow(m, v17Stats.get(slab), registeredBySlab?.get(slab));
+    });
   } catch {
     return [];
   }
@@ -418,7 +434,15 @@ async function discoverMarketsOnChain(): Promise<Record<string, unknown>[]> {
  */
 async function onChainOrStaticResponse(request: NextRequest, reason: string): Promise<NextResponse> {
   try {
-    const rows = await discoverMarketsOnChain();
+    // Read the registration Blob ONCE per request — feeds both row metadata
+    // (symbol/name for wizard-launched markets) and the visibility filter
+    // below. Guarded: Blob unavailable → empty map, curated-only behavior.
+    const registeredBySlab = new Map<string, RegisteredMarket>();
+    try {
+      for (const rm of await readRegisteredMarkets()) registeredBySlab.set(rm.slabAddress, rm);
+    } catch { /* curated-only */ }
+
+    const rows = await discoverMarketsOnChain(registeredBySlab);
     if (rows.length > 0) {
       const programIdParam = request?.nextUrl?.searchParams?.get("program_id") ?? null;
       const searchParam =
@@ -430,11 +454,8 @@ async function onChainOrStaticResponse(request: NextRequest, reason: string): Pr
       // Cross-instance user-created markets live in the registration Blob — the local
       // allowed-slab Set is per-serverless-instance and doesn't persist across cold
       // starts, so union the Blob in so a wizard-launched market appears from any
-      // instance. Guarded: Blob unavailable → fall back to curated ∪ local.
-      const blobSlabs = new Set<string>();
-      try {
-        for (const rm of await readRegisteredMarkets()) blobSlabs.add(rm.slabAddress);
-      } catch { /* fall back to curated ∪ local */ }
+      // instance. (Same read as the metadata map above — one Blob fetch per request.)
+      const blobSlabs = new Set<string>(registeredBySlab.keys());
 
       const filtered = rows
         .filter(m => !BLOCKED_SLAB_ADDRESSES.has(m.slab_address as string))

--- a/app/app/api/playground/keeper-register/route.ts
+++ b/app/app/api/playground/keeper-register/route.ts
@@ -12,10 +12,15 @@
  * is the only place the market↔pool binding is recorded.
  *
  * This route:
- *   1. Validates the request (devnet-only, pubkey shapes, dexType allow-list).
- *   2. Upserts { slabAddress, marketAddress, poolAddress, dexType, symbol, label,
+ *   1. Validates the request (devnet-only, pubkey shapes).
+ *   2. Resolves the dexType AUTHORITATIVELY by classifying the pool account's
+ *      mainnet owner program (CLMM/DLMM/PumpSwap program ids) — the client
+ *      string is only a fallback when mainnet RPC is unreachable. This also
+ *      verifies the pool actually exists on mainnet before the keeper is
+ *      pointed at it.
+ *   3. Upserts { slabAddress, marketAddress, poolAddress, dexType, symbol, label,
  *      mainnetCA, collateral, registeredAt } into the blob, keyed by slabAddress.
- *   3. Returns { ok: true, registered: true, ... } on success, or a 502 with a clear
+ *   4. Returns { ok: true, registered: true, ... } on success, or a 502 with a clear
  *      message if the Blob write fails (never throws uncaught — market creation
  *      itself already landed on-chain regardless of this route's outcome).
  *
@@ -23,7 +28,8 @@
  *   slabAddress:    string  — devnet market account
  *   mainnetCA:      string  — mainnet token CA (for keeper labelling)
  *   dexPoolAddress: string  — mainnet DEX pool address
- *   dexType:        string  — "raydium-clmm" | "meteora-dlmm" | "pumpswap"
+ *   dexType:        string  — hint; DexScreener dexIds accepted ("meteora",
+ *                             "raydium", …) — see lib/dex-type.ts
  *   symbol?:        string  — token symbol (e.g. "SOL")
  *   label?:         string  — human label (e.g. "SOL/USDC — Raydium CLMM")
  * }
@@ -33,15 +39,56 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { PublicKey } from "@solana/web3.js";
+import { Connection, PublicKey } from "@solana/web3.js";
 import type { RegisteredMarket } from "@/lib/playground-registered-markets";
 import { upsertRegisteredMarket } from "@/lib/playground-registered-markets";
+import { normalizeDexType, KEEPER_DEX_TYPES, type KeeperDexType } from "@/lib/dex-type";
 
 export const dynamic = "force-dynamic";
 
+/** Mainnet DEX program → keeper dexType. The AUTHORITATIVE classification:
+ *  the keeper parses the pool with the layout this type names, so the binding
+ *  must come from the pool account's owner program, not from a client string.
+ *  (DexScreener reports "meteora" for both DLMM and DAMM pools and "raydium"
+ *  for CLMM and CPMM — trusting it risks handing the keeper a pool whose byte
+ *  layout doesn't match its parser.) Verified against the curated playground
+ *  pools: SOL→CAMM (CLMM), JUP/TRUMP/PENGU→LBUZ (DLMM).
+ */
+const DEX_PROGRAM_TO_TYPE: Record<string, KeeperDexType> = {
+  CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK: "raydium-clmm", // Raydium Concentrated Liquidity
+  LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo: "meteora-dlmm", // Meteora DLMM
+  pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA: "pumpswap", // PumpSwap AMM
+};
+
+const MAINNET_RPC_URL = process.env.MAINNET_RPC_URL?.trim() || "https://api.mainnet-beta.solana.com";
+
+/** Classify a mainnet pool by its owner program.
+ *  Returns a dexType, "unsupported" (account exists under an unknown program),
+ *  "missing" (no such account on mainnet), or "rpc-failed" (couldn't check —
+ *  callers fall back to the client-supplied string). One getAccountInfo call. */
+async function classifyPoolByOwner(
+  poolAddress: string,
+): Promise<KeeperDexType | "unsupported" | "missing" | "rpc-failed"> {
+  try {
+    const conn = new Connection(MAINNET_RPC_URL, "confirmed");
+    const info = await Promise.race([
+      conn.getAccountInfo(new PublicKey(poolAddress)),
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error("mainnet RPC timeout")), 8_000)),
+    ]);
+    if (!info) return "missing";
+    return DEX_PROGRAM_TO_TYPE[info.owner.toBase58()] ?? "unsupported";
+  } catch {
+    return "rpc-failed";
+  }
+}
+
 const NETWORK = process.env.NEXT_PUBLIC_DEFAULT_NETWORK?.trim() ?? process.env.NEXT_PUBLIC_SOLANA_NETWORK?.trim();
 
-const VALID_DEX_TYPES = new Set(["raydium-clmm", "meteora-dlmm", "pumpswap"]);
+// Alias-tolerant: the wizard passes DexScreener dexIds ("meteora", "raydium")
+// which normalizeDexType maps into the keeper vocabulary. Rejecting raw ids
+// here silently orphaned every Meteora/Raydium-pool market (no keeper price,
+// no name, invisible on /markets) because the wizard treats registration
+// failures as non-fatal.
 
 /** sim-USDC — the single collateral mint shared by every playground market. */
 const PLAYGROUND_COLLATERAL_MINT = "DJ54k4wH92NTtNP8RuHAwG8si1bevXEknzctDdqYN8eC";
@@ -69,12 +116,6 @@ export async function POST(req: NextRequest) {
 
   if (!slabAddress) return NextResponse.json({ error: "slabAddress required" }, { status: 400 });
   if (!dexPoolAddress) return NextResponse.json({ error: "dexPoolAddress required" }, { status: 400 });
-  if (!dexType || !VALID_DEX_TYPES.has(dexType)) {
-    return NextResponse.json(
-      { error: `dexType must be one of: ${[...VALID_DEX_TYPES].join(", ")}` },
-      { status: 400 },
-    );
-  }
 
   // Validate addresses
   try { new PublicKey(slabAddress); } catch {
@@ -89,13 +130,46 @@ export async function POST(req: NextRequest) {
     }
   }
 
-  const resolvedLabel = label ?? (symbol ? `${symbol}/USDC — ${dexType}` : `${slabAddress.slice(0, 8)}… — ${dexType}`);
+  // Resolve the dexType. Authoritative: classify the pool by its mainnet owner
+  // program. Fallback (mainnet RPC unreachable): normalize the client string —
+  // alias-tolerant, since the wizard passes DexScreener dexIds ("meteora",
+  // "raydium") that previously 400'd here and silently orphaned the market
+  // (wizard treats registration as non-fatal → market live on-chain, but no
+  // keeper price, no name, invisible on /markets).
+  let normalizedDexType: KeeperDexType;
+  const classified = await classifyPoolByOwner(dexPoolAddress);
+  if (classified === "missing") {
+    return NextResponse.json(
+      { error: `dexPoolAddress ${dexPoolAddress} does not exist on mainnet` },
+      { status: 400 },
+    );
+  }
+  if (classified === "unsupported") {
+    return NextResponse.json(
+      { error: `dexPoolAddress is owned by an unsupported DEX program — the keeper can only price ${KEEPER_DEX_TYPES.join(", ")} pools` },
+      { status: 400 },
+    );
+  }
+  if (classified === "rpc-failed") {
+    const fromString = normalizeDexType(dexType);
+    if (!fromString) {
+      return NextResponse.json(
+        { error: `Could not verify the pool on mainnet, and dexType "${dexType ?? ""}" does not map to any of: ${KEEPER_DEX_TYPES.join(", ")}` },
+        { status: 502 },
+      );
+    }
+    normalizedDexType = fromString;
+  } else {
+    normalizedDexType = classified;
+  }
+
+  const resolvedLabel = label ?? (symbol ? `${symbol}/USDC — ${normalizedDexType}` : `${slabAddress.slice(0, 8)}… — ${normalizedDexType}`);
 
   const entry: RegisteredMarket = {
     slabAddress,
     marketAddress: slabAddress,
     poolAddress: dexPoolAddress,
-    dexType,
+    dexType: normalizedDexType,
     symbol: symbol ?? null,
     label: resolvedLabel,
     mainnetCA: mainnetCA ?? null,
@@ -127,7 +201,7 @@ export async function POST(req: NextRequest) {
     message: "Registered — the keeper will pick this up on its next poll (~30s)",
     slabAddress,
     dexPoolAddress,
-    dexType,
+    dexType: normalizedDexType,
     label: resolvedLabel,
   });
 }

--- a/app/hooks/useCreateMarket.ts
+++ b/app/hooks/useCreateMarket.ts
@@ -65,6 +65,7 @@ import { PERCOLATOR_NFT_PROGRAM_ID } from "@/lib/nft-program";
 // We guard all callsites with isAdminOracle && !isV17Slab before using these.
 import { sendTx } from "@/lib/tx";
 import { getConfig, getNetwork } from "@/lib/config";
+import { normalizeDexType } from "@/lib/dex-type";
 import { parseMarketCreationError } from "@/lib/parseMarketError";
 import {
   saveInFlightMarket,
@@ -1502,20 +1503,31 @@ export function useCreateMarket() {
                 slabAddress: slabPk.toBase58(),
                 mainnetCA: params.mainnetCA ?? null,
                 dexPoolAddress: params.dexPoolAddress,
-                dexType: params.dexType ?? "raydium-clmm",
+                // params.dexType carries DexScreener's raw dexId ("meteora",
+                // "raydium") — normalize to the keeper vocabulary or the route
+                // 400s and the market is orphaned (no price, no name).
+                dexType: normalizeDexType(params.dexType) ?? params.dexType ?? "raydium-clmm",
                 symbol: params.symbol ?? null,
               }),
             });
             const keeperRegData = await keeperRegResp.json() as {
               registered?: boolean;
               message?: string;
+              error?: string;
             };
             keeperDelegated = keeperRegData.registered ?? false;
-            keeperMessage = keeperRegData.message ?? null;
+            // Error responses put their reason in `error`, not `message` —
+            // previously a 400/502 left keeperMessage null and the wizard
+            // showed nothing, so users had no idea their market wasn't priced.
+            keeperMessage =
+              keeperRegData.message ??
+              (keeperRegData.error
+                ? `Keeper registration failed: ${keeperRegData.error} — the market is live on-chain but won't be priced or listed until it's registered.`
+                : null);
             console.log("[useCreateMarket] Keeper registration:", keeperRegData);
           } catch (keeperErr) {
             console.warn("[useCreateMarket] Keeper registration failed (non-fatal):", keeperErr);
-            keeperMessage = "Keeper registration failed — prices will start on next keeper discovery cycle";
+            keeperMessage = "Keeper registration failed — the market is live on-chain but won't be priced or listed until it's registered.";
           }
         }
 

--- a/app/lib/dex-type.ts
+++ b/app/lib/dex-type.ts
@@ -1,0 +1,37 @@
+/**
+ * Keeper dexType vocabulary + normalization. Client-safe module — imported by
+ * both the create wizard (client) and the keeper-register API route (server).
+ * Deliberately separate from lib/playground-registered-markets.ts, which
+ * imports the server-only @vercel/blob SDK.
+ */
+
+/** The dex types the keeper can price against. */
+export const KEEPER_DEX_TYPES = ["raydium-clmm", "meteora-dlmm", "pumpswap"] as const;
+export type KeeperDexType = (typeof KEEPER_DEX_TYPES)[number];
+
+/**
+ * Normalize a DexScreener `dexId` (what the create wizard's pool lookup
+ * carries) to the keeper's dexType vocabulary.
+ *
+ * DexScreener reports `"meteora"` / `"raydium"` for the very pools the keeper
+ * calls `"meteora-dlmm"` / `"raydium-clmm"`. Passing the raw id through made
+ * POST /api/playground/keeper-register 400 for every token whose top pool is
+ * on Meteora or Raydium — and the wizard swallowed that as a non-fatal warn,
+ * so the market launched on-chain but never got registered: no keeper cranks,
+ * no price, no name, invisible on /markets.
+ *
+ * This is the best-effort STRING mapping (client hint / RPC-outage fallback).
+ * The keeper-register route's authoritative classification is by the pool
+ * account's mainnet owner program — see classifyPoolByOwner there.
+ *
+ * Returns null for dexes the keeper cannot price.
+ */
+export function normalizeDexType(raw: string | null | undefined): KeeperDexType | null {
+  if (!raw) return null;
+  const v = raw.trim().toLowerCase();
+  if ((KEEPER_DEX_TYPES as readonly string[]).includes(v)) return v as KeeperDexType;
+  if (v === "meteora" || v === "meteora-damm" || v === "meteoradlmm") return "meteora-dlmm";
+  if (v === "raydium" || v === "raydium-cpmm" || v === "raydium-amm") return "raydium-clmm";
+  if (v === "pump" || v === "pumpfun" || v === "pump-swap") return "pumpswap";
+  return null;
+}


### PR DESCRIPTION
## Bug (reproduced end-to-end with a real launch)

A user launched a market for `$ansem` (`9cRCn9…pump`) through the wizard. On-chain creation succeeded — and the market was born orphaned: **"No oracle cranked"** flashing, no price, no chart, header showing **USDC/USD**, absent from `/markets`. The hosted registration Blob was **empty**, meaning every user launch to date has ended this way.

## Three root causes, all fixed

**1. dexType vocabulary mismatch silently killed registration.**
The wizard passes DexScreener's raw `dexId` — `"meteora"`, `"raydium"` — but `keeper-register` only accepted `meteora-dlmm` / `raydium-clmm` / `pumpswap` and 400'd. Registration is deliberately non-fatal in the wizard, so the failure was a `console.warn` and the market never reached the keeper. ANSEM's top pool is on Meteora → guaranteed hit.

**The fix is stronger than string-mapping.** DexScreener ids are ambiguous (`"meteora"` covers DLMM *and* DAMM; `"raydium"` covers CLMM *and* CPMM) — and dexType tells the keeper **which byte layout to parse the pool with**, so guessing risks a mis-parse. The route now classifies the pool by its **mainnet owner program**:

| Owner program | dexType |
|---|---|
| `CAMMCzo5…` (Raydium CL) | `raydium-clmm` |
| `LBUZKhRx…` (Meteora DLMM) | `meteora-dlmm` |
| `pAMMBay6…` (PumpSwap) | `pumpswap` |

Verified empirically against the curated playground pools (SOL→CAMM, JUP→LBUZ) and ANSEM's pools. This also **verifies the pool exists on mainnet** before the keeper is pointed at it — previously any well-formed pubkey could be registered (junk-pool DoS on the keeper). Unknown owner program → clean 400. Mainnet RPC unreachable → falls back to alias-tolerant string normalization (new client-safe `lib/dex-type.ts`, unit-tested); still unmappable → clear error.

**2. Even registered markets rendered nameless.**
`/api/markets` used the registry only as a **visibility filter** — never its metadata — and `/api/markets/[slab]` didn't consult it at all. So a registered market passed the filter but showed `symbol: null` everywhere, and the trade-page header fell back to the collateral token: "USDC/USD". Both routes now resolve metadata curated-first, registry-second (symbol, name, `dex_pool_address`, `mainnet_ca`). Cost: **zero extra Blob reads** on the list route (the existing read moved up and is shared); the `[slab]` route reads it only for non-curated slabs.

**3. Registration failures were invisible.**
Error responses carry `error`, not `message`; the wizard read only `message`, so a 400/502 left `keeperMessage` null and `LaunchSuccess` rendered nothing. Users had no idea their market wasn't going to be priced. Now surfaced with plain-language consequences.

Drive-by (same line touched): `[slab]`'s `oracle_mode` now maps byte 3 → `"keeper"` like the list route (was `"admin"`, which would badge user keeper-markets MANUAL).

## Review/security notes

- The mainnet read is one `getAccountInfo` per registration POST, 8s timeout, fixed RPC URL (`MAINNET_RPC_URL` env or public endpoint) — no user-controlled fetch targets; addresses are pubkey-validated before use; existing per-IP rate limiting applies.
- Blob outage degrades exactly to today's behavior everywhere (verified locally where no Blob credentials exist: `/api/markets` returns the curated 5, no errors).
- Curated metadata always wins over registry entries — the 5 seeded markets are unaffected.

## Testing

- `tsc` clean · new `dex-type` unit tests 4/4 · markets API suites 89/89
- All four `keeper-register` branches exercised live against the dev server: **`"meteora"` alias + real DLMM pool now passes classification** (stops only at the expected local Blob-credentials 502); nonexistent pool → 400; token-mint-as-pool → 400 unsupported; malformed pubkey → 400
- Program-id map verified on mainnet against known pools of all three dexes

## Related

The orphaned ANSEM market (`7mzqfnuA…CHPV`) was manually registered via the endpoint during diagnosis and is now in the registry — it should be priced/named once the keeper picks it up and this PR's metadata fallback deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
