### PR TITLE
fix(stake): refresh withdraw position after deposit

### DIFF
--- a/app/app/stake/page.tsx
+++ b/app/app/stake/page.tsx
@@ -634,6 +634,7 @@ function DepositWidget({
   useEffect(() => {
     if (!connected || !publicKey || !pool?.slabAddress) {
       setWithdrawPosition(null);
+      setWithdrawPositionLoading(false);
       return;
     }
     let cancelled = false;
@@ -685,6 +686,11 @@ function DepositWidget({
       const sig = await deposit(rawAmount);
       setAmount("");
       setTxStatus({ type: "success", msg: `Deposit confirmed: ${sig.slice(0, 8)}…` });
+
+      // Refresh the selected pool's withdraw position immediately after a deposit
+      // so the Withdraw tab can enable manual amount entry and MAX without waiting
+      // for a full pool/position reload.
+      setWithdrawRefreshKey((k) => k + 1);
       onTxSuccess?.();
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);


### PR DESCRIPTION
## Summary

Fixes a small Stake page UX issue where the Withdraw tab could keep reading stale selected-pool position state after a successful deposit.

## Root Cause

The Stake page already refreshes parent pool/position data after a transaction, but the DepositWidget also keeps a local selected-pool `withdrawPosition` state.

After a successful deposit, that local withdraw position was not refreshed immediately. Because the Withdraw tab depends on `withdrawPosition`, it could temporarily keep reading a stale/null position, leaving manual amount entry and MAX unavailable until another refresh, pool switch, or full position reload happened.

## Fix

- Clear `withdrawPositionLoading` when wallet/pool context is unavailable.
- Bump `withdrawRefreshKey` after a successful deposit so the selected pool's withdraw position is rechecked immediately.

## Difference from prior PRs

This is not the same as the previous pool TVL refresh fix. That PR refreshed pool-level TVL/cap data after transactions.

This PR only refreshes the selected pool's local withdraw position state inside the Stake deposit/withdraw widget.

## User Impact

After depositing into a stake pool, users can switch to Withdraw and have the selected pool position rechecked immediately, so the amount input and MAX state can update correctly once the LP position is available.

## Test Plan

- `git diff --check`
- `pnpm exec tsc --noEmit --pretty false`

## Risk

Low. This is limited to frontend Stake page state refresh behavior. It does not change transaction construction, backend APIs, or on-chain instructions.