### PR TITLE
feat(layout): site-wide open-positions strip under the header

### DIFF
--- a/app/__tests__/lib/priceStore-poll.test.ts
+++ b/app/__tests__/lib/priceStore-poll.test.ts
@@ -1,0 +1,87 @@
+/**
+ * applyOnChainPoll (PositionsBar's recurring on-chain freshness floor):
+ * the poll may only ever REPLACE data staler than itself — a slab with a
+ * recent live WS tick must be untouchable, and a slab whose feed went
+ * quiet must become updatable again after LIVE_TICK_STALE_MS.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+// Capture the WS message listener so tests can inject "live" ticks without
+// a real socket. subscribeChannel/onMessage mirror WsManagerHandle's shape.
+const messageListeners: Array<(data: unknown) => void> = [];
+vi.mock("@/lib/priceStore/wsManager", () => ({
+  getWsManager: () => ({
+    subscribeChannel: () => () => {},
+    onMessage: (l: (data: unknown) => void) => {
+      messageListeners.push(l);
+      return () => {};
+    },
+    onStatusChange: () => () => {},
+  }),
+}));
+
+import {
+  subscribeSlab,
+  getSnapshot,
+  applyOnChainPoll,
+  seedFromDbIfEmpty,
+} from "@/lib/priceStore/priceStore";
+
+/** Deliver a live WS tick and force the store's buffered flush (the
+ *  visibilitychange handler flushes pending ticks synchronously — same
+ *  path the real store uses when a backgrounded tab returns). */
+function deliverLiveTick(slab: string, price: number) {
+  for (const l of messageListeners) l({ type: "price", slab, price });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("applyOnChainPoll", () => {
+  it("seeds an empty slab", () => {
+    applyOnChainPoll("poll-slab-empty", 5_000_000n);
+    const snap = getSnapshot("poll-slab-empty");
+    expect(snap.priceE6).toBe(5_000_000n);
+    expect(snap.loading).toBe(false);
+  });
+
+  it("ignores non-positive prices", () => {
+    applyOnChainPoll("poll-slab-zero", 0n);
+    expect(getSnapshot("poll-slab-zero").priceE6).toBe(null);
+  });
+
+  it("overwrites a DB seed (poll data is fresher than a cold-start seed)", () => {
+    seedFromDbIfEmpty("poll-slab-db", 1.5, undefined);
+    expect(getSnapshot("poll-slab-db").priceE6).toBe(1_500_000n);
+    applyOnChainPoll("poll-slab-db", 2_000_000n);
+    expect(getSnapshot("poll-slab-db").priceE6).toBe(2_000_000n);
+  });
+
+  it("NEVER overwrites a recent live WS tick", () => {
+    const slab = "poll-slab-live";
+    const unsub = subscribeSlab(slab, () => {});
+    deliverLiveTick(slab, 42);
+    expect(getSnapshot(slab).priceE6).toBe(42_000_000n);
+
+    applyOnChainPoll(slab, 999_000_000n);
+    expect(getSnapshot(slab).priceE6).toBe(42_000_000n); // live wins
+    unsub();
+  });
+
+  it("updates again once the live feed has been silent past the staleness window", () => {
+    const slab = "poll-slab-stale-live";
+    const unsub = subscribeSlab(slab, () => {});
+    deliverLiveTick(slab, 42);
+    expect(getSnapshot(slab).priceE6).toBe(42_000_000n);
+
+    // 11s of feed silence (> LIVE_TICK_STALE_MS = 10s)
+    const realNow = Date.now();
+    vi.spyOn(Date, "now").mockReturnValue(realNow + 11_000);
+
+    applyOnChainPoll(slab, 43_000_000n);
+    expect(getSnapshot(slab).priceE6).toBe(43_000_000n); // poll allowed now
+    unsub();
+  });
+});

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -9,6 +9,7 @@ import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
 import { MobileBottomNav } from "@/components/layout/MobileBottomNav";
 import { TickerBanner } from "@/components/layout/TickerBanner";
+import { PositionsBar } from "@/components/layout/PositionsBar";
 import { CursorGlow } from "@/components/ui/CursorGlow";
 import { MusicPlayer } from "@/components/ui/MusicPlayer";
 import { MainnetBetaBanner } from "@/components/layout/MainnetBetaBanner";
@@ -118,6 +119,9 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               <MainnetBetaBanner />
             </ChromeGate>
             <Header />
+            <ChromeGate>
+              <PositionsBar />
+            </ChromeGate>
             <main className="flex-1 pb-[60px] md:pb-0">{children}</main>
             <Footer />
             <MobileBottomNav />

--- a/app/components/layout/PositionsBar.tsx
+++ b/app/components/layout/PositionsBar.tsx
@@ -7,7 +7,7 @@ import { PublicKey } from "@solana/web3.js";
 import { parseWrapperConfigV17, isV17Account, V17_HEADER_LEN } from "@percolatorct/sdk";
 import { subscribeSlab, getSnapshot, applyOnChainPoll } from "@/lib/priceStore/priceStore";
 import { sanitizePriceE6 } from "@/lib/oraclePrice";
-import { computeMarkPnl, computeMarkPnlCollateral } from "@/lib/trading";
+import { computeMarkPnl, computeMarkPnlCollateral, computePnlPercent, computePositionInitialMargin } from "@/lib/trading";
 import { usePortfolio, type PortfolioPosition } from "@/hooks/usePortfolio";
 import { useConnectionCompat, useWalletCompat } from "@/hooks/useWalletCompat";
 import { useMultiTokenMeta } from "@/hooks/useMultiTokenMeta";
@@ -51,6 +51,19 @@ function PositionChip({ pos, decimals }: { pos: PortfolioPosition; decimals: num
     }
   })();
 
