### PR TITLE
fix(security): cap chart route's in-process GeckoTerminal caches (#2373 follow-up)

### DIFF
--- a/app/__tests__/lib/bounded-map.test.ts
+++ b/app/__tests__/lib/bounded-map.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { boundedSet } from "@/lib/bounded-map";
+
+/**
+ * boundedSet caps in-process caches whose keys are attacker-influenced (the
+ * chart route's GeckoTerminal pool/candle caches), so a flood of distinct
+ * keys can't grow the Map without bound.
+ */
+describe("boundedSet", () => {
+  it("never exceeds the cap no matter how many distinct keys are inserted", () => {
+    const m = new Map<string, number>();
+    for (let i = 0; i < 10_000; i++) boundedSet(m, `k${i}`, i, 100);
+    expect(m.size).toBe(100);
+  });
+
+  it("evicts the OLDEST entry first (FIFO on fresh keys)", () => {
+    const m = new Map<string, number>();
+    for (let i = 0; i < 5; i++) boundedSet(m, `k${i}`, i, 3);
+    // Cap 3 → only the last three keys survive.
+    expect([...m.keys()]).toEqual(["k2", "k3", "k4"]);
+  });
+
+  it("re-writing an existing key refreshes it to newest (hot keys survive)", () => {
+    const m = new Map<string, number>();
+    boundedSet(m, "a", 1, 3);
+    boundedSet(m, "b", 1, 3);
+    boundedSet(m, "c", 1, 3);
+    boundedSet(m, "a", 99, 3); // touch 'a' → now newest; 'b' is oldest
+    boundedSet(m, "d", 1, 3); // evicts 'b', not 'a'
+    expect(m.has("a")).toBe(true);
+    expect(m.get("a")).toBe(99); // value updated
+    expect(m.has("b")).toBe(false); // evicted
+    expect([...m.keys()]).toEqual(["c", "a", "d"]);
+  });
+
+  it("updating an existing key does not grow the map", () => {
+    const m = new Map<string, number>();
+    boundedSet(m, "x", 1, 10);
+    boundedSet(m, "x", 2, 10);
+    boundedSet(m, "x", 3, 10);
+    expect(m.size).toBe(1);
+    expect(m.get("x")).toBe(3);
+  });
+
+  it("cap of 1 keeps only the most recent entry", () => {
+    const m = new Map<string, number>();
+    boundedSet(m, "a", 1, 1);
+    boundedSet(m, "b", 2, 1);
+    expect([...m.keys()]).toEqual(["b"]);
+    expect(m.size).toBe(1);
+  });
+});

--- a/app/app/api/chart/[mint]/route.ts
+++ b/app/app/api/chart/[mint]/route.ts
@@ -28,6 +28,7 @@
 
 import { type NextRequest, NextResponse } from "next/server";
 import { PublicKey } from "@solana/web3.js";
+import { boundedSet } from "@/lib/bounded-map";
 
 export const dynamic = "force-dynamic";
 
@@ -78,6 +79,13 @@ const POOL_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 const POOL_MISS_TTL_MS = 60 * 1000;
 const CANDLE_CACHE_TTL_MS = 45 * 1000;
 const CANDLE_STALE_MAX_MS = 15 * 60 * 1000;
+// Hard entry cap per cache. The route validates `mint` only as a well-formed
+// pubkey (not a real token), and resolveTopPool caches even NULL misses — so a
+// warm/long-lived instance hit with millions of distinct random pubkeys would
+// grow these Maps without bound (memory DoS). TTL is checked only on read,
+// never evicted, so the cap is the real backstop. ~10k small entries is far
+// above the handful of live markets yet trivially bounded (~sub-MB).
+const CACHE_MAX_ENTRIES = 10_000;
 const poolCache = new Map<string, { pool: string | null; at: number }>();
 const candleCache = new Map<string, { candles: CandleData[]; at: number }>();
 
