### PR TITLE
feat(create,api): one market per token — block duplicate-token launches

### DIFF
--- a/app/__tests__/api/markets-one-market-per-token.test.ts
+++ b/app/__tests__/api/markets-one-market-per-token.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * One market per token: launching a second market for a token that already
+ * has one must be rejected. Guard is keyed on mainnet_ca (the token's
+ * identity field) — NOT mint_address, which on the playground is the
+ * COLLATERAL mint (the same sim-USDC for every market) and would 409 every
+ * legitimate launch. Source-assertion style mirrors
+ * markets-duplicate-slab-guard.test.ts.
+ */
+describe("one market per token", () => {
+  const routeSource = readFileSync(
+    resolve(__dirname, "../../app/api/markets/route.ts"),
+    "utf8",
+  );
+
+  it("POST rejects a second market for the same mainnet_ca (Supabase path)", () => {
+    expect(routeSource).toContain('.eq("mainnet_ca", canonicalMainnetCa)');
+    expect(routeSource).toContain("A market for this token already exists");
+    expect(routeSource).toContain("One market per token");
+  });
+
+  it("POST canonicalizes mainnet_ca before deduping (no alternate-encoding dodge)", () => {
+    expect(routeSource).toContain("canonicalMainnetCa = new PublicKey(mainnet_ca).toBase58()");
+  });
+
+  it("POST dedupes on mainnet_ca, never on mint_address (shared sim-USDC collateral)", () => {
+    // The dedupe query must not filter markets by mint_address — every
+    // playground market shares the sim-USDC collateral there, so that key
+    // would false-positive every launch after the first.
+    expect(routeSource).not.toContain('.eq("mint_address"');
+  });
+
+  it("POST also guards the no-Supabase (Blob registry) path", () => {
+    expect(routeSource).toContain("r.mainnetCA === canonicalMainnetCa");
+  });
+
+  it("GET search matches mainnet_ca so the wizard's duplicate lookup can find the market", () => {
+    // Both list-shaped search filters (on-chain-discovery + static fallback)
+    // must include the CA in their match set.
+    const caMatches = routeSource.match(/ca\.includes\(searchTrimmed\)/g) ?? [];
+    expect(caMatches.length).toBeGreaterThanOrEqual(2);
+    // Supabase path's direct-address match:
+    expect(routeSource).toContain("mainnetCa.toLowerCase().includes(q)");
+  });
+
+  it("create wizard blocks Continue when the token already has a market", () => {
+    const stepSource = readFileSync(
+      resolve(__dirname, "../../components/create/StepTokenSelect.tsx"),
+      "utf8",
+    );
+    expect(stepSource).toContain("duplicateBlocked");
+    expect(stepSource).toContain("!duplicateBlocked");
+    expect(stepSource).toContain("one market per token");
+  });
+
+  it("wizard gates BOTH Quick Launch auto-advance and step-1 Continue on the check", () => {
+    // The guard must live in CreateMarketWizard (not only StepTokenSelect):
+    // Quick Launch auto-advances and unmounts the step, so step-local state
+    // can't gate anything. step1CanAdvance also waits while the lookup is
+    // in flight so auto-advance can't race past a pending check.
+    const wizardSource = readFileSync(
+      resolve(__dirname, "../../components/create/CreateMarketWizard.tsx"),
+      "utf8",
+    );
+    expect(wizardSource).toContain("useDuplicateMarket(");
+    expect(wizardSource).toContain(
+      "const step1CanAdvance = step1Valid && !duplicateCheck.checking && duplicateCheck.duplicates.length === 0",
+    );
+    expect(wizardSource).toContain("if (!step1CanAdvance) return;");
+    expect(wizardSource).toContain("canContinue={step1CanAdvance}");
+  });
+
+  it("lookup hook fails open (server 409 is the authoritative gate)", () => {
+    const hookSource = readFileSync(
+      resolve(__dirname, "../../hooks/useDuplicateMarket.ts"),
+      "utf8",
+    );
+    expect(hookSource).toContain("setState(CLEAR); // fail-open");
+    expect(hookSource).toContain("mint === ca || mainnetCa === ca");
+  });
+});

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -503,7 +503,11 @@ async function onChainOrStaticResponse(request: NextRequest, reason: string): Pr
           const name = String(m.name ?? "").toLowerCase();
           const slab = String(m.slab_address ?? "").toLowerCase();
           const mint = String(m.mint_address ?? "").toLowerCase();
