### PR TITLE
trade terminal: bug fixes, accessibility, and visual consistency

### DIFF
--- a/app/app/trade/[slab]/loading.tsx
+++ b/app/app/trade/[slab]/loading.tsx
@@ -41,55 +41,77 @@ export default function TradingPageLoading() {
         </div>
       </div>
 
-      {/* Mobile layout skeleton */}
+      {/* Mobile layout skeleton — mirrors the real mobile stack: chart,
+          positions dock (2 tabs: Positions / Trades), bottom order-sheet
+          trigger. The order ticket itself is a tap-to-open bottom sheet, so
+          it isn't shown inline here. */}
       <div className="flex flex-col gap-1.5 px-2 pt-2 pb-4 lg:hidden">
         {/* Chart */}
-        <ShimmerSkeleton className="h-[400px] w-full" />
-        {/* Trade form */}
-        <ShimmerSkeleton className="h-[300px] w-full" />
-        {/* Position */}
-        <ShimmerSkeleton className="h-[200px] w-full" />
-        {/* Tabs */}
-        <div className="border border-[var(--border)]">
+        <ShimmerSkeleton className="h-[360px] w-full" />
+        {/* Positions dock — 2 tabs */}
+        <div className="h-[45vh] min-h-[280px] border border-[var(--border)]">
           <div className="flex border-b border-[var(--border)]/50">
-            {[1, 2, 3, 4].map((i) => (
-              <ShimmerSkeleton key={i} className="h-8 flex-1 rounded-none" />
+            {[1, 2].map((i) => (
+              <ShimmerSkeleton key={i} className="h-8 w-24 rounded-none" />
             ))}
           </div>
-          <ShimmerSkeleton className="h-[250px] w-full rounded-none" />
+          <ShimmerSkeleton className="h-[calc(100%-2rem)] w-full rounded-none" />
         </div>
+        {/* Bottom order-ticket trigger bar */}
+        <ShimmerSkeleton className="h-10 w-full" />
       </div>
 
-      {/* Desktop layout skeleton */}
-      <div className="hidden lg:grid grid-cols-[1fr_340px] gap-1.5 px-3 pb-3 pt-1.5">
-        {/* Left column */}
-        <div className="min-w-0 space-y-1.5">
-          {/* Chart */}
-          <ShimmerSkeleton className="h-[500px] w-full" />
-          {/* Tabs */}
-          <div className="border border-[var(--border)]">
-            <div className="flex border-b border-[var(--border)]/50">
-              {[1, 2, 3].map((i) => (
-                <ShimmerSkeleton key={i} className="h-10 flex-1 rounded-none" />
-              ))}
-            </div>
-            <ShimmerSkeleton className="h-[200px] w-full rounded-none" />
-          </div>
+      {/* Desktop layout skeleton — mirrors the named grid in page.tsx: chart
+          (left, dominant), order-ticket rail (right, 340px, spans both rows),
+          positions dock (bottom-left, 2 tabs). */}
+      <div
+        className="hidden lg:grid gap-3 px-4 lg:px-6 pb-3 pt-2"
+        style={{
+          gridTemplateAreas: '"Chart OrderTicket" "PositionsDock OrderTicket"',
+          gridTemplateColumns: "minmax(0,1fr) 340px",
+          gridTemplateRows: "minmax(0,1fr) minmax(220px,340px)",
+        }}
+      >
+        {/* Chart */}
+        <div style={{ gridArea: "Chart" }} className="min-w-0">
+          <ShimmerSkeleton className="h-[460px] w-full" />
         </div>
 
-        {/* Right column */}
-        <div className="min-w-0 space-y-1.5">
-          {/* Trade form */}
-          <ShimmerSkeleton className="h-[350px] w-full" />
-          {/* Info tabs */}
-          <div className="border border-[var(--border)]">
-            <div className="flex border-b border-[var(--border)]/50">
-              {[1, 2, 3, 4, 5].map((i) => (
-                <ShimmerSkeleton key={i} className="h-10 flex-1 rounded-none" />
-              ))}
-            </div>
-            <ShimmerSkeleton className="h-[300px] w-full rounded-none" />
+        {/* Order-ticket rail — single framed panel (order ticket + NFT panel) */}
+        <div style={{ gridArea: "OrderTicket" }} className="border border-[var(--border)] p-3.5 space-y-3">
+          {/* Long / Short segmented */}
+          <div className="flex gap-1">
+            <ShimmerSkeleton className="h-9 flex-1" />
+            <ShimmerSkeleton className="h-9 flex-1" />
           </div>
+          {/* Size input */}
+          <ShimmerSkeleton className="h-10 w-full" />
+          {/* Quick-fill chips */}
+          <div className="flex gap-1">
+            {[1, 2, 3, 4].map((i) => (
+              <ShimmerSkeleton key={i} className="h-6 flex-1" />
+            ))}
+          </div>
+          {/* Leverage slider */}
+          <ShimmerSkeleton className="h-8 w-full" />
+          {/* Receipt rows */}
+          <div className="space-y-2 pt-1">
+            {[1, 2, 3, 4].map((i) => (
+              <ShimmerSkeleton key={i} className="h-3.5 w-full" />
+            ))}
+          </div>
+          {/* Submit */}
+          <ShimmerSkeleton className="h-11 w-full" />
+        </div>
+
+        {/* Positions dock — 2 tabs (Positions / Trades) */}
+        <div style={{ gridArea: "PositionsDock" }} className="min-w-0 border border-[var(--border)]">
+          <div className="flex border-b border-[var(--border)]/50">
+            {[1, 2].map((i) => (
+              <ShimmerSkeleton key={i} className="h-9 w-28 rounded-none" />
+            ))}
+          </div>
+          <ShimmerSkeleton className="h-[200px] w-full rounded-none" />
         </div>
       </div>
     </div>

--- a/app/app/trade/[slab]/page.tsx
+++ b/app/app/trade/[slab]/page.tsx
@@ -13,7 +13,6 @@ import { MarketInfoBar } from "@/components/trade/MarketInfoBar";
 import { useIsLargeScreen } from "@/hooks/useIsLargeScreen";
 import { useAdvanceOraclePhase } from "@/hooks/useAdvanceOraclePhase";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
-import { formatUsdFromNumber } from "@/lib/format";
 import { useLivePrice } from "@/hooks/useLivePrice";
 import { useTokenMeta } from "@/hooks/useTokenMeta";
 import { useToast } from "@/hooks/useToast";
@@ -357,22 +356,20 @@ function TradePageInner({ slab }: { slab: string }) {
   })();
   const logoUrl = supabaseMarket?.logo_url ?? null;
 
-  // Dynamic page title and meta tags
+  // Dynamic tab title — the symbol is resolved client-side (Supabase → on-chain
+  // → truncated address), which is strictly more available than the server's
+  // generateMetadata() `fetchMarketMeta`: on a devnet market the indexer doesn't
+  // know, the server title falls back to the generic "Perpetual Futures Market"
+  // while this still shows the real ticker. Only document.title is touched here.
+  //
+  // The og:*/meta[description] tags are intentionally NOT rewritten client-side:
+  // social crawlers (Twitter/Discord/Facebook) never execute JS, so mutating
+  // them after hydration is a no-op for their only purpose (link previews) —
+  // layout.tsx's server-rendered generateMetadata is the sole source of truth
+  // for those.
   useEffect(() => {
     document.title = `Trade ${symbol} | Percolator`;
-    const metaDesc = document.querySelector('meta[name="description"]');
-    if (metaDesc) {
-      const priceText = priceUsd != null ? `Current price: ${formatUsdFromNumber(priceUsd)}` : "";
-      metaDesc.setAttribute("content", `Trade ${symbol} perpetual futures on Percolator. ${priceText}`);
-    }
-    const ogTitle = document.querySelector('meta[property="og:title"]');
-    if (ogTitle) ogTitle.setAttribute("content", `Trade ${symbol} | Percolator`);
-    const ogDesc = document.querySelector('meta[property="og:description"]');
-    if (ogDesc) {
-      const priceText = priceUsd != null ? `Current price: ${formatUsdFromNumber(priceUsd)}` : "";
-      ogDesc.setAttribute("content", `Trade ${symbol} perpetual futures on Percolator. ${priceText}`);
-    }
-  }, [symbol, priceUsd]);
+  }, [symbol]);
 
   if (slabLoading && !engine) {
     return <TradingPageLoading />;

--- a/app/components/trade/ChartDrawingToolbar.tsx
+++ b/app/components/trade/ChartDrawingToolbar.tsx
@@ -234,7 +234,7 @@ export const ChartDrawingToolbar: FC<ChartDrawingToolbarProps> = ({
           // accent-foreground discipline as the active tools, but
           // semantically different (this is a destructive op, not a
           // selectable mode).
-          "text-[var(--text-secondary)] enabled:hover:bg-[var(--bg-surface)] enabled:hover:text-red-400",
+          "text-[var(--text-secondary)] enabled:hover:bg-[var(--bg-surface)] enabled:hover:text-[var(--short)]",
           // Disabled state: drop the cursor affordance and dim the
           // icon further. The button still focuses (we don't add
           // tabIndex=-1) so keyboard users can find it and learn

--- a/app/components/trade/ChartEmptyState.tsx
+++ b/app/components/trade/ChartEmptyState.tsx
@@ -60,7 +60,7 @@ export const ChartEmptyState: FC<ChartEmptyStateProps> = ({
               strokeWidth="1.5"
               strokeLinecap="round"
               strokeLinejoin="round"
-              className="mb-2 text-[#475569]"
+              className="mb-2 text-[var(--text-muted)]"
               aria-hidden="true"
             >
               {/* Candlestick chart icon */}
@@ -75,14 +75,14 @@ export const ChartEmptyState: FC<ChartEmptyStateProps> = ({
               <rect x="3" y="10" width="6" height="7" rx="1" />
             </svg>
             <div
-              className="text-[15px] font-semibold text-[#94a3b8]"
-              style={{ fontFamily: "'Space Grotesk', system-ui, sans-serif" }}
+              className="text-[15px] font-semibold text-[var(--text-secondary)]"
+              style={{ fontFamily: "var(--font-display)" }}
             >
               No chart data yet
             </div>
             <div
-              className="mt-1 text-xs text-[#475569]"
-              style={{ fontFamily: "'Space Grotesk', system-ui, sans-serif" }}
+              className="mt-1 text-xs text-[var(--text-muted)]"
+              style={{ fontFamily: "var(--font-display)" }}
             >
               Price history will appear once trading begins
             </div>

--- a/app/components/trade/ChartPnlBadge.tsx
+++ b/app/components/trade/ChartPnlBadge.tsx
@@ -80,7 +80,7 @@ export const ChartPnlBadge: FC<ChartPnlBadgeProps> = ({ slabAddress }) => {
 
   const { display, sign } = formatPnl(pnlUsd, roe);
   const colorClass =
-    sign === "positive" ? "text-green-400" : sign === "negative" ? "text-red-400" : "text-[var(--text-secondary)]";
+    sign === "positive" ? "text-[var(--long)]" : sign === "negative" ? "text-[var(--short)]" : "text-[var(--text-secondary)]";
 
   // Positioning is owned by DraggableChartBadges in TradingChart — this chip
   // stacks under PositionSummary and drags with it as one unit.

--- a/app/components/trade/ClosePositionModal.tsx
+++ b/app/components/trade/ClosePositionModal.tsx
@@ -332,8 +332,8 @@ export const ClosePositionModal: FC<ClosePositionModalProps> = ({
 
         {/* GH#1842: Oracle staleness warning — mirrors TradeForm oracle stale block */}
         {oracleStale && (
-          <div className="mb-4 rounded-none border border-amber-500/30 bg-amber-500/[0.07] p-2.5">
-            <p className="text-[9px] font-bold uppercase tracking-[0.15em] text-amber-400">
+          <div className="mb-4 rounded-none border border-[var(--warning)]/30 bg-[var(--warning)]/[0.07] p-2.5">
+            <p className="text-[9px] font-bold uppercase tracking-[0.15em] text-[var(--warning)]">
               ⚠ Oracle Stale
             </p>
             <p className="mt-1 text-[9px] text-[var(--text-secondary)] leading-relaxed">

--- a/app/components/trade/DepositWithdrawCard.tsx
+++ b/app/components/trade/DepositWithdrawCard.tsx
@@ -289,8 +289,9 @@ export const DepositWithdrawCard: FC<DepositWithdrawCardProps> = ({ slabAddress,
         <div className="relative">
           <input
             type="text"
+            inputMode="decimal"
             value={amount}
-            onChange={(e) => { 
+            onChange={(e) => {
               const newValue = sanitizeDecimalInput(e.target.value);
               if (newValue !== amount) {
                 maxRawRef.current = null;

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -708,7 +708,8 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
           />
           <button
             onClick={toggleSizeUnit}
-            className="w-16 shrink-0 rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] text-[10px] font-medium uppercase tracking-[0.1em] text-[var(--text-secondary)] transition-colors duration-150 hover:border-[var(--border-hover)] hover:text-[var(--text)]"
+            title={`Switch size unit (currently ${sizeUnit === "token" ? symbol : "USD"})`}
+            className="w-16 shrink-0 truncate rounded-none border border-[var(--border)] bg-[var(--bg-elevated)] px-1 text-[10px] font-medium uppercase tracking-[0.1em] text-[var(--text-secondary)] transition-colors duration-150 hover:border-[var(--border-hover)] hover:text-[var(--text)]"
           >
             {sizeUnit === "token" ? symbol : "USD"}
           </button>

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -689,12 +689,13 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
 
       {/* Size — single input + unit toggle + quick-fill chips */}
       <div className="mb-2">
-        <label className="mb-1.5 block text-[10px] uppercase tracking-[0.15em] text-[var(--text)]">
+        <label htmlFor="order-size-input" className="mb-1.5 block text-[10px] uppercase tracking-[0.15em] text-[var(--text)]">
           Size
           <InfoIcon tooltip="Position size in the toggled unit. Switch between token and USD - both stay in sync." />
         </label>
         <div className="flex gap-1.5">
           <input
+            id="order-size-input"
             type="text"
             value={sizeInput}
             onChange={(e) => handleSizeChange(e.target.value)}
@@ -749,12 +750,13 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
           instead of one continuous unbroken stack. */}
       <div className="mb-4 border-t border-[var(--border)]/20 pt-3">
         <div className="mb-1 flex items-center justify-between">
-          <label className="text-[10px] uppercase tracking-[0.15em] text-[var(--text)]">
+          <label htmlFor="order-leverage-input" className="text-[10px] uppercase tracking-[0.15em] text-[var(--text)]">
             Leverage
             <InfoIcon tooltip="The multiplier used to size this order. On-chain margin params are the authoritative cap." />
           </label>
           <div className="flex items-center gap-1">
             <input
+              id="order-leverage-input"
               type="text"
               value={leverageText}
               onChange={(e) => {

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -697,6 +697,7 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
           <input
             id="order-size-input"
             type="text"
+            inputMode="decimal"
             value={sizeInput}
             onChange={(e) => handleSizeChange(e.target.value)}
             placeholder={sizeUnit === "token" ? "0.000000" : "$0.00"}
@@ -758,6 +759,7 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
             <input
               id="order-leverage-input"
               type="text"
+              inputMode="numeric"
               value={leverageText}
               onChange={(e) => {
                 const raw = sanitizeDecimalInput(e.target.value);

--- a/app/components/trade/SendPositionNftModal.tsx
+++ b/app/components/trade/SendPositionNftModal.tsx
@@ -122,7 +122,7 @@ export const SendPositionNftModal: FC<SendPositionNftModalProps> = ({
       onClick={(e) => {
         if (e.target === e.currentTarget && !loading) onCancel();
       }}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-[2px] p-4"
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/60 backdrop-blur-[2px] p-4"
       aria-modal="true"
       role="dialog"
       aria-label="Send Position NFT"

--- a/app/components/trade/SendPositionNftModal.tsx
+++ b/app/components/trade/SendPositionNftModal.tsx
@@ -48,6 +48,23 @@ export const SendPositionNftModal: FC<SendPositionNftModalProps> = ({
   const prefersReduced = usePrefersReducedMotion();
   useLockBodyScroll();
 
+  // Mark a dialog as open on the body-level counter for the whole time this
+  // modal is mounted — same as ClosePositionModal / TradeConfirmationModal.
+  // The Position NFT panel that opens this modal lives inside the mobile order
+  // sheet (page.tsx MobileOrderSheet → OrderTicketRail → PositionNftPanel),
+  // whose own document-level Escape handler collapses the sheet. Without this
+  // counter a single Escape here fired BOTH: this modal cancelled AND the sheet
+  // collapsed underneath it. The sheet's handler ignores Escape while it's > 0.
+  useEffect(() => {
+    const current = Number(document.body.dataset.percOpenDialogs ?? "0");
+    document.body.dataset.percOpenDialogs = String(current + 1);
+    return () => {
+      const remaining = Number(document.body.dataset.percOpenDialogs ?? "1") - 1;
+      if (remaining <= 0) delete document.body.dataset.percOpenDialogs;
+      else document.body.dataset.percOpenDialogs = String(remaining);
+    };
+  }, []);
+
   const [destInput, setDestInput] = useState("");
   const [acknowledged, setAcknowledged] = useState(false);
 

--- a/app/components/trade/TradeConfirmationModal.tsx
+++ b/app/components/trade/TradeConfirmationModal.tsx
@@ -283,8 +283,8 @@ export const TradeConfirmationModal: FC<TradeConfirmationModalProps> = ({
           <button
             onClick={handleConfirm}
             disabled={submitting}
-            className={`flex-1 rounded-none py-2.5 text-[11px] font-medium uppercase tracking-[0.1em] text-white transition-[background-color,filter,opacity] duration-150 hover:brightness-110 disabled:opacity-50 ${
-              direction === "long" ? "bg-[var(--long)]" : "bg-[var(--short)]"
+            className={`flex-1 rounded-none py-2.5 text-[11px] font-medium uppercase tracking-[0.1em] transition-[background-color,filter,opacity] duration-150 hover:brightness-110 disabled:opacity-50 ${
+              direction === "long" ? "bg-[var(--long)] text-black" : "bg-[var(--short)] text-white"
             }`}
           >
             Confirm Trade

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -1270,13 +1270,13 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
                 </svg>
                 <div
                   className="text-[15px] font-semibold text-[var(--text-secondary)]"
-                  style={{ fontFamily: "'Space Grotesk', system-ui, sans-serif" }}
+                  style={{ fontFamily: "var(--font-display)" }}
                 >
                   No chart data yet
                 </div>
                 <div
                   className="mt-1 text-xs text-[var(--text-muted)]"
-                  style={{ fontFamily: "'Space Grotesk', system-ui, sans-serif" }}
+                  style={{ fontFamily: "var(--font-display)" }}
                 >
                   Price history will appear once trading begins
                 </div>

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -125,7 +125,7 @@ function PositionSummary({ slabAddress }: PositionSummaryProps) {
 
   const isLong = account.positionSize > 0n;
   const direction = isLong ? "LONG" : "SHORT";
-  const dirColor = isLong ? "text-green-400" : "text-red-400";
+  const dirColor = isLong ? "text-[var(--long)]" : "text-[var(--short)]";
 
   return (
     <div className="flex items-center gap-1.5 rounded-none border border-[var(--border)]/60 bg-[var(--bg)]/90 px-2 py-1 backdrop-blur-sm">

--- a/app/components/trade/WarmupProgress.tsx
+++ b/app/components/trade/WarmupProgress.tsx
@@ -151,7 +151,14 @@ export const WarmupProgress: FC<{
           </button>
 
           {/* Thin progress bar */}
-          <div className="flex-1 h-1 overflow-hidden rounded-full bg-[var(--border)]/20">
+          <div
+            className="flex-1 h-1 overflow-hidden rounded-full bg-[var(--border)]/20"
+            role="progressbar"
+            aria-valuenow={Math.round(progress)}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuetext={`Profit unlock ${progress.toFixed(0)}% complete`}
+          >
             <div
               className="h-full rounded-full bg-[var(--accent)]/60 transition-[width] duration-1000 ease-linear"
               style={{ width: `${progress}%` }}


### PR DESCRIPTION
## Summary

Frontend-only audit pass over the trade terminal (`app/app/trade/[slab]/` +
`app/components/trade/`). Fixes three real defects plus a set of accessibility,
visual-consistency, and mobile-UX issues. No protocol, program, or data-layer
changes — presentational and attribute-level only.

## What's fixed

**Bugs** (closes #2366)
- Chart empty-state heading now uses `var(--font-display)` instead of the literal
  `'Space Grotesk'` string, which never matched next/font's hashed family name and
  silently fell back to `system-ui`.
- Send-NFT modal raised to `z-[9999]` — it was `z-50` and could render behind the
  mobile order sheet (`z-[61]`) that launches it.
- Send-NFT modal now sets the `percOpenDialogs` counter, so Escape no longer
  cancels the modal *and* collapses the mobile order sheet underneath it.

**Accessibility** (closes #2367)
- Order-ticket Size and Leverage inputs associated with their labels (`htmlFor`/`id`).
- Warmup profit-unlock bar given `role="progressbar"` + `aria-value*`.

**Visual / consistency** (addresses #2368)
- Hardcoded `green/red/amber` swapped for `var(--long)`/`var(--short)`/`var(--warning)`
  across ChartPnlBadge, TradingChart, ChartDrawingToolbar, ClosePositionModal.
- Trade confirm modal's Long button uses `text-black` on green (was low-contrast white).
- Loading skeleton realigned to the real named-grid layout (was the pre-rebuild layout,
  causing a jump on load).
- Removed dead client-side `og:`/`meta` mutations; server `generateMetadata` owns them.
- _Not included:_ the `formatUsdPriceE6` 6-decimal inconsistency (#2368 item 5) — that's a
  shared, test-pinned formatter and belongs in its own tested change.

**Mobile UX** (closes #2369)
- Added `inputMode="decimal"`/`"numeric"` to the Size, Leverage, and Deposit/Withdraw
  amount inputs so mobile shows a numeric keypad.
- Size-unit toggle truncates long asset symbols instead of overflowing.

## Testing
- `npx tsc --noEmit` — clean (only the pre-existing `vitest.config.ts` type error).
- `pnpm test` (trade + format suites) — green.
- Ran the trade routes locally: `/trade/[slab]`, slug resolution, and an invalid slug
  all return 200 with no console/hydration errors; verified the realigned skeleton renders.

Fixes #2366
Fixes #2367
Fixes #2369
Addresses #2368