+  // Live ROE — same basis as the portfolio cards: PnL ÷ the position's own
+  // locked initial margin, capital fallback, hook's pnlPercent last resort.
+  const pnlPct = (() => {
+    try {
+      const im = computePositionInitialMargin(posSize, posEntry, pos.initialMarginBps);
+      if (im > 0n) return computePnlPercent(pnl, im);
+      const capital = pos.account?.capital ?? 0n;
+      return capital > 0n ? computePnlPercent(pnl, capital) : pos.pnlPercent;
+    } catch {
+      return pos.pnlPercent;
+    }
+  })();
+
   const symbol = pos.symbol ?? `${pos.slabAddress.slice(0, 4)}…`;
   const colorClass =
     pnl > 0n ? "text-[var(--long)]" : pnl < 0n ? "text-[var(--short)]" : "text-[var(--text)]";
@@ -72,6 +85,11 @@ function PositionChip({ pos, decimals }: { pos: PortfolioPosition; decimals: num
       </span>
       <span className={`text-[11px] font-bold ${colorClass}`}>
         {sign}{formatTokenAmount(abs, decimals)}
+      </span>
+      {/* ROE — smaller + dimmed so the dollar figure stays the loud number;
+          no extra sign (color + the main value already carry direction). */}
+      <span className={`text-[10px] font-medium opacity-60 ${colorClass}`}>
+        {Math.abs(pnlPct).toFixed(1)}%
       </span>
     </Link>
   );

--- a/app/components/layout/PositionsBar.tsx
+++ b/app/components/layout/PositionsBar.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useSyncExternalStore } from "react";
+import { usePathname } from "next/navigation";
+import { subscribeSlab, getSnapshot } from "@/lib/priceStore/priceStore";
+import { computeMarkPnl, computeMarkPnlCollateral } from "@/lib/trading";
+import { usePortfolio, type PortfolioPosition } from "@/hooks/usePortfolio";
+import { useWalletCompat } from "@/hooks/useWalletCompat";
+import { useMultiTokenMeta } from "@/hooks/useMultiTokenMeta";
+import { formatTokenAmount } from "@/lib/format";
+import { isMockMode } from "@/lib/mock-mode";
+import { getMockPortfolioPositions } from "@/lib/mock-trade-data";
+
+// The portfolio page already renders every position in full (and mounts its
+// own usePortfolio) — showing the strip there doubles both the chrome and
+// the RPC scan for no information gain.
+const HIDDEN_ROUTES = ["/portfolio"];
+
+/** One position chip: ticker + live PnL, colored by sign, linking to the market. */
+function PositionChip({ pos, decimals }: { pos: PortfolioPosition; decimals: number }) {
+  // Live mark from the shared WS price store (same feed as the trade page);
+  // falls back to the portfolio poll's oracle price until the first tick.
+  const subscribe = useCallback((cb: () => void) => subscribeSlab(pos.slabAddress, cb), [pos.slabAddress]);
+  const getSnap = useCallback(() => getSnapshot(pos.slabAddress).priceE6, [pos.slabAddress]);
+  const livePriceE6 = useSyncExternalStore(subscribe, getSnap, () => null);
+
+  const posSize = pos.account?.positionSize ?? 0n;
+  const posEntry = pos.effectiveEntryPrice;
+  const markE6 = livePriceE6 != null && livePriceE6 > 0n ? livePriceE6 : pos.oraclePriceE6;
+
+  // Same collateral-unit conversion as usePortfolio / the portfolio cards:
+  // computeMarkPnl is coin-margined native units, NOT collateral — convert
+  // via computeMarkPnlCollateral. Falls back to the hook's own (already
+  // collateral-converted) unrealizedPnl when entry/mark are unavailable.
+  const pnl = (() => {
+    if (posSize === 0n || posEntry <= 0n || markE6 <= 0n) return pos.unrealizedPnl;
+    try {
+      return computeMarkPnlCollateral(computeMarkPnl(posSize, posEntry, markE6), markE6);
+    } catch {
+      return pos.unrealizedPnl;
+    }
+  })();
+
+  const symbol = pos.symbol ?? `${pos.slabAddress.slice(0, 4)}…`;
+  const colorClass =
+    pnl > 0n ? "text-[var(--long)]" : pnl < 0n ? "text-[var(--short)]" : "text-[var(--text)]";
+  const sign = pnl > 0n ? "+" : pnl < 0n ? "-" : "";
+  const abs = pnl < 0n ? -pnl : pnl;
+
+  return (
+    <Link
+      href={`/trade/${pos.slabAddress}`}
+      className="group flex shrink-0 items-center gap-1.5 px-3 py-1 transition-colors hover:bg-[var(--bg-elevated)]"
+      style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}
+    >
+      <span
+        className={`h-1 w-1 rounded-full ${posSize > 0n ? "bg-[var(--long)]" : "bg-[var(--short)]"}`}
+        aria-hidden
+      />
+      <span className="text-[11px] font-semibold text-[var(--text-secondary)] transition-colors group-hover:text-[var(--text)]">
+        {symbol.replace(/-PERP$/i, "")}
+      </span>
+      <span className={`text-[11px] font-bold ${colorClass}`}>
+        {sign}{formatTokenAmount(abs, decimals)}
+      </span>
+    </Link>
+  );
+}
+
+/**
+ * Site-wide open-positions strip, rendered directly under the sticky header.
+ * One chip per open position — ticker + live PnL (green/red/white by sign) —
+ * so a trader navigating anywhere on the site can watch their book and jump
+ * straight to a market that's moving against them.
+ *
+ * Renders nothing (zero height) when the wallet is disconnected, the
+ * portfolio is still on its first load, or there are no open positions.
+ */
+export function PositionsBar() {
+  const pathname = usePathname();
+  const { connected: walletConnected } = useWalletCompat();
+  const mockMode = isMockMode();
+  const portfolio = usePortfolio();
+
+  const hidden =
+    pathname != null && HIDDEN_ROUTES.some((r) => pathname === r || pathname.startsWith(r + "/"));
+
+  const mockPositions = mockMode && !walletConnected ? getMockPortfolioPositions() : null;
+  const positions = mockPositions ?? portfolio.positions;
+  // Largest book exposure first (left → right). Notional (|size| × oracle
+  // price) rather than raw size so positions are comparable across markets
+  // (1000 WIF ≠ 1000 SOL). Sorted on the poll's oracle price, not the live
+  // mark, so chips don't reshuffle on every price tick.
+  const notionalOf = (pos: PortfolioPosition): bigint => {
+    const size = pos.account?.positionSize ?? 0n;
+    const abs = size < 0n ? -size : size;
+    return pos.oraclePriceE6 > 0n ? (abs * pos.oraclePriceE6) / 1_000_000n : abs;
+  };
+  const openPositions = positions
+    .filter((pos) => (pos.account?.positionSize ?? 0n) !== 0n)
+    .sort((a, b) => (notionalOf(b) > notionalOf(a) ? 1 : notionalOf(b) < notionalOf(a) ? -1 : 0));
+
+  // Collateral decimals per mint (all playground markets use 6-decimal
+  // sim-USDC; resolved properly anyway, matching the portfolio page).
+  const tokenMetaMap = useMultiTokenMeta(openPositions.map((pos) => pos.collateralMint));
+
+  if (hidden || (!walletConnected && !mockPositions) || openPositions.length === 0) return null;
+
+  return (
+    <div
+      className="sticky top-14 z-40 flex items-center overflow-x-auto border-b border-[var(--border)] bg-[var(--bg)]/95 backdrop-blur-md [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      data-testid="positions-bar"
+    >
+      <span className="shrink-0 select-none border-r border-[var(--border)] px-3 py-1 text-[9px] font-medium uppercase tracking-[0.2em] text-[var(--text-secondary)]">
+        Positions
+      </span>
+      {openPositions.map((pos, i) => (
+        <PositionChip
+          key={`${pos.slabAddress}-${pos.idx ?? i}`}
+          pos={pos}
+          decimals={tokenMetaMap.get(pos.collateralMint.toBase58())?.decimals ?? 6}
+        />
+      ))}
+    </div>
+  );
+}

