### PR TITLE
fix(trade): select v17 portfolio deterministically

### DIFF
--- a/app/__tests__/hooks/useTrade.test.ts
+++ b/app/__tests__/hooks/useTrade.test.ts
@@ -136,6 +136,7 @@ describe("useTrade", () => {
         },
       ],
       programId: mockProgramId,
+      refresh: vi.fn(),
     };
 
     vi.mocked(useConnectionCompat).mockReturnValue({ connection: mockConnection });

--- a/app/__tests__/hooks/useTrade.v17-portfolio-selection.test.ts
+++ b/app/__tests__/hooks/useTrade.v17-portfolio-selection.test.ts
@@ -1,0 +1,286 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PublicKey } from "@solana/web3.js";
+
+const mocks = vi.hoisted(() => ({
+  useConnectionCompat: vi.fn(),
+  useWalletCompat: vi.fn(),
+  useSlabState: vi.fn(),
+  sendTx: vi.fn(),
+  isV17Account: vi.fn(),
+  parsePortfolioV17: vi.fn(),
+  deriveMatcherDelegate: vi.fn(),
+  getLivePriceSnapshot: vi.fn(),
+}));
+
+vi.mock("@/hooks/useWalletCompat", () => ({
+  useConnectionCompat: mocks.useConnectionCompat,
+  useWalletCompat: mocks.useWalletCompat,
+}));
+
+vi.mock("@/components/providers/SlabProvider", () => ({
+  useSlabState: mocks.useSlabState,
+}));
+
+vi.mock("@/lib/tx", () => ({
+  sendTx: mocks.sendTx,
+}));
+
+vi.mock("@/lib/programAllowlist", () => ({
+  isKnownProgram: () => true,
+  assertKnownProgram: () => {},
+}));
+
+vi.mock("@/lib/oraclePrice", () => ({
+  detectOracleMode: () => "admin",
+}));
+
+vi.mock("@/lib/priceStore/priceStore", () => ({
+  getLivePriceSnapshot: mocks.getLivePriceSnapshot,
+}));
+
+vi.mock("@percolatorct/sdk", async () => {
+  const actual =
+    await vi.importActual<typeof import("@percolatorct/sdk")>(
+      "@percolatorct/sdk",
+    );
+
+  return {
+    ...actual,
+    isV17Account: mocks.isV17Account,
+    parsePortfolioV17: mocks.parsePortfolioV17,
+    deriveMatcherDelegate: mocks.deriveMatcherDelegate,
+  };
+});
+
+import { useTrade } from "@/hooks/useTrade";
+
+describe("useTrade v17 portfolio selection", () => {
+  const slabAddress = "11111111111111111111111111111111";
+
+  const walletPk = new PublicKey(
+    new Uint8Array(32).fill(11),
+  );
+
+  const programId = new PublicKey(
+    new Uint8Array(32).fill(12),
+  );
+
+  const lpPortfolioPk = new PublicKey(
+    new Uint8Array(32).fill(13),
+  );
+
+  const lpOwner = new PublicKey(
+    new Uint8Array(32).fill(14),
+  );
+
+  const matcherProgram = new PublicKey(
+    new Uint8Array(32).fill(15),
+  );
+
+  const matcherContext = new PublicKey(
+    new Uint8Array(32).fill(16),
+  );
+
+  const matcherDelegate = new PublicKey(
+    new Uint8Array(32).fill(17),
+  );
+
+  const portfolioOne = new PublicKey(
+    new Uint8Array(32).fill(21),
+  );
+
+  const portfolioTwo = new PublicKey(
+    new Uint8Array(32).fill(22),
+  );
+
+  let connection: {
+    getProgramAccounts: ReturnType<typeof vi.fn>;
+    getAccountInfo: ReturnType<typeof vi.fn>;
+  };
+
+  function createLpPortfolioData(): Buffer {
+    const data = Buffer.alloc(240);
+
+    // readPortfolioOwner() reads provenance owner at offset 80.
+    lpOwner.toBuffer().copy(data, 80);
+
+    // PortfolioMatcherConfigV16 occupies the final 104 bytes.
+    const matcherConfigOffset = data.length - 104;
+
+    matcherProgram
+      .toBuffer()
+      .copy(data, matcherConfigOffset);
+
+    matcherContext
+      .toBuffer()
+      .copy(data, matcherConfigOffset + 32);
+
+    matcherDelegate
+      .toBuffer()
+      .copy(data, matcherConfigOffset + 64);
+
+    // enabled = 1
+    data.writeBigUInt64LE(
+      1n,
+      matcherConfigOffset + 96,
+    );
+
+    return data;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    connection = {
+      getProgramAccounts: vi.fn(),
+      getAccountInfo: vi.fn().mockResolvedValue(null),
+    };
+
+    mocks.isV17Account.mockReturnValue(true);
+
+    mocks.parsePortfolioV17.mockReturnValue({
+      owner: walletPk,
+      legs: [],
+    });
+
+    mocks.deriveMatcherDelegate.mockReturnValue([
+      matcherDelegate,
+      254,
+    ]);
+
+    mocks.getLivePriceSnapshot.mockReturnValue({
+      priceUsd: 1.5,
+      priceE6: 1_500_000n,
+      price: 1.5,
+      change24h: null,
+      high24h: null,
+      low24h: null,
+      loading: false,
+    });
+
+    mocks.sendTx.mockResolvedValue({
+      signature: "mock-signature",
+    });
+
+    mocks.useConnectionCompat.mockReturnValue({
+      connection,
+    });
+
+    mocks.useWalletCompat.mockReturnValue({
+      publicKey: walletPk,
+      connected: true,
+    });
+
+    mocks.useSlabState.mockReturnValue({
+      config: {
+        oracleAuthority: PublicKey.default,
+        indexFeedId: PublicKey.default,
+        authorityPriceE6: 1_000_000n,
+      },
+      accounts: [],
+      raw: Buffer.from([1]),
+      programId,
+      wrapperConfigV17: {
+        oracleMode: 0,
+      },
+      refresh: vi.fn(),
+      slabAddress,
+    });
+  });
+
+  async function selectedAccountA(
+    rpcPortfolioOrder: PublicKey[],
+  ): Promise<PublicKey> {
+    connection.getProgramAccounts
+      // First GPA call: LP portfolio discovery.
+      .mockResolvedValueOnce([
+        {
+          pubkey: lpPortfolioPk,
+          account: {
+            data: createLpPortfolioData(),
+          },
+        },
+      ])
+      // Second GPA call: taker portfolio discovery.
+      .mockResolvedValueOnce(
+        rpcPortfolioOrder.map((pubkey, index) => ({
+          pubkey,
+          account: {
+            data: Buffer.from([index + 1]),
+          },
+        })),
+      );
+
+    mocks.sendTx.mockClear();
+
+    const { result, unmount } = renderHook(() =>
+      useTrade(slabAddress),
+    );
+
+    await act(async () => {
+      await result.current.trade({
+        lpIdx: 0,
+        userIdx: 7,
+        size: 1_000_000n,
+      });
+    });
+
+    const sendCall = mocks.sendTx.mock.calls.at(-1)?.[0];
+
+    expect(sendCall).toBeDefined();
+
+    const instructions = sendCall.instructions as Array<{
+      keys: Array<{ pubkey: PublicKey }>;
+    }>;
+
+    const tradeInstruction =
+      instructions[instructions.length - 1];
+
+    // TradeCpi account index 2 is accountA:
+    // the taker's standalone v17 portfolio.
+    const accountA = tradeInstruction.keys[2].pubkey;
+
+    unmount();
+
+    return accountA;
+  }
+
+  it("selects the canonical portfolio regardless of RPC result order", async () => {
+    const ordered = [portfolioOne, portfolioTwo].sort(
+      (a, b) =>
+        a
+          .toBase58()
+          .localeCompare(b.toBase58()),
+    );
+
+    const canonicalPortfolio = ordered[0];
+    const nonCanonicalPortfolio = ordered[1];
+
+    const selectedFromReversedOrder =
+      await selectedAccountA([
+        nonCanonicalPortfolio,
+        canonicalPortfolio,
+      ]);
+
+    const selectedFromCanonicalOrder =
+      await selectedAccountA([
+        canonicalPortfolio,
+        nonCanonicalPortfolio,
+      ]);
+
+    // A deterministic client must submit the same portfolio regardless
+    // of the array order returned by getProgramAccounts().
+    expect(
+      selectedFromReversedOrder.toBase58(),
+    ).toBe(
+      selectedFromCanonicalOrder.toBase58(),
+    );
+
+    expect(
+      selectedFromCanonicalOrder.toBase58(),
+    ).toBe(
+      canonicalPortfolio.toBase58(),
+    );
+  });
+});