-          return symbol.includes(searchTrimmed) || name.includes(searchTrimmed) || slab.includes(searchTrimmed) || mint.includes(searchTrimmed);
+          // mainnet_ca is the TOKEN's identity on the playground (mint_address
+          // is the shared sim-USDC collateral) — searching by a token's CA must
+          // find its market (create-wizard duplicate check + markets search box).
+          const ca = String(m.mainnet_ca ?? "").toLowerCase();
+          return symbol.includes(searchTrimmed) || name.includes(searchTrimmed) || slab.includes(searchTrimmed) || mint.includes(searchTrimmed) || ca.includes(searchTrimmed);
         });
 
       if (filtered.length > 0) {
@@ -590,10 +594,14 @@ function fallbackMarketsResponse(request: NextRequest, reason: string): NextResp
       const name = String(m.name ?? "").toLowerCase();
       const slab = String(m.slab_address ?? "").toLowerCase();
       const mint = String(m.mint_address ?? "").toLowerCase();
+      // Same mainnet_ca match as the on-chain-discovery path above — the CA is
+      // the token's identity on the playground (mint_address is shared sim-USDC).
+      const ca = String((m as Record<string, unknown>).mainnet_ca ?? "").toLowerCase();
       return symbol.includes(searchTrimmed) ||
         name.includes(searchTrimmed) ||
         slab.includes(searchTrimmed) ||
-        mint.includes(searchTrimmed);
+        mint.includes(searchTrimmed) ||
+        ca.includes(searchTrimmed);
     })
     .filter((m) => !dbOracleMode || m.oracle_mode === dbOracleMode);
 
@@ -1040,6 +1048,17 @@ export async function GET(request: NextRequest) {
             const mintAddress = ((m as Record<string, unknown>).mint_address as string | null) ?? "";
             const mainnetCa = ((m as Record<string, unknown>).mainnet_ca as string | null) ?? "";
             if (matchingMints.has(mintAddress) || matchingMints.has(mainnetCa)) return true;
+            // Direct address match: searching a token's CA (or mint/slab) must find
+            // its market — used by the create-wizard's one-market-per-token check
+            // and CA lookups in the markets search box. Substring like the other
+            // GET paths' filters.
+            if (
+              mintAddress.toLowerCase().includes(q) ||
+              mainnetCa.toLowerCase().includes(q) ||
+              (((m as Record<string, unknown>).slab_address as string | null) ?? "").toLowerCase().includes(q)
+            ) {
+              return true;
+            }
             return false;
           });
         })()
