### PR TITLE
fix(security): validate attacker-suppliable market logo_url (+ latent validateUrl bug)

### DIFF
--- a/app/__tests__/lib/sanitize-logo-url.test.ts
+++ b/app/__tests__/lib/sanitize-logo-url.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeLogoUrl } from "@/lib/token-metadata-validators";
+
+/**
+ * sanitizeLogoUrl gates the attacker-suppliable market `logo_url` (POST
+ * /api/markets body) to the same allowlist external-API metadata already
+ * gets. It renders as an <img src>, so the danger is tracking-pixel /
+ * phishing-image loads from an arbitrary host — bounded (an <img> can't run
+ * javascript:), but real. Reject → null (fallback avatar), never throw.
+ */
+describe("sanitizeLogoUrl", () => {
+  it("accepts a normal https CDN URL unchanged", () => {
+    const u = "https://assets.coingecko.com/coins/images/4128/standard/solana.png";
+    expect(sanitizeLogoUrl(u)).toBe(u);
+  });
+
+  it("accepts ipfs:// (app policy — browsers can't resolve it to a network hit anyway)", () => {
+    const u = "ipfs://bafybeigdyrexample";
+    expect(sanitizeLogoUrl(u)).toBe(u);
+  });
+
+  it("rejects javascript: scheme", () => {
+    expect(sanitizeLogoUrl("javascript:alert(1)")).toBeNull();
+  });
+
+  it("rejects data: URIs (stored-blob / oversized-row vector)", () => {
+    expect(sanitizeLogoUrl("data:image/svg+xml,<svg onload=alert(1)>")).toBeNull();
+  });
+
+  it("rejects plain http (tracking beacon over cleartext)", () => {
+    expect(sanitizeLogoUrl("http://attacker.example/px.gif")).toBeNull();
+  });
+
+  it("rejects a URL longer than the 500-char cap", () => {
+    expect(sanitizeLogoUrl("https://a.example/" + "x".repeat(600))).toBeNull();
+  });
+
+  it("returns null for empty / non-string / nullish input without throwing", () => {
+    expect(sanitizeLogoUrl(null)).toBeNull();
+    expect(sanitizeLogoUrl(undefined)).toBeNull();
+    expect(sanitizeLogoUrl("")).toBeNull();
+    expect(sanitizeLogoUrl(123)).toBeNull();
+    expect(sanitizeLogoUrl("not a url")).toBeNull();
+  });
+});

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -18,6 +18,7 @@ import { isSaneMarketValue, isActiveMarket, isZombieMarket } from "@/lib/activeM
 import { getKnownMarketLpCapitals, scanEnabledMarketLpCapitals } from "@/lib/lp-portfolio";
 import { isPhantomOpenInterest, MIN_VAULT_FOR_OI } from "@/lib/phantom-oi";
 import { computeDisplayOiUsd } from "@/lib/oi-display";
+import { sanitizeLogoUrl } from "@/lib/token-metadata-validators";
 import { computeMarketHealthFromStats } from "@/lib/health";
 import { BLOCKED_SLAB_ADDRESSES } from "@/lib/blocklist";
 import { SLUG_ALIASES } from "@/lib/symbol-utils";