--- a/app/components/layout/PositionsBar.tsx
+++ b/app/components/layout/PositionsBar.tsx
@@ -1,16 +1,25 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useSyncExternalStore } from "react";
 import { usePathname } from "next/navigation";
-import { subscribeSlab, getSnapshot } from "@/lib/priceStore/priceStore";
+import { PublicKey } from "@solana/web3.js";
+import { parseWrapperConfigV17, isV17Account, V17_HEADER_LEN } from "@percolatorct/sdk";
+import { subscribeSlab, getSnapshot, applyOnChainPoll } from "@/lib/priceStore/priceStore";
+import { sanitizePriceE6 } from "@/lib/oraclePrice";
 import { computeMarkPnl, computeMarkPnlCollateral } from "@/lib/trading";
 import { usePortfolio, type PortfolioPosition } from "@/hooks/usePortfolio";
-import { useWalletCompat } from "@/hooks/useWalletCompat";
+import { useConnectionCompat, useWalletCompat } from "@/hooks/useWalletCompat";
 import { useMultiTokenMeta } from "@/hooks/useMultiTokenMeta";
 import { formatTokenAmount } from "@/lib/format";
 import { isMockMode } from "@/lib/mock-mode";
 import { getMockPortfolioPositions } from "@/lib/mock-trade-data";