--- a/app/hooks/useTrade.ts
+++ b/app/hooks/useTrade.ts
@@ -126,12 +126,19 @@ async function findV17Portfolio(
       ],
     });
     if (accounts.length === 0) return null;
+
+    // getProgramAccounts() does not guarantee stable result ordering.
+    // Use the same canonical pubkey ordering as deposit and withdraw
+    // so every owner+market flow targets the same portfolio account.
+    const sorted = [...accounts].sort((a, b) =>
+      a.pubkey.toBase58().localeCompare(b.pubkey.toBase58()),
+    );
     // Defense-in-depth: re-verify the mutable owner actually matches after fetch —
     // memcmp filters are advisory server-side; don't trust them blindly.
-    const data = Buffer.from(accounts[0].account.data);
+    const data = Buffer.from(sorted[0].account.data);
     const portfolio = parsePortfolioV17(data);
     if (!portfolio.owner.equals(ownerPk)) return null;
-    return accounts[0].pubkey;
+    return sorted[0].pubkey;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

Makes v17 portfolio selection deterministic when multiple standalone portfolio accounts match the same wallet and market.

Previously, `findV17Portfolio()` selected the first element returned by `getProgramAccounts()`. Because the matching accounts were not normalized before selection, a different valid RPC result order could change the portfolio submitted as the writable `TradeCpi accountA`.

## Changes

- Sort matching v17 portfolio accounts by Base58 public key before selecting one.
- Use the same canonical account for:
  - account-data parsing;
  - mutable-owner verification;
  - the public key returned to the trade transaction builder.
- Preserve the existing post-fetch owner validation.
- Add regression coverage proving that reversed RPC result ordering produces the same submitted `accountA`.
- Add the required `refresh` mock to the existing `useTrade` test fixture.

## Validation

The existing `useTrade` suite and the new regression test pass:

```text
Test Files  2 passed
Tests       17 passed
```

Commands executed:

```bash
pnpm exec vitest run \
  __tests__/hooks/useTrade.test.ts \
  __tests__/hooks/useTrade.v17-portfolio-selection.test.ts

pnpm exec tsc --noEmit --pretty false

git diff --check
```

TypeScript validation and whitespace checks completed without errors.

## Scope

This patch only changes client-side v17 portfolio resolution.

It does not modify:

- transaction account layout;
- signer requirements;
- trade size or direction;
- slippage or limit-price calculations;
- margin or fee calculations;
- retry behavior;
- on-chain program logic.

Fixes #2371