### PR TITLE
fix: protocol, terminal hardening and test updates

### DIFF
--- a/app/__tests__/api/stake-pool-apr.test.ts
+++ b/app/__tests__/api/stake-pool-apr.test.ts
@@ -53,10 +53,10 @@ function computeAprs(
     const elapsed = cur.ts - old.ts;
     if (elapsed < MS_PER_DAY) { result[slab] = 0; continue; }
 
-    const growth = (cur.rate - old.rate) / old.rate;
-    const annualized = growth * (365 * MS_PER_DAY) / elapsed;
-    // Clamp to 0: negative APR (insurance drawdown) would confuse stakers.
-    result[slab] = isFinite(annualized) ? Math.max(0, Math.round(annualized * 10_000) / 100) : 0;
+    const periods = (365 * MS_PER_DAY) / elapsed;
+    const compounded = Math.pow(cur.rate / old.rate, periods) - 1;
+    // Clamp to 0: negative APY (insurance drawdown) would confuse stakers.
+    result[slab] = isFinite(compounded) ? Math.max(0, Math.round(compounded * 10_000) / 100) : 0;
   }
   return result;
 }
@@ -101,9 +101,9 @@ describe("computeAprs", () => {
       earliest30d: [{ slab: SLAB_A, redemption_rate_e6: 1_000_000, created_at: sevenDaysAgo }],
       latest: [{ slab: SLAB_A, redemption_rate_e6: 1_010_000, created_at: new Date().toISOString() }],
     });
-    // 1% over 7d → (0.01 * 365/7) * 100 ≈ 52.14%
-    expect(result[SLAB_A]).toBeGreaterThan(50);
-    expect(result[SLAB_A]).toBeLessThan(55);
+    // 1% over 7d compounded → (1.01^(365/7) - 1) * 100 ≈ 67.97%
+    expect(result[SLAB_A]).toBeGreaterThan(65);
+    expect(result[SLAB_A]).toBeLessThan(70);
   });
 
   it("returns 0 when redemption rate has not grown (no fees earned)", () => {
@@ -124,9 +124,9 @@ describe("computeAprs", () => {
       earliest30d: [{ slab: SLAB_A, redemption_rate_e6: 1_000_000, created_at: thirtyDaysAgo }],
       latest: [{ slab: SLAB_A, redemption_rate_e6: 1_030_000, created_at: new Date().toISOString() }],
     });
-    // 3% over 30 days → ≈ 36.5% annualised
-    expect(result[SLAB_A]).toBeGreaterThan(34);
-    expect(result[SLAB_A]).toBeLessThan(39);
+    // 3% over 30 days compounded → (1.03^(365/30) - 1) * 100 ≈ 43.3%
+    expect(result[SLAB_A]).toBeGreaterThan(41);
+    expect(result[SLAB_A]).toBeLessThan(45);
   });
 
   it("handles multiple slabs independently", () => {

--- a/app/__tests__/hooks/useInsuranceLP.test.ts
+++ b/app/__tests__/hooks/useInsuranceLP.test.ts
@@ -323,6 +323,29 @@ describe("useInsuranceLP", () => {
         expect(result.current.state.insuranceBalance).toBe(largeBalance);
       });
     });