@@ -1528,9 +1547,12 @@ export async function POST(req: NextRequest) {
 
   // GH#1963: Validate mainnet_ca is a valid Solana pubkey (when provided).
   // Previously inserted raw — could accept arbitrary strings that poison downstream UI/parsers.
+  // Canonicalized (PublicKey round-trip) so the one-market-per-token dedupe below can't be
+  // dodged with a non-canonical base58 encoding of the same key.
+  let canonicalMainnetCa: string | null = null;
   if (mainnet_ca) {
     try {
-      new PublicKey(mainnet_ca);
+      canonicalMainnetCa = new PublicKey(mainnet_ca).toBase58();
     } catch {
       return NextResponse.json(
         { error: "Invalid mainnet_ca: must be a valid Solana public key" },
@@ -1748,6 +1770,36 @@ export async function POST(req: NextRequest) {
     supabase = getServiceClient();
   } catch {
     // Supabase not configured — register in the playground-local registry.
+    //
+    // One market per token: even without a DB, reject a SECOND market for the
+    // same underlying token. Keyed on mainnet_ca (the token's identity field —
+    // mint_address is the COLLATERAL mint, the same sim-USDC for every
+    // playground market, so deduping on it would false-positive everything).
+    // The Blob keeper-registry is the closest thing to a cross-instance
+    // market list in this mode; best-effort — an unreadable registry must not
+    // block legitimate launches (fail-open here; the Supabase path below is
+    // the authoritative gate on deployments that have a DB).
+    if (canonicalMainnetCa) {
+      try {
+        const registered = await readRegisteredMarkets();
+        const dup = registered.find(
+          (r) => r.mainnetCA === canonicalMainnetCa && r.slabAddress !== slab_address,
+        );
+        if (dup) {
+          return NextResponse.json(
+            {
+              error:
+                `A market for this token already exists (${dup.symbol ?? dup.label} — slab ${dup.slabAddress}). ` +
+                "One market per token: trade the existing market instead of launching a duplicate.",
+              existing_slab: dup.slabAddress,
+            },
+            { status: 409 },
+          );
+        }
+      } catch {
+        /* registry unreadable — fail open, see comment above */
+      }
+    }
     registerPlaygroundSlab(slab_address);
     // Return a synthetic market row so the client flow can continue.
     const syntheticMarket = {
@@ -1792,6 +1844,44 @@ export async function POST(req: NextRequest) {
       },
       { status: 409 },
     );
+  }
+
+  // One market per token: reject registering a SECOND market for the same
+  // underlying token on this network. Keyed on mainnet_ca — the token identity
+  // field the wizard always sends — NOT mint_address, which is the on-chain
+  // COLLATERAL mint (the same sim-USDC for every playground market; deduping
+  // on it would 409 every launch). canonicalMainnetCa is the PublicKey
+  // round-trip of the validated input, so alternate encodings of the same key
+  // can't dodge the check. Duplicates fragment liquidity and let a clone
+  // impersonate an existing listing; each market is isolated so this is a
+  // UX/trust policy, not a fund-safety guard.
+  if (canonicalMainnetCa) {
+    const { data: dupTokenRows, error: dupTokenError } = await supabase
+      .from("markets")
+      .select("slab_address, symbol")
+      .eq("network", insertNetwork)
+      .eq("mainnet_ca", canonicalMainnetCa)
+      .limit(1);
+
+    if (dupTokenError) {
+      return NextResponse.json(
+        { error: "Failed to validate existing markets for this token" },
+        { status: 500 },
+      );
+    }
+
+    const dupToken = dupTokenRows?.[0];
+    if (dupToken) {
+      return NextResponse.json(
+        {
+          error:
+            `A market for this token already exists (${dupToken.symbol ?? "unnamed"} — slab ${dupToken.slab_address}). ` +
+            "One market per token: trade the existing market instead of launching a duplicate.",
+          existing_slab: dupToken.slab_address,
+        },
+        { status: 409 },
+      );
+    }
   }
 
   // Insert market

--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -19,6 +19,7 @@ import { SLAB_TIERS, type SlabTierKey } from "@/lib/slabTiers";
 import { getConfig, getNetwork } from "@/lib/config";
 import { toE6 } from "@/lib/format";
 
+import { useDuplicateMarket } from "@/hooks/useDuplicateMarket";
 import { ModeSelector } from "./ModeSelector";
 import { WizardProgress } from "./WizardProgress";
 import { StepTokenSelect } from "./StepTokenSelect";
@@ -292,6 +293,18 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
 
   // Step validation
   const step1Valid = mintValid && wizard.tokenMeta !== null && (wizard.tokenMeta.decimals <= 12) && mintExistsOnNetwork;
+  // One market per token: an existing market for this CA blocks step 1 —
+  // both the Continue button and Quick Launch's auto-advance — BEFORE the
+  // user spends SOL deploying a slab that POST /api/markets will 409 anyway
+  // (the server check is the authoritative half of this guard). Lives here,
+  // not in StepTokenSelect, because Quick Launch unmounts the step the
+  // moment it auto-advances — step-local state would be discarded before it
+  // could gate anything. Scoped to step-1 advancement only (NOT allValid) so
+  // a mid-launch/resume flow can't be flipped invalid by its own market
+  // appearing in the registry. Fail-open on lookup errors; auto-advance also
+  // waits while `checking` so a slow lookup can't be raced past.
+  const duplicateCheck = useDuplicateMarket(wizard.step === 1 ? wizard.mintAddress : null);
+  const step1CanAdvance = step1Valid && !duplicateCheck.checking && duplicateCheck.duplicates.length === 0;
   const step2Valid = (() => {
     if (wizard.oracleType === "admin") return true;
     if (wizard.oracleType === "pyth") return isValidHex64(wizard.oracleFeed);
@@ -398,14 +411,17 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
     if (wizard.mode !== "quick") { quickAutoAdvancedRef.current = false; return; }
     if (quickAutoAdvancedRef.current) return;
     if (wizard.step !== 1) return;
-    if (!step1Valid) return;
+    // One market per token: step1CanAdvance additionally waits for the
+    // duplicate-market lookup to settle and come back clear — auto-advance
+    // must not race past a pending check (see useDuplicateMarket).
+    if (!step1CanAdvance) return;
     if (quickLaunch.loading) return;
     if (!quickLaunch.config) return;
 
     quickAutoAdvancedRef.current = true;
     setCompletedSteps((prev) => new Set(prev).add(1));
     setWizard((prev) => ({ ...prev, step: 2 as WizardStep }));
-  }, [wizard.mode, wizard.step, step1Valid, quickLaunch.loading, quickLaunch.config]);
+  }, [wizard.mode, wizard.step, step1CanAdvance, quickLaunch.loading, quickLaunch.config]);
 
   // Quick Launch: step 2 is slab selection (NOT oracle).
   // Oracle is resolved from useQuickLaunch and applied when user clicks Continue.
@@ -1038,7 +1054,8 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
             onBalanceChange={setWalletBalance}
             onMintNetworkValidChange={setMintExistsOnNetwork}
             onContinue={() => advanceStep(1)}
-            canContinue={step1Valid}
+            canContinue={step1CanAdvance}
+            duplicateMarkets={duplicateCheck.duplicates}
           />
         )}
 

