### PR TITLE
fix(app): recover and verify incomplete v17 matcher initialization

### DIFF
--- a/app/__tests__/hooks/useCreateMarket.v17-matcher-recovery.test.ts
+++ b/app/__tests__/hooks/useCreateMarket.v17-matcher-recovery.test.ts
@@ -1,0 +1,418 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Keypair, PublicKey } from '@solana/web3.js';
+
+const mocks = vi.hoisted(() => ({
+  sendTx: vi.fn(),
+  getAccountInfo: vi.fn(),
+  getProgramAccounts: vi.fn(),
+  getMinimumBalanceForRentExemption: vi.fn(),
+  getAccount: vi.fn(),
+  updateInFlightStep: vi.fn(),
+  deriveVaultAuthority: vi.fn(),
+  deriveMatcherDelegate: vi.fn(),
+
+  connection: null as unknown as Record<string, unknown>,
+  wallet: null as unknown as Record<string, unknown>,
+  config: null as unknown as Record<string, unknown>,
+  getAssociatedTokenAddress: vi.fn(),
+}));
+
+vi.mock('@/hooks/useWalletCompat', () => ({
+  useConnectionCompat: () => ({
+    connection: mocks.connection,
+  }),
+  useWalletCompat: () => mocks.wallet,
+}));
+
+vi.mock('@/lib/tx', () => ({
+  sendTx: mocks.sendTx,
+}));
+
+vi.mock('@/lib/config', () => ({
+  getConfig: () => mocks.config,
+  // Mainnet forces the insufficient-balance path to stop execution
+  // immediately after Step 2, without calling the pre-fund endpoint.
+  getNetwork: () => 'mainnet',
+}));
+
+vi.mock('@/lib/inFlightMarket', () => ({
+  saveInFlightMarket: vi.fn(),
+  updateInFlightStep: mocks.updateInFlightStep,
+  clearInFlightMarket: vi.fn(),
+  loadLastInFlightMarket: vi.fn(() => null),
+}));
+
+vi.mock('@solana/spl-token', async () => {
+  const actual = await vi.importActual<typeof import('@solana/spl-token')>('@solana/spl-token');
+
+  return {
+    ...actual,
+    getAccount: mocks.getAccount,
+    getAssociatedTokenAddress: mocks.getAssociatedTokenAddress,
+  };
+});
+
+vi.mock('@percolatorct/sdk', async () => {
+  const actual = await vi.importActual<typeof import('@percolatorct/sdk')>('@percolatorct/sdk');
+
+  return {
+    ...actual,
+    deriveVaultAuthority: mocks.deriveVaultAuthority,
+    deriveMatcherDelegate: mocks.deriveMatcherDelegate,
+  };
+});
+
+import { useCreateMarket } from '@/hooks/useCreateMarket';
+
+describe('useCreateMarket v17 matcher recovery', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    mocks.getMinimumBalanceForRentExemption.mockReset();
+    mocks.getMinimumBalanceForRentExemption.mockResolvedValue(1_000_000);
+    mocks.deriveMatcherDelegate.mockReset();
+
+    mocks.getAssociatedTokenAddress.mockReset();
+    mocks.getAssociatedTokenAddress.mockResolvedValue(new PublicKey(new Uint8Array(32).fill(24)));
+
+    const walletKeypair = Keypair.generate();
+    const programId = new PublicKey('69VUZ7a2BeXBTpRRManLamF5UWTaNR9B1hy5Se3cdXy9');
+    const matcherProgramId = new PublicKey('4seJWjv3R5qfXY8R5ntuPHWsoqcVvaxvfFSnU2AnGMhT');
+
+    mocks.connection = {
+      getAccountInfo: mocks.getAccountInfo,
+      getProgramAccounts: mocks.getProgramAccounts,
+      getMinimumBalanceForRentExemption: mocks.getMinimumBalanceForRentExemption,
+    };
+
+    mocks.wallet = {
+      publicKey: walletKeypair.publicKey,
+      connected: true,
+      connecting: false,
+      signTransaction: vi.fn(async (tx) => tx),
+      signAllTransactions: vi.fn(async (txs) => txs),
+      signMessage: vi.fn(),
+      disconnect: vi.fn(),
+    };
+
+    mocks.config = {
+      programId: programId.toBase58(),
+      matcherProgramId: matcherProgramId.toBase58(),
+      programsBySlabTier: undefined,
+    };
+
+    mocks.sendTx.mockResolvedValue('mock-signature');
+
+    mocks.deriveVaultAuthority.mockReturnValue([new PublicKey(new Uint8Array(32).fill(23)), 255]);
+
+    // Stop execution at the beginning of Step 3. This isolates Step 2:
+    // no deposit, insurance, or crank transaction can be submitted.
+    mocks.getAccount.mockResolvedValue({
+      amount: 0n,
+    });
+  });
+
+  const createParams = (mint: PublicKey) => ({
+    mint,
+    initialPriceE6: 100_000_000n,
+    lpCollateral: 1_000_000n,
+    insuranceAmount: 100_000n,
+    oracleFeed: '0'.repeat(64),
+    invert: false,
+    tradingFeeBps: 10,
+    initialMarginBps: 1_500,
+    maxAccounts: 4_096,
+    decimals: 6,
+    symbol: 'TEST',
+    name: 'Test Market',
+    oracleMode: 'admin' as const,
+  });
+
+  const makeAccount = (data: Buffer, owner: PublicKey) => ({
+    data,
+    executable: false,
+    lamports: 1,
+    owner,
+    rentEpoch: 0,
+  });
+
+  it('resumes TX B-D when the existing LP matcher config is empty', async () => {
+    const actualSdk =
+      await vi.importActual<typeof import('@percolatorct/sdk')>('@percolatorct/sdk');
+
+    const walletPublicKey = (mocks.wallet as { publicKey: PublicKey }).publicKey;
+
+    const programId = new PublicKey((mocks.config as { programId: string }).programId);
+
+    const matcherProgramId = new PublicKey(
+      (mocks.config as { matcherProgramId: string }).matcherProgramId,
+    );
+
+    const slabKeypair = Keypair.fromSeed(new Uint8Array(32).fill(41));
+
+    const lpPortfolioKeypair = Keypair.generate();
+    const mint = Keypair.generate().publicKey;
+
+    const v17Magic = Buffer.from([0x00, 0x36, 0x31, 0x56, 0x43, 0x52, 0x45, 0x50]);
+
+    const slabData = Buffer.alloc(26_364);
+    v17Magic.copy(slabData, 0);
+    slabData.writeUInt16LE(16, 8);
+
+    const slabAccount = makeAccount(slabData, programId);
+
+    const emptyPortfolioData = Buffer.alloc(actualSdk.V17_PORTFOLIO_ACCOUNT_LEN);
+
+    v17Magic.copy(emptyPortfolioData, 0);
+    emptyPortfolioData.writeUInt16LE(16, 8);
+
+    slabKeypair.publicKey.toBuffer().copy(emptyPortfolioData, 16);
+
+    walletPublicKey.toBuffer().copy(emptyPortfolioData, 80);
+
+    mocks.getProgramAccounts.mockResolvedValue([
+      {
+        pubkey: lpPortfolioKeypair.publicKey,
+        account: makeAccount(emptyPortfolioData, programId),
+      },
+    ]);
+
+    const expectedDelegate = new PublicKey(new Uint8Array(32).fill(42));
+
+    let recoveredContextPk: PublicKey | null = null;
+
+    mocks.deriveMatcherDelegate.mockImplementation((...args: unknown[]) => {
+      recoveredContextPk = args[5] as PublicKey;
+      return [expectedDelegate, 255];
+    });
+
+    const actualWeb3ForSystemProgram =
+      await vi.importActual<typeof import('@solana/web3.js')>('@solana/web3.js');
+
+    const createMatcherAccountSpy = vi
+      .spyOn(actualWeb3ForSystemProgram.SystemProgram, 'createAccount')
+      .mockImplementation(
+        () =>
+          new actualWeb3ForSystemProgram.TransactionInstruction({
+            keys: [],
+            programId: actualWeb3ForSystemProgram.SystemProgram.programId,
+            data: Buffer.alloc(0),
+          }),
+      );
+
+    mocks.sendTx
+      .mockResolvedValueOnce('matcher-context-created')
+      .mockResolvedValueOnce('matcher-config-stored')
+      .mockResolvedValueOnce('matcher-context-initialized');
+
+    mocks.getAccountInfo.mockImplementation(async (pubkey: PublicKey) => {
+      if (pubkey.equals(slabKeypair.publicKey)) {
+        return slabAccount;
+      }
+
+      if (pubkey.equals(lpPortfolioKeypair.publicKey)) {
+        if (!recoveredContextPk) {
+          throw new Error('Recovered context was not derived before verification');
+        }
+
+        const recoveredPortfolioData = Buffer.from(emptyPortfolioData);
+
+        const configOffset = recoveredPortfolioData.length - 104;
+
+        matcherProgramId.toBuffer().copy(recoveredPortfolioData, configOffset);
+
+        recoveredContextPk.toBuffer().copy(recoveredPortfolioData, configOffset + 32);
+
+        expectedDelegate.toBuffer().copy(recoveredPortfolioData, configOffset + 64);
+
+        recoveredPortfolioData.writeBigUInt64LE(1n, configOffset + 96);
+
+        return makeAccount(recoveredPortfolioData, programId);
+      }
+
+      if (recoveredContextPk && pubkey.equals(recoveredContextPk)) {
+        const matcherContextData = Buffer.alloc(actualSdk.MATCHER_CONTEXT_LEN);
+
+        expectedDelegate.toBuffer().copy(matcherContextData, actualSdk.CTX_VAMM_OFFSET);
+
+        return makeAccount(matcherContextData, matcherProgramId);
+      }
+
+      return null;
+    });
+
+    // create(params, 2) continues into Step 3 after successful recovery.
+    // Stop deliberately before any Step 3 transaction is submitted.
+    const { result } = renderHook(() => useCreateMarket());
+
+    act(() => {
+      result.current.restoreSlabKeypair(slabKeypair, slabKeypair.publicKey.toBase58());
+    });
+
+    await act(async () => {
+      await result.current.create(createParams(mint), 2);
+    });
+
+    expect(createMatcherAccountSpy).toHaveBeenCalledTimes(1);
+
+    const createMatcherAccountParams = createMatcherAccountSpy.mock.calls[0]?.[0];
+
+    expect(createMatcherAccountParams).toBeDefined();
+
+    expect(createMatcherAccountParams?.fromPubkey.equals(walletPublicKey)).toBe(true);
+
+    expect(
+      createMatcherAccountParams?.newAccountPubkey.equals(recoveredContextPk as PublicKey),
+    ).toBe(true);
+
+    expect(createMatcherAccountParams?.programId.equals(matcherProgramId)).toBe(true);
+
+    expect(createMatcherAccountParams?.lamports).toBe(1_000_000);
+
+    expect(createMatcherAccountParams?.space).toBe(actualSdk.MATCHER_CONTEXT_LEN);
+
+    // Step 2 recovery completed successfully. The zero-balance fixture
+    // stops the flow before any Step 3 deposit transaction is submitted.
+    expect(result.current.state.error).toContain('Insufficient token balance for deposit');
+
+    expect(mocks.sendTx).toHaveBeenCalledTimes(3);
+
+    const calls = mocks.sendTx.mock.calls.map(
+      ([request]) =>
+        request as {
+          instructions: Array<{
+            data: Uint8Array;
+            programId: PublicKey;
+          }>;
+          signers?: Keypair[];
+        },
+    );
+
+    // TX A must not be repeated. The first recovery transaction is TX B.
+    expect(calls[0]?.instructions).toHaveLength(1);
+    expect(calls[0]?.signers).toHaveLength(1);
+
+    expect(calls[0]?.signers?.[0]?.publicKey.equals(recoveredContextPk as PublicKey)).toBe(true);
+
+    // TX C and TX D retain their wrapper instruction tags.
+    expect(calls[1]?.instructions[0]?.data[0]).toBe(68);
+    expect(calls[2]?.instructions[0]?.data[0]).toBe(83);
+
+    expect(mocks.updateInFlightStep).toHaveBeenCalledWith(slabKeypair.publicKey.toBase58(), 3);
+  });
+
+  it('resumes TX D only when the committed matcher context is uninitialized', async () => {
+    const actualSdk =
+      await vi.importActual<typeof import('@percolatorct/sdk')>('@percolatorct/sdk');
+
+    const walletPublicKey = (mocks.wallet as { publicKey: PublicKey }).publicKey;
+
+    const programId = new PublicKey((mocks.config as { programId: string }).programId);
+
+    const matcherProgramId = new PublicKey(
+      (mocks.config as { matcherProgramId: string }).matcherProgramId,
+    );
+
+    const slabKeypair = Keypair.fromSeed(new Uint8Array(32).fill(43));
+
+    const lpPortfolioKeypair = Keypair.generate();
+    const matcherContextKeypair = Keypair.generate();
+    const mint = Keypair.generate().publicKey;
+
+    const expectedDelegate = new PublicKey(new Uint8Array(32).fill(44));
+
+    mocks.deriveMatcherDelegate.mockReturnValue([expectedDelegate, 255]);
+
+    const v17Magic = Buffer.from([0x00, 0x36, 0x31, 0x56, 0x43, 0x52, 0x45, 0x50]);
+
+    const slabData = Buffer.alloc(26_364);
+    v17Magic.copy(slabData, 0);
+    slabData.writeUInt16LE(16, 8);
+
+    const slabAccount = makeAccount(slabData, programId);
+
+    const portfolioData = Buffer.alloc(actualSdk.V17_PORTFOLIO_ACCOUNT_LEN);
+
+    v17Magic.copy(portfolioData, 0);
+    portfolioData.writeUInt16LE(16, 8);
+
+    slabKeypair.publicKey.toBuffer().copy(portfolioData, 16);
+
+    walletPublicKey.toBuffer().copy(portfolioData, 80);
+
+    const configOffset = portfolioData.length - 104;
+
+    matcherProgramId.toBuffer().copy(portfolioData, configOffset);
+
+    matcherContextKeypair.publicKey.toBuffer().copy(portfolioData, configOffset + 32);
+
+    expectedDelegate.toBuffer().copy(portfolioData, configOffset + 64);
+
+    portfolioData.writeBigUInt64LE(1n, configOffset + 96);
+
+    mocks.getProgramAccounts.mockResolvedValue([
+      {
+        pubkey: lpPortfolioKeypair.publicKey,
+        account: makeAccount(portfolioData, programId),
+      },
+    ]);
+
+    let contextReads = 0;
+
+    mocks.getAccountInfo.mockImplementation(async (pubkey: PublicKey) => {
+      if (pubkey.equals(slabKeypair.publicKey)) {
+        return slabAccount;
+      }
+
+      if (pubkey.equals(lpPortfolioKeypair.publicKey)) {
+        return makeAccount(portfolioData, programId);
+      }
+
+      if (pubkey.equals(matcherContextKeypair.publicKey)) {
+        contextReads += 1;
+
+        const matcherContextData = Buffer.alloc(actualSdk.MATCHER_CONTEXT_LEN);
+
+        // First read: TX D has not landed.
+        // Second read: final post-recovery verification.
+        if (contextReads >= 2) {
+          expectedDelegate.toBuffer().copy(matcherContextData, actualSdk.CTX_VAMM_OFFSET);
+        }
+
+        return makeAccount(matcherContextData, matcherProgramId);
+      }
+
+      return null;
+    });
+
+    mocks.sendTx.mockResolvedValue('matcher-context-initialized');
+
+    const { result } = renderHook(() => useCreateMarket());
+
+    act(() => {
+      result.current.restoreSlabKeypair(slabKeypair, slabKeypair.publicKey.toBase58());
+    });
+
+    await act(async () => {
+      await result.current.create(createParams(mint), 2);
+    });
+
+    expect(mocks.sendTx).toHaveBeenCalledTimes(1);
+
+    const request = mocks.sendTx.mock.calls[0]?.[0] as {
+      instructions: Array<{
+        data: Uint8Array;
+      }>;
+      signers?: Keypair[];
+    };
+
+    expect(request.instructions).toHaveLength(1);
+    expect(request.instructions[0]?.data[0]).toBe(83);
+    expect(request.signers).toBeUndefined();
+
+    expect(contextReads).toBe(2);
+
+    expect(mocks.updateInFlightStep).toHaveBeenCalledWith(slabKeypair.publicKey.toBase58(), 3);
+  });
+});

