### PR TITLE
fix(forms): normalize decimal amount input

### DIFF
--- a/app/components/trade/DepositWithdrawCard.tsx
+++ b/app/components/trade/DepositWithdrawCard.tsx
@@ -28,6 +28,13 @@ interface DepositWithdrawCardProps {
   initialMode?: "deposit" | "withdraw";
 }
 
+function sanitizeDecimalInput(value: string): string {
+  const cleaned = value.replace(/[^0-9.]/g, "");
+  const dotIndex = cleaned.indexOf(".");
+  if (dotIndex === -1) return cleaned;
+  return cleaned.slice(0, dotIndex + 1) + cleaned.slice(dotIndex + 1).replace(/\./g, "");
+}
+
 export const DepositWithdrawCard: FC<DepositWithdrawCardProps> = ({ slabAddress, isDevnetMirror = false, initialMode = "deposit" }) => {
   const { connected: walletConnected, publicKey } = useWalletCompat();
   const { connection } = useConnectionCompat();
@@ -270,7 +277,7 @@ export const DepositWithdrawCard: FC<DepositWithdrawCardProps> = ({ slabAddress,
             type="text"
             value={amount}
             onChange={(e) => { 
-              const newValue = e.target.value.replace(/[^0-9.]/g, "");
+              const newValue = sanitizeDecimalInput(e.target.value);
               if (newValue !== amount) {
                 maxRawRef.current = null;
               }

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -67,6 +67,15 @@ const LEVERAGE_SNAP_POINTS = [1, 3, 5, 10, 20];
 const SIZE_PRESETS = [25, 50, 75, 100];
 const MAX_DISPLAY_LEVERAGE = 200;
 
+function sanitizeDecimalInput(value: string): string {
+  const cleaned = value.replace(/[^0-9.]/g, "");
+  const dotIndex = cleaned.indexOf(".");
+  if (dotIndex === -1) return cleaned;
+  return cleaned.slice(0, dotIndex + 1) + cleaned.slice(dotIndex + 1).replace(/\./g, "");
+}
+
+
+
 function parsePercToNative(input: string, decimals = 6): bigint {
   const parts = input.split(".");
   if (parts.length > 2) return 0n;
@@ -396,7 +405,7 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
 
   const handleSizeChange = useCallback(
     (val: string) => {
-      const cleaned = val.replace(/[^0-9.]/g, "");
+      const cleaned = sanitizeDecimalInput(val);
       setSizeInput(cleaned);
       recomputeFromSize(cleaned, sizeUnit, leverage);
     },
@@ -749,7 +758,7 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
               type="text"
               value={leverageText}
               onChange={(e) => {
-                const raw = e.target.value.replace(/[^0-9.]/g, "");
+                const raw = sanitizeDecimalInput(e.target.value);
                 setLeverageText(raw);
                 const parsed = parseFloat(raw);
                 if (!isNaN(parsed)) updateLeverage(Math.max(1, Math.min(maxLeverage, Math.round(parsed))));


### PR DESCRIPTION
## Summary

This PR fixes a small UI/UX issue where decimal amount inputs could accept multiple decimal points, such as `1..2` or `1.2.3`.

The affected inputs already strip non-numeric characters, but they did not normalize duplicate decimal separators. In some flows, the parser can resolve malformed decimal input to `0n`, which makes the form look filled while the calculated amount becomes zero or the submit path silently no-ops.

## Changes

- Adds local decimal input normalization for trade ticket inputs.
- Applies the same normalization to deposit/withdraw amount input.
- Keeps the first decimal point and removes any additional decimal separators.
- Does not change trade instruction logic, deposit/withdraw hooks, parsing utilities, or on-chain behavior.

## Impact

This prevents confusing user input states such as:

- `1..2`
- `1.2.3`
- `10...5`

from reaching the form calculation path.

Instead, the UI normalizes them into a single valid decimal format before parsing.

## Validation

- `pnpm build` passes.
- `git diff --check` passes.
- PR is scoped to UI input normalization only:
  - `app/components/trade/OrderTicket.tsx`
  - `app/components/trade/DepositWithdrawCard.tsx`