### PR TITLE
fix(earn): correctness, data-integrity, and accessibility pass

### DIFF
--- a/app/__tests__/hooks/earnStatsTvlSentinel.test.ts
+++ b/app/__tests__/hooks/earnStatsTvlSentinel.test.ts
@@ -1,133 +1,104 @@
 /**
- * GH#1165 — /earn TVL sentinel filter for vault_balance
- * GH#1204 — /earn TVL uses vault_balance (actual deposits), not lp_collateral (bootstrap config)
+ * GH#1165 — /earn TVL sentinel filter for the on-chain LP Vault Registry balance
+ * GH#1204 — /earn TVL uses the LP Vault Registry's real backing, not a bootstrap
+ * config value
  *
- * Root cause (GH#1165): corrupt vault_balance values (e.g. ~4e14 at 6 decimals = $400M)
- * passed the existing sentinel filter (isSentinel = v > 1e18) but produced
- * wildly inflated TVL on the /earn page.
+ * Root cause (GH#1165): corrupt vault_balance values (e.g. ~4e14 at 6 decimals =
+ * $400M) passed the old u64::MAX-class sentinel filter but produced wildly
+ * inflated TVL on the /earn page.
  *
- * Root cause (GH#1204): lp_collateral was used instead of vault_balance.
- * lp_collateral = 10^11 for NNOB-PERP at 6 decimals = $100K TVL even when
- * vault has zero actual deposits (vault_balance = 0).
+ * Root cause (GH#1204): a bootstrap config value was used instead of the vault's
+ * actual on-chain deposits.
  *
- * Fix: use vault_balance (actual on-chain deposits) and apply sentinel + USD cap.
+ * Fix: apply a sane USD cap on top of the sentinel filter, in the same code path
+ * the /earn page actually renders from (`buildMarketVaultInfo` in
+ * hooks/useEarnStats.ts) — not a re-implementation that can silently drift from it.
  */
 
 import { describe, it, expect } from 'vitest';
+import {
+  buildMarketVaultInfo,
+  CURATED_COLLATERAL_DECIMALS,
+  MAX_VAULT_USD,
+  type CuratedVaultOnChain,
+} from '@/hooks/useEarnStats';
 
-// ─── Inline the same logic as hooks/useEarnStats.ts ───────────────────────
-const isSentinel = (v: number) => v > 1e18;
-const MAX_VAULT_USD = 10_000_000; // $10M cap per vault
+const emptySupabase = new Map<string, Record<string, unknown>>();
 
