### PR TITLE
fix(create): Earn-vault step failed on-chain — force market writable in CreateLpVault

### DIFF
--- a/app/__tests__/unit/create-lp-vault-market-writable.test.ts
+++ b/app/__tests__/unit/create-lp-vault-market-writable.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * The deployed wrapper program writes to the market account in CreateLpVault
+ * (tag 74). Whether the installed SDK's ACCOUNTS_CREATE_LP_VAULT marks
+ * `market` writable depends on WHICH SNAPSHOT of the git-pinned SDK the
+ * install resolved — the version string says 3.0.0 either way, but the
+ * known-good tree the hosted deploy was reverted to (fba2a6d) ships it
+ * read-only, which made every hosted wizard "Create Earn vault" step fail
+ * on-chain with error 7 (AccountNotWritable), surfaced as "Unexpected
+ * error". Proven by devnet simulation: read-only → 0x7 at ~1.8k CU;
+ * writable → past the check (0x8 Unauthorized for a non-marketauth signer,
+ * the next gate).
+ *
+ * The wizard therefore force-sets the flag itself — a no-op on SDK
+ * snapshots that already carry the fix, the bugfix on the ones that don't.
+ * Safe to delete only once the SDK bump has actually shipped to the hosted
+ * deploy.
+ */
+describe("CreateLpVault market-writable override", () => {
+  it("useCreateMarket overrides the market meta to writable (wizard step 5)", () => {
+    const source = readFileSync(
+      resolve(__dirname, "../../hooks/useCreateMarket.ts"),
+      "utf8",
+    );
+    expect(source).toContain("marketMeta.isWritable = true");
+    expect(source).toContain("AccountNotWritable");
+  });
+
+  it("useInsuranceLP overrides the market meta too (Earn page's createMint)", () => {
+    // Same instruction, second call site — the Earn page's admin
+    // "create vault" action fails identically without the override.
+    const source = readFileSync(
+      resolve(__dirname, "../../hooks/useInsuranceLP.ts"),
+      "utf8",
+    );
+    expect(source).toContain("marketMeta.isWritable = true");
+    expect(source).toContain("AccountNotWritable");
+  });
+});