@@ -123,7 +131,7 @@ async function resolveTopPool(mint: string): Promise<string | null> {
   const pool = await resolveTopPoolUncached(mint);
   // A resolved pool is durable knowledge; a null may just be a 429 — the
   // short miss-TTL above keeps us from hammering GT while never pinning it.
-  poolCache.set(mint, { pool: pool ?? cached?.pool ?? null, at: Date.now() });
+  boundedSet(poolCache, mint, { pool: pool ?? cached?.pool ?? null, at: Date.now() }, CACHE_MAX_ENTRIES);
   // If this attempt failed but we have ANY previously-known pool, keep using
   // it — pools don't move, and a rate-limited lookup must not blank a chart
   // that worked a minute ago.
@@ -238,7 +246,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ mint
 
     const candles = await fetchCandles(pool, timeframe, aggregate, limit);
     if (candles.length > 0) {
-      candleCache.set(cacheKey, { candles, at: Date.now() });
+      boundedSet(candleCache, cacheKey, { candles, at: Date.now() }, CACHE_MAX_ENTRIES);
       return NextResponse.json({ candles, poolAddress: pool, cached: false }, { headers: CACHE_HEADERS });
     }
 

--- a/app/lib/bounded-map.ts
+++ b/app/lib/bounded-map.ts
@@ -1,0 +1,31 @@
+/**
+ * LRU-bounded `Map.set`. `Map` preserves insertion order, so the first key is
+ * the oldest — deleting it evicts the least-recently-written entry; deleting
+ * `key` before re-inserting moves a refreshed entry to the newest position so
+ * hot keys survive eviction.
+ *
+ * Used by in-process caches (e.g. the chart route's GeckoTerminal pool/candle
+ * caches) whose keys are attacker-influenced: without a cap, a flood of
+ * distinct keys grows the Map without bound (memory DoS), because TTL is
+ * checked only on read and entries are never otherwise evicted.
+ *
+ * @param map        the cache Map to mutate
+ * @param key        entry key
+ * @param value      entry value
+ * @param maxEntries hard cap; the Map never exceeds this size after the call
+ *                   (must be >= 1)
+ */
+export function boundedSet<V>(
+  map: Map<string, V>,
+  key: string,
+  value: V,
+  maxEntries: number,
+): void {
+  if (map.has(key)) map.delete(key);
+  map.set(key, value);
+  while (map.size > maxEntries) {
+    const oldest = map.keys().next().value;
+    if (oldest === undefined) break;
+    map.delete(oldest);
+  }
+}


### PR DESCRIPTION
## What (security-sweep finding, Medium — follow-up to the merged #2373)

The chart route's in-process GeckoTerminal caches had **no size cap**. The route validates `mint` only as a well-formed pubkey (not necessarily a real token), and `resolveTopPool` caches even **null misses** — so a warm/long-lived instance hit with a flood of distinct random pubkeys grows `poolCache` (and `candleCache`) without bound. TTL is checked only on read; entries are never otherwise evicted. Vercel's serverless recycling caps the blast radius, but it's a real memory-DoS defect on any long-lived instance.

## Fix

A small reusable **`boundedSet(map, key, value, maxEntries)`** (`lib/bounded-map.ts`) — LRU-on-write using `Map`'s insertion order: delete-then-reinsert moves a refreshed (hot) key to newest, and the oldest key is evicted once over the cap. Both chart caches are capped at **10k entries** (~sub-MB, far above the handful of live markets).

No behavior change otherwise — TTL, stale-if-error, and null-miss semantics are untouched; only the unbounded `.set` is replaced.

## Testing

- `npx tsc --noEmit` clean.
- New `bounded-map` suite — 5 cases: never exceeds the cap across 10k inserts, FIFO eviction order on fresh keys, **hot-key refresh survives eviction**, updating a key doesn't grow the Map, cap=1 keeps only the newest.
- `priceStore-poll` suite green (10/10).
- Live chart route re-verified: still returns candles and serves `cached: true` on repeat (100 bars, pool resolved) — the cap doesn't disturb the quota-protection behavior it guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
