### PR TITLE
fix(chart): real scrollable history + GeckoTerminal quota protection

### DIFF
--- a/app/app/api/chart/[mint]/route.ts
+++ b/app/app/api/chart/[mint]/route.ts
@@ -49,9 +49,37 @@ const GECKO_HEADERS = { Accept: "application/json", "User-Agent": "percolator-ch
 const CACHE_HEADERS = {
   "Cache-Control": "public, s-maxage=60, stale-while-revalidate=120",
 } as const;
+/** Failure responses must NOT be CDN-cached: a GeckoTerminal 429/error would
+ *  otherwise pin an EMPTY chart for 60s+ even though a retry seconds later
+ *  would succeed — one rate-limit blip blanked every viewer's chart. */
+const NO_STORE_HEADERS = { "Cache-Control": "no-store" } as const;
 
 /** GeckoTerminal-supported OHLCV timeframe granularities. */
 const VALID_TIMEFRAMES = new Set(["minute", "hour", "day"]);
+
+/* ── In-process GeckoTerminal quota protection ──────────────────────────────
+ * GT's free tier allows ~30 calls/min per IP, and every chart request used to
+ * spend TWO of them (token→top_pools + ohlcv) with zero reuse — the pool
+ * lookup was repeated on every 60s poll and every timeframe switch, for every
+ * open chart. A single browser session could exhaust the quota, after which
+ * this route silently served empty candles (and the CDN cached the emptiness).
+ * Verified empirically: two chart requests in quick succession succeeded, the
+ * following ones returned 0 bars with pool resolution dead until cooldown.
+ *
+ * - mint → pool: pools don't move; cache hits for 6h, misses for 60s (a miss
+ *   may be a 429, not a real "no pools" — don't pin it).
+ * - candles: cache per (pool, timeframe, aggregate, limit) for 45s (matches
+ *   the client's 60s poll), and keep the last good batch for 15min as a
+ *   stale-if-error fallback so a 429 degrades to slightly-old candles
+ *   instead of a blank chart.
+ * Per-instance only (serverless), but the CDN s-maxage covers cross-instance
+ * reuse on the hosted deployment. */
+const POOL_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+const POOL_MISS_TTL_MS = 60 * 1000;
+const CANDLE_CACHE_TTL_MS = 45 * 1000;
+const CANDLE_STALE_MAX_MS = 15 * 60 * 1000;
+const poolCache = new Map<string, { pool: string | null; at: number }>();
+const candleCache = new Map<string, { candles: CandleData[]; at: number }>();
 
 /** [unixSeconds, open, high, low, close, volume] — GeckoTerminal's OHLCV row shape. */
 type GeckoOhlcvBar = [number, number, number, number, number, number];
@@ -64,9 +92,11 @@ interface GeckoPoolIncluded {
 }
 
 function emptyResponse() {
+  // Empty results are almost always transient (GT rate limit / upstream
+  // hiccup) — never CDN-cache them; see NO_STORE_HEADERS.
   return NextResponse.json(
     { candles: [] as CandleData[], poolAddress: null, cached: false },
-    { headers: CACHE_HEADERS },
+    { headers: NO_STORE_HEADERS },
   );
 }
 
@@ -85,6 +115,22 @@ function emptyResponse() {
  * Returns null on any failure or when the token has no indexed pools.
  */
 async function resolveTopPool(mint: string): Promise<string | null> {
+  const cached = poolCache.get(mint);
+  if (cached) {
+    const ttl = cached.pool ? POOL_CACHE_TTL_MS : POOL_MISS_TTL_MS;
+    if (Date.now() - cached.at < ttl) return cached.pool;
+  }
+  const pool = await resolveTopPoolUncached(mint);
+  // A resolved pool is durable knowledge; a null may just be a 429 — the
+  // short miss-TTL above keeps us from hammering GT while never pinning it.
+  poolCache.set(mint, { pool: pool ?? cached?.pool ?? null, at: Date.now() });
+  // If this attempt failed but we have ANY previously-known pool, keep using
+  // it — pools don't move, and a rate-limited lookup must not blank a chart
+  // that worked a minute ago.
+  return pool ?? cached?.pool ?? null;
+}
+
+async function resolveTopPoolUncached(mint: string): Promise<string | null> {
   try {
     const res = await fetch(`${GECKOTERMINAL_BASE}/tokens/${mint}?include=top_pools`, {
       headers: GECKO_HEADERS,
@@ -177,8 +223,38 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ mint
     const pool = await resolveTopPool(canonicalMint);
     if (!pool) return emptyResponse();
 
+    const cacheKey = `${pool}:${timeframe}:${aggregate}:${limit}`;
+    const cached = candleCache.get(cacheKey);
+    const age = cached ? Date.now() - cached.at : Infinity;
+
+    // Fresh enough — serve without spending a GeckoTerminal call. This is
+    // what keeps N open charts + the client's 60s poll inside GT's quota.
+    if (cached && age < CANDLE_CACHE_TTL_MS) {
+      return NextResponse.json(
+        { candles: cached.candles, poolAddress: pool, cached: true },
+        { headers: CACHE_HEADERS },
+      );
+    }
+
     const candles = await fetchCandles(pool, timeframe, aggregate, limit);
-    return NextResponse.json({ candles, poolAddress: pool, cached: false }, { headers: CACHE_HEADERS });
+    if (candles.length > 0) {
+      candleCache.set(cacheKey, { candles, at: Date.now() });
+      return NextResponse.json({ candles, poolAddress: pool, cached: false }, { headers: CACHE_HEADERS });
+    }
+
+    // Empty fetch = usually a GT 429, not "this pool has no history".
+    // Stale-if-error: serve the last good batch (up to 15min old) instead of
+    // blanking a chart that rendered fine a minute ago.
+    if (cached && age < CANDLE_STALE_MAX_MS && cached.candles.length > 0) {
+      return NextResponse.json(
+        { candles: cached.candles, poolAddress: pool, cached: true },
+        { headers: NO_STORE_HEADERS },
+      );
+    }
+    return NextResponse.json(
+      { candles, poolAddress: pool, cached: false },
+      { headers: NO_STORE_HEADERS },
+    );
   } catch {
     // Never let an unexpected error break the chart — the client falls back
     // to drawing from the live oracle price when candles is empty.

--- a/app/hooks/useTokenChart.ts
+++ b/app/hooks/useTokenChart.ts
@@ -16,18 +16,29 @@ export interface UseTokenChartResult {
 // Phase 2: 15m added
 type Timeframe = "1m" | "5m" | "15m" | "1h" | "4h" | "1d" | "7d" | "30d";
 
+/**
+ * Timeframe → GeckoTerminal request. The selector means CANDLE SIZE (like
+ * every trading terminal), not window length: "1h" = 1-hour candles with as
+ * much history as one request allows, NOT "one hour of data".
+ *
+ * The previous mapping used window semantics with 12–42 bar limits — "1h"
+ * fetched twelve 5-minute bars — so every chart was a couple of lines with
+ * nothing to scroll back into (user report). GeckoTerminal serves up to
+ * 1000 bars per request at no extra call cost; ask for the full depth.
+ * (GT aggregates: minute 1/5/15, hour 1/4/12, day 1.)
+ */
 const TIMEFRAME_TO_API: Record<
   Timeframe,
   { timeframe: "minute" | "hour" | "day"; aggregate: number; limit: number }
 > = {
-  "1m":  { timeframe: "minute", aggregate: 1,  limit: 30 },  // 1-min candles, 30min of data
-  "5m":  { timeframe: "minute", aggregate: 5,  limit: 24 },  // 5-min candles, 2h of data
-  "15m": { timeframe: "minute", aggregate: 15, limit: 24 },  // 15-min candles, 6h of data
-  "1h":  { timeframe: "minute", aggregate: 5,  limit: 12 },  // 5-min candles, 1h of data
-  "4h":  { timeframe: "minute", aggregate: 15, limit: 16 },  // 15-min candles, 4h of data
-  "1d":  { timeframe: "hour",   aggregate: 1,  limit: 24 },  // 1-hour candles, 1d of data
-  "7d":  { timeframe: "hour",   aggregate: 4,  limit: 42 },  // 4-hour candles, 7d of data
-  "30d": { timeframe: "day",    aggregate: 1,  limit: 30 },  // 1-day candles, 30d of data
+  "1m":  { timeframe: "minute", aggregate: 1,  limit: 1000 }, // ~16h of history
+  "5m":  { timeframe: "minute", aggregate: 5,  limit: 1000 }, // ~3.5d
+  "15m": { timeframe: "minute", aggregate: 15, limit: 1000 }, // ~10d
+  "1h":  { timeframe: "hour",   aggregate: 1,  limit: 1000 }, // ~41d
+  "4h":  { timeframe: "hour",   aggregate: 4,  limit: 1000 }, // ~5.5mo
+  "1d":  { timeframe: "day",    aggregate: 1,  limit: 365 },  // 1y
+  "7d":  { timeframe: "day",    aggregate: 1,  limit: 730 },  // 2y of daily bars
+  "30d": { timeframe: "day",    aggregate: 1,  limit: 1000 }, // ~3y of daily bars
 };
 
 /** Fetch interval: 60s for short timeframes, 5min for daily */


### PR DESCRIPTION
## What (user-reported)

Charts "don't look like they're properly picking up data, in all different timeframes… can't go back… sometimes it's only a couple lines" — worst on non-Pyth markets (BURNIE, PERCOLATOR); SOL/JUP better but still off. Two root causes found and verified on the GeckoTerminal path (majors mostly ride the Pyth path, whose 120–180-bar lookbacks are why they looked better):

## Root cause 1 — window semantics with tiny limits

`useTokenChart`'s `TIMEFRAME_TO_API` treated the timeframe selector as **window length**: "1h" fetched **twelve 5-minute bars**, "1d" twenty-four hourly bars, 5m/15m 24 bars. There was never anything to scroll back into. Every trading terminal treats the selector as **candle size**.

Remapped (same single API call — GT serves up to 1000 bars per request): `1m/5m/15m → minute agg 1/5/15`, `1h/4h → hour agg 1/4`, `1d → day`, at the 1000-bar max.

**Verified:** BURNIE "1h" now returns **1000 hourly bars spanning 41 days** (previously 12 five-minute bars); BURNIE default "1d" loads the token's entire 99-day life; PERCOLATOR daily returns 181 bars back to January.

## Root cause 2 — self-inflicted rate limiting, then caching the failure

GT's free tier is ~30 calls/min/IP, and every chart request spent **two** (the `mint→top_pools` lookup was re-done on every 60s poll and every timeframe switch, for every open chart) with zero reuse. Verified empirically: two chart requests in quick succession succeeded, then **everything — including pool resolution — returned empty** until cooldown. Worse, that empty 429 result went out with `s-maxage=60`, pinning a blank chart on the CDN for a minute at a time. This is the "sometimes it's only a couple lines / seems off on all timeframes" intermittency.

Route fixes:

- **mint→pool cached in-process** (6h hit / 60s miss TTL — a miss may itself be a 429, never pin it; a previously-known pool is kept when a re-lookup fails, pools don't move)
- **candles cached** per (pool, timeframe, aggregate, limit) for 45s, matching the client's 60s poll — N open charts now cost ~1 GT call/min each instead of 2 per poll per chart
- **stale-if-error**: a rate-limited refresh serves the last good batch (≤15min old) instead of blanking a chart that rendered fine a minute ago
- **failures are `Cache-Control: no-store`** — only real data gets the `s-maxage=60` CDN cache

## New / future markets

Covered automatically: the chart never depends on anything registered per-market — it resolves the token's top pool from its **mainnet CA** (which every wizard launch stores) directly against GeckoTerminal. Any token GT indexes (i.e. anything with a real DEX pool) charts identically to the curated markets, first render included. Tokens GT hasn't indexed yet (brand-new pools) degrade to the existing live-oracle fallback and pick up DEX candles as soon as GT indexes them.

## Testing

- `npx tsc --noEmit` clean; `chart-mint-validation` suite green.
- Live route checks: BURNIE 1h → 1000 bars/41 days; immediate repeat → `cached: true` (zero GT spend); PERCOLATOR daily → 181 bars.
- Headless trade page (BURNIE): default 1d loads full history, 1h/5m switches pull 1000 bars each, candlestick chart renders with volume — screenshot verified — zero page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