+
+/** On-chain freshness floor for chips the WS feed isn't ticking: one batched
+ *  getMultipleAccountsInfo across every position slab per interval. */
+const ONCHAIN_POLL_MS = 4_000;
+/** getMultipleAccountsInfo hard cap per request (RPC rejects >100). */
+const RPC_ACCOUNT_BATCH_CAP = 100;
 
 // The portfolio page already renders every position in full (and mounts its
 // own usePortfolio) — showing the strip there doubles both the chrome and
@@ -104,6 +113,52 @@ export function PositionsBar() {
   // Collateral decimals per mint (all playground markets use 6-decimal
   // sim-USDC; resolved properly anyway, matching the portfolio page).
   const tokenMetaMap = useMultiTokenMeta(openPositions.map((pos) => pos.collateralMint));
+
+  // Freshness floor for markets the WS feed isn't ticking: read every
+  // position slab's markEwmaE6 (the exact field usePortfolio publishes as
+  // oraclePriceE6) in ONE batched RPC call every ONCHAIN_POLL_MS, and hand
+  // it to the store. `applyOnChainPoll` refuses to touch any slab with a
+  // recent live WS tick, so streaming feeds always outrank this poll —
+  // it only ever REPLACES data that is already staler than itself.
+  const { connection } = useConnectionCompat();
+  const usingMockData = mockPositions != null;
+  const slabKey = openPositions.map((pos) => pos.slabAddress).join(",");
+  useEffect(() => {
+    // No poll when the bar isn't showing (hidden route) or the book is mock
+    // (mock slabs aren't on-chain accounts) — zero RPC when invisible.
+    if (!slabKey || usingMockData || hidden) return;
+    const slabAddrs = slabKey.split(",").slice(0, RPC_ACCOUNT_BATCH_CAP);
+    let keys: PublicKey[];
+    try {
+      keys = slabAddrs.map((s) => new PublicKey(s));
+    } catch {
+      return; // defensive: a malformed address would throw on every tick
+    }
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const infos = await connection.getMultipleAccountsInfo(keys);
+        if (cancelled) return;
+        infos.forEach((info, i) => {
+          if (!info?.data || !isV17Account(info.data)) return;
+          try {
+            const e6 = sanitizePriceE6(parseWrapperConfigV17(info.data, V17_HEADER_LEN).markEwmaE6);
+            if (e6 > 0n) applyOnChainPoll(slabAddrs[i], e6);
+          } catch {
+            /* unparseable slab — skip, keep the rest of the batch */
+          }
+        });
+      } catch {
+        /* transient RPC failure — next interval retries */
+      }
+    };
+    poll();
+    const id = setInterval(poll, ONCHAIN_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [connection, slabKey, usingMockData, hidden]);
 
   if (hidden || (!walletConnected && !mockPositions) || openPositions.length === 0) return null;
 

--- a/app/hooks/usePortfolio.ts
+++ b/app/hooks/usePortfolio.ts
@@ -153,6 +153,11 @@ export interface PortfolioPosition {
   leverage: number;
   /** Maintenance margin bps for this market */
   maintenanceMarginBps: bigint;
+  /** Initial margin bps for this market — consumers recomputing PnL% with a
+   *  LIVE mark (PositionsBar chips) must divide by the position's initial
+   *  margin (computePositionInitialMargin), matching this hook's own
+   *  pnlPercent, NOT by total account capital. */
+  initialMarginBps: bigint;
   /**
    * True when this position is escrowed inside a Position NFT (v17). Minting an
    * NFT B-3-transfers `portfolio.owner` to the NFT program's escrow PDA, so the
@@ -292,6 +297,7 @@ function buildV17Position(
     pnlPercent,
     leverage,
     maintenanceMarginBps,
+    initialMarginBps,
     nftWrapped,
   };
 }
@@ -614,6 +620,7 @@ export function usePortfolio(): PortfolioData {
                     pnlPercent,
                     leverage,
                     maintenanceMarginBps,
+                    initialMarginBps,
                   });
                   // Guard account.pnl against u64::MAX sentinel values before accumulating.
                   // Uninitialized / flat positions store u64::MAX as a sentinel — summing them

--- a/app/lib/mock-trade-data.ts
+++ b/app/lib/mock-trade-data.ts
@@ -482,6 +482,7 @@ export function getMockPortfolioPositions(): PortfolioPosition[] {
       pnlPercent,
       leverage,
       maintenanceMarginBps: maintenanceBps,
+      initialMarginBps: BigInt(m.initialMarginBps),
       account: {
         kind: AccountKind.User,
         accountId: BigInt(positions.length + 1),

--- a/app/lib/priceStore/priceStore.ts
+++ b/app/lib/priceStore/priceStore.ts
@@ -108,6 +108,10 @@ interface SlabEntry {
    *  invert atomically inside `resolveMarketPriceE6`, and live WS ticks
    *  read `entry.invert` fresh on every message. */
   lastDbRawE6: bigint | null;
+  /** Wall-clock ms of the last applied LIVE WS tick — lets `applyOnChainPoll`
+   *  distinguish "feed is streaming, don't touch" from "feed went quiet /
+   *  never covered this market, poll data is the freshest we have". */
+  lastLiveTickAt: number;
 }
 
 const entries = new Map<string, SlabEntry>();
@@ -126,6 +130,7 @@ function getOrCreateEntry(slab: string): SlabEntry {
       invert: undefined,
       source: null,
       lastDbRawE6: null,
+      lastLiveTickAt: 0,
     };
     entries.set(slab, entry);
   }
