### PR TITLE
fix(trade): require verified fresh position state before closing

### DIFF
--- a/app/__tests__/hooks/useClosePosition.fresh-state.test.ts
+++ b/app/__tests__/hooks/useClosePosition.fresh-state.test.ts
@@ -1,0 +1,223 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PublicKey } from "@solana/web3.js";
+
+const mocks = vi.hoisted(() => ({
+  trade: vi.fn(),
+  fetchSlab: vi.fn(),
+  parseAccount: vi.fn(),
+  isV17Account: vi.fn(),
+  parsePortfolioV17: vi.fn(),
+  getProgramAccounts: vi.fn(),
+  getLivePriceSnapshot: vi.fn(),
+}));
+
+vi.mock("@/hooks/useWalletCompat", () => ({
+  useConnectionCompat: vi.fn(),
+  useWalletCompat: vi.fn(),
+}));
+
+vi.mock("@/hooks/useTrade", () => ({
+  useTrade: vi.fn(),
+}));
+
+vi.mock("@/hooks/useUserAccount", () => ({
+  useUserAccount: vi.fn(),
+}));
+
+vi.mock("@/components/providers/SlabProvider", () => ({
+  useSlabState: vi.fn(),
+}));
+
+vi.mock("@/lib/priceStore/priceStore", () => ({
+  getLivePriceSnapshot: mocks.getLivePriceSnapshot,
+}));
+
+vi.mock("@/lib/mock-mode", () => ({
+  isMockMode: () => false,
+}));
+
+vi.mock("@/lib/mock-trade-data", () => ({
+  isMockSlab: () => false,
+}));
+
+vi.mock("@/lib/errorMessages", () => ({
+  humanizeError: (message: string) => message,
+  withTransientRetry: async (
+    operation: () => Promise<unknown>,
+  ) => operation(),
+}));
+
+vi.mock("@percolatorct/sdk", () => ({
+  AccountKind: {
+    LP: "LP",
+  },
+  isV17Account: mocks.isV17Account,
+  parsePortfolioV17: mocks.parsePortfolioV17,
+  fetchSlab: mocks.fetchSlab,
+  parseAccount: mocks.parseAccount,
+}));
+
+import {
+  useConnectionCompat,
+  useWalletCompat,
+} from "@/hooks/useWalletCompat";
+import { useTrade } from "@/hooks/useTrade";
+import { useUserAccount } from "@/hooks/useUserAccount";
+import { useSlabState } from "@/components/providers/SlabProvider";
+import { useClosePosition } from "@/hooks/useClosePosition";
+
+describe("useClosePosition fresh-state verification", () => {
+  const slabAddress =
+    "11111111111111111111111111111111";
+
+  const walletPublicKey = new PublicKey(
+    "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+  );
+
+  const programId = new PublicKey(
+    "5BZWY6XWPxuWFxs2nPCLLsVaKRWZVnzZh3FkJDLJBkJf",
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.trade.mockResolvedValue("mock-signature");
+    mocks.isV17Account.mockReturnValue(false);
+    mocks.getLivePriceSnapshot.mockReturnValue({
+      priceE6: 100_000_000n,
+    });
+
+    vi.mocked(useConnectionCompat).mockReturnValue({
+      connection: {
+        getProgramAccounts: mocks.getProgramAccounts,
+      },
+    } as ReturnType<typeof useConnectionCompat>);
+
+    vi.mocked(useWalletCompat).mockReturnValue({
+      publicKey: walletPublicKey,
+      connected: true,
+    } as ReturnType<typeof useWalletCompat>);
+
+    vi.mocked(useTrade).mockReturnValue({
+      trade: mocks.trade,
+    } as unknown as ReturnType<typeof useTrade>);
+
+    // Cached UI state reports a long position of +10.
+    vi.mocked(useUserAccount).mockReturnValue({
+      idx: 7,
+      account: {
+        positionSize: 10n,
+      },
+    } as ReturnType<typeof useUserAccount>);
+
+    vi.mocked(useSlabState).mockReturnValue({
+      accounts: [
+        {
+          idx: 3,
+          account: {
+            kind: "LP",
+          },
+        },
+      ],
+      raw: Buffer.from([1]),
+      programId,
+    } as unknown as ReturnType<typeof useSlabState>);
+  });
+
+  it("control: uses the fresh v12 position when verification succeeds", async () => {
+    mocks.fetchSlab.mockResolvedValue(Buffer.alloc(1));
+    mocks.parseAccount.mockReturnValue({
+      positionSize: 2n,
+    });
+
+    const { result } = renderHook(() =>
+      useClosePosition(slabAddress),
+    );
+
+    await act(async () => {
+      await result.current.closePosition(100);
+    });
+
+    expect(mocks.trade).toHaveBeenCalledWith({
+      lpIdx: 3,
+      userIdx: 7,
+      size: -2n,
+    });
+  });
+
+  it("control: uses the fresh v17 position when verification succeeds", async () => {
+    mocks.isV17Account.mockReturnValue(true);
+    mocks.getProgramAccounts.mockResolvedValue([
+      {
+        account: {
+          data: Buffer.alloc(1),
+        },
+      },
+    ]);
+
+    mocks.parsePortfolioV17.mockReturnValue({
+      owner: walletPublicKey,
+      legs: [
+        {
+          active: true,
+          basisPosQ: 2n,
+        },
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useClosePosition(slabAddress),
+    );
+
+    await act(async () => {
+      await result.current.closePosition(100);
+    });
+
+    expect(mocks.getProgramAccounts).toHaveBeenCalled();
+    expect(mocks.trade).toHaveBeenCalledWith({
+      lpIdx: 3,
+      userIdx: 7,
+      size: -2n,
+    });
+  });
+
+  it("blocks close when the v12 fresh-position read fails", async () => {
+    mocks.fetchSlab.mockRejectedValue(
+      new Error("RPC fresh-state read failed"),
+    );
+
+    const { result } = renderHook(() =>
+      useClosePosition(slabAddress),
+    );
+
+    await act(async () => {
+      await expect(
+        result.current.closePosition(100),
+      ).rejects.toThrow(/verify current on-chain position/i);
+    });
+
+    expect(mocks.trade).not.toHaveBeenCalled();
+  });
+
+  it("blocks close when the v17 fresh-position read fails", async () => {
+    mocks.isV17Account.mockReturnValue(true);
+    mocks.getProgramAccounts.mockRejectedValue(
+      new Error("RPC getProgramAccounts failed"),
+    );
+
+    const { result } = renderHook(() =>
+      useClosePosition(slabAddress),
+    );
+
+    await act(async () => {
+      await expect(
+        result.current.closePosition(100),
+      ).rejects.toThrow(/verify current on-chain position/i);
+    });
+
+    expect(mocks.getProgramAccounts).toHaveBeenCalled();
+    expect(mocks.trade).not.toHaveBeenCalled();
+  });
+
+});

--- a/app/hooks/useClosePosition.ts
+++ b/app/hooks/useClosePosition.ts
@@ -84,52 +84,113 @@ export function useClosePosition(slabAddress: string): UseClosePositionReturn {
           return { signature: null };
         }
 
-        // Fetch fresh on-chain position size to avoid stale state.
-        let freshPositionSize = userAccount.account.positionSize;
+        // Fetch the authoritative on-chain position size before closing.
+    // Never fall back to cached UI state: an outdated size can over-close
+    // the actual position and unintentionally open exposure in the
+    // opposite direction.
+    let freshPositionSize: bigint | null = null;
 
-        if (isV17Market) {
-          // v17: re-fetch via getProgramAccounts + parsePortfolioV17.
-          // parseAccount(bitmap, idx) is a v12-only function and throws on v17 data.
-          try {
-            if (programId && publicKey) {
-              const slabPk = new PublicKey(slabAddress);
-              const results = await connection.getProgramAccounts(programId, {
-                filters: [
-                  { memcmp: { offset: 0, bytes: V17_PORTFOLIO_MAGIC_CP.toString("base64"), encoding: "base64" } },
-                  { memcmp: { offset: V17_PF_MARKET_OFF_CP, bytes: slabPk.toBase58() } },
-                  { memcmp: { offset: V17_PF_OWNER_OFF_CP, bytes: publicKey.toBase58() } },
-                ],
-              });
-              if (results.length > 0) {
-                const data = results[0].account.data;
-                const portfolio = parsePortfolioV17(
-                  data instanceof Buffer ? data : Buffer.from(data),
-                );
-                // Defense-in-depth: re-verify the mutable owner actually matches
-                // after fetch — memcmp filters are advisory server-side; don't
-                // trust them blindly. Otherwise fall through and use cached state.
-                if (portfolio.owner.equals(publicKey)) {
-                  const activeLeg = portfolio.legs.find((l) => l.active);
-                  freshPositionSize = activeLeg ? activeLeg.basisPosQ : 0n;
-                }
-              }
-            }
-          } catch {
-            console.warn("[useClosePosition] v17 fresh portfolio fetch failed — using cached state");
-          }
-        } else {
-          // v12: re-fetch via fetchSlab + parseAccount (bitmap-based).
-          try {
-            const { fetchSlab, parseAccount } = await import("@percolatorct/sdk");
-            const freshData = await fetchSlab(connection, new PublicKey(slabAddress));
-            const freshAccount = parseAccount(freshData, userAccount.idx);
-            freshPositionSize = freshAccount.positionSize;
-          } catch {
-            console.warn("[useClosePosition] Could not fetch fresh position — using cached state");
-          }
+    if (isV17Market) {
+      // v17: re-fetch via getProgramAccounts + parsePortfolioV17.
+      // parseAccount(bitmap, idx) is a v12-only function and throws on v17 data.
+      try {
+        if (!programId || !publicKey) {
+          throw new Error(
+            "Wallet or market program is unavailable for position verification.",
+          );
         }
 
-        if (freshPositionSize === 0n) {
+        const slabPk = new PublicKey(slabAddress);
+        const results = await connection.getProgramAccounts(programId, {
+          filters: [
+            {
+              memcmp: {
+                offset: 0,
+                bytes: V17_PORTFOLIO_MAGIC_CP.toString("base64"),
+                encoding: "base64",
+              },
+            },
+            {
+              memcmp: {
+                offset: V17_PF_MARKET_OFF_CP,
+                bytes: slabPk.toBase58(),
+              },
+            },
+            {
+              memcmp: {
+                offset: V17_PF_OWNER_OFF_CP,
+                bytes: publicKey.toBase58(),
+              },
+            },
+          ],
+        });
+
+        if (results.length === 0) {
+          // The query completed successfully and found no current
+          // portfolio for this wallet and market.
+          freshPositionSize = 0n;
+        } else {
+          const data = results[0].account.data;
+          const portfolio = parsePortfolioV17(
+            data instanceof Buffer ? data : Buffer.from(data),
+          );
+
+          // Re-check the mutable owner after the RPC-side memcmp filter.
+          if (!portfolio.owner.equals(publicKey)) {
+            throw new Error(
+              "Fresh portfolio owner does not match the connected wallet.",
+            );
+          }
+
+          const activeLeg = portfolio.legs.find((leg) => leg.active);
+          freshPositionSize = activeLeg ? activeLeg.basisPosQ : 0n;
+        }
+      } catch (cause) {
+        console.warn(
+          "[useClosePosition] v17 fresh portfolio verification failed",
+          cause,
+        );
+
+        throw new Error(
+          "Could not verify current on-chain position. Please try again.",
+        );
+      }
+    } else {
+      // v12: re-fetch via fetchSlab + parseAccount (bitmap-based).
+      try {
+        const { fetchSlab, parseAccount } =
+          await import("@percolatorct/sdk");
+
+        const freshData = await fetchSlab(
+          connection,
+          new PublicKey(slabAddress),
+        );
+
+        const freshAccount = parseAccount(
+          freshData,
+          userAccount.idx,
+        );
+
+        freshPositionSize = freshAccount.positionSize;
+      } catch (cause) {
+        console.warn(
+          "[useClosePosition] v12 fresh position verification failed",
+          cause,
+        );
+
+        throw new Error(
+          "Could not verify current on-chain position. Please try again.",
+        );
+      }
+    }
+
+    if (freshPositionSize === null) {
+      throw new Error(
+        "Could not verify current on-chain position. Please try again.",
+      );
+    }
+
+    if (freshPositionSize === 0n) {
           setPhase("idle");
           inflightRef.current = false;
           setLoading(false);


### PR DESCRIPTION
## Summary

Prevents the close-position flow from submitting a trade using stale cached position data when the latest on-chain position cannot be verified.

Previously, `useClosePosition` initialized the close size from cached UI state. When the v12 or v17 fresh-position request failed, the hook logged a warning and continued using the cached position size.

This could cause a **Close Position** action to over-close the actual position and unintentionally open exposure in the opposite direction.

Fixes #2364

## Problem

The previous flow used cached state as the initial authoritative value:

```ts
let freshPositionSize = userAccount.account.positionSize;
```

The hook then attempted to refresh the position from the blockchain.

However, both supported account paths allowed execution to continue after a failed refresh:

- v12: `fetchSlab()` or `parseAccount()` failure
- v17: `getProgramAccounts()` or `parsePortfolioV17()` failure

Because `freshPositionSize` still contained the cached value, the hook could calculate and submit a close amount that no longer matched the current on-chain position.

Example:

```text
Cached UI position:       Long +10
Actual on-chain position: Long +2
Requested close:          100%
Fresh position read:      Failed
Submitted trade size:     -10
Resulting position:       Short -8
```

The user intended to close the existing position, but the submitted trade could cross zero and create a new opposite-side position.

## Root Cause

The close flow treated cached React state as a fallback source for transaction construction.

Fresh position verification was attempted, but verification failure was not considered fatal:

```text
Fresh read fails
→ warning is logged
→ cached size remains available
→ close size is calculated
→ trade() is submitted
```

Cached state is appropriate for display, but it must not be considered authoritative when building a close-position transaction.

## Changes

### Fail closed when fresh verification fails

The authoritative position value now starts as unavailable:

```ts
let freshPositionSize: bigint | null = null;
```

The value is populated only after a successful on-chain position read.

When verification fails, the hook now throws:

```text
Could not verify current on-chain position. Please try again.
```

This prevents execution from reaching `trade()` with an unverified position size.

### v12 position verification

The v12 flow now requires both operations to succeed:

```text
fetchSlab()
→ parseAccount()
→ read fresh positionSize
```

Any fetch or parsing failure stops close submission.

### v17 position verification

The v17 flow now requires:

```text
getProgramAccounts()
→ parsePortfolioV17()
→ verify portfolio owner
→ read active leg position
```

The returned portfolio owner is revalidated against the connected wallet before its position data is trusted.

A successful query with no matching portfolio is treated as a confirmed zero position, not as a verification failure.

### Transaction safety invariant

The close transaction is submitted only when the current on-chain position has been successfully verified.

```text
Fresh verification succeeds
→ calculate close size from fresh state
→ submit trade

Fresh verification fails
→ reject close request
→ do not call trade()
```

## Tests

Added:

```text
app/__tests__/hooks/useClosePosition.fresh-state.test.ts
```

The regression suite covers both v12 and v17 account paths:

```text
✓ uses the fresh v12 position when verification succeeds
✓ uses the fresh v17 position when verification succeeds
✓ blocks close when the v12 fresh-position read fails
✓ blocks close when the v17 fresh-position read fails
```

The success-path tests use:

```text
Cached UI position: +10
Fresh position:     +2
Close request:      100%
Expected trade:     -2
```

This verifies that the close amount is calculated from current on-chain state rather than the cached UI value.

The failure-path tests verify that:

```ts
expect(mocks.trade).not.toHaveBeenCalled();
```

## Validation

Focused regression test:

```bash
pnpm exec vitest run \
  __tests__/hooks/useClosePosition.fresh-state.test.ts
```

Result:

```text
Test Files  1 passed
Tests       4 passed
```

TypeScript validation:

```bash
pnpm exec tsc --noEmit --pretty false
```

Result:

```text
Passed with no TypeScript errors
```

Patch validation:

```bash
git diff --check
```

Result:

```text
No whitespace errors
```

## Impact

This change prevents a close-position request from:

- using stale cached position size;
- submitting an oversized close transaction;
- crossing the position through zero;
- unintentionally opening an opposite-side position;
- increasing unexpected margin and liquidation exposure.

## Scope

Changed files:

```text
app/hooks/useClosePosition.ts
app/__tests__/hooks/useClosePosition.fresh-state.test.ts
```

This PR does not modify:

- on-chain programs;
- instruction encoding;
- trade execution semantics;
- oracle validation;
- slippage calculation;
- deposit or withdrawal flows.

## Risk

Low.

The behavioral change is intentionally fail-closed:

```text
Before:
Fresh verification failure
→ submit close using cached state

After:
Fresh verification failure
→ block close and request retry
```

Users may need to retry during a temporary RPC failure, but an unverified close amount will no longer be submitted.