-function computeVaultBalance(vault_balance: number | null, collDivisor: number): number {
-  const vaultBalanceRaw = vault_balance ?? 0;
-  const vaultBalanceHuman = isSentinel(vaultBalanceRaw) ? Infinity : vaultBalanceRaw / collDivisor;
-  return vaultBalanceHuman > MAX_VAULT_USD ? 0 : vaultBalanceRaw;
+/** Build the curatedVaults map buildMarketVaultInfo expects, for a single slab. */
+function vaultsFor(slab: string, tvlAtoms: bigint): Record<string, CuratedVaultOnChain> {
+  return { [slab]: { tvlAtoms, cooldownSlots: 0n, found: true } };
 }
 
-function computeTvl(markets: { vault_balance: number | null; decimals: number }[]): number {
-  return markets.reduce((s, m) => {
-    const collDivisor = 10 ** m.decimals;
-    const vaultBalance = computeVaultBalance(m.vault_balance, collDivisor);
-    return s + vaultBalance / collDivisor;
-  }, 0);
+function tvlUsdFor(slab: string, tvlAtoms: bigint): number {
+  const info = buildMarketVaultInfo(slab, 'TEST', 'Test Market', null, vaultsFor(slab, tvlAtoms), emptySupabase);
+  return info.vaultBalance / (10 ** info.decimals);
 }
-// ──────────────────────────────────────────────────────────────────────────
 
-describe('useEarnStats — vault_balance sentinel filter (GH#1165, GH#1204)', () => {
-  it('passes legitimate USDC LP (e.g. 1,000 USDC at 6 decimals)', () => {
-    const raw = 1_000 * 1e6; // 1,000 USDC
-    const bal = computeVaultBalance(raw, 1e6);
-    expect(bal).toBe(raw);
+describe('useEarnStats — buildMarketVaultInfo TVL sentinel + cap (GH#1165, GH#1204)', () => {
+  it('collateral decimals are the shared Sim-USDC constant (6)', () => {
+    expect(CURATED_COLLATERAL_DECIMALS).toBe(6);
   });
 
-  it('passes legitimate SOL LP (e.g. 500 SOL at 9 decimals)', () => {
-    const raw = 500 * 1e9; // 500 SOL
-    const bal = computeVaultBalance(raw, 1e9);
-    expect(bal).toBe(raw);
-    expect(bal / 1e9).toBe(500); // 500 SOL in human units
+  it('passes legitimate LP vault TVL (1,000 Sim-USDC at 6 decimals)', () => {
+    const atoms = BigInt(1_000 * 1e6);
+    expect(tvlUsdFor('slabA', atoms)).toBe(1_000);
   });
 
-  it('blocks corrupt USDC value producing $400M TVL (4e14 at 6 decimals)', () => {
-    // 4e14 / 1e6 = 4e8 = $400M — should be zeroed
-    const corrupt = 4e14;
-    const bal = computeVaultBalance(corrupt, 1e6);
-    expect(bal).toBe(0);
+  it('blocks corrupt value producing $400M TVL (4e14 atoms at 6 decimals)', () => {
+    // 4e14 / 1e6 = 4e8 = $400M — below the u64::MAX-class sentinel threshold but
+    // still implausible; must be zeroed by the $10M cap.
+    const atoms = 4_00_000_000_000_000n;
+    expect(tvlUsdFor('slabA', atoms)).toBe(0);
   });
 
-  it('blocks corrupt SOL value producing $400M TVL (4e17 at 9 decimals)', () => {
-    // 4e17 / 1e9 = 4e8 = $400M SOL (at any price this is huge) — should be zeroed
-    const corrupt = 4e17;
-    const bal = computeVaultBalance(corrupt, 1e9);
-    expect(bal).toBe(0);
+  it('blocks sentinel-range values (>= 18e18, ~u64::MAX)', () => {
+    const atoms = 18_000_000_000_000_000_001n;
+    expect(tvlUsdFor('slabA', atoms)).toBe(0);
   });
 
-  it('blocks sentinel values > 1e18', () => {
-    const sentinel = 1.844e19; // u64::MAX approx
-    const bal = computeVaultBalance(sentinel, 1e6);
-    expect(bal).toBe(0);
+  it('blocks negative-looking (impossible) atoms defensively via 0 fallback', () => {
+    const info = buildMarketVaultInfo('slabA', 'TEST', 'Test Market', null, {}, emptySupabase);
+    expect(info.vaultBalance).toBe(0);
   });
 
-  it('handles null vault_balance as 0', () => {
-    const bal = computeVaultBalance(null, 1e6);
-    expect(bal).toBe(0);
+  it(`$${(MAX_VAULT_USD - 100_000).toLocaleString()} vault is allowed (just under the cap)`, () => {
+    const underCapUsd = MAX_VAULT_USD - 100_000;
+    const atoms = BigInt(underCapUsd) * 1_000_000n;
+    expect(tvlUsdFor('slabA', atoms)).toBe(underCapUsd);
   });
 
-  it('TVL with one corrupt market is not inflated', () => {
-    const markets = [
-      { vault_balance: 1_000 * 1e6, decimals: 6 },   // 1,000 USDC — legit
-      { vault_balance: 4e14, decimals: 6 },            // $400M USDC — corrupt
-      { vault_balance: 500 * 1e9, decimals: 9 },      // 500 SOL — legit
-    ];
-    const tvl = computeTvl(markets);
-    // Should only include the two legit vaults: 1,000 + 500 = 1,500 human units
-    expect(tvl).toBe(1_500);
+  it(`$${(MAX_VAULT_USD + 100_000).toLocaleString()} vault is blocked (just over the cap)`, () => {
+    const overCapUsd = MAX_VAULT_USD + 100_000;
+    const atoms = BigInt(overCapUsd) * 1_000_000n;
+    expect(tvlUsdFor('slabA', atoms)).toBe(0);
   });
 
-  it('TVL with all legit markets aggregates correctly', () => {
-    const markets = [
-      { vault_balance: 100 * 1e6, decimals: 6 },   // 100 USDC
-      { vault_balance: 200 * 1e6, decimals: 6 },   // 200 USDC
-      { vault_balance: 50 * 1e9,  decimals: 9 },   // 50 SOL
-    ];
-    const tvl = computeTvl(markets);
-    expect(tvl).toBeCloseTo(350, 5); // 100 + 200 + 50
+  it('a market with no LP Vault Registry entry shows $0 TVL, not a fabricated value', () => {
+    // GH#1204 shape: the registry hasn't been read/created for this slab yet.
+    expect(tvlUsdFor('slabA', 0n)).toBe(0);
   });
 
-  it('$9.9M vault is allowed (just under cap)', () => {
-    // $9,900,000 in USDC micro-units
-    const raw = 9_900_000 * 1e6; // 9.9e12
-    const bal = computeVaultBalance(raw, 1e6);
-    expect(bal).toBe(raw);
-  });
-
-  it('$10.1M vault is blocked (just over cap)', () => {
-    // $10,100,000 in USDC micro-units
-    const raw = 10_100_000 * 1e6; // 1.01e13
-    const bal = computeVaultBalance(raw, 1e6);
-    expect(bal).toBe(0);
-  });
-
-  // ─── GH#1204 regression test ─────────────────────────────────────────────
-  it('GH#1204: NNOB-PERP shows $0 TVL when vault_balance=0 despite lp_collateral=10^11', () => {
-    // lp_collateral = 100000000000 (bootstrap config) — NOT the actual deposits
-    // vault_balance = 0 (actual on-chain SOL in vault)
-    // Before fix: would show $100K TVL using lp_collateral / 10^6
-    // After fix: must show $0 using vault_balance
-    const vault_balance = 0;
-    const decimals = 6;
-    const collDivisor = 10 ** decimals;
-    const bal = computeVaultBalance(vault_balance, collDivisor);
-    expect(bal).toBe(0);
-    expect(bal / collDivisor).toBe(0); // TVL = $0
-  });
-
-  it('GH#1204: market with small real deposits shows correct TVL', () => {
-    // vault_balance = 5_000 USDC (5e9 micro-units at 6 decimals) — real deposits
-    const vault_balance = 5_000 * 1e6;
-    const decimals = 6;
-    const collDivisor = 10 ** decimals;
-    const bal = computeVaultBalance(vault_balance, collDivisor);
-    expect(bal / collDivisor).toBe(5_000); // TVL = $5,000
+  it('one corrupt market does not inflate the aggregate TVL across markets', () => {
+    const legitA = buildMarketVaultInfo(
+      'slabA', 'A', 'Market A', null,
+      { slabA: { tvlAtoms: BigInt(1_000 * 1e6), cooldownSlots: 0n, found: true } },
+      emptySupabase,
+    );
+    const corruptB = buildMarketVaultInfo(
+      'slabB', 'B', 'Market B', null,
+      { slabB: { tvlAtoms: 4_00_000_000_000_000n, cooldownSlots: 0n, found: true } },
+      emptySupabase,
+    );
+    const legitC = buildMarketVaultInfo(
+      'slabC', 'C', 'Market C', null,
+      { slabC: { tvlAtoms: BigInt(500 * 1e6), cooldownSlots: 0n, found: true } },
+      emptySupabase,
+    );
+    const tvl = [legitA, corruptB, legitC].reduce(
+      (s, m) => s + m.vaultBalance / (10 ** m.decimals),
+      0,
+    );
+    expect(tvl).toBe(1_500); // only the two legit vaults: 1,000 + 500
   });
 });

--- a/app/app/earn/[slab]/error.tsx
+++ b/app/app/earn/[slab]/error.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect } from 'react';
 import Link from 'next/link';
 import { GlowButton } from '@/components/ui/GlowButton';
 
@@ -10,18 +11,22 @@ export default function VaultDetailError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  useEffect(() => {
+    console.error('[earn/[slab]] vault error boundary:', error);
+  }, [error]);
+
   return (
-    <div className="min-h-[calc(100dvh-48px)] flex items-center justify-center">
+    <div role="alert" className="min-h-[calc(100dvh-48px)] flex items-center justify-center">
       <div className="max-w-md mx-auto text-center px-4">
-        <div className="text-4xl mb-4">⚠️</div>
+        <div aria-hidden="true" className="text-4xl mb-4">⚠️</div>
         <h1
-          className="text-lg font-medium text-white mb-2"
+          className="text-lg font-medium text-[var(--text)] mb-2"
           style={{ fontFamily: 'var(--font-heading)' }}
         >
           Vault Error
         </h1>
         <p className="text-[13px] text-[var(--text-secondary)] mb-6">
-          {error.message || 'Something went wrong loading this vault.'}
+          Something went wrong loading this vault. Please try again.
         </p>
         <div className="flex items-center justify-center gap-3">
           <GlowButton onClick={reset} variant="primary" size="md">

--- a/app/app/earn/[slab]/page.tsx
+++ b/app/app/earn/[slab]/page.tsx
@@ -106,11 +106,6 @@ export default function VaultDetailPage() {
 }
 
 function VaultDetailInner({ slabAddress }: { slabAddress: string }) {
-
-  useEffect(() => {
-    document.title = 'Vault — Percolator';
-  }, []);
-
   // LP Vault ("Earn") state for this market — v17 CreateLpVault/DepositToLpVault/
   // RequestRedeemLpShares/ExecuteRedemption mechanism (wrapper program, tags 74-77).
   // NOT the percolator-stake pool — that's a separate on-chain account backing the

--- a/app/app/earn/[slab]/page.tsx
+++ b/app/app/earn/[slab]/page.tsx
@@ -196,6 +196,13 @@ function VaultDetailInner({ slabAddress }: { slabAddress: string }) {
     [lpVaultWithdraw, refreshState, refreshEarnStats],
   );
 
+  // No signal about this slab from any source (not in earn stats, no Supabase
+  // row, no on-chain LP vault registry) once both loads have settled — a
+  // genuinely bad/unknown slab, distinct from a market that's just excluded
+  // from useEarnStats (e.g. non-'active' status) but still has a real vault.
+  const marketNotFound =
+    !loading && !marketInfo && !fallbackSymbol && !lpVaultState.registryExists;
+
   const symbol = marketInfo?.symbol ?? fallbackSymbol ?? 'UNKNOWN';
   // maxOI is only known once marketInfo resolves — without it we can't tell "no OI
   // cap" (real 0) apart from "cap unknown" (marketInfo not loaded yet / market not
@@ -209,6 +216,21 @@ function VaultDetailInner({ slabAddress }: { slabAddress: string }) {
   // percolator-stake pool (poolState.vaultBalance, wrong account — see hook comment above).
   const vaultUsd = Number(lpVaultState.vaultTotalAtoms) / collateralScale;
   const insuranceFund = marketInfo?.insuranceFund ?? 0;
+
+  if (marketNotFound) {
+    return (
+      <div className="min-h-[60vh] flex items-center justify-center">
+        <div className="text-center space-y-4 px-4">
+          <div className="text-[var(--text-secondary)] text-sm">
+            This market could not be found.
+          </div>
+          <Link href="/earn" className="text-[var(--accent)] text-sm hover:underline">
+            ← Back to Earn
+          </Link>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-[calc(100dvh-48px)] animate-fade-in">
@@ -314,7 +336,7 @@ function VaultDetailInner({ slabAddress }: { slabAddress: string }) {
             </StatCell>
             <StatCell label="Max Leverage" loading={loading}>
               <span className="text-sm font-mono tabular-nums text-[var(--text)]">
-                {marketInfo?.maxLeverage || 10}×
+                {marketInfo?.maxLeverage ?? 10}×
               </span>
             </StatCell>
           </div>
@@ -402,7 +424,7 @@ function VaultDetailInner({ slabAddress }: { slabAddress: string }) {
               <InfoRow label="Deposit Cap" value="Unlimited" />
               <InfoRow
                 label="Trading Fee"
-                value={`${(marketInfo?.tradingFeeBps ?? 10) / 100}%`}
+                value={`${((marketInfo?.tradingFeeBps ?? 10) / 100).toFixed(2)}%`}
               />
               <InfoRow
                 label="Pool Status"

--- a/app/app/earn/[slab]/page.tsx
+++ b/app/app/earn/[slab]/page.tsx
@@ -134,7 +134,7 @@ function VaultDetailInner({ slabAddress }: { slabAddress: string }) {
   const collateralDecimals = collateralTokenMeta?.decimals ?? 6;
 
   // Get market info from earn stats
-  const { stats: earnStats, loading: earnLoading, error: earnStatsError } = useEarnStats();
+  const { stats: earnStats, loading: earnLoading, error: earnStatsError, refresh: refreshEarnStats } = useEarnStats();
   const marketInfo = useMemo<MarketVaultInfo | null>(() => {
     return earnStats.markets.find((m) => m.slabAddress === slabAddress) ?? null;
   }, [earnStats.markets, slabAddress]);
@@ -174,8 +174,13 @@ function VaultDetailInner({ slabAddress }: { slabAddress: string }) {
     async (amount: bigint) => {
       await lpVaultDeposit(amount);
       await refreshState();
+      // marketInfo (maxOI, insurance, APY) comes from a separate useEarnStats
+      // instance that only advances on its own 15s timer — without this the
+      // OI meter/APY/insurance figures would sit stale for up to 15s after a
+      // deposit changes the vault's TVL.
+      refreshEarnStats();
     },
-    [lpVaultDeposit, refreshState],
+    [lpVaultDeposit, refreshState, refreshEarnStats],
   );
 
   const handleWithdraw = useCallback(
@@ -185,9 +190,10 @@ function VaultDetailInner({ slabAddress }: { slabAddress: string }) {
       // instead of a blanket "Withdrawal successful!".
       const result = await lpVaultWithdraw(lpAmount);
       await refreshState();
+      refreshEarnStats();
       return result;
     },
-    [lpVaultWithdraw, refreshState],
+    [lpVaultWithdraw, refreshState, refreshEarnStats],
   );
 
   const symbol = marketInfo?.symbol ?? fallbackSymbol ?? 'UNKNOWN';
@@ -336,6 +342,7 @@ function VaultDetailInner({ slabAddress }: { slabAddress: string }) {
               lpSupply={lpVaultState.lpSupply}
               vaultBalance={lpVaultState.vaultTotalAtoms}
               decimals={collateralDecimals}
+              lpDecimals={lpVaultState.lpDecimals}
               collateralSymbol={collateralSymbol}
               redemptionRateE6={lpVaultState.vaultSharePriceE6}
               loading={loading}

--- a/app/app/earn/[slab]/page.tsx
+++ b/app/app/earn/[slab]/page.tsx
@@ -145,16 +145,25 @@ function VaultDetailInner({ slabAddress }: { slabAddress: string }) {
   useEffect(() => {
     if (marketInfo || earnLoading) return;
     let cancelled = false;
-    getSupabase()
-      .from('markets_with_stats')
-      .select('symbol, name')
-      .eq('slab_address', slabAddress)
-      .maybeSingle()
-      .then(({ data }) => {
-        if (!cancelled && data?.symbol) {
-          setFallbackSymbol(data.symbol);
-        }
-      });
+    try {
+      getSupabase()
+        .from('markets_with_stats')
+        .select('symbol, name')
+        .eq('slab_address', slabAddress)
+        .maybeSingle()
+        .then(
+          ({ data }) => {
+            if (!cancelled && data?.symbol) {
+              setFallbackSymbol(data.symbol);
+            }
+          },
+          (err: unknown) => {
+            console.error('[earn/[slab]] fallback symbol lookup failed:', err);
+          },
+        );
+    } catch (err) {
+      console.error('[earn/[slab]] fallback symbol lookup failed:', err);
+    }
     return () => { cancelled = true; };
   }, [marketInfo, earnLoading, slabAddress]);
 
@@ -182,7 +191,11 @@ function VaultDetailInner({ slabAddress }: { slabAddress: string }) {
   );
 
   const symbol = marketInfo?.symbol ?? fallbackSymbol ?? 'UNKNOWN';
+  // maxOI is only known once marketInfo resolves — without it we can't tell "no OI
+  // cap" (real 0) apart from "cap unknown" (marketInfo not loaded yet / market not
+  // in earn stats), so the meter must not claim a health status in the latter case.
   const maxOI = marketInfo?.maxOI ?? 0;
+  const oiCapKnown = marketInfo != null;
   const collDivisor = 10 ** collateralDecimals;
   const currentOI = marketInfo?.totalOI ?? (totalOI ? Number(totalOI) / collDivisor : 0);
   const collateralScale = Math.pow(10, collateralDecimals);
@@ -285,7 +298,7 @@ function VaultDetailInner({ slabAddress }: { slabAddress: string }) {
             </StatCell>
             <StatCell label="Open Interest" loading={loading}>
               <span className="text-sm font-mono tabular-nums text-[var(--text)]">
-                ${formatCompact(currentOI)}
+                {oiCapKnown ? `$${formatCompact(currentOI)}` : '—'}
               </span>
             </StatCell>
             <StatCell label="Insurance" loading={loading}>
@@ -304,7 +317,13 @@ function VaultDetailInner({ slabAddress }: { slabAddress: string }) {
         {/* OI meter */}
         <ScrollReveal>
           <div className="mb-8 border border-[var(--border)] bg-[var(--panel-bg)] rounded-sm p-5 hud-corners">
-            <OiCapMeter currentOI={currentOI} maxOI={maxOI} />
+            {oiCapKnown ? (
+              <OiCapMeter currentOI={currentOI} maxOI={maxOI} />
+            ) : (
+              <div className="text-[11px] text-[var(--text-secondary)]">
+                OI capacity data unavailable for this market.
+              </div>
+            )}
           </div>
         </ScrollReveal>
 

--- a/app/app/earn/page.tsx
+++ b/app/app/earn/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useState } from 'react';
 import dynamic from 'next/dynamic';
 import { useEarnStats } from '@/hooks/useEarnStats';
 import { ScrollReveal } from '@/components/ui/ScrollReveal';
@@ -134,11 +134,9 @@ const InsuranceFundDisplay = dynamic(
 );
 
 export default function EarnPage() {
-  useEffect(() => {
-    document.title = 'Earn — Percolator';
-  }, []);
-
   const { stats, loading, error } = useEarnStats();
+  const [dismissedError, setDismissedError] = useState<string | null>(null);
+  const showError = error && error !== dismissedError;
 
   return (
     <div className="min-h-[calc(100dvh-48px)] animate-fade-in">
@@ -232,9 +230,19 @@ export default function EarnPage() {
         </div>
 
         {/* Error toast */}
-        {error && (
-          <div className="fixed bottom-4 right-4 z-50 bg-[var(--short)]/10 border border-[var(--short)]/30 rounded-sm px-4 py-3 text-[12px] text-[var(--short)]">
-            {error}
+        {showError && (
+          <div
+            role="alert"
+            className="fixed bottom-4 right-4 z-50 flex items-start gap-3 bg-[var(--short)]/10 border border-[var(--short)]/30 rounded-sm px-4 py-3 text-[12px] text-[var(--short)]"
+          >
+            <span>{error}</span>
+            <button
+              onClick={() => setDismissedError(error)}
+              aria-label="Dismiss error"
+              className="text-[var(--short)]/70 hover:text-[var(--short)] transition-colors"
+            >
+              ✕
+            </button>
           </div>
         )}
       </div>

--- a/app/app/earn/page.tsx
+++ b/app/app/earn/page.tsx
@@ -5,6 +5,7 @@ import dynamic from 'next/dynamic';
 import { useEarnStats } from '@/hooks/useEarnStats';
 import { ScrollReveal } from '@/components/ui/ScrollReveal';
 import { ShimmerSkeleton } from '@/components/ui/ShimmerSkeleton';
+import { VaultCardSkeleton } from '@/components/earn/VaultCardSkeleton';
 
 const EarnHeader = dynamic(
   () => import('@/components/earn/EarnHeader').then((m) => m.EarnHeader),
@@ -66,30 +67,7 @@ const VaultGrid = dynamic(
         </div>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {[1, 2, 3].map((i) => (
-            <div key={i} className="border border-[var(--border)] bg-[var(--panel-bg)] p-5 space-y-4 rounded-sm">
-              <div className="flex justify-between items-center">
-                <div className="flex items-center gap-3">
-                  <ShimmerSkeleton className="w-8 h-8 rounded-full" />
-                  <div>
-                    <ShimmerSkeleton className="h-4 w-20 mb-1" />
-                    <ShimmerSkeleton className="h-3 w-16" />
-                  </div>
-                </div>
-                <div className="text-right space-y-1">
-                  <ShimmerSkeleton className="h-2.5 w-12" />
-                  <ShimmerSkeleton className="h-5 w-16" />
-                </div>
-              </div>
-              <div className="grid grid-cols-2 gap-3">
-                {[1, 2, 3, 4].map(j => (
-                  <div key={j} className="space-y-1">
-                    <ShimmerSkeleton className="h-2 w-10" />
-                    <ShimmerSkeleton className="h-4.5 w-16" />
-                  </div>
-                ))}
-              </div>
-              <ShimmerSkeleton className="h-2 w-full mt-2" />
-            </div>
+            <VaultCardSkeleton key={i} />
           ))}
         </div>
       </div>

--- a/app/app/earn/page.tsx
+++ b/app/app/earn/page.tsx
@@ -170,7 +170,7 @@ export default function EarnPage() {
                   {stats.markets.length} market{stats.markets.length !== 1 ? 's' : ''}
                 </span>
               </div>
-              <VaultGrid markets={stats.markets} loading={loading} />
+              <VaultGrid markets={stats.markets} loading={loading} error={error} />
             </ScrollReveal>
           </div>
 

--- a/app/components/earn/DepositWithdrawPanel.tsx
+++ b/app/components/earn/DepositWithdrawPanel.tsx
@@ -282,10 +282,10 @@ export function DepositWithdrawPanel({
           </p>
 
           {claimError && (
-            <p className="mb-2 text-[11px] text-[var(--short)]">{claimError}</p>
+            <p role="alert" className="mb-2 text-[11px] text-[var(--short)]">{claimError}</p>
           )}
           {claimSuccess && (
-            <p className="mb-2 text-[11px] text-[var(--cyan)]">{claimSuccess}</p>
+            <p role="status" aria-live="polite" className="mb-2 text-[11px] text-[var(--cyan)]">{claimSuccess}</p>
           )}
 
           <GlowButton
@@ -308,11 +308,12 @@ export function DepositWithdrawPanel({
         {/* Amount input */}
         <div className="mb-4">
           <div className="flex items-center justify-between mb-2">
-            <label className="text-[10px] uppercase tracking-[0.2em] text-[var(--text-secondary)]">
+            <label htmlFor="earn-amount-input" className="text-[10px] uppercase tracking-[0.2em] text-[var(--text-secondary)]">
               {tab === 'deposit' ? 'Deposit Amount' : 'LP Tokens to Burn'}
             </label>
             <button
               onClick={handleSetMax}
+              aria-label={`Set maximum amount: ${displayMaxAmount} ${tab === 'deposit' ? collateralSymbol : 'LP'}`}
               className="text-[10px] text-[var(--accent)] hover:text-[var(--accent)]/80 transition-colors"
             >
               Max: {displayMaxAmount} {tab === 'deposit' ? collateralSymbol : 'LP'}
@@ -321,6 +322,7 @@ export function DepositWithdrawPanel({
 
           <div className="relative">
             <input
+              id="earn-amount-input"
               type="text"
               inputMode="decimal"
               placeholder="0.00"
@@ -451,12 +453,12 @@ export function DepositWithdrawPanel({
 
         {/* Error / Success */}
         {txError && (
-          <div className="mb-4 p-3 bg-[var(--short)]/5 border border-[var(--short)]/20 rounded-sm">
+          <div role="alert" className="mb-4 p-3 bg-[var(--short)]/5 border border-[var(--short)]/20 rounded-sm">
             <p className="text-[11px] text-[var(--short)]">{txError}</p>
           </div>
         )}
         {txSuccess && (
-          <div className="mb-4 p-3 bg-[var(--cyan)]/5 border border-[var(--cyan)]/20 rounded-sm">
+          <div role="status" aria-live="polite" className="mb-4 p-3 bg-[var(--cyan)]/5 border border-[var(--cyan)]/20 rounded-sm">
             <p className="text-[11px] text-[var(--cyan)]">{txSuccess}</p>
           </div>
         )}

--- a/app/components/earn/DepositWithdrawPanel.tsx
+++ b/app/components/earn/DepositWithdrawPanel.tsx
@@ -277,7 +277,7 @@ export function DepositWithdrawPanel({
             {cooldownElapsed
               ? 'Cooldown elapsed — claim your redemption to receive the underlying collateral.'
               : cooldownRemainingSlots > 0n
-                ? `Cooldown in progress — ~${Math.ceil(Number(cooldownRemainingSlots) * 0.4)}s remaining.`
+                ? `Cooldown in progress — ~${slotsToSeconds(cooldownRemainingSlots)}s remaining.`
                 : 'Cooldown in progress.'}
           </p>
 
@@ -404,23 +404,28 @@ export function DepositWithdrawPanel({
                 <div className="flex items-center justify-between text-[12px]">
                   <span className="text-[var(--text-secondary)]">Rate (1 LP)</span>
                   <span className="font-mono tabular-nums text-[var(--text)]">
-                    ≈ {lpSupply > 0n
-                        ? formatRaw((vaultBalance * divisor) / lpSupply, decimals)
-                        : '1.0000'
-                      } {collateralSymbol}
+                    ≈ {formatRaw((vaultBalance * divisor) / lpSupply, decimals)} {collateralSymbol}
                   </span>
                 </div>
               )}
 
-              {/* Cooldown status */}
+              {/* Cooldown status — withdraw() only ever REQUESTS a redemption when
+                  there's no pending ticket yet (hasPendingRedemption === false);
+                  cooldownElapsed defaults to true in that state (nothing to wait
+                  on), so it must not drive this copy or it reads as "ready to
+                  withdraw now" when the action actually just starts the cooldown. */}
               <div className="flex items-center justify-between text-[12px]">
                 <span className="text-[var(--text-secondary)]">Cooldown</span>
-                <span className={`font-medium ${cooldownElapsed ? 'text-[var(--cyan)]' : 'text-[var(--warning)]'}`}>
-                  {cooldownElapsed
-                    ? 'Elapsed — ready to withdraw'
-                    : cooldownSlots && cooldownSlots > 0n
-                      ? `~${Math.ceil(Number(cooldownSlots) * 0.4)}s remaining`
-                      : 'Not elapsed'
+                <span className={`font-medium ${!hasPendingRedemption || cooldownElapsed ? 'text-[var(--cyan)]' : 'text-[var(--warning)]'}`}>
+                  {!hasPendingRedemption
+                    ? cooldownSlots && cooldownSlots > 0n
+                      ? `Starts on request (~${slotsToSeconds(cooldownSlots)}s)`
+                      : 'Starts on request'
+                    : cooldownElapsed
+                      ? 'Elapsed — ready to claim'
+                      : cooldownSlots && cooldownSlots > 0n
+                        ? `~${slotsToSeconds(cooldownSlots)}s remaining`
+                        : 'Not elapsed'
                   }
                 </span>
               </div>
@@ -435,7 +440,9 @@ export function DepositWithdrawPanel({
             {withdrawConfirming && (
               <div className="mt-3 pt-3 border-t border-[var(--warning)]/20">
                 <p className="text-[11px] text-[var(--warning)]">
-                  LP tokens will be permanently burned. This action cannot be undone.
+                  {hasPendingRedemption
+                    ? 'LP tokens will be permanently burned. This action cannot be undone.'
+                    : 'LP tokens will be locked in escrow until the cooldown completes and you claim the redemption.'}
                 </p>
               </div>
             )}
@@ -484,14 +491,21 @@ export function DepositWithdrawPanel({
               ? 'Confirming...'
               : tab === 'deposit'
                 ? 'Deposit'
-                : withdrawConfirming
-                  ? 'Confirm Withdrawal'
-                  : 'Withdraw'}
+                : hasPendingRedemption
+                  ? (withdrawConfirming ? 'Confirm Withdrawal' : 'Withdraw')
+                  : (withdrawConfirming ? 'Confirm Request' : 'Request Withdrawal')}
           </GlowButton>
         </div>
       </div>
     </div>
   );
+}
+
+/** Solana devnet slot time, used to render cooldowns as an approximate wall-clock duration. */
+const SLOT_SECONDS = 0.4;
+
+function slotsToSeconds(slots: bigint): number {
+  return Math.ceil(Number(slots) * SLOT_SECONDS);
 }
 
 /** Format raw bigint to human-readable decimal string */

--- a/app/components/earn/InsuranceFundDisplay.tsx
+++ b/app/components/earn/InsuranceFundDisplay.tsx
@@ -54,7 +54,7 @@ export function InsuranceFundDisplay({
       <div className="p-5">
         {/* Header */}
         <div className="flex items-center gap-2 mb-4">
-          <div className="w-6 h-6 rounded-sm bg-[var(--warning)]/10 flex items-center justify-center text-xs">
+          <div aria-hidden="true" className="w-6 h-6 rounded-sm bg-[var(--warning)]/10 flex items-center justify-center text-xs">
             🛡️
           </div>
           <h3
@@ -144,7 +144,7 @@ function CoverageItem({
 }) {
   return (
     <div className="flex items-start gap-2">
-      <span className="text-xs mt-0.5">{icon}</span>
+      <span aria-hidden="true" className="text-xs mt-0.5">{icon}</span>
       <div>
         <div className="text-[12px] text-[var(--text)] font-medium">{label}</div>
         <div className="text-[11px] text-[var(--text-secondary)]">

--- a/app/components/earn/InsuranceFundDisplay.tsx
+++ b/app/components/earn/InsuranceFundDisplay.tsx
@@ -109,7 +109,7 @@ export function InsuranceFundDisplay({
               By Market
             </div>
             <div className="space-y-2">
-              {stats.markets
+              {[...stats.markets]
                 .sort((a, b) => b.insuranceFund - a.insuranceFund)
                 .slice(0, 5)
                 .map((m) => (

--- a/app/components/earn/LpPositionDashboard.tsx
+++ b/app/components/earn/LpPositionDashboard.tsx
@@ -13,6 +13,8 @@ interface LpPositionDashboardProps {
   vaultBalance: bigint;
   /** Decimals for collateral */
   decimals: number;
+  /** Decimals for the LP token mint — NOT necessarily the same as collateral decimals */
+  lpDecimals: number;
   /** Collateral symbol */
   collateralSymbol: string;
   /** Redemption rate (e6) */
@@ -26,6 +28,7 @@ export function LpPositionDashboard({
   lpSupply,
   vaultBalance,
   decimals,
+  lpDecimals,
   collateralSymbol,
   redemptionRateE6,
   loading,
@@ -118,7 +121,7 @@ export function LpPositionDashboard({
             <div className="grid grid-cols-2 gap-4">
               <MetricCell
                 label="LP Tokens"
-                value={formatRaw(userLpBalance, decimals)}
+                value={formatRaw(userLpBalance, lpDecimals)}
               />
               <MetricCell
                 label="Pool Share"

--- a/app/components/earn/LpPositionDashboard.tsx
+++ b/app/components/earn/LpPositionDashboard.tsx
@@ -47,12 +47,6 @@ export function LpPositionDashboard({
 
   const userRedeemableFloat = Number(userRedeemableValue) / Number(divisor);
 
-  // Share value (how much 1 LP token is worth)
-  const shareValue =
-    lpSupply > 0n
-      ? Number(vaultBalance * 1_000_000n / lpSupply) / 1_000_000
-      : 1;
-
   if (loading) {
     return (
       <div className="border border-[var(--border)] bg-[var(--panel-bg)] rounded-sm p-5 hud-corners">
@@ -128,9 +122,13 @@ export function LpPositionDashboard({
                 value={`${userSharePct.toFixed(2)}%`}
                 highlight
               />
+              {/* "Share Value" — how much 1 LP token redeems for. Sourced from the
+                  on-chain redemption rate (vaultTotalAtoms / lpSupply, read fresh
+                  by useInsuranceLP) rather than recomputed locally — the two used
+                  to be shown as separate cells that could visibly disagree. */}
               <MetricCell
                 label="Share Value"
-                value={`${shareValue.toFixed(4)} ${collateralSymbol}`}
+                value={`${(Number(redemptionRateE6) / 1_000_000).toFixed(4)} ${collateralSymbol}`}
               />
               <MetricCell
                 label="Redemption Rate"

--- a/app/components/earn/OiCapMeter.tsx
+++ b/app/components/earn/OiCapMeter.tsx
@@ -30,7 +30,7 @@ export function OiCapMeter({
   const barColor = useMemo(() => {
     if (utilPct >= 90) return 'var(--short)';
     if (utilPct >= 75) return 'var(--warning)';
-    if (utilPct >= 50) return '#E5A100';
+    if (utilPct >= 50) return 'var(--warning)';
     return 'var(--cyan)';
   }, [utilPct]);
 
@@ -82,8 +82,8 @@ export function OiCapMeter({
           className="text-[10px] uppercase tracking-[0.15em] font-medium px-2 py-0.5 rounded-sm border"
           style={{
             color: barColor,
-            borderColor: `${barColor}33`,
-            backgroundColor: `${barColor}0A`,
+            borderColor: `color-mix(in srgb, ${barColor} 20%, transparent)`,
+            backgroundColor: `color-mix(in srgb, ${barColor} 4%, transparent)`,
           }}
         >
           {statusLabel}

--- a/app/components/earn/OiCapMeter.tsx
+++ b/app/components/earn/OiCapMeter.tsx
@@ -51,7 +51,15 @@ export function OiCapMeter({
   if (compact) {
     return (
       <div className={`flex items-center gap-2 ${className}`}>
-        <div className="flex-1 h-1.5 bg-[var(--border)] rounded-full overflow-hidden">
+        <div
+          role="progressbar"
+          aria-label="OI capacity utilization"
+          aria-valuenow={Math.round(utilPct)}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuetext={`${utilPct.toFixed(0)}% — ${statusLabel}`}
+          className="flex-1 h-1.5 bg-[var(--border)] rounded-full overflow-hidden"
+        >
           <div
             className="h-full rounded-full transition-all duration-700 ease-out"
             style={{
@@ -91,7 +99,15 @@ export function OiCapMeter({
       </div>
 
       {/* Meter bar */}
-      <div className="relative h-3 bg-[var(--border)] rounded-sm overflow-hidden">
+      <div
+        role="progressbar"
+        aria-label="OI capacity utilization"
+        aria-valuenow={Math.round(utilPct)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuetext={`${utilPct.toFixed(1)}% — ${statusLabel}`}
+        className="relative h-3 bg-[var(--border)] rounded-sm overflow-hidden"
+      >
         {/* Segment markers */}
         <div className="absolute inset-0 flex">
           <div className="w-1/2 border-r border-[var(--bg)]/30" />

--- a/app/components/earn/VaultCard.tsx
+++ b/app/components/earn/VaultCard.tsx
@@ -56,7 +56,7 @@ export function VaultCard({ vault }: VaultCardProps) {
             />
             <MetricCell
               label="Max Leverage"
-              value={`${vault.maxLeverage || 10}×`}
+              value={`${vault.maxLeverage ?? 10}×`}
             />
           </div>
 

--- a/app/components/earn/VaultCard.tsx
+++ b/app/components/earn/VaultCard.tsx
@@ -72,7 +72,7 @@ export function VaultCard({ vault }: VaultCardProps) {
             <span className="text-[11px] text-[var(--text-secondary)]">
               Fee: {(vault.tradingFeeBps / 100).toFixed(2)}%
             </span>
-            <span className="text-[11px] font-medium text-[var(--accent)] opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+            <span className="text-[11px] font-medium text-[var(--accent)] opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-visible:opacity-100 transition-opacity duration-200">
               Deposit →
             </span>
           </div>

--- a/app/components/earn/VaultCardSkeleton.tsx
+++ b/app/components/earn/VaultCardSkeleton.tsx
@@ -1,0 +1,37 @@
+import { ShimmerSkeleton } from '@/components/ui/ShimmerSkeleton';
+
+/** Loading placeholder matching VaultCard's layout — shared so the route-level
+ * loading.tsx, the VaultGrid's dynamic-import fallback, and VaultGrid's own
+ * initial/pagination loading states render the identical skeleton. */
+export function VaultCardSkeleton() {
+  return (
+    <div className="border border-[var(--border)] bg-[var(--panel-bg)] p-5 space-y-4 rounded-sm">
+      <div className="flex justify-between items-center">
+        <div className="flex items-center gap-3">
+          <ShimmerSkeleton className="w-8 h-8 rounded-full" />
+          <div>
+            <ShimmerSkeleton className="h-4 w-20 mb-1" />
+            <ShimmerSkeleton className="h-3 w-16" />
+          </div>
+        </div>
+        <div className="text-right space-y-1">
+          <ShimmerSkeleton className="h-2.5 w-12" />
+          <ShimmerSkeleton className="h-5 w-16" />
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        {[1, 2, 3, 4].map((j) => (
+          <div key={j} className="space-y-1">
+            <ShimmerSkeleton className="h-2 w-10" />
+            <ShimmerSkeleton className="h-4.5 w-16" />
+          </div>
+        ))}
+      </div>
+      <ShimmerSkeleton className="h-2 w-full mt-2" />
+      <div className="flex justify-between items-center pt-2 border-t border-[var(--border)]/30">
+        <ShimmerSkeleton className="h-3.5 w-16" />
+        <ShimmerSkeleton className="h-3.5 w-12" />
+      </div>
+    </div>
+  );
+}

--- a/app/components/earn/VaultGrid.tsx
+++ b/app/components/earn/VaultGrid.tsx
@@ -12,9 +12,11 @@ const PAGE_SIZE = 24;
 interface VaultGridProps {
   markets: MarketVaultInfo[];
   loading: boolean;
+  /** Set when the last fetch failed — distinguishes "genuinely no vaults" from "couldn't load". */
+  error?: string | null;
 }
 
-export function VaultGrid({ markets, loading }: VaultGridProps) {
+export function VaultGrid({ markets, loading, error }: VaultGridProps) {
   const [sortBy, setSortBy] = useState<SortKey>('tvl');
   const [searchQuery, setSearchQuery] = useState('');
   const [displayCount, setDisplayCount] = useState(PAGE_SIZE);
@@ -172,11 +174,13 @@ export function VaultGrid({ markets, loading }: VaultGridProps) {
         </div>
       ) : sorted.length === 0 ? (
         <div className="border border-[var(--border)] bg-[var(--panel-bg)] rounded-sm p-12 text-center">
-          <div className="text-3xl mb-3">🔍</div>
+          <div aria-hidden="true" className="text-3xl mb-3">{error && !searchQuery ? '⚠' : '🔍'}</div>
           <p className="text-[13px] text-[var(--text-secondary)]">
             {searchQuery
               ? `No vaults matching "${searchQuery}"`
-              : 'No active vaults found'}
+              : error
+                ? "Couldn't load vaults — please try again shortly"
+                : 'No active vaults found'}
           </p>
         </div>
       ) : (

--- a/app/components/earn/VaultGrid.tsx
+++ b/app/components/earn/VaultGrid.tsx
@@ -2,8 +2,8 @@
 
 import { useState, useMemo, useEffect, useRef } from 'react';
 import { VaultCard } from './VaultCard';
+import { VaultCardSkeleton } from './VaultCardSkeleton';
 import type { MarketVaultInfo } from '@/hooks/useEarnStats';
-import { ShimmerSkeleton } from '@/components/ui/ShimmerSkeleton';
 
 type SortKey = 'tvl' | 'volume' | 'utilization';
 
@@ -55,16 +55,8 @@ export function VaultGrid({ markets, loading, error }: VaultGridProps) {
     setDisplayCount(PAGE_SIZE);
   }, [searchQuery, sortBy]);
 
-  // Progressive auto-reveal (loads batches via rAF)
-  useEffect(() => {
-    if (loading || displayCount >= sorted.length) return;
-    const handle = requestAnimationFrame(() => {
-      setDisplayCount((prev) => Math.min(prev + PAGE_SIZE, sorted.length));
-    });
-    return () => cancelAnimationFrame(handle);
-  }, [displayCount, sorted.length, loading]);
-
-  // IntersectionObserver backup for scroll-triggered loading
+  // Scroll-triggered progressive loading — reveals the next page once the
+  // sentinel div at the bottom of the grid enters the viewport.
   useEffect(() => {
     const target = observerTarget.current;
     if (!target) return;
@@ -142,34 +134,7 @@ export function VaultGrid({ markets, loading, error }: VaultGridProps) {
       {loading ? (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {[1, 2, 3, 4, 5, 6].map((i) => (
-            <div key={i} className="border border-[var(--border)] bg-[var(--panel-bg)] p-5 space-y-4 rounded-sm">
-              <div className="flex justify-between items-center">
-                <div className="flex items-center gap-3">
-                  <ShimmerSkeleton className="w-8 h-8 rounded-full" />
-                  <div>
-                    <ShimmerSkeleton className="h-4 w-20 mb-1" />
-                    <ShimmerSkeleton className="h-3 w-16" />
-                  </div>
-                </div>
-                <div className="text-right space-y-1">
-                  <ShimmerSkeleton className="h-2.5 w-12" />
-                  <ShimmerSkeleton className="h-5 w-16" />
-                </div>
-              </div>
-              <div className="grid grid-cols-2 gap-3">
-                {[1, 2, 3, 4].map(j => (
-                  <div key={j} className="space-y-1">
-                    <ShimmerSkeleton className="h-2 w-10" />
-                    <ShimmerSkeleton className="h-4.5 w-16" />
-                  </div>
-                ))}
-              </div>
-              <ShimmerSkeleton className="h-2 w-full mt-2" />
-              <div className="flex justify-between items-center pt-2 border-t border-[var(--border)]/30">
-                <ShimmerSkeleton className="h-3.5 w-16" />
-                <ShimmerSkeleton className="h-3.5 w-12" />
-              </div>
-            </div>
+            <VaultCardSkeleton key={i} />
           ))}
         </div>
       ) : sorted.length === 0 ? (
@@ -194,34 +159,7 @@ export function VaultGrid({ markets, loading, error }: VaultGridProps) {
             <div>
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
                 {[1, 2, 3].map((i) => (
-                  <div key={i} className="border border-[var(--border)] bg-[var(--panel-bg)] p-5 space-y-4 rounded-sm">
-                    <div className="flex justify-between items-center">
-                      <div className="flex items-center gap-3">
-                        <ShimmerSkeleton className="w-8 h-8 rounded-full" />
-                        <div>
-                          <ShimmerSkeleton className="h-4 w-20 mb-1" />
-                          <ShimmerSkeleton className="h-3 w-16" />
-                        </div>
-                      </div>
-                      <div className="text-right space-y-1">
-                        <ShimmerSkeleton className="h-2.5 w-12" />
-                        <ShimmerSkeleton className="h-5 w-16" />
-                      </div>
-                    </div>
-                    <div className="grid grid-cols-2 gap-3">
-                      {[1, 2, 3, 4].map(j => (
-                        <div key={j} className="space-y-1">
-                          <ShimmerSkeleton className="h-2 w-10" />
-                          <ShimmerSkeleton className="h-4.5 w-16" />
-                        </div>
-                      ))}
-                    </div>
-                    <ShimmerSkeleton className="h-2 w-full mt-2" />
-                    <div className="flex justify-between items-center pt-2 border-t border-[var(--border)]/30">
-                      <ShimmerSkeleton className="h-3.5 w-16" />
-                      <ShimmerSkeleton className="h-3.5 w-12" />
-                    </div>
-                  </div>
+                  <VaultCardSkeleton key={i} />
                 ))}
               </div>
               <div ref={observerTarget} className="h-2 w-full" />

--- a/app/components/earn/VaultGrid.tsx
+++ b/app/components/earn/VaultGrid.tsx
@@ -86,12 +86,14 @@ export function VaultGrid({ markets, loading }: VaultGridProps) {
         <div className="relative w-full sm:w-64">
           <input
             type="text"
+            aria-label="Search markets"
             placeholder="Search markets..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             className="w-full h-9 px-3 pl-8 text-[13px] bg-[var(--panel-bg)] border border-[var(--border)] rounded-sm text-[var(--text)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)]/30 transition-colors"
           />
           <svg
+            aria-hidden="true"
             className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-[var(--text-muted)]"
             fill="none"
             viewBox="0 0 24 24"
@@ -121,6 +123,7 @@ export function VaultGrid({ markets, loading }: VaultGridProps) {
             <button
               key={key}
               onClick={() => setSortBy(key)}
+              aria-pressed={sortBy === key}
               className={`px-3 py-1.5 text-[11px] rounded-sm border transition-all duration-150 ${
                 sortBy === key
                   ? 'border-[var(--accent)]/40 bg-[var(--accent)]/[0.06] text-[var(--accent)]'
@@ -226,7 +229,7 @@ export function VaultGrid({ markets, loading }: VaultGridProps) {
               </span>
               <button
                 onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-                className="text-[11px] text-[var(--accent)]/60 hover:text-[var(--accent)] transition-colors"
+                className="text-[12px] text-[var(--accent)] hover:text-[var(--accent)]/80 transition-colors"
               >
                 ↑ top
               </button>

--- a/app/hooks/useEarnStats.ts
+++ b/app/hooks/useEarnStats.ts
@@ -548,7 +548,7 @@ export function useEarnStats() {
       // Total failure (e.g. RPC unreachable) — still show the 5 curated markets
       // with zeroed stats rather than fabricated mock ones. Recompute the
       // aggregates from the zeroed markets too — otherwise the header keeps
-      // showing a stale non-zero TVL/APY while every card reads $0, which
+      // showing a stale non-zero TVL while every card reads $0, which
       // reads as two contradictory sources of truth.
       const markets = buildCuratedMarkets({}, new Map());
       const tvl = markets.reduce((s, m) => s + m.vaultBalance / (10 ** m.decimals), 0);
@@ -562,15 +562,10 @@ export function useEarnStats() {
         (s, m) => s + (m.volume24h * m.tradingFeeBps) / 10_000,
         0,
       );
-      const avgApy =
-        markets.length > 0
-          ? markets.reduce((s, m) => s + m.estimatedApyPct, 0) / markets.length
-          : 0;
       setStats({
         tvl,
         totalOI,
         maxOI,
-        avgApyPct: avgApy,
         oiUtilPct: maxOI > 0 ? (totalOI / maxOI) * 100 : 0,
         totalInsurance,
         markets,

--- a/app/hooks/useEarnStats.ts
+++ b/app/hooks/useEarnStats.ts
@@ -174,9 +174,12 @@ function generateMockStats(): EarnStats {
 // ═══════════════════════════════════════════════════════════════
 
 /** Sim-USDC collateral decimals — the single collateral token shared by every playground market. */
-const CURATED_COLLATERAL_DECIMALS = 6;
+export const CURATED_COLLATERAL_DECIMALS = 6;
 
-interface CuratedVaultOnChain {
+/** GH#1165 — sanity cap on any single vault's displayed TVL (USD). */
+export const MAX_VAULT_USD = 10_000_000;
+
+export interface CuratedVaultOnChain {
   /** Total atoms backing the LP vault (shares outstanding + distributed fee atoms). */
   tvlAtoms: bigint;
   /** Redemption cooldown period from the registry, in slots. */
@@ -336,7 +339,7 @@ async function fetchOnChainMaxLeverage(slabs: string[]): Promise<Record<string, 
  * Supabase cosmetic row. Shared by both the curated (PLAYGROUND_SLAB_META) markets
  * and the registered (user-launched) markets below.
  */
-function buildMarketVaultInfo(
+export function buildMarketVaultInfo(
   slab: string,
   symbol: string,
   name: string,
@@ -351,7 +354,12 @@ function buildMarketVaultInfo(
   const collDivisor = 10 ** decimals;
 
   const vaultAtoms = curatedVaults[slab]?.tvlAtoms ?? 0n;
-  const vaultBalance = Number(vaultAtoms); // atoms — matches MarketVaultInfo.vaultBalance convention
+  const vaultBalanceRaw = Number(vaultAtoms); // atoms — matches MarketVaultInfo.vaultBalance convention
+  // GH#1165: a corrupt-but-sub-sentinel atom count (e.g. 4e14 at 6 decimals =
+  // $400M) passes sanitizeOnChainValue's u64::MAX-class filter untouched. Cap
+  // any single vault's displayed TVL at a sane ceiling rather than trust it blind.
+  const vaultUsdUncapped = vaultBalanceRaw / collDivisor;
+  const vaultBalance = vaultUsdUncapped > MAX_VAULT_USD ? 0 : vaultBalanceRaw;
   const vaultUsd = vaultBalance / collDivisor;
 
   const oiLongRaw = Number(row?.open_interest_long ?? 0);
@@ -538,11 +546,36 @@ export function useEarnStats() {
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load earn stats');
       // Total failure (e.g. RPC unreachable) — still show the 5 curated markets
-      // with zeroed stats rather than fabricated mock ones.
-      setStats((prev) => ({
-        ...prev,
-        markets: buildCuratedMarkets({}, new Map()),
-      }));
+      // with zeroed stats rather than fabricated mock ones. Recompute the
+      // aggregates from the zeroed markets too — otherwise the header keeps
+      // showing a stale non-zero TVL/APY while every card reads $0, which
+      // reads as two contradictory sources of truth.
+      const markets = buildCuratedMarkets({}, new Map());
+      const tvl = markets.reduce((s, m) => s + m.vaultBalance / (10 ** m.decimals), 0);
+      const totalOI = markets.reduce((s, m) => s + m.totalOI, 0);
+      const maxOI = markets.reduce((s, m) => s + m.maxOI, 0);
+      const totalInsurance = markets.reduce(
+        (s, m) => s + m.insuranceFund / (10 ** m.decimals),
+        0,
+      );
+      const dailyFeeRevenue = markets.reduce(
+        (s, m) => s + (m.volume24h * m.tradingFeeBps) / 10_000,
+        0,
+      );
+      const avgApy =
+        markets.length > 0
+          ? markets.reduce((s, m) => s + m.estimatedApyPct, 0) / markets.length
+          : 0;
+      setStats({
+        tvl,
+        totalOI,
+        maxOI,
+        avgApyPct: avgApy,
+        oiUtilPct: maxOI > 0 ? (totalOI / maxOI) * 100 : 0,
+        totalInsurance,
+        markets,
+        dailyFeeRevenue,
+      });
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary

Audit and fix pass on the Earn page (`/earn` and `/earn/[slab]`) covering rendering bugs, data-layer correctness, accessibility, and misleading copy.

- **Rendering bugs:** stopped `InsuranceFundDisplay` from sorting the shared `stats.markets` array in place (was silently reordering it for other consumers); fixed invalid CSS in `OiCapMeter`'s zone tints (`var(--short)33` isn't valid CSS — string-concatenating opacity onto a CSS var); the OI meter no longer reports a false "Healthy 0%" when the OI cap is genuinely unknown.
- **Data integrity:** restored the sanity cap on displayed vault TVL (a corrupt-but-plausible on-chain value could previously render as an inflated multi-hundred-million-dollar TVL with no guard); fixed the error-state where stats went stale on the header while cards zeroed out underneath it; wired up a stats refresh after deposit/withdraw so the OI meter, APY, and insurance figures don't sit stale for 15 seconds; corrected LP-token vs. collateral decimal handling; rewrote the TVL sentinel test to actually exercise the real code path instead of a disconnected copy that had drifted from it.
- **Misleading UX:** the withdraw flow's cooldown copy and button label previously implied an immediate withdrawal when the action was actually just requesting a redemption (starting a cooldown, no funds moving) — copy now matches the real on-chain behavior at each step. Added a genuine "market not found" state, and a couldn't-load state distinct from a genuinely-empty vault list.
- **Accessibility:** proper `progressbar` semantics and live regions on the OI meter and transaction feedback, labeled form controls, keyboard/touch-reachable controls that were previously hover-only.
- **Cleanup:** removed a redundant fake progressive-reveal loop in the vault grid, deduplicated repeated skeleton markup, and dropped client-side title overrides that were clobbering the richer server-rendered metadata.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `pnpm test` — all earn-scoped tests pass (including the rewritten TVL sentinel test); full suite shows the same pre-existing failures as the unmodified baseline, confirmed via direct comparison — no regressions
- [x] `next dev` smoke test — `/earn`, a real market detail page, and an unknown-slab page all return 200 with no server errors; server-rendered page titles now reflect real per-page/per-market metadata
- [ ] Manual wallet-connected walkthrough of deposit → request withdrawal → claim (not exercised — no devnet wallet available in this environment)