@@ -162,6 +167,7 @@ function flushEntry(entry: SlabEntry): void {
   entry.pendingTick = null;
   if (tick) {
     entry.source = "live";
+    entry.lastLiveTickAt = Date.now();
     const prevHigh = entry.snapshot.high24h;
     const prevLow = entry.snapshot.low24h;
     applyPatch(entry, {
@@ -343,6 +349,34 @@ export function seedFromDbIfEmpty(slab: string, dbPrice: number, invert: number 
   const usd = e6 > 0n ? Number(e6) / 1_000_000 : dbPrice;
   entry.source = "seed-db";
   applyPatch(entry, { price: usd, priceUsd: usd, priceE6: e6, loading: false });
+}
+
+/** How long the live WS feed may go silent on a slab before a recurring
+ *  on-chain poll is allowed to update its price. Live ticks arrive
+ *  sub-second when a feed exists, so 10s of silence means the feed is down,
+ *  reconnecting, or never covered this market. */
+const LIVE_TICK_STALE_MS = 10_000;
+
+/**
+ * Recurring on-chain poll update (PositionsBar's ≤4s freshness floor for
+ * markets the WS feed isn't covering). Unlike `seedFromOnChain` (one-shot,
+ * only-if-empty), this MAY overwrite an existing price — but never a live
+ * one: it applies only when the slab has no live WS tick in the last
+ * `LIVE_TICK_STALE_MS`, so a streaming feed always outranks the poll and
+ * the flicker-to-stale-price bug `seedFromDbIfEmpty`'s doc describes can't
+ * come back through this path.
+ *
+ * Expects an already-sanitized post-invert e6 price (callers read
+ * `wrapperConfigV17.markEwmaE6` via `sanitizePriceE6`, exactly the value
+ * usePortfolio publishes as `oraclePriceE6`).
+ */
+export function applyOnChainPoll(slab: string, onChainE6: bigint): void {
+  if (onChainE6 <= 0n) return;
+  const entry = getOrCreateEntry(slab);
+  if (entry.source === "live" && Date.now() - entry.lastLiveTickAt < LIVE_TICK_STALE_MS) return;
+  const usd = Number(onChainE6) / 1_000_000;
+  if (entry.source === null) entry.source = "seed-onchain";
+  applyPatch(entry, { price: usd, priceUsd: usd, priceE6: onChainE6, loading: false });
 }
 
 /** On-chain oracle fallback — only-if-empty, same semantics as the pre-refactor hook. */


### PR DESCRIPTION
## What

A site-wide **open-positions strip** in the thin row directly under the sticky header (same pattern as Axiom/Photon): one chip per open position — ticker + that position's live PnL — visible on every page, so a trader browsing markets/analytics/anywhere can watch their book and click straight through to a market moving against them.

- **Chip** = side dot (green long / red short) + market symbol + the user's PnL for that position: green with `+` when winning, red with `-` when losing, white at breakeven.
- **Sorted by notional** (|size| × oracle price) descending, largest exposure leftmost — sorted on the poll price, not the live mark, so chips don't reshuffle on every tick. Overflow scrolls horizontally.
- **Click → `/trade/<slab>`.**
- **Zero-height when it has nothing to say**: wallet disconnected (usePortfolio no-ops without a publicKey, so logged-out visitors pay no RPC), first load, no open positions, or on `/portfolio` (which already renders every position in full and mounts its own usePortfolio — the strip there would double both chrome and scan).

## Freshness

- Chips subscribe per-slab to the shared WS price store (one refcounted socket; the same feed the trade page and markets page tick off) — **sub-second** where a feed exists. PnL recomputes per tick with the exact math the terminal uses: `computeMarkPnlCollateral(computeMarkPnl(size, entry, mark), mark)`, falling back to the hook's own collateral-converted `unrealizedPnl` when entry/mark are unavailable.
- For markets the feed isn't streaming (e.g. a user-launched market with no Pyth feed), the bar reads every position slab's `markEwmaE6` (the exact field usePortfolio publishes as `oraclePriceE6`: `parseWrapperConfigV17` + `sanitizePriceE6`, `isV17Account`-guarded) in **one batched `getMultipleAccountsInfo` every 4s** — worst-case staleness drops from the portfolio poll's 30s to ~4s.
- New store entry point `applyOnChainPoll(slab, e6)`: unlike `seedFromOnChain` (one-shot, only-if-empty) it may overwrite an existing price — **but never a live one**. It refuses to touch any slab with a live WS tick in the last 10s (new `lastLiveTickAt` stamp), so a streaming feed always outranks the poll and the flicker-to-stale-price bug documented on `seedFromDbIfEmpty` can't return through this path.
- Poll lifecycle: skipped entirely when the bar is hidden or the book is mock; interval keyed on the position set (not renders/ticks); in-flight results discarded after unmount; capped at the RPC's 100-account batch limit.

## Testing

- `npx tsc --noEmit` clean.
- **New unit tests** (`priceStore-poll.test.ts`, 5 tests) pin the poll's safety invariants: seeds empty, rejects non-positive, overwrites a DB cold-start seed, **never overwrites a recent live tick**, updates again after 10s of feed silence.
- Header / mock-data / trading-ui suites green (49/49).
- Headless-browser checks against the dev server (mock book): chips render sorted by notional (SOL → USDC → JUP → WIF) with correct `/trade/<slab>` links; `+` values render in `--long` green and `-` values in `--short` red (verified both by temporarily inverting the mock entries); bar absent on `/portfolio` and when disconnected; zero page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