--- a/app/components/create/StepTokenSelect.tsx
+++ b/app/components/create/StepTokenSelect.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { FC, useState, useEffect, useMemo, useRef } from "react";
+import Link from "next/link";
 import { PublicKey } from "@solana/web3.js";
 import { useWalletCompat, useConnectionCompat } from "@/hooks/useWalletCompat";
 import { getAssociatedTokenAddress, getAccount, TOKEN_PROGRAM_ID, TOKEN_2022_PROGRAM_ID } from "@solana/spl-token";
@@ -8,6 +9,7 @@ import { useTokenMeta } from "@/hooks/useTokenMeta";
 import { formatHumanAmount } from "@/lib/parseAmount";
 import { isValidBase58Pubkey } from "@/lib/createWizardUtils";
 import { getNetwork } from "@/lib/config";
+import type { DuplicateMarket } from "@/hooks/useDuplicateMarket";
 
 /** Derive whether we're on devnet from the live RPC endpoint (not build-time env var). */
 function isDevnetEndpoint(rpcEndpoint: string): boolean {
@@ -25,6 +27,11 @@ interface StepTokenSelectProps {
   onMintNetworkValidChange?: (valid: boolean) => void;
   onContinue: () => void;
   canContinue: boolean;
+  /** One market per token — markets already listed for this CA (owned by the
+   *  WIZARD via useDuplicateMarket, since Quick Launch auto-advances and
+   *  unmounts this step; `canContinue` above is already gated on it there).
+   *  Non-empty renders the blocking card. */
+  duplicateMarkets?: DuplicateMarket[];
 }
 
 /**
@@ -39,6 +46,7 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
   onMintNetworkValidChange,
   onContinue,
   canContinue,
+  duplicateMarkets = [],
 }) => {
   const { publicKey } = useWalletCompat();
   const { connection } = useConnectionCompat();
@@ -244,7 +252,10 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
   const showResolved = mintValid && effectiveMeta && mintNetworkStatus === "valid";
   // Block continue if mint doesn't exist on the current network or is still being checked
   const mintNetworkBlocked = mintValid && (mintNetworkStatus === "loading" || mintNetworkStatus === "invalid");
-  const effectiveCanContinue = canContinue && !mintNetworkBlocked;
+  // One market per token — an existing market for this CA blocks Continue
+  // (server enforces the same rule with a 409 at registration).
+  const duplicateBlocked = mintValid && duplicateMarkets.length > 0;
+  const effectiveCanContinue = canContinue && !mintNetworkBlocked && !duplicateBlocked;
 
   return (
     <div className="space-y-5">
@@ -333,6 +344,30 @@ export const StepTokenSelect: FC<StepTokenSelectProps> = ({
               </p>
             </div>
           )}
+        </div>
+      )}
+
+      {/* One market per token — an existing market for this CA blocks the step */}
+      {duplicateBlocked && (
+        <div className="border border-[var(--short)]/30 bg-[var(--short)]/[0.04] p-4">
+          <p className="text-[11px] font-semibold text-[var(--short)]">
+            ✗ This token already has a market — one market per token
+          </p>
+          <p className="mt-1 text-[10px] leading-relaxed text-[var(--text-secondary)]">
+            A second market would split liquidity, positions, and pricing across two
+            identical-looking listings. Trade the existing market instead:
+          </p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {duplicateMarkets.slice(0, 3).map((m) => (
+              <Link
+                key={m.slab}
+                href={`/trade/${m.slab}`}
+                className="border border-[var(--accent)]/40 px-3 py-1 text-[10px] font-medium text-[var(--accent)] transition-colors hover:border-[var(--accent)]/70 hover:bg-[var(--accent)]/[0.08]"
+              >
+                Trade {m.symbol ?? `${m.slab.slice(0, 6)}…`} →
+              </Link>
+            ))}
+          </div>
         </div>
       )}
 

