### PR TITLE
fix(trade): improve wrapper error 0x9 message and clean up format helpers

### DIFF
--- a/app/__tests__/lib/errorMessages-lighthouse.test.ts
+++ b/app/__tests__/lib/errorMessages-lighthouse.test.ts
@@ -24,11 +24,11 @@ describe("humanizeError — Lighthouse/Blowfish detection", () => {
     expect(humanizeError(raw)).toBe(LIGHTHOUSE_USER_MESSAGE);
   });
 
-  it("does NOT classify generic 0x0e (Percolator error 14) as Lighthouse", () => {
-    const raw = `Transaction simulation failed: custom program error: 0x0e`;
+  it("does NOT classify generic 0x31 (Percolator error 49) as Lighthouse", () => {
+    const raw = `Transaction simulation failed: custom program error: 0x31`;
     const result = humanizeError(raw);
     expect(result).not.toBe(LIGHTHOUSE_USER_MESSAGE);
-    expect(result).toContain("Undercollateralized");
+    expect(result).toContain("Insufficient margin");
   });
 
   it("does NOT classify generic unknown errors as Lighthouse", () => {

--- a/app/__tests__/lib/errorMessages.test.ts
+++ b/app/__tests__/lib/errorMessages.test.ts
@@ -8,22 +8,22 @@ import {
 
 describe("humanizeError", () => {
   it("maps known Custom(N) error codes", () => {
-    expect(humanizeError('{"InstructionError":[4,{"Custom":14}]}')).toContain(
-      "Undercollateralized"
+    expect(humanizeError('{"InstructionError":[4,{"Custom":49}]}')).toContain(
+      "Insufficient margin"
     );
   });
 
   it("maps hex error codes", () => {
-    // 0x0e = 14 decimal = Undercollateralized
-    expect(humanizeError("custom program error: 0x0e")).toContain(
-      "Undercollateralized"
+    // 0x31 = 49 decimal = Insufficient margin
+    expect(humanizeError("custom program error: 0x31")).toContain(
+      "Insufficient margin"
     );
   });
 
   it("provides instruction hint when available", () => {
-    const msg = '{"InstructionError":[4,{"Custom":14}]}';
-    // Custom(14) = Undercollateralized; humanizeError returns the mapped message directly
-    expect(humanizeError(msg)).toContain("Undercollateralized");
+    const msg = '{"InstructionError":[4,{"Custom":49}]}';
+    // Custom(49) = Insufficient margin; humanizeError returns the mapped message directly
+    expect(humanizeError(msg)).toContain("Insufficient margin");
   });
 
   it("handles blockhash expiry", () => {
@@ -64,30 +64,34 @@ describe("humanizeError", () => {
     expect(result.length).toBeLessThan(200);
   });
 
-  it("maps oracle stale error (code 6)", () => {
-    expect(humanizeError('Custom(6)')).toContain("Oracle price is stale");
+  it("maps oracle stale error (code 27)", () => {
+    expect(humanizeError('Custom(27)')).toContain("Oracle price is stale");
   });
 
-  it("maps market paused error (code 33)", () => {
-    expect(humanizeError('Custom(33)')).toContain("paused");
+  it("maps market paused error (code 32)", () => {
+    expect(humanizeError('Custom(32)')).toContain("paused");
   });
 
-  it("maps insurance errors (code 30)", () => {
-    expect(humanizeError('Custom(30)')).toContain("Insurance fund below");
+  it("maps invalid or unsupported instruction error (code 9)", () => {
+    expect(humanizeError('Custom(9)')).toContain("matcher config may be misaligned");
+  });
+
+  it("maps insurance errors (code 47)", () => {
+    expect(humanizeError('Custom(47)')).toContain("Insurance");
   });
 
   it("maps JSON Custom format", () => {
-    expect(humanizeError('"Custom":13')).toContain("Insufficient balance");
+    expect(humanizeError('"Custom":11')).toContain("Invalid token");
   });
 });
 
 describe("isTransientError", () => {
-  it("returns true for oracle stale (code 6)", () => {
-    expect(isTransientError("Custom(6)")).toBe(true);
+  it("returns true for oracle stale (code 27)", () => {
+    expect(isTransientError("Custom(27)")).toBe(true);
   });
 
-  it("returns true for oracle invalid (code 12)", () => {
-    expect(isTransientError("Custom(12)")).toBe(true);
+  it("returns true for oracle invalid (code 26)", () => {
+    expect(isTransientError("Custom(26)")).toBe(true);
   });
 
   it("returns true for blockhash expiry", () => {
@@ -112,12 +116,12 @@ describe("isTransientError", () => {
 });
 
 describe("isOracleStaleError", () => {
-  it("returns true for code 6", () => {
-    expect(isOracleStaleError("Custom(6)")).toBe(true);
+  it("returns true for code 27", () => {
+    expect(isOracleStaleError("Custom(27)")).toBe(true);
   });
 
-  it("returns true for code 12", () => {
-    expect(isOracleStaleError("Custom(12)")).toBe(true);
+  it("returns true for code 26", () => {
+    expect(isOracleStaleError("Custom(26)")).toBe(true);
   });
 
   it("returns false for other codes", () => {
@@ -136,7 +140,7 @@ describe("withTransientRetry", () => {
   it("retries on transient error then succeeds", async () => {
     const fn = vi
       .fn()
-      .mockRejectedValueOnce(new Error("Custom(6)"))
+      .mockRejectedValueOnce(new Error("Custom(27)"))
       .mockResolvedValueOnce("ok");
     const result = await withTransientRetry(fn, { maxRetries: 2, delayMs: 0 });
     expect(result).toBe("ok");

--- a/app/__tests__/lib/format-extended.test.ts
+++ b/app/__tests__/lib/format-extended.test.ts
@@ -1,14 +1,12 @@
 import { describe, it, expect } from "vitest";
 import {
   formatTokenAmount,
-  formatPriceE6,
   formatBps,
   formatUsd,
   formatLiqPrice,
   LIQ_PRICE_UNLIQUIDATABLE,
   shortenAddress,
   formatSlotAge,
-  formatI128Amount,
   formatPnl,
   formatMarginPct,
   formatPercent,
@@ -24,17 +22,6 @@ describe("formatTokenAmount (extended)", () => {
   it("handles sub-unit with 9 decimals", () => expect(formatTokenAmount(1n, 9)).toBe("0.000000001"));
 });
 
-describe("formatPriceE6", () => {
-  it("delegates to formatTokenAmount with 6 decimals", () => {
-    expect(formatPriceE6(1_000_000n)).toBe("1");
-  });
-  it("formats fractional prices", () => {
-    expect(formatPriceE6(1_500_000n)).toBe("1.5");
-  });
-  it("formats sub-dollar prices", () => {
-    expect(formatPriceE6(500n)).toBe("0.0005");
-  });
-});
 
 describe("formatUsd (extended)", () => {
   it("returns $0.00 for null", () => expect(formatUsd(null)).toBe("$0.00"));
@@ -106,20 +93,6 @@ describe("formatSlotAge (extended)", () => {
   });
 });
 
-describe("formatI128Amount", () => {
-  it("formats positive value", () => {
-    expect(formatI128Amount(1_500_000n)).toBe("1");
-  });
-  it("formats negative value", () => {
-    expect(formatI128Amount(-2_000_000n)).toBe("-2");
-  });
-  it("formats zero", () => {
-    expect(formatI128Amount(0n)).toBe("0");
-  });
-  it("respects custom decimals", () => {
-    expect(formatI128Amount(1_500_000_000n, 9)).toBe("1");
-  });
-});
 
 describe("formatPnl (extended)", () => {
   it("returns '0' for null", () => expect(formatPnl(null)).toBe("0"));

--- a/app/__tests__/lib/format.test.ts
+++ b/app/__tests__/lib/format.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import {
   formatTokenAmount,
   formatCompactTokenAmount,
-  formatPriceE6,
   formatBps,
   LIQ_PRICE_UNLIQUIDATABLE,
   formatUsd,
@@ -11,7 +10,6 @@ import {
   formatLiqPrice,
   shortenAddress,
   formatSlotAge,
-  formatI128Amount,
   formatPnl,
   formatMarginPct,
   formatPercent,
@@ -64,19 +62,6 @@ describe("formatTokenAmount", () => {
   });
 });
 
-describe("formatPriceE6", () => {
-  it("delegates to formatTokenAmount with 6 decimals", () => {
-    expect(formatPriceE6(1_000_000n)).toBe("1");
-  });
-
-  it("formats fractional price", () => {
-    expect(formatPriceE6(42_690_000n)).toBe("42.69");
-  });
-
-  it("formats sub-dollar price", () => {
-    expect(formatPriceE6(500_000n)).toBe("0.5");
-  });
-});
 
 describe("formatBps", () => {
   it("formats bigint bps", () => {
@@ -146,7 +131,7 @@ describe("formatUsd", () => {
     // Exactly at limit ($1B) — should still format normally
     const result = formatUsd(1_000_000_000_000_000n);
     expect(result).not.toBe("$—");
-    expect(result).toContain("1,000,000,000");
+    expect(result.replace(/,/g, "")).toContain("1000000000");
   });
 });
 
@@ -258,27 +243,6 @@ describe("formatSlotAge", () => {
   });
 });
 
-describe("formatI128Amount", () => {
-  it("formats positive value", () => {
-    expect(formatI128Amount(1_000_000n, 6)).toBe("1");
-  });
-
-  it("formats negative value", () => {
-    expect(formatI128Amount(-5_000_000n, 6)).toBe("-5");
-  });
-
-  it("formats zero", () => {
-    expect(formatI128Amount(0n, 6)).toBe("0");
-  });
-
-  it("truncates fractional part (integer division)", () => {
-    expect(formatI128Amount(1_500_000n, 6)).toBe("1");
-  });
-
-  it("respects custom decimals", () => {
-    expect(formatI128Amount(12345n, 2)).toBe("123");
-  });
-});
 
 describe("formatPnl", () => {
   it("returns '0' for null", () => {

--- a/app/lib/errorMessages.ts
+++ b/app/lib/errorMessages.ts
@@ -52,7 +52,7 @@ const ERROR_CODE_MAP: Record<number, string> = {
   6: "Missing required signature.",
   7: "An account that must be writable was passed as read-only.",
   8: "Unauthorized - you don't have permission for this action.",
-  9: "Invalid or unsupported instruction.",
+  9: "Invalid or unsupported instruction. (If this is a market order, the market's matcher config may be misaligned on-chain. Please report this to the team.)",
   10: "Invalid mint account.",
   11: "Invalid token account.",
   12: "Invalid vault account.",

--- a/app/lib/format.ts
+++ b/app/lib/format.ts
@@ -35,20 +35,6 @@ export function formatTokenAmount(
   return negative ? `-${formatted}` : formatted;
 }
 
-/**
- * Format an oracle price in E6 format (price * 10^6) into a readable decimal string.
- * Convenience wrapper around formatTokenAmount for 6-decimal prices.
- * 
- * @param priceE6 - Price value with 6 decimal places (E6 format)
- * @returns Formatted price string (e.g. "0.05" for 50000 E6)
- * 
- * @example
- * formatPriceE6(50000n) // → "0.05"
- * formatPriceE6(1000000n) // → "1"
- */
-export function formatPriceE6(priceE6: bigint): string {
-  return formatTokenAmount(priceE6, 6);
-}
 
 /**
  * Format a basis points value (1/100th of a percent) into a percentage string.
@@ -272,26 +258,6 @@ export function formatSlotAge(currentSlot: bigint | null | undefined, targetSlot
   return `${(seconds / 3600).toFixed(1)}h`;
 }
 
-/**
- * Format a signed 128-bit integer into a whole number string.
- * Useful for displaying net PnL or balance changes that can be negative.
- * 
- * @param raw - Signed i128 value in smallest units
- * @param decimals - Number of decimal places (default: 6)
- * @returns Formatted integer string with optional minus sign (e.g. "-100" or "50")
- * 
- * @example
- * formatI128Amount(500000000n, 6) // → "500"
- * formatI128Amount(-250000000n, 6) // → "-250"
- */
-export function formatI128Amount(raw: bigint, decimals: number = 6): string {
-  const negative = raw < 0n;
-  const abs = negative ? -raw : raw;
-  const divisor = 10n ** BigInt(decimals);
-  const whole = abs / divisor;
-  const formatted = whole.toString();
-  return negative ? `-${formatted}` : formatted;
-}
 
 /**
  * Format a profit/loss amount with signed indicator and full fractional precision.


### PR DESCRIPTION
## Summary

Resolves https://github.com/dcccrypto/percolator-launch/issues/2310

- **Improved Error Message**: Updated the translation mapping for custom error code 9 in `app/lib/errorMessages.ts` to indicate a possible market-side matcher configuration misalignment.
- **Unit Test Alignment**: Updated assertions in `app/__tests__/lib/errorMessages.test.ts` and `app/__tests__/lib/errorMessages-lighthouse.test.ts` to align with the current v17 error code map.
- **Code Cleanups**: Deleted unused utility functions `formatI128Amount` and `formatPriceE6` and removed their respective test cases from the format test suites.
- **Locale Compatibility**: Fixed a locale-dependent unit test issue in `app/__tests__/lib/format.test.ts` for `formatUsd` price boundary checks.