### PR TITLE
fix(security): reject invisible/bidi chars in market names

### DIFF
--- a/app/__tests__/lib/text-safety.test.ts
+++ b/app/__tests__/lib/text-safety.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { hasInvisibleOrBidi } from "@/lib/text-safety";
+
+// Build dangerous inputs from code points (never typed literally) so the
+// test source stays plain ASCII.
+const cp = (n: number) => String.fromCodePoint(n);
+
+describe("hasInvisibleOrBidi", () => {
+  it("allows plain ASCII names", () => {
+    expect(hasInvisibleOrBidi("SOL Perpetual")).toBe(false);
+    expect(hasInvisibleOrBidi("Wrapped BTC / USD")).toBe(false);
+  });
+
+  it("allows legitimate visible Unicode (accents, CJK, emoji)", () => {
+    expect(hasInvisibleOrBidi("Café Coin")).toBe(false);
+    expect(hasInvisibleOrBidi("柴犬")).toBe(false);
+    expect(hasInvisibleOrBidi("Doge 🐕")).toBe(false);
+  });
+
+  it("rejects RTL override (U+202E) — the classic reordering attack", () => {
+    expect(hasInvisibleOrBidi("SOL" + cp(0x202e) + "DUS")).toBe(true);
+  });
+
+  it("rejects the other bidi embeddings/overrides and isolates", () => {
+    for (const c of [0x202a, 0x202b, 0x202c, 0x202d, 0x2066, 0x2067, 0x2068, 0x2069]) {
+      expect(hasInvisibleOrBidi("A" + cp(c) + "B")).toBe(true);
+    }
+  });
+
+  it("rejects zero-width characters (ZWSP/ZWNJ/ZWJ, word joiner, BOM)", () => {
+    for (const c of [0x200b, 0x200c, 0x200d, 0x2060, 0xfeff]) {
+      expect(hasInvisibleOrBidi("SO" + cp(c) + "L")).toBe(true);
+    }
+  });
+
+  it("rejects LRM/RLM marks, soft hyphen, and C1 controls", () => {
+    for (const c of [0x200e, 0x200f, 0x00ad, 0x0085, 0x009f]) {
+      expect(hasInvisibleOrBidi("X" + cp(c) + "Y")).toBe(true);
+    }
+  });
+
+  it("does not reject an em-dash or other visible punctuation", () => {
+    expect(hasInvisibleOrBidi("Token — Perp")).toBe(false); // U+2014
+    expect(hasInvisibleOrBidi("A·B")).toBe(false); // U+00B7 middle dot (visible)
+  });
+});

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -18,6 +18,7 @@ import { isSaneMarketValue, isActiveMarket, isZombieMarket } from "@/lib/activeM
 import { getKnownMarketLpCapitals, scanEnabledMarketLpCapitals } from "@/lib/lp-portfolio";
 import { isPhantomOpenInterest, MIN_VAULT_FOR_OI } from "@/lib/phantom-oi";
 import { computeDisplayOiUsd } from "@/lib/oi-display";
+import { hasInvisibleOrBidi } from "@/lib/text-safety";
 import { computeMarketHealthFromStats } from "@/lib/health";
 import { BLOCKED_SLAB_ADDRESSES } from "@/lib/blocklist";
 import { SLUG_ALIASES } from "@/lib/symbol-utils";
@@ -1585,6 +1586,16 @@ export async function POST(req: NextRequest) {
   if (/[\x00-\x1f\x7f]/.test(resolvedName)) {
     return NextResponse.json(
       { error: "Invalid name: must not contain control characters" },
+      { status: 400 }
+    );
+  }
+  // SEC: reject invisible / bidirectional / format characters (RTL overrides,
+  // zero-width chars, etc.) \u2014 the name-impersonation vectors the sweep
+  // flagged. These are NOT control chars (they passed the check above).
+  // Visible Unicode (accents, CJK, emoji) stays allowed. See hasInvisibleOrBidi.
+  if (hasInvisibleOrBidi(resolvedName)) {
+    return NextResponse.json(
+      { error: "Invalid name: must not contain invisible or bidirectional formatting characters" },
       { status: 400 }
     );
   }

--- a/app/lib/text-safety.ts
+++ b/app/lib/text-safety.ts
@@ -1,0 +1,23 @@
+/**
+ * Detects invisible / bidirectional / format characters in user-supplied
+ * display text (e.g. a market name). These are NOT C0 control chars — they
+ * pass a `[\x00-\x1f\x7f]` filter — but they are the active impersonation
+ * vectors: RTL/LTR overrides and isolates can visually reorder text to mimic
+ * another market or scramble adjacent UI, and zero-width characters hide
+ * payloads and defeat dedupe-by-eye.
+ *
+ * Visible Unicode (accents, CJK, emoji) is intentionally NOT matched — legit
+ * tokens use it, so this is not an ASCII-only filter. Homoglyph confusables
+ * (e.g. Cyrillic letters that look Latin) are visible and out of scope here;
+ * those are best handled by a verified-market badge.
+ *
+ * Ranges, in order: C1 controls; soft hyphen; zero-width chars + bidi marks
+ * (LRM/RLM); line/paragraph separators; bidi embeddings + overrides; word
+ * joiner + invisible math operators; bidi isolates; BOM / ZW no-break space.
+ */
+const INVISIBLE_OR_BIDI =
+  /[\u0080-\u009F\u00AD\u200B-\u200F\u2028\u2029\u202A-\u202E\u2060-\u2064\u2066-\u2069\uFEFF]/;
+
+export function hasInvisibleOrBidi(text: string): boolean {
+  return INVISIBLE_OR_BIDI.test(text);
+}


### PR DESCRIPTION
## What (security-sweep finding, Low–Medium, impersonation)

Market `name` validation rejected only C0 control chars — it accepted **RTL/LTR overrides, zero-width characters, bidi isolates, LRM/RLM marks, soft hyphen, C1 controls, and the BOM**. Those are the active impersonation vectors: a bidi override can visually reorder a name to mimic another market or scramble adjacent UI, and zero-width chars hide payloads and defeat symbol/name dedupe-by-eye. (React auto-escaping means this is impersonation/phishing, not XSS.)

## Fix

New **`hasInvisibleOrBidi()`** (`lib/text-safety.ts`) rejects those Unicode ranges while **intentionally allowing visible Unicode** — accents, CJK, emoji — because legit tokens use it; this is **not** an ASCII-only filter. Applied to the market POST name check.

Homoglyph confusables (e.g. Cyrillic letters that look Latin) are *visible* and out of scope here — best handled by a verified-market badge (noted for follow-up).

The detection regex is written with `\u` escapes — no literal invisible characters in source, which for a security regex is a real robustness concern (editors/git/copy-paste silently mangle them).

## Testing

- `npx tsc --noEmit` clean.
- New `text-safety` suite — 7 cases, dangerous inputs built via `String.fromCodePoint` so the test source stays plain ASCII: **allows** ASCII / accents / CJK / emoji / em-dash / middle-dot; **rejects** U+202E and the other bidi embeddings+overrides+isolates, zero-width chars (ZWSP/ZWNJ/ZWJ/word-joiner/BOM), LRM/RLM, soft hyphen, and C1 controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