--- a/app/hooks/useDuplicateMarket.ts
+++ b/app/hooks/useDuplicateMarket.ts
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { isValidBase58Pubkey } from "@/lib/createWizardUtils";
+import { isMockMode } from "@/lib/mock-mode";
+
+/** An already-listed market for the same underlying token. */
+export interface DuplicateMarket {
+  slab: string;
+  symbol: string | null;
+}
+
+export interface DuplicateMarketCheck {
+  /** True while the lookup is in flight — callers gating an auto-advance
+   *  should wait for it to settle so a slow lookup can't be raced past. */
+  checking: boolean;
+  /** Markets already listed for this token (empty = clear to launch). */
+  duplicates: DuplicateMarket[];
+}
+
+const CLEAR: DuplicateMarketCheck = { checking: false, duplicates: [] };
+
+/**
+ * One market per token — client half of the guard (POST /api/markets 409s
+ * authoritatively): looks up whether the pasted token CA already has a
+ * listed market, so the create wizard can block step 1 BEFORE the user
+ * spends SOL deploying a slab the registry will reject.
+ *
+ * Owned by the WIZARD, not StepTokenSelect: Quick Launch auto-advances
+ * step 1 → 2 the moment the token resolves, unmounting the step — state
+ * living inside the step would be thrown away before it could gate
+ * anything.
+ *
+ * Matches on mint_address OR mainnet_ca: playground markets store the
+ * pasted CA in mainnet_ca (mint_address is the shared sim-USDC collateral);
+ * mainnet deployments collateralize in the token itself, so there
+ * mint_address IS the token.
+ *
+ * Fail-open: a failed/slow/aborted lookup reports "clear" — the server-side
+ * 409 is the authoritative gate, and a registry hiccup must never block a
+ * legitimate launch. Disabled entirely in mock mode (demo walkthroughs
+ * paste CAs of tokens that DO have curated markets).
+ */
+export function useDuplicateMarket(tokenCa: string | null): DuplicateMarketCheck {
+  const [state, setState] = useState<DuplicateMarketCheck>(CLEAR);
+
+  useEffect(() => {
+    const ca = tokenCa?.trim() ?? "";
+    if (!ca || !isValidBase58Pubkey(ca) || ca.length < 32 || isMockMode()) {
+      setState(CLEAR);
+      return;
+    }
+    let cancelled = false;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 8_000);
+    setState({ checking: true, duplicates: [] });
+    (async () => {
+      try {
+        const res = await fetch(`/api/markets?search=${encodeURIComponent(ca)}&limit=50`, {
+          headers: { Accept: "application/json" },
+          signal: controller.signal,
+        });
+        if (cancelled) return;
+        if (!res.ok) {
+          setState(CLEAR); // fail-open — server 409 backstops
+          return;
+        }
+        const body = (await res.json()) as { markets?: unknown };
+        const rows = Array.isArray(body.markets) ? body.markets : [];
+        const duplicates: DuplicateMarket[] = [];
+        for (const row of rows) {
+          if (!row || typeof row !== "object") continue;
+          const m = row as Record<string, unknown>;
+          // Exact-match the token — `search` is a fuzzy substring filter
+          // over symbol/name/slab/mint/ca, so re-verify identity here.
+          const mint = typeof m.mint_address === "string" ? m.mint_address : null;
+          const mainnetCa = typeof m.mainnet_ca === "string" ? m.mainnet_ca : null;
+          const slab = typeof m.slab_address === "string" ? m.slab_address : null;
+          if (slab && (mint === ca || mainnetCa === ca)) {
+            duplicates.push({ slab, symbol: typeof m.symbol === "string" ? m.symbol : null });
+          }
+        }
+        if (!cancelled) setState({ checking: false, duplicates });
+      } catch {
+        if (!cancelled) setState(CLEAR); // fail-open, incl. the 8s timeout abort
+      } finally {
+        clearTimeout(timer);
+      }
+    })();
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [tokenCa]);
+
+  return state;
+}