@@ -1589,6 +1590,14 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  // SEC: sanitize the attacker-suppliable logo_url with the SAME allowlist
+  // (https/ipfs only, ≤500 chars) that external-API metadata already gets —
+  // the raw body value was previously stored and rendered as an <img src>,
+  // letting a market creator point every viewer's browser at an arbitrary
+  // host (tracking pixel / phishing graphic inside the trusted UI). Dropped
+  // to null (fallback avatar) when invalid rather than rejecting the launch.
+  const sanitizedLogoUrl = sanitizeLogoUrl(logo_url);
+
   // #813: Validate dex_pool_address is a valid Solana pubkey (when provided)
   if (dex_pool_address) {
     try {
@@ -1900,7 +1909,7 @@ export async function POST(req: NextRequest) {
       trading_fee_bps: trading_fee_bps || 10,
       lp_collateral,
       matcher_context,
-      logo_url: logo_url || null,
+      logo_url: sanitizedLogoUrl,
       mainnet_ca: mainnet_ca || null,
       oracle_mode: resolvedOracleMode,
       dex_pool_address: dex_pool_address || null,

--- a/app/lib/token-metadata-validators.ts
+++ b/app/lib/token-metadata-validators.ts
@@ -30,7 +30,12 @@ function validateUrl(url: string, allowedProtocols: readonly string[]): string |
 
   try {
     const parsed = new URL(url);
-    const protocol = parsed.protocol.replace('://', '').toLowerCase();
+    // URL.protocol is the scheme plus a trailing colon ("https:"), never
+    // "https://" — the old `.replace('://','')` was a no-op that left the
+    // colon on, so `['https','ipfs'].includes('https:')` was ALWAYS false
+    // and this validator silently rejected every URL (incl. legit https),
+    // dropping all DexScreener/Jupiter logos. Strip the trailing colon.
+    const protocol = parsed.protocol.replace(/:$/, '').toLowerCase();
 
     if (!allowedProtocols.includes(protocol)) {
       console.warn(
@@ -51,6 +56,27 @@ function validateUrl(url: string, allowedProtocols: readonly string[]): string |
     console.warn('[validateUrl] Invalid URL format for logo');
     return undefined;
   }
+}
+
+/**
+ * Sanitize an attacker-suppliable logo URL for storage/display.
+ *
+ * Same policy as the DexScreener/Jupiter validator above (https/ipfs only,
+ * ≤500 chars, rejects javascript:/data:/other schemes) — exported so the
+ * permissionless market-creation path (POST /api/markets, whose `logo_url`
+ * comes straight from the request body) applies the identical allowlist that
+ * external-API metadata already gets, instead of storing the raw value.
+ *
+ * Returns the URL when it passes, or `null` when absent/invalid — the caller
+ * stores `null` (the fallback avatar renders), never an untrusted string.
+ * A rejected URL is dropped, not an error: market creation must not fail just
+ * because a logo is malformed.
+ *
+ * @param url Raw logo URL (or null/undefined) from an untrusted source
+ */
+export function sanitizeLogoUrl(url: unknown): string | null {
+  if (typeof url !== 'string' || url.length === 0) return null;
+  return validateUrl(url, CONSTRAINTS.ALLOWED_URL_PROTOCOLS) ?? null;
 }
 
 /**


### PR DESCRIPTION
## What (security-sweep finding, Medium)

Market creation is permissionless, and `POST /api/markets` stored `logo_url` **straight from the request body**. It renders as an `<img src>` (MarketLogo → `next/image` `unoptimized`, which bypasses the `next.config` host allowlist), and CSP `img-src` permits any https host. So a market creator could point **every viewer's browser at an arbitrary host** — an IP/geo/UA tracking beacon keyed to that market's audience, or a phishing graphic ("claim airdrop") rendered inside the trusted app chrome.

Not XSS (an `<img>` can't execute `javascript:`), but a real privacy/phishing vector — and the odd field out, since `symbol`/`name`/`mainnet_ca`/`oracle_authority` all already get GH#1963 validation.

## Fix

The right policy already exists in-repo — `validateUrl` (https/ipfs only, ≤500 chars, rejects `javascript:`/`data:`) — it was just never wired to this attacker-controlled path. Exported as **`sanitizeLogoUrl`** and applied at the market POST; invalid URLs drop to `null` (fallback avatar renders) rather than failing the launch. The other logo writers (`[slab]/logo`, `[mint]/logo`) store server-generated Supabase Storage URLs, not request strings — unaffected.

### Latent bug this uncovered

`URL.protocol` is `"https:"` (trailing colon, never `"https://"`), so `validateUrl`'s old `.replace('://','')` was a **no-op** — `['https','ipfs'].includes('https:')` was **always false**, meaning the validator silently rejected *every* URL including legitimate https, and DexScreener/Jupiter logos were being dropped too. Fixed to strip the trailing colon (`/:$/`). Net effect: valid https/ipfs logos now pass as intended; `javascript:`/`data:`/`http` stay blocked (both proven by the new tests).

## Testing

- `npx tsc --noEmit` clean.
- New `sanitize-logo-url` suite — 7 cases: accepts https + ipfs, rejects `javascript:`/`data:`/`http`/oversized/non-string.
- `devnet-mirror-mint` (the other `validateUrl` consumer) + markets suites green — **39/39**, no regression.

Note: pre-existing rows keep their stored `logo_url` (render path is `<img>`, XSS-safe; `img-src` CSP bounds it). A one-time re-sanitize backfill could be run but isn't required for correctness. Tightening `img-src` to specific logo CDNs is a reasonable defense-in-depth follow-up, left out here to keep this focused and avoid breaking legit CDN logos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