--- a/app/__tests__/hooks/useCreateMarket.v17-matcher-resume.test.ts
+++ b/app/__tests__/hooks/useCreateMarket.v17-matcher-resume.test.ts
@@ -1,0 +1,402 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Keypair, PublicKey } from '@solana/web3.js';
+
+const mocks = vi.hoisted(() => ({
+  sendTx: vi.fn(),
+  getAccountInfo: vi.fn(),
+  getProgramAccounts: vi.fn(),
+  getAccount: vi.fn(),
+  updateInFlightStep: vi.fn(),
+  deriveVaultAuthority: vi.fn(),
+  deriveMatcherDelegate: vi.fn(),
+
+  connection: null as unknown as Record<string, unknown>,
+  wallet: null as unknown as Record<string, unknown>,
+  config: null as unknown as Record<string, unknown>,
+  getAssociatedTokenAddress: vi.fn(),
+}));
+
+vi.mock('@/hooks/useWalletCompat', () => ({
+  useConnectionCompat: () => ({
+    connection: mocks.connection,
+  }),
+  useWalletCompat: () => mocks.wallet,
+}));
+
+vi.mock('@/lib/tx', () => ({
+  sendTx: mocks.sendTx,
+}));
+
+vi.mock('@/lib/config', () => ({
+  getConfig: () => mocks.config,
+  // Mainnet forces the insufficient-balance path to stop execution
+  // immediately after Step 2, without calling the pre-fund endpoint.
+  getNetwork: () => 'mainnet',
+}));
+
+vi.mock('@/lib/inFlightMarket', () => ({
+  saveInFlightMarket: vi.fn(),
+  updateInFlightStep: mocks.updateInFlightStep,
+  clearInFlightMarket: vi.fn(),
+  loadLastInFlightMarket: vi.fn(() => null),
+}));
+
+vi.mock('@solana/spl-token', async () => {
+  const actual = await vi.importActual<typeof import('@solana/spl-token')>('@solana/spl-token');
+
+  return {
+    ...actual,
+    getAccount: mocks.getAccount,
+    getAssociatedTokenAddress: mocks.getAssociatedTokenAddress,
+  };
+});
+
+vi.mock('@percolatorct/sdk', async () => {
+  const actual = await vi.importActual<typeof import('@percolatorct/sdk')>('@percolatorct/sdk');
+
+  return {
+    ...actual,
+    deriveVaultAuthority: mocks.deriveVaultAuthority,
+    deriveMatcherDelegate: mocks.deriveMatcherDelegate,
+  };
+});
+
+import { useCreateMarket } from '@/hooks/useCreateMarket';
+
+describe('useCreateMarket v17 matcher resume PoC', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.deriveMatcherDelegate.mockReset();
+
+    mocks.getAssociatedTokenAddress.mockReset();
+    mocks.getAssociatedTokenAddress.mockResolvedValue(new PublicKey(new Uint8Array(32).fill(24)));
+
+    const walletKeypair = Keypair.generate();
+    const programId = new PublicKey('69VUZ7a2BeXBTpRRManLamF5UWTaNR9B1hy5Se3cdXy9');
+    const matcherProgramId = new PublicKey('4seJWjv3R5qfXY8R5ntuPHWsoqcVvaxvfFSnU2AnGMhT');
+
+    mocks.connection = {
+      getAccountInfo: mocks.getAccountInfo,
+      getProgramAccounts: mocks.getProgramAccounts,
+    };
+
+    mocks.wallet = {
+      publicKey: walletKeypair.publicKey,
+      connected: true,
+      connecting: false,
+      signTransaction: vi.fn(async (tx) => tx),
+      signAllTransactions: vi.fn(async (txs) => txs),
+      signMessage: vi.fn(),
+      disconnect: vi.fn(),
+    };
+
+    mocks.config = {
+      programId: programId.toBase58(),
+      matcherProgramId: matcherProgramId.toBase58(),
+      programsBySlabTier: undefined,
+    };
+
+    mocks.sendTx.mockResolvedValue('mock-signature');
+
+    mocks.deriveVaultAuthority.mockReturnValue([new PublicKey(new Uint8Array(32).fill(23)), 255]);
+
+    // Stop execution at the beginning of Step 3. This isolates Step 2:
+    // no deposit, insurance, or crank transaction can be submitted.
+    mocks.getAccount.mockResolvedValue({
+      amount: 0n,
+    });
+  });
+
+  it('fails closed when a disabled v17 matcher config contains committed fields', async () => {
+    const walletPublicKey = (
+      mocks.wallet as {
+        publicKey: PublicKey;
+      }
+    ).publicKey;
+
+    const programId = new PublicKey((mocks.config as { programId: string }).programId);
+
+    const slabKeypair = Keypair.fromSeed(new Uint8Array(32).fill(31));
+    const lpPortfolioKeypair = Keypair.generate();
+    const mint = Keypair.generate().publicKey;
+
+    // V17 magic used by the production account-discovery path:
+    // [00, 36, 31, 56, 43, 52, 45, 50].
+    const v17Magic = Buffer.from([0x00, 0x36, 0x31, 0x56, 0x43, 0x52, 0x45, 0x50]);
+    const v17Version = 16;
+    // A v17 market/slab response so create(params, 2) enters
+    // the v17 matcher-initialization branch.
+    const slabData = Buffer.alloc(26_364);
+    v17Magic.copy(slabData, 0);
+    slabData.writeUInt16LE(v17Version, 8);
+    mocks.getAccountInfo.mockResolvedValue({
+      data: slabData,
+      executable: false,
+      lamports: 1,
+      owner: programId,
+      rentEpoch: 0,
+    });
+
+    // Existing LP portfolio:
+    // - same market at offset 16;
+    // - same mutable owner at offset 80;
+    // - remaining bytes zeroed, including matcher config enabled state.
+    //
+    // This models TX A having landed while TX C / TX D did not.
+    const lpPortfolioData = Buffer.alloc(9_347);
+    v17Magic.copy(lpPortfolioData, 0);
+    lpPortfolioData.writeUInt16LE(v17Version, 8);
+    slabKeypair.publicKey.toBuffer().copy(lpPortfolioData, 16);
+    walletPublicKey.toBuffer().copy(lpPortfolioData, 80);
+
+    // Prove that the mocked account matches the same identity fields
+    // used by the production getProgramAccounts lookup.
+    expect(lpPortfolioData).toHaveLength(9_347);
+    expect(lpPortfolioData.subarray(0, 8)).toEqual(v17Magic);
+    expect(lpPortfolioData.subarray(16, 48)).toEqual(slabKeypair.publicKey.toBuffer());
+    expect(lpPortfolioData.subarray(80, 112)).toEqual(walletPublicKey.toBuffer());
+
+    // PortfolioMatcherConfigV16 occupies the final 104 bytes:
+    // matcher_program[32] + matcher_context[32] +
+    // matcher_delegate[32] + enabled[u64].
+    const matcherConfigOffset = lpPortfolioData.length - 104;
+    expect(matcherConfigOffset).toBe(9_243);
+    expect(lpPortfolioData.subarray(matcherConfigOffset, matcherConfigOffset + 96)).toEqual(
+      Buffer.alloc(96),
+    );
+    expect(lpPortfolioData.readBigUInt64LE(matcherConfigOffset + 96)).toBe(0n);
+
+    // A disabled-but-non-empty configuration is inconsistent and must not
+    // be silently overwritten during recovery.
+    lpPortfolioData[matcherConfigOffset] = 1;
+
+    mocks.getProgramAccounts.mockResolvedValue([
+      {
+        pubkey: lpPortfolioKeypair.publicKey,
+        account: {
+          data: lpPortfolioData,
+          executable: false,
+          lamports: 1,
+          owner: programId,
+          rentEpoch: 0,
+        },
+      },
+    ]);
+
+    const { result } = renderHook(() => useCreateMarket());
+
+    act(() => {
+      result.current.restoreSlabKeypair(slabKeypair, slabKeypair.publicKey.toBase58());
+    });
+
+    await act(async () => {
+      await result.current.create(
+        {
+          mint,
+          initialPriceE6: 100_000_000n,
+          lpCollateral: 1_000_000n,
+          insuranceAmount: 100_000n,
+          oracleFeed: '0'.repeat(64),
+          invert: false,
+          tradingFeeBps: 10,
+          initialMarginBps: 1_500,
+          maxAccounts: 4_096,
+          decimals: 6,
+          symbol: 'TEST',
+          name: 'Test Market',
+          oracleMode: 'admin',
+        },
+        2,
+      );
+    });
+
+    const deriveCall = mocks.deriveVaultAuthority.mock.calls[0];
+
+    expect(deriveCall).toBeDefined();
+    expect((deriveCall[0] as PublicKey).toBase58()).toBe(programId.toBase58());
+    expect((deriveCall[1] as PublicKey).toBase58()).toBe(slabKeypair.publicKey.toBase58());
+
+    const actualSdk =
+      await vi.importActual<typeof import('@percolatorct/sdk')>('@percolatorct/sdk');
+
+    const slabHeaderHex = slabData.subarray(0, 10).toString('hex');
+
+    const slabRecognizedByActualSdk = actualSdk.isV17Account(new Uint8Array(slabData));
+
+    expect(slabHeaderHex).toBe('00363156435245501000');
+    expect(slabRecognizedByActualSdk).toBe(true);
+
+    // The existing LP lookup must occur before matcher readiness is evaluated.
+    expect(mocks.getProgramAccounts).toHaveBeenCalledTimes(1);
+
+    // Incomplete matcher state must not submit later-stage transactions.
+    expect(mocks.sendTx).not.toHaveBeenCalled();
+
+    // Recovery must not mark Step 2 complete unless matcher initialization
+    // is verified from authoritative on-chain state.
+    expect(mocks.updateInFlightStep).not.toHaveBeenCalledWith(slabKeypair.publicKey.toBase58(), 3);
+
+    expect(result.current.state.step).toBe(2);
+
+    expect(result.current.state.error).toMatch(
+      /incomplete matcher initialization|cannot safely advance past step 2/i,
+    );
+  });
+
+  it('advances past Step 2 only when an existing v17 LP matcher is fully initialized', async () => {
+    const walletPublicKey = (
+      mocks.wallet as {
+        publicKey: PublicKey;
+      }
+    ).publicKey;
+
+    const programId = new PublicKey(
+      (
+        mocks.config as {
+          programId: string;
+        }
+      ).programId,
+    );
+
+    const matcherProgramId = new PublicKey(
+      (
+        mocks.config as {
+          matcherProgramId: string;
+        }
+      ).matcherProgramId,
+    );
+
+    const slabKeypair = Keypair.fromSeed(new Uint8Array(32).fill(32));
+
+    const lpPortfolioKeypair = Keypair.generate();
+    const matcherContextKeypair = Keypair.generate();
+    const mint = Keypair.generate().publicKey;
+
+    const actualSdk =
+      await vi.importActual<typeof import('@percolatorct/sdk')>('@percolatorct/sdk');
+
+    const expectedDelegate = new PublicKey(new Uint8Array(32).fill(26));
+
+    mocks.deriveMatcherDelegate.mockReturnValue([expectedDelegate, 255]);
+
+    // Valid v17 slab fixture.
+    const v17Magic = Buffer.from([0x00, 0x36, 0x31, 0x56, 0x43, 0x52, 0x45, 0x50]);
+
+    const v17Version = 16;
+    const slabData = Buffer.alloc(26_364);
+
+    v17Magic.copy(slabData, 0);
+    slabData.writeUInt16LE(v17Version, 8);
+
+    const slabAccount = {
+      data: slabData,
+      executable: false,
+      lamports: 1,
+      owner: programId,
+      rentEpoch: 0,
+    };
+
+    // Existing LP portfolio with a complete and enabled matcher config.
+    const lpPortfolioData = Buffer.alloc(actualSdk.V17_PORTFOLIO_ACCOUNT_LEN);
+
+    v17Magic.copy(lpPortfolioData, 0);
+    lpPortfolioData.writeUInt16LE(v17Version, 8);
+
+    slabKeypair.publicKey.toBuffer().copy(lpPortfolioData, 16);
+
+    walletPublicKey.toBuffer().copy(lpPortfolioData, 80);
+
+    const matcherConfigOffset = lpPortfolioData.length - 104;
+
+    matcherProgramId.toBuffer().copy(lpPortfolioData, matcherConfigOffset);
+
+    matcherContextKeypair.publicKey.toBuffer().copy(lpPortfolioData, matcherConfigOffset + 32);
+
+    expectedDelegate.toBuffer().copy(lpPortfolioData, matcherConfigOffset + 64);
+
+    lpPortfolioData.writeBigUInt64LE(1n, matcherConfigOffset + 96);
+
+    // Initialized matcher context:
+    // the wrapper delegate PDA is stored at CTX_VAMM_OFFSET.
+    const matcherContextData = Buffer.alloc(actualSdk.MATCHER_CONTEXT_LEN);
+
+    expectedDelegate.toBuffer().copy(matcherContextData, actualSdk.CTX_VAMM_OFFSET);
+
+    mocks.getAccountInfo.mockReset();
+
+    mocks.getAccountInfo
+      // Initial Step 2 slab lookup.
+      .mockResolvedValueOnce(slabAccount)
+      // Matcher-context readiness lookup.
+      .mockResolvedValueOnce({
+        data: matcherContextData,
+        executable: false,
+        lamports: 1,
+        owner: matcherProgramId,
+        rentEpoch: 0,
+      })
+      // Later Step 3 slab re-read.
+      .mockResolvedValue(slabAccount);
+
+    mocks.getProgramAccounts.mockResolvedValue([
+      {
+        pubkey: lpPortfolioKeypair.publicKey,
+        account: {
+          data: lpPortfolioData,
+          executable: false,
+          lamports: 1,
+          owner: programId,
+          rentEpoch: 0,
+        },
+      },
+    ]);
+
+    const { result } = renderHook(() => useCreateMarket());
+
+    act(() => {
+      result.current.restoreSlabKeypair(slabKeypair, slabKeypair.publicKey.toBase58());
+    });
+
+    await act(async () => {
+      await result.current.create(
+        {
+          mint,
+          initialPriceE6: 100_000_000n,
+          lpCollateral: 1_000_000n,
+          insuranceAmount: 100_000n,
+          oracleFeed: '0'.repeat(64),
+          invert: false,
+          tradingFeeBps: 10,
+          initialMarginBps: 1_500,
+          maxAccounts: 4_096,
+          decimals: 6,
+          symbol: 'TEST',
+          name: 'Test Market',
+          oracleMode: 'admin',
+        },
+        2,
+      );
+    });
+
+    expect(mocks.getProgramAccounts).toHaveBeenCalledTimes(1);
+
+    expect(mocks.deriveMatcherDelegate).toHaveBeenCalledWith(
+      programId,
+      slabKeypair.publicKey,
+      lpPortfolioKeypair.publicKey,
+      walletPublicKey,
+      matcherProgramId,
+      matcherContextKeypair.publicKey,
+    );
+
+    expect(mocks.getAccountInfo).toHaveBeenCalledWith(matcherContextKeypair.publicKey);
+
+    // A verified matcher must not cause TX A-D to be repeated.
+    expect(mocks.sendTx).not.toHaveBeenCalled();
+
+    // The persisted recovery marker may advance only after
+    // authoritative matcher readiness validation succeeds.
+    expect(mocks.updateInFlightStep).toHaveBeenCalledWith(slabKeypair.publicKey.toBase58(), 3);
+  });
+});