### PR DESCRIPTION
## What

**One market per token.** Nothing prevented launching a *second* market for a token that already has one — only re-registering the same **slab** was guarded (an anti-tampering check, not a duplicate-token check). Duplicates aren't a fund-safety issue (markets are fully isolated), but they fragment liquidity and positions across identical-looking listings and let a clone impersonate the original.

## Server — the authoritative gate

`POST /api/markets` now rejects **409** when a market for the same token already exists on the network:

- Keyed on **`mainnet_ca`** (the token's identity field the wizard always sends) — deliberately **not** `mint_address`, which is the on-chain *collateral* mint: the same sim-USDC for every playground market, so deduping on it would 409 every legitimate launch. The new test suite pins this ("never dedupe on mint_address").
- The CA is canonicalized via a `PublicKey` round-trip so alternate base58 encodings of the same key can't dodge the check.
- Both paths guarded: the Supabase insert path, and the no-DB playground path (checked against the Blob keeper-registry, excluding the slab being registered so resume-retries still work; fail-open if the registry is unreadable).

## Client — catch it before SOL is spent

New `useDuplicateMarket` hook + wizard gating, so the duplicate is caught at **step 1**, before the user deploys a slab the registry would reject:

- `CreateMarketWizard` gates **both** the step-1 Continue **and Quick Launch's auto-advance** on the verdict; the gate also waits while the lookup is in flight so auto-advance can't race past a pending check. (The check must live in the wizard, not the step — Quick Launch unmounts `StepTokenSelect` the moment it advances, discarding step-local state. Found this the hard way in headless testing.)
- `StepTokenSelect` renders a blocking card with **`Trade <SYMBOL> →`** links to the existing market.
- Fail-open on lookup errors (the server 409 backstops), disabled in mock mode, and scoped to step-1 advancement only so a mid-launch/resume flow can't be flipped invalid by its own just-registered market.

## Also

`GET /api/markets` search now matches **`mainnet_ca`** in all three list paths — the CA is the token's identity on the playground, so searching a CA must find its market (powers the wizard lookup, and makes pasting a CA into the markets search box work).

## Testing

- `npx tsc --noEmit` clean.
- New `markets-one-market-per-token` suite (8 assertions) + duplicate-slab / search-filter / gh1526-gh1527 / sort / deployer-auth suites: **55/55 green** (no search regressions).
- Headless browser: pasting **SOL's CA** shows the blocking card, holds the wizard on step 1 with Continue disabled and a working "Trade SOL-PERP →" link; a **fresh CA** sails through Quick Launch's auto-advance untouched; zero page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