+
+    it("should catch and log error on math overflow (MAX_U128)", async () => {
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const overflowingBalance = 340282366920938463463374607431768211456n; // > MAX_U128
+      mockSlabState.engine.insuranceFund.balance = overflowingBalance;
+      mockConnection.getAccountInfo.mockResolvedValue({
+        data: Buffer.alloc(82),
+        executable: false,
+        lamports: 1_000_000,
+        owner: new PublicKey("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"),
+      });
+      vi.mocked(unpackMint).mockReturnValue({ supply: 1n, decimals: 6, isInitialized: true });
+
+      renderHook(() => useInsuranceLP());
+
+      await waitFor(() => {
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          "[useInsuranceLP] Error fetching LP info:",
+          expect.any(Error)
+        );
+      });
+      consoleErrorSpy.mockRestore();
+    });
   });
 
   describe("LP Token Supply & Redemption Rate", () => {

--- a/app/__tests__/lib/admin-session-security-v2.test.ts
+++ b/app/__tests__/lib/admin-session-security-v2.test.ts
@@ -9,28 +9,29 @@ describe("admin session security checks", () => {
       "utf8",
     );
 
-    expect(source).toContain("Admin auth is not configured");
+    expect(source).toContain("Neither PRIVY_ADMIN_DIDS nor PRIVY_ADMIN_EMAILS is configured on the server");
     expect(source).toContain("{ status: 503 }");
   });
 
-  it("requires confirmed email before admin_users lookup", () => {
+  it("requires a valid Privy session", () => {
     const source = readFileSync(
       resolve(__dirname, "../../lib/admin-session.ts"),
       "utf8",
     );
 
-    expect(source).toContain("if (!user.email_confirmed_at)");
-    expect(source).toContain('response: NextResponse.json({ error: "Unauthorized" }, { status: 401 })');
+    expect(source).toContain("verifyPrivyAuth");
+    expect(source).toContain("Session expired or invalid — sign in again");
   });
 
-  it("normalizes email before service-role admin query", () => {
+  it("normalizes identity elements before admin check", () => {
     const source = readFileSync(
       resolve(__dirname, "../../lib/admin-session.ts"),
       "utf8",
     );
 
-    expect(source).toContain("function normalizeEmail(value: string): string");
-    expect(source).toContain("const email = normalizeEmail(user.email);");
-    expect(source).toContain('.eq("email", email)');
+    expect(source).toContain("function normalizeEmail");
+    expect(source).toContain("function stripDidPrefix");
+    expect(source).toContain("getAdminEmailSet");
+    expect(source).toContain("getAdminDidSet");
   });
 });

--- a/app/__tests__/lib/upstash-rate-limit.test.ts
+++ b/app/__tests__/lib/upstash-rate-limit.test.ts
@@ -8,6 +8,21 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { createUpstashRateLimiter } from "../../lib/upstash-rate-limit";
 
+const mockLimit = vi.fn();
+
+vi.mock("@upstash/ratelimit", () => {
+  const MockRatelimit = vi.fn().mockImplementation(function (this: any) {
+    this.limit = mockLimit;
+  });
+  (MockRatelimit as any).slidingWindow = vi.fn().mockReturnValue({ kind: "sliding" });
+  return {
+    Ratelimit: MockRatelimit,
+  };
+});
+vi.mock("@upstash/redis", () => ({
+  Redis: vi.fn(function (this: any) { return this; }),
+}));
+
 // Ensure Upstash env vars are absent so factory always falls back to local
 beforeEach(() => {
   delete process.env.UPSTASH_REDIS_REST_URL;
@@ -129,6 +144,8 @@ describe("createUpstashRateLimiter — in-memory fallback", () => {
   });
 
   it("falls back to in-memory when Redis throws at runtime", async () => {
+    mockLimit.mockRejectedValueOnce(new Error("Redis connection error"));
+
     // Set env vars so the factory tries to create a real Upstash limiter
     process.env.UPSTASH_REDIS_REST_URL = "https://fake.upstash.io";
     process.env.UPSTASH_REDIS_REST_TOKEN = "fake-token";

--- a/app/__tests__/providers/SlabProvider-allowlist.test.tsx
+++ b/app/__tests__/providers/SlabProvider-allowlist.test.tsx
@@ -14,7 +14,7 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { FC, ReactNode } from "react";
 import { PublicKey } from "@solana/web3.js";
 
-const ALLOWED_PROGRAM = "FxfD37s1AZTeWfFQps9Zpebi2dNQ9QSSDtfMKdbsfKrD"; // devnet default + large tier
+const ALLOWED_PROGRAM = "69VUZ7a2BeXBTpRRManLamF5UWTaNR9B1hy5Se3cdXy9"; // v17 devnet default
 const ATTACKER_PROGRAM = "11111111111111111111111111111112";
 const SLAB_ADDRESS = "So11111111111111111111111111111111111111112";
 

--- a/app/app/api/stake/pools/route.ts
+++ b/app/app/api/stake/pools/route.ts
@@ -92,64 +92,9 @@ async function computeAprs(
       .limit(slabAddresses.length * 10),
   ]);
 
-  // Handle network column fallback for all three queries in parallel
-  const networkFallbackPromises: PromiseLike<{ data: InsuranceSnapshotRow[] | null }>[] = [];
-  
-  if (result7d.error && result7d.error.message?.includes("network")) {
-    networkFallbackPromises.push(
-      db
-        .from("insurance_snapshots")
-        .select("slab, redemption_rate_e6, created_at")
-        .in("slab", slabAddresses)
-        .gte("created_at", since7d)
-        .order("created_at", { ascending: true })
-    );
-  } else {
-    networkFallbackPromises.push(Promise.resolve({ data: result7d.data }));
-  }
-
-  if (result30d.error && result30d.error.message?.includes("network")) {
-    networkFallbackPromises.push(
-      db
-        .from("insurance_snapshots")
-        .select("slab, redemption_rate_e6, created_at")
-        .in("slab", slabAddresses)
-        .gte("created_at", since30d)
-        .order("created_at", { ascending: true })
-    );
-  } else {
-    networkFallbackPromises.push(Promise.resolve({ data: result30d.data }));
-  }
-
-  if (resultLatest.error && resultLatest.error.message?.includes("network")) {
-    console.warn(
-      "[/api/stake/pools] PERC-8256: network column missing on insurance_snapshots — falling back to unfiltered query. " +
-      "Apply 20260329180000_add_network_column.sql to fix."
-    );
-    networkFallbackPromises.push(
-      db
-        .from("insurance_snapshots")
-        .select("slab, redemption_rate_e6, created_at")
-        .in("slab", slabAddresses)
-        .order("created_at", { ascending: false })
-        .limit(slabAddresses.length * 10)
-    );
-  } else {
-    networkFallbackPromises.push(Promise.resolve({ data: resultLatest.data }));
-  }
-
-  // Resolve all fallback queries in parallel
-  const [fallback7d, fallback30d, fallbackLatest] = await Promise.all(
-    networkFallbackPromises
-  );
-
-  const earliest7dRaw = result7d.data ?? fallback7d.data;
-  const earliest30dRaw = result30d.data ?? fallback30d.data;
-  const latestRaw = resultLatest.data ?? fallbackLatest.data;
-
-  const earliest7d: InsuranceSnapshotRow[] = earliest7dRaw ?? [];
-  const earliest30d: InsuranceSnapshotRow[] = earliest30dRaw ?? [];
-  const latest: InsuranceSnapshotRow[] = latestRaw ?? [];
+  const earliest7d: InsuranceSnapshotRow[] = result7d.data ?? [];
+  const earliest30d: InsuranceSnapshotRow[] = result30d.data ?? [];
+  const latest: InsuranceSnapshotRow[] = resultLatest.data ?? [];
 
   // Build lookup maps: slab → first record in window
   const earliest7dBySlab = new Map<string, { rate: number; ts: number }>();
@@ -204,12 +149,12 @@ async function computeAprs(
       continue;
     }
 
-    const growth = (cur.rate - old.rate) / old.rate;
-    const annualized = growth * (365 * MS_PER_DAY) / elapsed;
+    const periods = (365 * MS_PER_DAY) / elapsed;
+    const compounded = Math.pow(cur.rate / old.rate, periods) - 1;
 
-    // Clamp to 0: negative APR (insurance drawdown) would confuse stakers.
-    result[slab] = isFinite(annualized)
-      ? Math.max(0, Math.round(annualized * 10_000) / 100)  // → percentage, 2dp, floor 0
+    // Clamp to 0: negative APY (insurance drawdown) would confuse stakers.
+    result[slab] = isFinite(compounded)
+      ? Math.max(0, Math.round(compounded * 10_000) / 100)  // → percentage, 2dp, floor 0
       : 0;
   }
 
@@ -470,14 +415,7 @@ export async function GET() {
           computeAprs(slabAddresses, supabase),
         ]);
 
-        let marketsData = marketsResult.data;
-        if (marketsResult.error && marketsResult.error.message?.includes("network")) {
-          const fallback = await supabase
-            .from("markets_with_stats")
-            .select("slab_address,symbol,name,logo_url,insurance_balance,vault_balance")
-            .in("slab_address", slabAddresses);
-          marketsData = fallback.data;
-        }
+        const marketsData = marketsResult.data;
         markets = marketsData as _MarketRow[] | null;
         aprBySlab = aprResult;
       } catch (sbErr) {

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -931,23 +931,65 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
         <button
           onClick={() => {
             if (submitDisabled) return;
-            const signedSize = direction === "short" ? -positionSize : positionSize;
-            // Submit-time: re-fetch rather than trust the render-scoped
-            // `livePriceE6` above — this is the one value in this component
-            // where "read via getLivePriceSnapshot at submit" needs to mean
-            // literally at this instant, not merely non-reactive.
+            // Recalculate click-time values to prevent state batching/desync issues!
             const freshPriceE6 = getLivePriceSnapshot(slabAddress).priceE6;
+            const freshPriceUsd = priceUsd ?? 0;
+            const freshDecimals = decimals;
+            const freshLeverage = leverage;
+
+            let freshMarginNative = 0n;
+            let freshPositionSize = 0n;
+
+            if (sizeInput && freshPriceUsd > 0) {
+              const n = parseFloat(sizeInput);
+              if (!isNaN(n)) {
+                const notionalUsd = sizeUnit === "token" ? n * freshPriceUsd : n;
+                const marginAmt = notionalUsd / freshLeverage;
+                freshMarginNative = parsePercToNative(marginAmt.toFixed(freshDecimals), freshDecimals);
+                const notionalNative = freshMarginNative * BigInt(freshLeverage);
+                const rawPositionSize = freshPriceE6 && freshPriceE6 > 0n ? (notionalNative * 1_000_000n) / freshPriceE6 : 0n;
+                freshPositionSize = rawPositionSize < 0n ? 0n : rawPositionSize;
+              }
+            }
+
+            const signedSize = direction === "short" ? -freshPositionSize : freshPositionSize;
             let worstFillPriceE6 = 0n;
             try {
               worstFillPriceE6 = freshPriceE6 && freshPriceE6 > 0n ? computeLimitPriceE6({ markE6: freshPriceE6, size: signedSize }) : 0n;
             } catch {
               worstFillPriceE6 = 0n;
             }
+
+            // Calculate fresh fee
+            const freshOracleE6 = freshPriceUsd ? toE6(freshPriceUsd) : 0n;
+            const freshHasOrder = freshMarginNative > 0n && freshPositionSize > 0n && !(freshMarginNative > effectiveBalance);
+            const freshFee = freshHasOrder ? computeTradingFee((freshPositionSize * freshOracleE6) / 1_000_000n, tradingFeeBps) : 0n;
+
+            // Calculate fresh afterLiqPrice
+            const freshNewSignedSize = direction === "short" ? -freshPositionSize : freshPositionSize;
+            const freshCombinedSignedSize = existingPositionSize + freshNewSignedSize;
+            const freshExistingAbsSize = existingPositionSize < 0n ? -existingPositionSize : existingPositionSize;
+            const freshSameDirection = existingPositionSize === 0n || (existingPositionSize > 0n) === (freshNewSignedSize > 0n);
+            const freshEstEntry = freshHasOrder ? computeEstimatedEntryPrice(freshOracleE6, tradingFeeBps, direction) : 0n;
+            const freshCombinedEntryPriceE6 = freshSameDirection
+              ? (freshExistingAbsSize + freshPositionSize > 0n
+                  ? (existingEntryPriceE6 * freshExistingAbsSize + freshEstEntry * freshPositionSize) / (freshExistingAbsSize + freshPositionSize)
+                  : 0n)
+              : (freshPositionSize < freshExistingAbsSize ? existingEntryPriceE6 : freshEstEntry);
+
+            const freshAfterLiqPrice = freshHasOrder
+              ? (existingPositionSize === 0n
+                  ? computePreTradeLiqPrice(freshOracleE6, freshMarginNative, freshPositionSize, maintenanceMarginBps, tradingFeeBps, direction)
+                  : (freshCombinedSignedSize !== 0n && freshCombinedEntryPriceE6 > 0n
+                      ? computeLiqPrice(freshCombinedEntryPriceE6, capital, freshCombinedSignedSize, maintenanceMarginBps)
+                      : 0n))
+              : 0n;
+
             setConfirmSnapshot({
-              positionSize,
-              marginNative,
-              estimatedLiqPrice: afterLiqPrice,
-              tradingFee: fee,
+              positionSize: freshPositionSize,
+              marginNative: freshMarginNative,
+              estimatedLiqPrice: freshAfterLiqPrice,
+              tradingFee: freshFee,
               worstFillPriceE6,
             });
             setShowConfirmModal(true);

--- a/app/hooks/useInsuranceLP.ts
+++ b/app/hooks/useInsuranceLP.ts
@@ -34,6 +34,17 @@ import { assertKnownProgram } from '@/lib/programAllowlist';
 import { useParams } from 'next/navigation';
 import { sanitizeOnChainValue } from '@/lib/health';
 
+const MAX_U128 = 340282366920938463463374607431768211455n;
+
+function safeMulDiv(a: bigint, b: bigint, denominator: bigint): bigint {
+  if (denominator === 0n) return 0n;
+  const product = a * b;
+  if (product > MAX_U128) {
+    throw new Error("Math overflow: intermediate product exceeds u128 limit");
+  }
+  return product / denominator;
+}
+
 /**
  * Which LP-vault redemption step a `withdraw()` call actually ran:
  *  - 'requested' — RequestRedeemLpShares (tag 76) fired. This only starts the
@@ -243,15 +254,15 @@ export function useInsuranceLP() {
 
       // Calculate derived values
       const redemptionRateE6 = lpSupply > 0n
-        ? (insuranceBalance * 1_000_000n) / lpSupply
+        ? safeMulDiv(insuranceBalance, 1_000_000n, lpSupply)
         : 1_000_000n; // 1:1 if no supply
 
       const userSharePct = lpSupply > 0n
-        ? Number((userLpBalance * 10000n) / lpSupply) / 100
+        ? Number(safeMulDiv(userLpBalance, 10000n, lpSupply)) / 100
         : 0;
 
       const userRedeemableValue = lpSupply > 0n
-        ? (userLpBalance * insuranceBalance) / lpSupply
+        ? safeMulDiv(userLpBalance, insuranceBalance, lpSupply)
         : 0n;
 
       // User's collateral ATA balance (available to deposit into the LP vault).
@@ -309,10 +320,10 @@ export function useInsuranceLP() {
             // denominator — it's read from the same mint as userLpBalance, so the two
             // stay consistent with each other.
             vaultSharePriceE6 = lpSupply > 0n
-              ? (vaultTotalAtoms * 1_000_000n) / lpSupply
+              ? safeMulDiv(vaultTotalAtoms, 1_000_000n, lpSupply)
               : 1_000_000n;
             userVaultValueAtoms = lpSupply > 0n
-              ? (userLpBalance * vaultTotalAtoms) / lpSupply
+              ? safeMulDiv(userLpBalance, vaultTotalAtoms, lpSupply)
               : 0n;
 
             // Pending redemption ticket (RequestRedeemLpShares → cooldown → ExecuteRedemption).

--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -5,30 +5,28 @@ import { Ratelimit } from "@upstash/ratelimit";
 import { BLOCKED_SLAB_ADDRESSES } from "@/lib/blocklist";
 
 // ── Rate limiter configuration ───────────────────────────────────────────────
-// Two tiers: RPC proxy gets a higher limit since Solana web3.js generates many calls per page load.
+// Three tiers: RPC proxy, general API endpoints, and warmup endpoint (strict limit).
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX = 120;         // General API endpoints
 const RPC_RATE_LIMIT_MAX = 600;     // /api/rpc — Solana needs many RPC calls per page
+const WARMUP_RATE_LIMIT_MAX = 20;    // /api/warmup/* — strict limit to prevent PnL timing scraping
 
 // ── Upstash Redis distributed rate limiter (GH#1213) ─────────────────────────
 // Primary: Upstash Redis + @upstash/ratelimit — globally consistent across
 //          Vercel serverless instances (uses REST API, Edge Runtime compatible).
 // Fallback: in-memory sliding window — for local dev / CI / when Redis is unconfigured.
-//
-// The previous pure in-memory Map approach was per-instance: on Vercel each cold
-// start resets counters independently, so an attacker distributing requests across
-// instances could bypass the limit entirely. Upstash Redis solves this.
 let _generalLimiter: Ratelimit | null = null;
 let _rpcLimiter: Ratelimit | null = null;
+let _warmupLimiter: Ratelimit | null = null;
 let _limitersInitialized = false;
 
-function getUpstashLimiters(): { general: Ratelimit | null; rpc: Ratelimit | null } {
-  if (_limitersInitialized) return { general: _generalLimiter, rpc: _rpcLimiter };
+function getUpstashLimiters(): { general: Ratelimit | null; rpc: Ratelimit | null; warmup: Ratelimit | null } {
+  if (_limitersInitialized) return { general: _generalLimiter, rpc: _rpcLimiter, warmup: _warmupLimiter };
   _limitersInitialized = true;
 
   const url = process.env.UPSTASH_REDIS_REST_URL;
   const token = process.env.UPSTASH_REDIS_REST_TOKEN;
-  if (!url || !token) return { general: null, rpc: null };
+  if (!url || !token) return { general: null, rpc: null, warmup: null };
 
   try {
     const redis = new Redis({ url, token });
@@ -44,13 +42,23 @@ function getUpstashLimiters(): { general: Ratelimit | null; rpc: Ratelimit | nul
       prefix: "rl:rpc",
       analytics: false,
     });
-  } catch {
+    _warmupLimiter = new Ratelimit({
+      redis,
+      limiter: Ratelimit.slidingWindow(WARMUP_RATE_LIMIT_MAX, "60 s"),
+      prefix: "rl:warmup",
+      analytics: false,
+    });
+  } catch (err) {
     // Redis init error — fall through to in-memory
+    if (process.env.NODE_ENV === "production") {
+      console.error("[RateLimit] ERROR: Upstash Redis initialization failed:", err);
+    }
     _generalLimiter = null;
     _rpcLimiter = null;
+    _warmupLimiter = null;
   }
 
-  return { general: _generalLimiter, rpc: _rpcLimiter };
+  return { general: _generalLimiter, rpc: _rpcLimiter, warmup: _warmupLimiter };
 }
 
 // ── In-memory fallback (per-instance) ────────────────────────────────────────
@@ -60,11 +68,15 @@ function getUpstashLimiters(): { general: Ratelimit | null; rpc: Ratelimit | nul
 // via UPSTASH_REDIS_REST_URL + UPSTASH_REDIS_REST_TOKEN env vars.
 const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
 const rpcRateLimitMap = new Map<string, { count: number; resetAt: number }>();
+const warmupRateLimitMap = new Map<string, { count: number; resetAt: number }>();
 
-function _getInMemoryRateLimit(ip: string, isRpc: boolean): { allowed: boolean; remaining: number; reset: number } {
+function _getInMemoryRateLimit(
+  ip: string,
+  type: "general" | "rpc" | "warmup",
+): { allowed: boolean; remaining: number; reset: number } {
   const now = Date.now();
-  const map = isRpc ? rpcRateLimitMap : rateLimitMap;
-  const max = isRpc ? RPC_RATE_LIMIT_MAX : RATE_LIMIT_MAX;
+  const map = type === "rpc" ? rpcRateLimitMap : type === "warmup" ? warmupRateLimitMap : rateLimitMap;
+  const max = type === "rpc" ? RPC_RATE_LIMIT_MAX : type === "warmup" ? WARMUP_RATE_LIMIT_MAX : RATE_LIMIT_MAX;
 
   let entry = map.get(ip);
   if (!entry || now > entry.resetAt) {
@@ -81,9 +93,7 @@ function _getInMemoryRateLimit(ip: string, isRpc: boolean): { allowed: boolean; 
   }
 
   // FIX(GH#1245): use strict inequality so request #max is the last ALLOWED
-  // one (not the first blocked one).  Previously `remaining = max - count`
-  // meant count=max → remaining=0 → `remaining <= 0` blocked that request,
-  // allowing only max-1 requests through instead of max.
+  // one (not the first blocked one).
   const allowed = entry.count <= max;
   return {
     allowed,
@@ -94,29 +104,34 @@ function _getInMemoryRateLimit(ip: string, isRpc: boolean): { allowed: boolean; 
 
 async function getRateLimit(
   ip: string,
-  isRpc: boolean = false,
+  type: "general" | "rpc" | "warmup" = "general",
 ): Promise<{ allowed: boolean; remaining: number; reset: number }> {
-  const { general, rpc } = getUpstashLimiters();
-  const limiter = isRpc ? rpc : general;
+  const { general, rpc, warmup } = getUpstashLimiters();
+  const limiter = type === "rpc" ? rpc : type === "warmup" ? warmup : general;
 
   if (limiter) {
     try {
       const { success, remaining, reset } = await limiter.limit(ip);
       // FIX(GH#1245): use `success` (the boolean Upstash provides) to drive
-      // the allow/block decision — NOT `remaining`.  When success=true and
-      // remaining=0 (the last allowed request), the old code returned
-      // remaining=0 and the `remaining <= 0` guard incorrectly blocked it.
+      // the allow/block decision — NOT `remaining`.
       return {
         allowed: success,
         remaining: Math.max(0, remaining),
         reset: Math.max(0, Math.ceil((reset - Date.now()) / 1000)),
       };
-    } catch {
+    } catch (err) {
       // Redis request failed — degrade gracefully to in-memory
+      if (process.env.NODE_ENV === "production") {
+        console.error("[RateLimit] ERROR: Upstash Redis request failed, falling back to in-memory rate limiting:", err);
+      }
+    }
+  } else {
+    if (process.env.NODE_ENV === "production") {
+      console.warn("[RateLimit] WARNING: Upstash Redis is not configured. Falling back to in-memory rate limiting in production!");
     }
   }
 
-  return _getInMemoryRateLimit(ip, isRpc);
+  return _getInMemoryRateLimit(ip, type);
 }
 
 // ── IP Blocklist ────────────────────────────────────────────────────────────
@@ -380,16 +395,35 @@ export async function middleware(request: NextRequest) {
   //   • Every /api/admin/* route gates on requireAdminSession(req) server-
   //     side, so even if the page leaked HTML the data is locked down.
   //
+  // Defense-in-depth: Reject any request to /admin/* or /api/admin/* that does
+  // not have a Bearer token in the Authorization header or a privy-token cookie.
   // We still attach the security headers + skip /admin/login from any host-
   // level redirects above.
   const isAdminRoute =
     request.nextUrl.pathname.startsWith("/admin") &&
     !request.nextUrl.pathname.startsWith("/admin/login");
+  const isAdminApiRoute = request.nextUrl.pathname.startsWith("/api/admin");
 
-  if (isAdminRoute) {
-    const response = NextResponse.next();
-    addSecurityHeaders(response);
-    return response;
+  if (isAdminRoute || isAdminApiRoute) {
+    const auth = request.headers.get("authorization");
+    const privyToken = request.cookies.get("privy-token");
+    if (!auth?.startsWith("Bearer ") && !privyToken) {
+      if (isAdminApiRoute) {
+        return new NextResponse(JSON.stringify({ error: "Unauthorized" }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        });
+      } else {
+        const url = request.nextUrl.clone();
+        url.pathname = "/admin/login";
+        return NextResponse.redirect(url);
+      }
+    }
+    if (isAdminRoute) {
+      const response = NextResponse.next();
+      addSecurityHeaders(response);
+      return response;
+    }
   }
 
   // Extract client IP respecting TRUSTED_PROXY_DEPTH env var.
@@ -411,8 +445,10 @@ export async function middleware(request: NextRequest) {
 
   if (isApi) {
     const isRpc = request.nextUrl.pathname === "/api/rpc";
-    const { allowed, remaining, reset } = await getRateLimit(ip, isRpc);
-    const limit = isRpc ? RPC_RATE_LIMIT_MAX : RATE_LIMIT_MAX;
+    const isWarmup = request.nextUrl.pathname.startsWith("/api/warmup");
+    const rateLimitType = isRpc ? "rpc" : isWarmup ? "warmup" : "general";
+    const { allowed, remaining, reset } = await getRateLimit(ip, rateLimitType);
+    const limit = isRpc ? RPC_RATE_LIMIT_MAX : isWarmup ? WARMUP_RATE_LIMIT_MAX : RATE_LIMIT_MAX;
 
     // FIX(GH#1245): gate on `allowed` (the authoritative boolean) rather than
     // `remaining <= 0`.  The old guard blocked the last *allowed* request
@@ -424,7 +460,7 @@ export async function middleware(request: NextRequest) {
       const logContext = {
         ip,
         path: request.nextUrl.pathname,
-        rpcLimit: isRpc,
+        limitType: rateLimitType,
         limit,
         remaining,
         reset,


### PR DESCRIPTION


This PR bundles all fixes for issues raised by @axeleagle1 on the `playground` branch.

#### Resolved Issues:
- **#2353 / #2352 (Dual Input / Leverage Desync)**: Fixed in `OrderTicket.tsx` by synchronously recalculating size, margin, liq price, entry price, and fee inside the Submit button's `onClick` handler at click-time, bypassing React state batching delay.
- **#2345 (Stake Pool Fallback)**: Fixed in `/api/stake/pools/route.ts` by removing unsafe fallback queries that omitted the `.eq("network", ...)` filter when Supabase returned errors.
- **#2344 (Stake Pool APY)**: Fixed in `/api/stake/pools/route.ts` by changing the stake pool APR simple interest calculation to a compounding APY formula. Inline helper and assertions in `stake-pool-apr.test.ts` were updated to match.
- **#2343 (Insurance LP Overflow)**: Fixed in `useInsuranceLP.ts` by adding a `safeMulDiv` helper checking intermediate products against `MAX_U128` (Solana limits). Added exception logging test in `useInsuranceLP.test.ts`.
- **#2342 (Admin Route Guard Bypass)**: Fixed in `middleware.ts` by enforcing a Privy Bearer token/cookie presence check on all `/admin/*` and `/api/admin/*` paths. Updated assertions in `admin-session-security-v2.test.ts` to match.
- **#2341 (In-Memory Rate Limit Bypass)**: Fixed in `middleware.ts` by logging production warnings/errors when Upstash Redis is unconfigured or failing.
- **#2340 (Warmup Endpoint PnL Leak)**: Fixed in `middleware.ts` by implementing a strict 20 req/min rate limit on `/api/warmup/*`.

#### Untouched / Out-of-Scope Issues:
- **#2351 (v17 Withdrawal Crank)**: **Untouched (By Design)**. Cranking empty portfolios returns `EngineNonProgress (0x16)` and aborts the transaction. The hook correctly prepends the crank only when active positions exist (`hasActiveLegs`).
- **#2347 (LP Vault NAV isolation)**: **Untouched (By Design)**. The ledger counters correctly track deposits instead of actual token balance, preventing direct transfer donation attacks.
- **#2350 (Single Keeper Key)**, **#2349 (Liquidation Front-Running)**, and **#2348 (Oracle DEX Price Manipulation)**: **Out of Scope**. Implemented in the `percolator-backend` repository (`packages/keeper`).
- **#2346 (Stress Envelope Threshold)**: **Out of Scope**. Implemented in the `percolator-risk-engine` repository (`percolator/src/v16.rs`).