--- a/app/__tests__/lib/v17-matcher-state.test.ts
+++ b/app/__tests__/lib/v17-matcher-state.test.ts
@@ -1,0 +1,103 @@
+import { PublicKey } from '@solana/web3.js';
+import { CTX_VAMM_OFFSET, MATCHER_CONTEXT_LEN, V17_PORTFOLIO_ACCOUNT_LEN } from '@percolatorct/sdk';
+import { describe, expect, it } from 'vitest';
+
+import {
+  inspectV17MatcherContext,
+  isEmptyV17PortfolioMatcherConfig,
+  readV17PortfolioMatcherConfig,
+  V17_PORTFOLIO_MATCHER_CONFIG_LEN,
+} from '@/lib/v17-matcher-state';
+
+function publicKey(fill: number): PublicKey {
+  return new PublicKey(new Uint8Array(32).fill(fill));
+}
+
+describe('v17 matcher-state helpers', () => {
+  it('parses an explicitly disabled portfolio matcher config', () => {
+    const data = new Uint8Array(V17_PORTFOLIO_ACCOUNT_LEN);
+
+    const config = readV17PortfolioMatcherConfig(data);
+
+    expect(config.enabled).toBe(false);
+    expect(config.matcherProgram.equals(PublicKey.default)).toBe(true);
+    expect(config.matcherContext.equals(PublicKey.default)).toBe(true);
+    expect(config.matcherDelegate.equals(PublicKey.default)).toBe(true);
+  });
+
+  it('parses an enabled portfolio matcher config', () => {
+    const data = new Uint8Array(V17_PORTFOLIO_ACCOUNT_LEN);
+    const offset = data.byteLength - V17_PORTFOLIO_MATCHER_CONFIG_LEN;
+
+    const matcherProgram = publicKey(11);
+    const matcherContext = publicKey(12);
+    const matcherDelegate = publicKey(13);
+
+    data.set(matcherProgram.toBytes(), offset);
+    data.set(matcherContext.toBytes(), offset + 32);
+    data.set(matcherDelegate.toBytes(), offset + 64);
+
+    new DataView(data.buffer, data.byteOffset, data.byteLength).setBigUint64(offset + 96, 1n, true);
+
+    const config = readV17PortfolioMatcherConfig(data);
+
+    expect(config.enabled).toBe(true);
+    expect(config.matcherProgram.equals(matcherProgram)).toBe(true);
+    expect(config.matcherContext.equals(matcherContext)).toBe(true);
+    expect(config.matcherDelegate.equals(matcherDelegate)).toBe(true);
+  });
+
+  it('rejects a non-boolean matcher enabled value', () => {
+    const data = new Uint8Array(V17_PORTFOLIO_ACCOUNT_LEN);
+    const offset = data.byteLength - V17_PORTFOLIO_MATCHER_CONFIG_LEN;
+
+    new DataView(data.buffer, data.byteOffset, data.byteLength).setBigUint64(offset + 96, 2n, true);
+
+    expect(() => readV17PortfolioMatcherConfig(data)).toThrow(/invalid v17 matcher enabled value/i);
+  });
+
+  it('classifies a zeroed matcher context as uninitialized', () => {
+    const data = new Uint8Array(MATCHER_CONTEXT_LEN);
+
+    expect(inspectV17MatcherContext(data, publicKey(21))).toBe('uninitialized');
+  });
+
+  it('classifies a context containing the expected delegate as initialized', () => {
+    const data = new Uint8Array(MATCHER_CONTEXT_LEN);
+    const delegate = publicKey(22);
+
+    data.set(delegate.toBytes(), CTX_VAMM_OFFSET);
+
+    expect(inspectV17MatcherContext(data, delegate)).toBe('initialized');
+  });
+
+  it('rejects a context bound to another delegate', () => {
+    const data = new Uint8Array(MATCHER_CONTEXT_LEN);
+
+    data.set(publicKey(23).toBytes(), CTX_VAMM_OFFSET);
+
+    expect(inspectV17MatcherContext(data, publicKey(24))).toBe('invalid');
+  });
+
+  it('rejects an undersized matcher context', () => {
+    const data = new Uint8Array(MATCHER_CONTEXT_LEN - 1);
+
+    expect(inspectV17MatcherContext(data, publicKey(25))).toBe('invalid');
+  });
+
+  it('distinguishes an empty disabled config from a partially committed config', () => {
+    const data = new Uint8Array(V17_PORTFOLIO_ACCOUNT_LEN);
+
+    const emptyConfig = readV17PortfolioMatcherConfig(data);
+
+    expect(isEmptyV17PortfolioMatcherConfig(emptyConfig)).toBe(true);
+
+    const offset = data.byteLength - V17_PORTFOLIO_MATCHER_CONFIG_LEN;
+
+    data.set(publicKey(31).toBytes(), offset);
+
+    const partialConfig = readV17PortfolioMatcherConfig(data);
+
+    expect(isEmptyV17PortfolioMatcherConfig(partialConfig)).toBe(false);
+  });
+});

