### PR TITLE
fix(trade): chart fallback line, 24h stats for wizard markets, Market LP relabel

### DIFF
--- a/app/app/api/prices/[slab]/route.ts
+++ b/app/app/api/prices/[slab]/route.ts
@@ -85,6 +85,80 @@ async function pythStatsFallback(slab: string): Promise<Stats24h | null> {
   return result;
 }
 
+const GECKOTERMINAL_OHLCV_BASE = "https://api.geckoterminal.com/api/v2/networks/solana/pools";
+
+/** [timestamp, open, high, low, close, volume] — GeckoTerminal's OHLCV row shape. */
+type GeckoOhlcvBar = [number, number, number, number, number, number];
+
+/**
+ * Fallback 24h stats derived directly from GeckoTerminal's public OHLCV API,
+ * for markets `pythStatsFallback` can't cover — anything without a
+ * `PLAYGROUND_SLAB_META` entry (every wizard/community-launched market) or
+ * without a mapped Pyth feed for its underlying asset. Same shape/caching
+ * discipline as `pythStatsFallback`; the only difference is the upstream
+ * source and that the DEX pool address comes from this app's OWN
+ * Supabase-backed `/api/markets/:slab` (reliable, independent of the
+ * Railway-hosted indexer the primary path above already degrades away from)
+ * instead of a hardcoded symbol map — so it works for ANY market, including
+ * ones for tokens Pyth has never heard of (e.g. a freshly-launched pump.fun
+ * coin), as long as GeckoTerminal has indexed its pool.
+ */
+async function geckoTerminalStatsFallback(slab: string, origin: string): Promise<Stats24h | null> {
+  const cacheKey = `gt:${slab}`;
+  const cached = fallbackCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.value;
+  }
+  const setCache = (value: Stats24h | null): Stats24h | null => {
+    fallbackCache.set(cacheKey, { value, expiresAt: Date.now() + FALLBACK_CACHE_TTL_MS });
+    return value;
+  };
+
+  try {
+    // Self-referential call rather than a fresh Supabase query here: /api/markets/:slab
+    // already owns blocklist filtering, network (devnet/mainnet) scoping, slug resolution,
+    // and the on-chain fallback for when Supabase itself isn't configured — reusing it keeps
+    // this route from having to duplicate (and risk drifting from) all of that.
+    const marketRes = await fetch(`${origin}/api/markets/${slab}`, {
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!marketRes.ok) return setCache(null);
+    const marketJson = (await marketRes.json()) as { market?: { dex_pool_address?: string | null } };
+    const pool = marketJson.market?.dex_pool_address;
+    if (!pool) return setCache(null);
+
+    const url = `${GECKOTERMINAL_OHLCV_BASE}/${encodeURIComponent(pool)}/ohlcv/hour?aggregate=1&limit=24`;
+    const res = await fetch(url, {
+      headers: { "User-Agent": "percolator-prices-proxy/1.0" },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return setCache(null);
+    const data = (await res.json()) as {
+      data?: { attributes?: { ohlcv_list?: GeckoOhlcvBar[] } };
+    };
+    const bars = data.data?.attributes?.ohlcv_list ?? [];
+    if (bars.length === 0) return setCache(null);
+
+    // Newest-first per GeckoTerminal's API contract.
+    const high = Math.max(...bars.map((b) => b[2]));
+    const low = Math.min(...bars.map((b) => b[3]));
+    const last = bars[0][4];                 // newest close
+    const first = bars[bars.length - 1][1];  // oldest open
+    if (!Number.isFinite(high) || !Number.isFinite(low) || !Number.isFinite(first) || first <= 0) {
+      return setCache(null);
+    }
+
+    const toE6Str = (v: number) => BigInt(Math.round(v * 1_000_000)).toString();
+    return setCache({
+      change24h: ((last - first) / first) * 100,
+      high24h: toE6Str(high),
+      low24h: toE6Str(low),
+    });
+  } catch {
+    return setCache(null);
+  }
+}
+
 /**
  * GET /api/prices/[slab]
  *
@@ -99,11 +173,11 @@ async function pythStatsFallback(slab: string): Promise<Stats24h | null> {
  * We compute 24h stats from the history:
  *  - high24h / low24h: max/min price_e6 in the window
  *  - change24h: % change from oldest entry in window vs latest
- * 
+ *
  * MEDIUM-003: Added slab parameter validation.
  */
 export async function GET(
-  _req: NextRequest,
+  req: NextRequest,
   { params }: { params: Promise<{ slab: string }> }
 ) {
   try {
@@ -139,11 +213,20 @@ export async function GET(
     }
 
     if (prices.length === 0) {
-      const stats = await pythStatsFallback(validSlab).catch(() => null);
+      // pythStatsFallback only covers the curated PLAYGROUND_SLAB_META markets
+      // (SOL/BONK/JUP/TRUMP/PENGU) — null for anything else, including every
+      // wizard/community-launched market. geckoTerminalStatsFallback picks up
+      // there: it works for ANY market (looks up the pool via /api/markets/:slab)
+      // as long as GeckoTerminal has indexed the pool, which is the common case
+      // even for a brand-new pump.fun-style coin.
+      let stats = await pythStatsFallback(validSlab).catch(() => null);
+      if (!stats) {
+        stats = await geckoTerminalStatsFallback(validSlab, req.nextUrl.origin).catch(() => null);
+      }
       // BUG 18 fix: was NO_STORE — this is the live path on the hosted playground
       // (no indexer backend), polled every ~10s by every viewer. Cache it briefly
-      // so repeated polls within the window don't each re-hit Pyth (see
-      // FALLBACK_CACHE_HEADERS / fallbackCache above).
+      // so repeated polls within the window don't each re-hit Pyth/GeckoTerminal
+      // (see FALLBACK_CACHE_HEADERS / fallbackCache above).
       return NextResponse.json({ stats }, { headers: FALLBACK_CACHE_HEADERS });
     }
 

--- a/app/app/markets/page.tsx
+++ b/app/app/markets/page.tsx
@@ -898,7 +898,7 @@ function MarketsPageInner() {
                   <div className="text-right">price</div>
                   <div className="hidden sm:block text-right">OI</div>
                   <div className="hidden sm:block text-right">vol</div>
-                  <div className="hidden sm:block text-right">insurance</div>
+                  <div className="hidden sm:block text-right">market lp</div>
                   <div className="text-right"><span className="sm:hidden">lev</span><span className="hidden sm:inline">max lev</span></div>
                   <div className="text-right">health</div>
                 </div>
@@ -992,10 +992,20 @@ function MarketsPageInner() {
                         const safe = isSentinelNum(v) ? 0 : Math.max(0, v);
                         return BigInt(Math.round(safe));
                       })();
-                  const insuranceTokensRaw = m.onChain && !m.onChain.configV17
-                    ? sanitizeOnChainValue(m.onChain.engine.insuranceFund.balance)
+                  // "Market LP" — the LP-vault collateral that actually backs trades on this
+                  // market, NOT the (separately admin-managed) insurance fund. Same
+                  // "prefer vault_balance, fall back to c_tot" precedent already used for the
+                  // oracle-down guard above (m.supabase?.vault_balance / c_tot, ~line 945) —
+                  // vault_balance is the external LP-vault account's balance; c_tot (total
+                  // on-chain collateral across all accounts) is the best available proxy for
+                  // markets that store collateral in-slab instead (e.g. FF7K keeper markets,
+                  // see lib/activeMarketFilter.ts). On-chain v12 path uses engine.vault, the
+                  // same field SystemCapitalCard.tsx labels "Total collateral deposited in
+                  // this market's vault".
+                  const marketLpTokensRaw = m.onChain && !m.onChain.configV17
+                    ? sanitizeOnChainValue(m.onChain.engine.vault || m.onChain.engine.cTot)
                     : (() => {
-                        const v = m.supabase?.insurance_balance ?? m.supabase?.insurance_fund ?? 0;
+                        const v = m.supabase?.vault_balance ?? m.supabase?.c_tot ?? 0;
                         const safe = isSentinelNum(v) ? 0 : Math.max(0, v);
                         return BigInt(Math.round(safe));
                       })();
@@ -1010,13 +1020,13 @@ function MarketsPageInner() {
                     : null;
                   const oiDisplay = oiTokensRaw === 0n ? "—"
                     : oiUsd != null ? (oiUsd > 0 ? formatNum(oiUsd) : "—") : formatStatValue(oiTokensRaw, 'number', mintDecimals);
-                  // Insurance is denominated in the COLLATERAL mint (Sim-USDC, 6dp) — it is
+                  // Market LP is denominated in the COLLATERAL mint (Sim-USDC, 6dp) — it is
                   // already a USD amount, so it is NEVER multiplied by the token price (unlike
                   // OI, which is a base-token quantity). Divide by the collateral decimals,
                   // independent of the market's base-token decimals or the USD/token toggle.
-                  const insVal = Math.round((Number(insuranceTokensRaw) / 1e6) * 100) / 100;
-                  const insuranceDisplay = insuranceTokensRaw === 0n ? "—"
-                    : insVal > 0 ? formatNum(insVal) : "—";
+                  const marketLpVal = Math.round((Number(marketLpTokensRaw) / 1e6) * 100) / 100;
+                  const marketLpDisplay = marketLpTokensRaw === 0n ? "—"
+                    : marketLpVal > 0 ? formatNum(marketLpVal) : "—";
                   const volumeDisplay = volume24hRaw != null && volume24hRaw > 0n
                     ? (showUsd && lastPrice != null
                         ? formatNum(Math.round((Number(volume24hRaw) / tokenDivisor) * lastPrice * 100) / 100)
@@ -1077,7 +1087,7 @@ function MarketsPageInner() {
                       <div className="hidden sm:block text-right text-sm text-[var(--text-secondary)] truncate tabular-nums" style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>
                         {volumeDisplay ?? "\u2014"}
                       </div>
-                      <div className="hidden sm:block text-right text-sm text-[var(--text)] truncate tabular-nums" style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>{insuranceDisplay}</div>
+                      <div className="hidden sm:block text-right text-sm text-[var(--text)] truncate tabular-nums" style={{ fontFamily: "var(--font-jetbrains-mono)", fontVariantNumeric: "tabular-nums" }}>{marketLpDisplay}</div>
                       <div className="text-right text-sm text-[var(--text-secondary)] tabular-nums" style={{ fontVariantNumeric: "tabular-nums" }}>{m.maxLeverage}x</div>
                       <div className="text-right"><HealthBadge level={effectiveHealth.level} /></div>
                     </Link>

--- a/app/app/trade/[slab]/page.tsx
+++ b/app/app/trade/[slab]/page.tsx
@@ -337,6 +337,16 @@ function TradePageInner({ slab }: { slab: string }) {
   // Resolve symbol: Supabase market symbol (trading pair) → on-chain (collateral) → truncated address
   const collateralMintAddress = config?.collateralMint?.toBase58() ?? "";
   const mintAddress = supabaseMarket?.mainnet_ca ?? collateralMintAddress;
+  // GH#chart-empty: TradingChart's GeckoTerminal lookup (useTokenChart) needs the market's
+  // MAINNET token CA, never the devnet Sim-USDC collateral mint (`collateralMintAddress`) —
+  // charting "Sim-USDC vs itself" is meaningless. `mintAddress` above intentionally falls
+  // back to the collateral mint (for symbol/logo resolution elsewhere), but on first render
+  // (before the `/api/markets/[slab]` fetch above resolves) that fallback fires, so
+  // useTokenChart briefly fetches the WRONG mint before re-fetching the correct one once
+  // `supabaseMarket` loads — a wasted request today (GeckoTerminal 404s either way while the
+  // indexer backend is down) and a real wrong-chart flash once it's back. Pass `undefined`
+  // instead of the collateral mint while the real CA is still unknown.
+  const chartMintAddress = supabaseMarket?.mainnet_ca ?? undefined;
   const onChainSymbol = tokenMeta?.symbol ?? null;
   const supabaseSymbol = supabaseMarket?.symbol ?? null;
   const symbol = (() => {
@@ -541,7 +551,7 @@ function TradePageInner({ slab }: { slab: string }) {
             <ErrorBoundary label="TradingChart">
               <RenderProfiler id="TradingChart">
                 <div className="h-full overflow-hidden">
-                  <TradingChart slabAddress={slab} mintAddress={mintAddress || undefined} />
+                  <TradingChart slabAddress={slab} mintAddress={chartMintAddress} />
                 </div>
               </RenderProfiler>
             </ErrorBoundary>
@@ -586,7 +596,7 @@ function TradePageInner({ slab }: { slab: string }) {
           <ErrorBoundary label="TradingChart">
             <RenderProfiler id="TradingChart">
               <div className="w-full overflow-hidden">
-                <TradingChart slabAddress={slab} mintAddress={mintAddress || undefined} />
+                <TradingChart slabAddress={slab} mintAddress={chartMintAddress} />
               </div>
             </RenderProfiler>
           </ErrorBoundary>

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -457,6 +457,58 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
     });
   }, [config, slabAddress]);
 
+  // Fallback poll: when no Percolator/Pyth/DEX candle source has data, the two
+  // effects above are the ONLY way `oraclePrices` ever grows — a one-shot
+  // history fetch (above, silently no-ops if the indexer backend is
+  // unreachable) and live WS ticks (also above, silently no-ops if the WS
+  // feed never covers this market or the backend is down). With both dark
+  // (e.g. the shared indexer/WS backend is unreachable — confirmed via the
+  // hosted playground returning "Application not found" for every indexer
+  // route, 2026-07), `oraclePrices` gets at most the single DB-seeded point
+  // `useLivePrice()` applies once on mount and then never grows — permanently
+  // stuck below `hasRenderableData`'s 2-point "sparse" threshold, so a fresh
+  // market's chart shows "Price chart building…" forever instead of an
+  // actual line. Poll the already-reliable `/api/markets/:slab` endpoint
+  // (Supabase-backed, independent of the indexer/WS backend — the same
+  // source MarketInfoBar's price already relies on) so the fallback line
+  // keeps building over time even when nothing else is available. No-ops the
+  // moment a real candle source has data.
+  useEffect(() => {
+    if (!slabAddress) return;
+    if (hasPercolatorData || hasPythData || hasExternalData) return;
+    // Wait for the real sources to SETTLE (not just "not successful yet")
+    // before engaging — otherwise this adds the first oraclePrices point
+    // while Pyth/Percolator/GeckoTerminal are still resolving (typically
+    // well under a second), which would prematurely swap the loading
+    // skeleton for the sparse "building…" overlay on a market that ends up
+    // with a real candle source moments later (e.g. every seeded market).
+    if (pythStatus === "loading" || percolatorStatus === "loading" || externalStatus === "loading") return;
+
+    let cancelled = false;
+    const poll = () => {
+      fetch(`/api/markets/${slabAddress}`)
+        .then((r) => r.json())
+        .then((d) => {
+          if (cancelled) return;
+          const price = d.market?.mark_price ?? d.market?.last_price;
+          if (typeof price !== "number" || !(price > 0)) return;
+          const now = Date.now();
+          setOraclePrices((prev) => {
+            const last = prev[prev.length - 1];
+            if (last && now - last.timestamp < 5000) return prev;
+            return [...prev, { timestamp: now, price }].slice(-1000);
+          });
+        })
+        .catch(() => {});
+    };
+    poll();
+    const interval = setInterval(poll, 10_000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [slabAddress, hasPercolatorData, hasPythData, hasExternalData, pythStatus, percolatorStatus, externalStatus]);
+
   // Derive data. Memoed because oraclePrices only changes on the 5s-gated
   // live-price effect (line ~287), so the filtered slice is reference-stable
   // between most renders. Same WS-tick churn argument as percolatorCandles


### PR DESCRIPTION
## Summary

Fixes 3 trade-page issues reported for a wizard-launched pump.fun market (`Percolator/USDC`, devnet slab `dLKhJAVPgmgxJJWvbcGvfQUNBmc7wwjdQp8Jzpg4UGq`, mainnet CA `8PzFWyLpCVEmbZmVJcaRTU5r69XKJx1rd7YGpWvnpump`):

1. **Chart empty** — never renders any candles/line, stuck on "Price chart building…"
2. **24h High/Low blank** — always "—" for wizard-launched markets
3. **"Insurance Fund" → "Market LP"** — relabel + re-source on the `/markets` list

### Root cause (all three)

The shared indexer + WS backend (percolator-api on Railway) is unreachable — a direct probe returns `{"status":"error","code":404,"message":"Application not found"}`, Railway's own signature for a deleted/expired service, not our code. This kills `/api/chart/[mint]` (GeckoTerminal proxy), `/api/candles/[slab]` (internal candles), `/api/markets/[slab]/prices` (oracle history), and the live WS price feed simultaneously — confirmed via a live browser session against the hosted playground (network tab + console). GeckoTerminal itself has real OHLCV data for this token's pool — the gap is entirely upstream of GeckoTerminal, on our side. This matches the known "Railway trial expiry" infra blocker — **out of scope for this PR** to fix directly (frontend-only, no deploy access), but all three fixes make the frontend degrade gracefully around it.

### 1. Chart (`app/components/trade/TradingChart.tsx`, `app/app/trade/[slab]/page.tsx`)

- `page.tsx` was passing the devnet Sim-USDC collateral mint to `TradingChart` as a fallback before the real mainnet CA loaded (confirmed in the network log: an early request to `/api/chart/DJ54k4wH...` — the collateral mint — followed by the correct `/api/chart/8PzFWy...pump`). Added `chartMintAddress` (CA-only, no collateral fallback) so the chart never fetches the wrong token.
- The existing oracle-price fallback chain (Percolator → Pyth → DEX → oracle aggregate) only ever gets ONE point (a one-shot DB seed) when the backend is down, permanently stuck below the 2-point "sparse" threshold — confirmed via DOM inspection the chart really does show "PRICE CHART BUILDING…" (near-invisible low-contrast text) forever. Added a poll of the already-reliable, Supabase-backed `/api/markets/:slab` so the fallback line keeps growing. Gated on the real sources having *settled* (not just "not successful yet") so seeded markets (SOL/JUP/TRUMP/PENGU, all Pyth-mapped) see zero behavior change.

### 2. 24h stats (`app/app/api/prices/[slab]/route.ts`)

The existing Pyth fallback (`pythStatsFallback`) only covers the 5 curated `PLAYGROUND_SLAB_META` markets. Added a parallel `geckoTerminalStatsFallback` that resolves ANY market's DEX pool via `/api/markets/:slab` (reliable, Supabase-backed, independent of the dead Railway backend) and computes real high/low/change24h directly from GeckoTerminal's public OHLCV API — works for wizard/community-launched markets with no Pyth feed. Same caching discipline as the existing Pyth path.

Verified the math against live production data (pool `Ebs3mXAzqZfzHfsdinTNw7gPy4uNyEAywcCiJxzLRrBW`):
```json
{ "change24h": 12.98, "high24h_usd": 0.00192, "low24h_usd": 0.00133 }
```
Sane and bracketing the current price (~$0.0018).

### 3. "Insurance Fund" → "Market LP" (`app/app/markets/page.tsx`)

The `/markets` list "insurance" column now shows the market's LP-vault backing (`vault_balance`, falling back to `c_tot` — the same precedent already used for the oracle-down guard elsewhere in this file) instead of the admin-managed insurance fund. Left `InsuranceDashboard`/`InsuranceTopUpModal`/the `/my-markets` "top up insurance" admin action untouched — those are a genuinely different on-chain concept (admin-fundable safety net vs. LP-deposited trading backing), not what this task asked to relabel.

Note: `vault_balance`/`c_tot` are currently `null` for all 6 live markets in the Supabase view (a pre-existing, systemic v17 data gap already visible elsewhere — `SystemCapitalCard`/`EngineHealthCard` show "—" for the equivalent on-chain fields on v17 too), so "Market LP" will show "—" today. That's honest given the real data gap, not a regression from this change — the wiring is correct and will populate the moment that field starts being populated for v17 markets.

## Test plan

- [x] `cd app && npx tsc --noEmit` — 0 errors
- [x] Confirmed via live browser session (network + console) that the empty chart / blank 24h / all-markets-down-not-just-this-one is a backend-wide outage, not mint-specific
- [x] Replicated the exact `geckoTerminalStatsFallback` algorithm against real production data — correct, sane output
- [x] Confirmed the new market's on-chain price ($0.00179) is NOT ~77x off vs DexScreener/GeckoTerminal reference (~$0.00184) — the keeper's PumpSwap pricing is correct
- [ ] `pnpm test` — 96 pre-existing failures across 25 files exist on a clean, unmodified `playground` HEAD too (verified via `git stash` + re-run); none touch the 4 files in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)