--- a/app/hooks/useCreateMarket.ts
+++ b/app/hooks/useCreateMarket.ts
@@ -1624,16 +1624,33 @@ export function useCreateMarket() {
           // even though the overall create() call subsequently failed/threw.
           const existingRegistry = await connection.getAccountInfo(lpVaultRegistry);
           if (!existingRegistry) {
+            const createLpVaultKeys = buildAccountMetas(ACCOUNTS_CREATE_LP_VAULT, {
+              admin: wallet.publicKey,
+              market: slabPk,
+              registry: lpVaultRegistry,
+              lpMint: lpVaultMint,
+              systemProgram: WELL_KNOWN.systemProgram,
+              tokenProgram: WELL_KNOWN.tokenProgram,
+            });
+            // The DEPLOYED wrapper program (updated with the born-immortal
+            // re-seed) writes to the market account in CreateLpVault, but
+            // whether ACCOUNTS_CREATE_LP_VAULT marks `market` writable depends
+            // on which snapshot of the git-pinned SDK an install resolved
+            // (both report version 3.0.0): the known-good tree the hosted
+            // deploy was reverted to (fba2a6d, Vercel Edge-bundle regression)
+            // ships it READ-ONLY — so every hosted wizard "Create Earn vault"
+            // step failed on-chain with error 7 (AccountNotWritable),
+            // surfaced as "Unexpected error". Proven by devnet simulation:
+            // read-only → 0x7 at ~1.8k CU; writable → past the check (0x8
+            // Unauthorized for a non-marketauth signer, the very next gate).
+            // Force the flag here — a no-op on SDK snapshots that already
+            // carry the fix, the bugfix on the ones that don't. Drop only
+            // once the SDK bump has actually shipped to the hosted deploy.
+            const marketMeta = createLpVaultKeys.find((k) => k.pubkey.equals(slabPk));
+            if (marketMeta) marketMeta.isWritable = true;
             const createLpVaultIx = buildIx({
               programId,
-              keys: buildAccountMetas(ACCOUNTS_CREATE_LP_VAULT, {
-                admin: wallet.publicKey,
-                market: slabPk,
-                registry: lpVaultRegistry,
-                lpMint: lpVaultMint,
-                systemProgram: WELL_KNOWN.systemProgram,
-                tokenProgram: WELL_KNOWN.tokenProgram,
-              }),
+              keys: createLpVaultKeys,
               data: encodeCreateLpVaultV17({
                 feeShareBps: 1000, // 10% fee share — matches the 5 seeded markets
                 oiReservationThresholdBps: 8000,

--- a/app/hooks/useInsuranceLP.ts
+++ b/app/hooks/useInsuranceLP.ts
@@ -418,7 +418,8 @@ export function useInsuranceLP() {
    *
    * Account list (ACCOUNTS_CREATE_LP_VAULT):
    *   [0] admin (signer, writable)
-   *   [1] market (readonly)
+   *   [1] market (WRITABLE on the current deployed program — see the meta
+   *       override below; older SDK snapshots still say readonly)
    *   [2] registry (writable, PDA: ["lp_vault_registry", market])
    *   [3] lpMint (writable, PDA: ["lp_vault_mint", market])
    *   [4] systemProgram
@@ -449,6 +450,13 @@ export function useInsuranceLP() {
         WELL_KNOWN.systemProgram,
         WELL_KNOWN.tokenProgram,
       ]);
+      // The deployed wrapper program writes to the market account in
+      // CreateLpVault, but some snapshots of the git-pinned SDK still mark it
+      // read-only (both report v3.0.0) — on-chain error 7 AccountNotWritable.
+      // Same override as useCreateMarket's Earn-vault step; see the full
+      // simulation-proven explanation there. Drop when the SDK bump ships.
+      const marketMeta = keys.find((k) => k.pubkey.equals(marketPk));
+      if (marketMeta) marketMeta.isWritable = true;
       const data = encodeCreateLpVaultV17({
         feeShareBps: 2000,          // 20% of insurance earnings to LP providers
         oiReservationThresholdBps: 5000, // 50% OI reservation threshold


### PR DESCRIPTION
## What (user-reported)

Wizard launches on the hosted playground fail at **"Create Earn vault"** with `Transaction failed: Unexpected error` — everything before it (slab init, deposit, insurance, finalize) succeeds, and the flow dead-ends at RETRY STEP 5.

## Root cause — proven by devnet simulation

Simulated the exact `CreateLpVault` (tag 74) instruction the wizard builds, against a live market:

| `market` meta | Result |
|---|---|
| **read-only** (shipped metas) | `custom program error 0x7` = **AccountNotWritable**, rejected after ~1.8k CU — this is the failure users hit |
| **writable** | runs ~11.5k CU, fails `0x8 Unauthorized` — i.e. **past** the account checks; it only stopped because the simulated signer wasn't marketauth. In a real launch the creator wallet IS marketauth at that point, so the instruction proceeds. |

The deployed wrapper program (updated alongside the born-immortal re-seed) now **writes to the market account** in `CreateLpVault`. Whether the SDK's `ACCOUNTS_CREATE_LP_VAULT` agrees depends on **which snapshot of the git-pinned SDK an install resolved — both report version 3.0.0**, but the known-good tree the hosted deploy was reverted to (fba2a6d, the Edge-bundle regression) ships `market` read-only. New program + old metas = every hosted launch dies at step 5. (Also consistent with the re-seeded lineup being created "no Earn vault" via script.)

## Fix

Force-set `isWritable` on the market meta after `buildAccountMetas` — a **no-op** on SDK snapshots that already carry the fix, the **bugfix** on the ones that don't, and independent of the deferred SDK bump. Applied at **both call sites** of the instruction: the wizard's step 5 (`useCreateMarket`) and the Earn page's admin "create vault" action (`useInsuranceLP.createMint`), which fails identically. Safe to delete once the bump actually ships to the hosted deploy.

## Audit performed before submitting

- **Mutation isolation proven**: `buildAccountMetas` returns fresh meta objects — the flag flip cannot leak into the shared SDK constant or any other instruction (tested empirically both directions).
- **No blast radius**: the account list, encode args, CU budget, idempotent-retry guard, and step ordering are all byte-identical to before; the only change is one boolean on one meta in two instruction builders. Broadening writability grants a program nothing it doesn't already have (it owns the account) — it just stops the runtime pre-check from rejecting what the program intends to do.
- **Step 6 verified healthy**: simulated the wizard's full stake-InitPool transaction the same way — it reaches the stake program's *logic* (already-initialized error against TRUMP's live pool), i.e. no stale-metas issue there; a fixed launch completes rather than dying one step later.
- All call sites of `ACCOUNTS_CREATE_LP_VAULT` in the app covered (grep-verified: exactly the two fixed).

## Testing

- `npx tsc --noEmit` clean; new source-assertion tests pin both overrides; `useInsuranceLP` suite green (26/26 across affected files).
- Simulation evidence above (0x7 → 0x8 progression on the TRUMP slab, `sigVerify: false`, funded borrowed fee payer). Full end-to-end launch on the hosted site needs this deployed — the failing tx is wallet-signed there, so it can't be exercised further from a fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