--- a/app/hooks/useCreateMarket.ts
+++ b/app/hooks/useCreateMarket.ts
@@ -74,6 +74,11 @@ import { getConfig, getNetwork } from "@/lib/config";
 import { normalizeDexType } from "@/lib/dex-type";
 import { parseMarketCreationError } from "@/lib/parseMarketError";
 import {
+  inspectV17MatcherContext,
+  isEmptyV17PortfolioMatcherConfig,
+  readV17PortfolioMatcherConfig,
+} from "@/lib/v17-matcher-state";
+import {
   saveInFlightMarket,
   updateInFlightStep,
   clearInFlightMarket,
@@ -1055,81 +1060,255 @@ export function useCreateMarket() {
             // magic+market+owner filter Step 3 below uses to FIND this portfolio — and
             // skip the whole TX A-D sequence if one already exists (mirrors the
             // existence-check pattern Steps 4/5 already use for their own accounts).
-            const V17_MAGIC_BYTES_STEP2 = Buffer.from([0x00, 0x36, 0x31, 0x56, 0x43, 0x52, 0x45, 0x50]);
-            const existingLpPortfolios = await connection.getProgramAccounts(programId, {
-              filters: [
-                { memcmp: { offset: 0, bytes: V17_MAGIC_BYTES_STEP2.toString("base64"), encoding: "base64" } },
-                { memcmp: { offset: 16, bytes: slabPk.toBase58() } },
-                { memcmp: { offset: 80, bytes: wallet.publicKey.toBase58() } },
-              ],
-            });
+            const V17_MAGIC_BYTES_STEP2 = Buffer.from([
+              0x00,
+              0x36,
+              0x31,
+              0x56,
+              0x43,
+              0x52,
+              0x45,
+              0x50,
+            ]);
 
-            if (existingLpPortfolios.length === 0) {
-              // TX A: Create LP portfolio account + InitPortfolio (tag 1).
-              // Size + fund rent for the FULL portfolio length (9347): InitPortfolio reallocs up to it
-              // and adds no lamports, so an undersized account fails with InsufficientFundsForRent.
-              const lpPortfolioKp = Keypair.generate();
-              const lpPortfolioPk = lpPortfolioKp.publicKey;
-              const portfolioRent = await connection.getMinimumBalanceForRentExemption(V17_PORTFOLIO_ACCOUNT_LEN);
+            const I128_MAX_STEP2 =
+              170141183460469231731687303715884105727n;
 
-              const createPortfolioIx = SystemProgram.createAccount({
-                fromPubkey: wallet.publicKey,
-                newAccountPubkey: lpPortfolioPk,
-                lamports: portfolioRent,
-                space: V17_PORTFOLIO_ACCOUNT_LEN,
+            const walletPublicKeyStep2 = wallet.publicKey;
+
+            if (!walletPublicKeyStep2) {
+              throw new Error(
+                "Wallet disconnected while recovering Step 2.",
+              );
+            }
+
+            const buildInitMatcherCtxInstruction = (
+              lpPortfolioPk: PublicKey,
+              matcherCtxPk: PublicKey,
+              delegatePk: PublicKey,
+            ): TransactionInstruction =>
+              buildIx({
                 programId,
-              });
-              const initPortfolioIx = buildIx({
-                programId,
-                keys: buildAccountMetas(ACCOUNTS_INIT_USER, [
-                  wallet.publicKey,
+                keys: buildAccountMetas(ACCOUNTS_INIT_MATCHER_CTX, [
+                  walletPublicKeyStep2,
                   slabPk,
                   lpPortfolioPk,
+                  matcherCtxPk,
+                  matcherProgramId,
+                  delegatePk,
                 ]),
-                data: encodeInitUser({}),
+                data: encodeInitMatcherCtx({
+                  kind: 0,
+                  tradingFeeBps: Number(params.tradingFeeBps),
+                  baseSpreadBps: 50,
+                  maxTotalBps: 200,
+                  impactKBps: 0,
+                  liquidityNotionalE6: 0n,
+                  maxFillAbs: I128_MAX_STEP2,
+                  maxInventoryAbs: I128_MAX_STEP2,
+                  feeToInsuranceBps: 0,
+                  skewSpreadMultBps: 0,
+                }),
               });
 
-              const sigPortfolio = await sendTx({
-                connection, wallet,
-                instructions: [createPortfolioIx, initPortfolioIx],
-                signers: [lpPortfolioKp],
+            const sendMatcherContextInitialization = async (
+              lpPortfolioPk: PublicKey,
+              matcherCtxPk: PublicKey,
+              delegatePk: PublicKey,
+            ): Promise<void> => {
+              const initMatcherCtxIx = buildInitMatcherCtxInstruction(
+                lpPortfolioPk,
+                matcherCtxPk,
+                delegatePk,
+              );
+
+              const signature = await sendTx({
+                connection,
+                wallet,
+                instructions: [initMatcherCtxIx],
                 computeUnits: 200_000,
               });
-              setState((s) => ({ ...s, txSigs: [...s.txSigs, sigPortfolio] }));
 
-              // TX B: Create matcher context account ONLY (empty, matcher-program-owned).
-              // No longer calls the matcher program directly here — see fix note above.
+              setState((state) => ({
+                ...state,
+                txSigs: [...state.txSigs, signature],
+              }));
+            };
+
+            const inspectConfiguredMatcherState = async (
+              lpPortfolioPk: PublicKey,
+              portfolioData: Uint8Array,
+            ) => {
+              const matcherConfig =
+                readV17PortfolioMatcherConfig(portfolioData);
+
+              if (!matcherConfig.enabled) {
+                throw new Error(
+                  "Existing LP portfolio has incomplete matcher initialization: " +
+                    "matcher configuration is disabled; cannot safely advance " +
+                    "past Step 2.",
+                );
+              }
+
+              if (!matcherConfig.matcherProgram.equals(matcherProgramId)) {
+                throw new Error(
+                  "Cannot safely resume Step 2: the existing LP portfolio " +
+                    "references an unexpected matcher program.",
+                );
+              }
+
+              if (matcherConfig.matcherContext.equals(PublicKey.default)) {
+                throw new Error(
+                  "Existing LP portfolio has incomplete matcher initialization: " +
+                    "matcher context is not configured; cannot safely advance " +
+                    "past Step 2.",
+                );
+              }
+
+              const [expectedDelegatePk] = deriveMatcherDelegate(
+                programId,
+                slabPk,
+                lpPortfolioPk,
+                walletPublicKeyStep2,
+                matcherProgramId,
+                matcherConfig.matcherContext,
+              );
+
+              if (!matcherConfig.matcherDelegate.equals(expectedDelegatePk)) {
+                throw new Error(
+                  "Cannot safely resume Step 2: the stored matcher delegate " +
+                    "does not match the expected PDA.",
+                );
+              }
+
+              const matcherContextInfo = await connection.getAccountInfo(
+                matcherConfig.matcherContext,
+              );
+
+              if (!matcherContextInfo) {
+                throw new Error(
+                  "Existing LP portfolio has incomplete matcher initialization: " +
+                    "the configured matcher-context account does not exist; " +
+                    "cannot safely advance past Step 2.",
+                );
+              }
+
+              if (!matcherContextInfo.owner.equals(matcherProgramId)) {
+                throw new Error(
+                  "Cannot safely resume Step 2: the matcher-context account " +
+                    "is owned by an unexpected program.",
+                );
+              }
+
+              const contextState = inspectV17MatcherContext(
+                new Uint8Array(matcherContextInfo.data),
+                expectedDelegatePk,
+              );
+
+              if (contextState === "invalid") {
+                throw new Error(
+                  "Cannot safely resume Step 2: the matcher-context account " +
+                    "has an invalid layout or is bound to another delegate.",
+                );
+              }
+
+              return {
+                matcherConfig,
+                expectedDelegatePk,
+                contextState,
+              };
+            };
+
+            const verifyMatcherReadiness = async (
+              lpPortfolioPk: PublicKey,
+            ): Promise<void> => {
+              const freshPortfolioInfo =
+                await connection.getAccountInfo(lpPortfolioPk);
+
+              if (!freshPortfolioInfo) {
+                throw new Error(
+                  "Matcher recovery could not be verified: the LP portfolio " +
+                    "account was not found after recovery.",
+                );
+              }
+
+              if (!freshPortfolioInfo.owner.equals(programId)) {
+                throw new Error(
+                  "Matcher recovery could not be verified: the LP portfolio " +
+                    "is owned by an unexpected program.",
+                );
+              }
+
+              if (
+                freshPortfolioInfo.data.length !==
+                V17_PORTFOLIO_ACCOUNT_LEN
+              ) {
+                throw new Error(
+                  "Matcher recovery could not be verified: the LP portfolio " +
+                    `has an unexpected length (${freshPortfolioInfo.data.length}).`,
+                );
+              }
+
+              const verifiedState = await inspectConfiguredMatcherState(
+                lpPortfolioPk,
+                new Uint8Array(freshPortfolioInfo.data),
+              );
+
+              if (verifiedState.contextState !== "initialized") {
+                throw new Error(
+                  "Matcher recovery transaction completed, but authoritative " +
+                    "on-chain state still reports an uninitialized matcher context.",
+                );
+              }
+            };
+
+            const createAndInitializeMatcher = async (
+              lpPortfolioPk: PublicKey,
+            ): Promise<void> => {
+              // TX B: create the matcher-program-owned context account.
               const matcherCtxKp = Keypair.generate();
               const matcherCtxPk = matcherCtxKp.publicKey;
-              const matcherCtxRent = await connection.getMinimumBalanceForRentExemption(MATCHER_CONTEXT_LEN);
+
+              const matcherCtxRent =
+                await connection.getMinimumBalanceForRentExemption(
+                  MATCHER_CONTEXT_LEN,
+                );
 
               const createCtxIx = SystemProgram.createAccount({
-                fromPubkey: wallet.publicKey,
+                fromPubkey: walletPublicKeyStep2,
                 newAccountPubkey: matcherCtxPk,
                 lamports: matcherCtxRent,
                 space: MATCHER_CONTEXT_LEN,
                 programId: matcherProgramId,
               });
 
-              // Derive matcher delegate PDA: seeds = ["matcher", market, lpPortfolio, lpOwner, matcherProg, ctx]
               const [delegatePk] = deriveMatcherDelegate(
-                programId, slabPk, lpPortfolioPk, wallet.publicKey, matcherProgramId, matcherCtxPk,
+                programId,
+                slabPk,
+                lpPortfolioPk,
+                walletPublicKeyStep2,
+                matcherProgramId,
+                matcherCtxPk,
               );
 
-              const sigCtx = await sendTx({
-                connection, wallet,
+              const contextSignature = await sendTx({
+                connection,
+                wallet,
                 instructions: [createCtxIx],
                 signers: [matcherCtxKp],
                 computeUnits: 150_000,
               });
-              setState((s) => ({ ...s, txSigs: [...s.txSigs, sigCtx] }));
 
-              // TX C: SetMatcherConfig (tag 68) on the LP portfolio — MUST land before TX D.
-              // Accounts: [lpOwner(s), market(ro), lpPortfolio(w), matcherProg(ro), matcherCtx(ro), delegate(ro)]
+              setState((state) => ({
+                ...state,
+                txSigs: [...state.txSigs, contextSignature],
+              }));
+
+              // TX C: commit the context and delegate to the LP portfolio.
               const setMatcherConfigIx = buildIx({
                 programId,
                 keys: buildAccountMetas(ACCOUNTS_SET_MATCHER_CONFIG, [
-                  wallet.publicKey,
+                  walletPublicKeyStep2,
                   slabPk,
                   lpPortfolioPk,
                   matcherProgramId,
@@ -1139,51 +1318,173 @@ export function useCreateMarket() {
                 data: encodeSetMatcherConfig({ enabled: 1 }),
               });
 
-              const sigMatcherCfg = await sendTx({
-                connection, wallet,
+              const configSignature = await sendTx({
+                connection,
+                wallet,
                 instructions: [setMatcherConfigIx],
                 computeUnits: 200_000,
               });
-              setState((s) => ({ ...s, txSigs: [...s.txSigs, sigMatcherCfg] }));
 
-              // TX D: InitMatcherCtx (tag 83) on the WRAPPER — CPIs into the matcher program,
-              // invoke_signed-ing the delegate PDA so the matcher's process_init sees
-              // lp_pda.is_signer == true. This is the real fix (see note above).
-              // Accounts: [lpOwner(s), market(ro), lpPortfolio(ro), matcherCtx(w), matcherProg(ro), matcherDelegate(ro)]
-              const I128_MAX = 170141183460469231731687303715884105727n;
-              const initMatcherCtxIx = buildIx({
+              setState((state) => ({
+                ...state,
+                txSigs: [...state.txSigs, configSignature],
+              }));
+
+              // TX D: initialize the committed matcher context through the wrapper.
+              await sendMatcherContextInitialization(
+                lpPortfolioPk,
+                matcherCtxPk,
+                delegatePk,
+              );
+            };
+
+            const existingLpPortfolios =
+              await connection.getProgramAccounts(programId, {
+                filters: [
+                  { dataSize: V17_PORTFOLIO_ACCOUNT_LEN },
+                  {
+                    memcmp: {
+                      offset: 0,
+                      bytes: V17_MAGIC_BYTES_STEP2.toString("base64"),
+                      encoding: "base64",
+                    },
+                  },
+                  {
+                    memcmp: {
+                      offset: 16,
+                      bytes: slabPk.toBase58(),
+                    },
+                  },
+                  {
+                    memcmp: {
+                      offset: 80,
+                      bytes: walletPublicKeyStep2.toBase58(),
+                    },
+                  },
+                ],
+              });
+
+            if (existingLpPortfolios.length === 0) {
+              // TX A: create and initialize the LP portfolio.
+              const lpPortfolioKp = Keypair.generate();
+              const lpPortfolioPk = lpPortfolioKp.publicKey;
+
+              const portfolioRent =
+                await connection.getMinimumBalanceForRentExemption(
+                  V17_PORTFOLIO_ACCOUNT_LEN,
+                );
+
+              const createPortfolioIx = SystemProgram.createAccount({
+                fromPubkey: walletPublicKeyStep2,
+                newAccountPubkey: lpPortfolioPk,
+                lamports: portfolioRent,
+                space: V17_PORTFOLIO_ACCOUNT_LEN,
                 programId,
-                keys: buildAccountMetas(ACCOUNTS_INIT_MATCHER_CTX, [
-                  wallet.publicKey,
+              });
+
+              const initPortfolioIx = buildIx({
+                programId,
+                keys: buildAccountMetas(ACCOUNTS_INIT_USER, [
+                  walletPublicKeyStep2,
                   slabPk,
                   lpPortfolioPk,
-                  matcherCtxPk,
-                  matcherProgramId,
-                  delegatePk,
                 ]),
-                data: encodeInitMatcherCtx({
-                  kind: 0, // Passive
-                  tradingFeeBps: Number(params.tradingFeeBps),
-                  baseSpreadBps: 50,
-                  maxTotalBps: 200,
-                  impactKBps: 0,
-                  liquidityNotionalE6: 0n,
-                  maxFillAbs: I128_MAX,
-                  maxInventoryAbs: I128_MAX,
-                  feeToInsuranceBps: 0,
-                  skewSpreadMultBps: 0,
-                }),
+                data: encodeInitUser({}),
               });
 
-              const sigInitMatcherCtx = await sendTx({
-                connection, wallet,
-                instructions: [initMatcherCtxIx],
+              const portfolioSignature = await sendTx({
+                connection,
+                wallet,
+                instructions: [createPortfolioIx, initPortfolioIx],
+                signers: [lpPortfolioKp],
                 computeUnits: 200_000,
               });
-              setState((s) => ({ ...s, txSigs: [...s.txSigs, sigInitMatcherCtx] }));
+
+              setState((state) => ({
+                ...state,
+                txSigs: [...state.txSigs, portfolioSignature],
+              }));
+
+              await createAndInitializeMatcher(lpPortfolioPk);
+              await verifyMatcherReadiness(lpPortfolioPk);
             } else {
-              console.log("[useCreateMarket] Step 2 already completed (LP portfolio exists) — skipping TX A-D.");
+              if (existingLpPortfolios.length !== 1) {
+                throw new Error(
+                  `Cannot safely resume Step 2: expected exactly one LP portfolio, ` +
+                    `found ${existingLpPortfolios.length}.`,
+                );
+              }
+
+              const existingLpPortfolio = existingLpPortfolios[0];
+
+              if (!existingLpPortfolio) {
+                throw new Error(
+                  "Cannot safely resume Step 2: the LP portfolio lookup " +
+                    "returned an empty result.",
+                );
+              }
+
+              const lpPortfolioPk = existingLpPortfolio.pubkey;
+              const lpPortfolioAccount = existingLpPortfolio.account;
+
+              if (!lpPortfolioAccount.owner.equals(programId)) {
+                throw new Error(
+                  "Cannot safely resume Step 2: the existing LP portfolio " +
+                    "is not owned by the configured wrapper program.",
+                );
+              }
+
+              const matcherConfig = readV17PortfolioMatcherConfig(
+                new Uint8Array(lpPortfolioAccount.data),
+              );
+
+              if (!matcherConfig.enabled) {
+                if (!isEmptyV17PortfolioMatcherConfig(matcherConfig)) {
+                  throw new Error(
+                    "Existing LP portfolio has incomplete matcher initialization: " +
+                      "the disabled matcher configuration contains committed " +
+                      "fields; cannot safely advance past Step 2.",
+                  );
+                }
+
+                // TX A already landed. Resume only TX B, TX C, and TX D.
+                await createAndInitializeMatcher(lpPortfolioPk);
+                await verifyMatcherReadiness(lpPortfolioPk);
+
+                console.log(
+                  "[useCreateMarket] Step 2 recovered missing matcher " +
+                    "context/config/initialization (TX B-D).",
+                );
+              } else {
+                const configuredState =
+                  await inspectConfiguredMatcherState(
+                    lpPortfolioPk,
+                    new Uint8Array(lpPortfolioAccount.data),
+                  );
+
+                if (configuredState.contextState === "uninitialized") {
+                  // TX A-C already landed. Resume only TX D using the committed context.
+                  await sendMatcherContextInitialization(
+                    lpPortfolioPk,
+                    configuredState.matcherConfig.matcherContext,
+                    configuredState.expectedDelegatePk,
+                  );
+
+                  await verifyMatcherReadiness(lpPortfolioPk);
+
+                  console.log(
+                    "[useCreateMarket] Step 2 recovered the missing matcher " +
+                      "context initialization (TX D only).",
+                  );
+                } else {
+                  console.log(
+                    "[useCreateMarket] Step 2 matcher state verified on-chain - " +
+                      "skipping duplicate TX A-D.",
+                  );
+                }
+              }
             }
+
             updateInFlightStep(slabPk.toBase58(), 3);
           } else {
             // v12 legacy: encodeInitLP (tag 2) is removed in v17 — skip for v17 slabs.

--- a/app/lib/v17-matcher-state.ts
+++ b/app/lib/v17-matcher-state.ts
@@ -1,0 +1,124 @@
+import { PublicKey } from '@solana/web3.js';
+import { CTX_VAMM_OFFSET, MATCHER_CONTEXT_LEN } from '@percolatorct/sdk';
+
+const PUBLIC_KEY_LEN = 32;
+
+/**
+ * PortfolioMatcherConfigV16 is appended to the end of each v17
+ * portfolio account:
+ *
+ * matcher_program[32]
+ * matcher_context[32]
+ * matcher_delegate[32]
+ * enabled[u64]
+ */
+export const V17_PORTFOLIO_MATCHER_CONFIG_LEN = 104;
+
+const MATCHER_PROGRAM_RELATIVE_OFFSET = 0;
+const MATCHER_CONTEXT_RELATIVE_OFFSET = 32;
+const MATCHER_DELEGATE_RELATIVE_OFFSET = 64;
+const MATCHER_ENABLED_RELATIVE_OFFSET = 96;
+
+export interface V17PortfolioMatcherConfig {
+  matcherProgram: PublicKey;
+  matcherContext: PublicKey;
+  matcherDelegate: PublicKey;
+  enabled: boolean;
+}
+
+export type V17MatcherContextState = 'initialized' | 'uninitialized' | 'invalid';
+
+/**
+ * Reads PortfolioMatcherConfigV16 from the trailing 104 bytes of a
+ * v17 portfolio account.
+ *
+ * Disabled configurations are returned with enabled=false so callers
+ * can distinguish a recoverable incomplete setup from malformed data.
+ */
+export function readV17PortfolioMatcherConfig(data: Uint8Array): V17PortfolioMatcherConfig {
+  if (data.byteLength < V17_PORTFOLIO_MATCHER_CONFIG_LEN) {
+    throw new Error(
+      `Invalid v17 portfolio length: expected at least ` +
+        `${V17_PORTFOLIO_MATCHER_CONFIG_LEN} bytes, received ` +
+        `${data.byteLength}`,
+    );
+  }
+
+  const offset = data.byteLength - V17_PORTFOLIO_MATCHER_CONFIG_LEN;
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+
+  const enabledRaw = view.getBigUint64(offset + MATCHER_ENABLED_RELATIVE_OFFSET, true);
+
+  if (enabledRaw !== 0n && enabledRaw !== 1n) {
+    throw new Error(`Invalid v17 matcher enabled value: ${enabledRaw.toString()}`);
+  }
+
+  return {
+    matcherProgram: new PublicKey(
+      data.subarray(
+        offset + MATCHER_PROGRAM_RELATIVE_OFFSET,
+        offset + MATCHER_PROGRAM_RELATIVE_OFFSET + PUBLIC_KEY_LEN,
+      ),
+    ),
+    matcherContext: new PublicKey(
+      data.subarray(
+        offset + MATCHER_CONTEXT_RELATIVE_OFFSET,
+        offset + MATCHER_CONTEXT_RELATIVE_OFFSET + PUBLIC_KEY_LEN,
+      ),
+    ),
+    matcherDelegate: new PublicKey(
+      data.subarray(
+        offset + MATCHER_DELEGATE_RELATIVE_OFFSET,
+        offset + MATCHER_DELEGATE_RELATIVE_OFFSET + PUBLIC_KEY_LEN,
+      ),
+    ),
+    enabled: enabledRaw === 1n,
+  };
+}
+
+function isAllZero(data: Uint8Array): boolean {
+  return data.every((value) => value === 0);
+}
+
+export function isEmptyV17PortfolioMatcherConfig(config: V17PortfolioMatcherConfig): boolean {
+  return (
+    !config.enabled &&
+    config.matcherProgram.equals(PublicKey.default) &&
+    config.matcherContext.equals(PublicKey.default) &&
+    config.matcherDelegate.equals(PublicKey.default)
+  );
+}
+
+/**
+ * Classifies a matcher-context account using the matcher program's
+ * authoritative context layout.
+ *
+ * The matcher writes its expected LP signer at CTX_VAMM_OFFSET during
+ * one-time initialization. In the wrapper flow that signer is the
+ * derived matcher-delegate PDA.
+ *
+ * Account ownership must be checked separately by the caller because
+ * ownership is part of AccountInfo rather than account data.
+ */
+export function inspectV17MatcherContext(
+  data: Uint8Array,
+  expectedDelegate: PublicKey,
+): V17MatcherContextState {
+  if (data.byteLength < MATCHER_CONTEXT_LEN) {
+    return 'invalid';
+  }
+
+  const delegateEnd = CTX_VAMM_OFFSET + PUBLIC_KEY_LEN;
+
+  if (delegateEnd > data.byteLength) {
+    return 'invalid';
+  }
+
+  const storedDelegate = data.subarray(CTX_VAMM_OFFSET, delegateEnd);
+
+  if (isAllZero(storedDelegate)) {
+    return 'uninitialized';
+  }
+
+  return new PublicKey(storedDelegate).equals(expectedDelegate) ? 'initialized' : 'invalid';
+}


### PR DESCRIPTION
## Summary

Fixes #2374.

The v17 market-creation flow previously treated the existence of an LP portfolio as sufficient evidence that Step 2 had completed.

That assumption is unsafe because Step 2 consists of four independently submitted transactions:

1. **TX A** — create and initialize the LP portfolio
2. **TX B** — create the matcher-context account
3. **TX C** — store matcher configuration on the LP portfolio
4. **TX D** — initialize the matcher context through the wrapper/CPI path

If market creation was interrupted after TX A, TX B, or TX C, a subsequent resume could detect the existing LP portfolio, skip the remaining matcher operations, persist Step 3, and continue while the matcher was still partially initialized.

This PR replaces that portfolio-existence shortcut with state-aware, fail-closed, and idempotent recovery.

---

## Root Cause

The previous Step 2 completion predicate was effectively:

```text
LP portfolio exists
    =>
Step 2 completed
```

However, LP portfolio existence proves only that TX A completed.

It does not prove that:

- the matcher-context account exists;
- matcher configuration was committed to the LP portfolio;
- the stored matcher program is correct;
- the stored matcher context is valid;
- the stored matcher delegate matches the expected PDA;
- the matcher-context account is owned by the configured matcher program;
- matcher initialization completed successfully;
- the matcher is ready for later market-creation stages.

As a result, partially initialized on-chain state could be incorrectly treated as a completed Step 2 state.

---

## Changes

### 1. Replace the unsafe portfolio-existence shortcut

Step 2 no longer advances solely because an LP portfolio account was discovered.

The recovery flow now reads and validates the authoritative matcher state before deciding whether to:

- perform the normal TX A–D initialization path;
- recover TX B–D;
- recover TX D only;
- skip duplicate transactions;
- fail closed and remain at Step 2.

---

### 2. Restrict LP portfolio discovery to exact v17 accounts

The Step 2 account lookup now includes an exact account-size filter:

```ts
{ dataSize: V17_PORTFOLIO_ACCOUNT_LEN }
```

This prevents unrelated, malformed, or legacy accounts that happen to match the identity memcmp filters from being accepted as valid v17 LP portfolios.

The discovered portfolio is also validated for:

- expected account owner;
- expected account length;
- expected market identity;
- expected wallet owner identity.

---

### 3. Add reusable v17 matcher-state parsing

A dedicated matcher-state helper was added to parse and classify the portfolio matcher configuration and matcher-context account.

The helper validates:

- matcher program;
- matcher context;
- matcher delegate;
- matcher enabled value;
- matcher-context account layout;
- matcher-context delegate binding;
- initialized versus uninitialized context state.

It distinguishes between:

- a fully empty matcher configuration that can be recovered;
- an enabled matcher configuration;
- a disabled but partially committed configuration;
- a zeroed matcher-context account;
- an initialized matcher context;
- an invalid, undersized, or incorrectly bound matcher context.

Malformed or inconsistent state is rejected instead of being treated as recoverable completion.

---

### 4. Recover TX B–D when only TX A completed

When the LP portfolio exists but its matcher configuration is still completely empty, the flow now:

1. reuses the existing LP portfolio;
2. creates a new matcher-context account through TX B;
3. stores matcher configuration through TX C;
4. initializes the matcher context through TX D;
5. re-fetches the resulting on-chain state;
6. verifies matcher readiness;
7. advances to Step 3 only after verification succeeds.

TX A is not submitted again.

The recovery path preserves the existing instruction contracts:

- TX C uses `SetMatcherConfig` tag `68`;
- TX D uses `InitMatcherCtx` tag `83`;
- TX D continues through the wrapper/CPI path;
- the matcher-context account is created with the expected size and owner program.

---

### 5. Recover TX D only when matcher configuration is already committed

When the LP portfolio already contains a valid matcher configuration but the committed matcher-context account is still uninitialized, the flow now:

1. reuses the matcher context already stored in the portfolio;
2. validates the committed matcher program;
3. validates the expected matcher delegate PDA;
4. validates the matcher-context account owner and layout;
5. submits TX D only;
6. re-fetches the matcher state;
7. advances only after initialization is confirmed.

The flow does not create or silently substitute a different matcher-context account after one has already been committed to the portfolio.

---

### 6. Skip duplicate TX A–D only after authoritative verification

When matcher configuration and matcher-context state are already fully initialized, the flow submits no duplicate Step 2 transactions.

Before advancing, it verifies that:

- matcher configuration is enabled;
- matcher program matches the configured matcher program;
- matcher context is non-default;
- matcher delegate matches the expected derived PDA;
- matcher-context account exists;
- matcher-context owner is correct;
- matcher-context layout is valid;
- matcher context is initialized and bound to the expected delegate.

Only verified on-chain state is treated as completed Step 2 state.

---

### 7. Fail closed on inconsistent matcher state

Recovery now stops safely when it encounters state that cannot be deterministically repaired.

Examples include:

- disabled matcher configuration containing committed non-zero fields;
- unexpected matcher program;
- unexpected matcher delegate;
- missing committed matcher-context account;
- matcher-context account owned by an unexpected program;
- undersized or malformed matcher-context data;
- matcher context bound to another delegate;
- invalid portfolio owner or account length;
- ambiguous portfolio discovery results.

In these cases:

- no later-stage market transactions are submitted;
- Step 3 is not persisted;
- the user remains at Step 2 with an actionable error.

---

### 8. Add final authoritative re-fetch verification

After TX B–D or TX D-only recovery, the implementation re-fetches the LP portfolio and matcher-context account from the connection.

The final verification confirms that:

- the LP portfolio still has the expected owner and size;
- matcher configuration is enabled;
- matcher program is correct;
- matcher context is correct;
- matcher delegate is correct;
- matcher-context account exists;
- matcher-context owner is correct;
- matcher-context layout is valid;
- matcher context is initialized.

`updateInFlightStep(..., 3)` is called only after this authoritative verification succeeds.

This prevents local transaction success or stale client state from being treated as proof of matcher readiness.

---

## Recovery Matrix

| Existing on-chain state | Result |
|---|---|
| No LP portfolio exists | Use the normal TX A–D initialization path |
| LP portfolio exists with completely empty matcher configuration | Skip TX A and recover TX B–D |
| Valid matcher configuration exists but context is uninitialized | Reuse the committed context and recover TX D only |
| Matcher configuration and context are fully initialized | Submit no duplicate TX A–D transactions |
| Disabled configuration contains committed fields | Fail closed and remain at Step 2 |
| Matcher identity, ownership, delegate, or layout is invalid | Fail closed and remain at Step 2 |
| Recovery transaction or final verification fails | Surface the error and do not persist Step 3 |

---

## Safety Properties

This patch preserves the following invariants:

- LP portfolio existence alone cannot advance recovery past Step 2.
- Already completed Step 2 transactions are not repeated.
- Recovery submits only the operations missing from authoritative state.
- A committed matcher context is reused rather than silently replaced.
- Disabled but partially committed matcher configuration is not overwritten.
- Unexpected matcher identity or ownership fails closed.
- Invalid matcher-context layout or delegate binding fails closed.
- Recovery failures do not persist Step 3.
- Final progress is based on re-fetched on-chain state.
- Later-stage transactions are not submitted unless matcher readiness is established.
- The existing wrapper/CPI matcher initialization contract remains unchanged.

---

## Regression Coverage

Added regression coverage for the following scenarios.

### Existing LP with empty matcher configuration

Verifies that:

- TX A is not repeated;
- TX B creates the matcher-context account;
- TX C stores matcher configuration;
- TX D initializes the matcher context;
- exactly three Step 2 recovery transactions are submitted;
- account creation uses the expected payer, context public key, program owner, rent, and account size;
- final matcher state is re-fetched;
- Step 3 is persisted only after verification succeeds.

### Existing committed matcher context that is uninitialized

Verifies that:

- the committed matcher context is reused;
- no replacement context is generated;
- only TX D is submitted;
- matcher state is re-fetched after recovery;
- Step 3 advances only after initialization is confirmed.

### Existing fully initialized matcher

Verifies that:

- no duplicate TX A–D transactions are submitted;
- matcher state is validated from authoritative on-chain data;
- Step 3 advances only after readiness is confirmed.

### Disabled configuration containing committed fields

Verifies that:

- inconsistent state fails closed;
- no later-stage transaction is submitted;
- Step 3 is not persisted;
- an actionable recovery error is surfaced.

### Matcher-state helper validation

Covers:

- explicitly disabled matcher configuration;
- enabled matcher configuration;
- invalid non-boolean enabled values;
- empty versus partially committed configuration;
- zeroed matcher context;
- initialized matcher context;
- incorrect delegate binding;
- undersized matcher-context data.

---

## Validation

The complete local validation gate passes:

```text
TX B-D recovery test:    0
Matcher recovery suite:  0
TypeScript check:        0
Related regression tests: 0
Production build:        0
Prettier check:          0
Source invariant check:  0
git diff --check:        0
```

Targeted matcher recovery results:

```text
Test Files  3 passed
Tests       12 passed
```

Additional validation confirms that:

- the unsafe portfolio-existence shortcut is absent;
- TX B–D recovery is present;
- TX D-only recovery is present;
- final matcher readiness verification is present;
- the exact v17 account-size filter is present;
- the production build completes successfully;
- the branch is synchronized with `upstream/playground`;
- the staged scope contains only the intended files;
- the committed worktree is clean;
- local and remote branch hashes match.

---

## Files Changed

### `app/hooks/useCreateMarket.ts`

- replaces the unsafe Step 2 completion shortcut;
- validates exact v17 LP portfolio accounts;
- classifies existing matcher state;
- adds TX B–D recovery;
- adds TX D-only recovery;
- validates matcher identity and account ownership;
- performs final authoritative readiness verification;
- advances to Step 3 only after verification.

### `app/lib/v17-matcher-state.ts`

- adds shared portfolio matcher-config parsing;
- adds matcher-context state inspection;
- adds empty versus inconsistent config classification;
- validates matcher enabled state and delegate binding.

### `app/__tests__/hooks/useCreateMarket.v17-matcher-resume.test.ts`

- covers fully initialized matcher resume;
- covers fail-closed handling for inconsistent matcher configuration.

### `app/__tests__/hooks/useCreateMarket.v17-matcher-recovery.test.ts`

- covers TX B–D recovery;
- covers TX D-only recovery;
- verifies transaction count and instruction behavior;
- verifies account-creation parameters;
- verifies final Step 3 persistence behavior.

### `app/__tests__/lib/v17-matcher-state.test.ts`

- covers matcher configuration parsing;
- covers matcher-context initialization classification;
- covers malformed and invalid state rejection.

---

## Scope

This PR is intentionally limited to the v17 Step 2 frontend recovery flow and its regression coverage.

It does not modify:

- on-chain program logic;
- matcher instruction formats;
- Step 3 deposit implementation;
- oracle initialization;
- keeper registration;
- earn or stake initialization;
- API routes;
- RPC or network configuration;
- unrelated UI behavior.