### PR TITLE
fix(security): assertKnownProgram parity in NFT mint/burn hooks

### DIFF
--- a/app/hooks/useBurnPositionNft.ts
+++ b/app/hooks/useBurnPositionNft.ts
@@ -5,6 +5,7 @@ import { PublicKey, TransactionInstruction } from "@solana/web3.js";
 import { TOKEN_2022_PROGRAM_ID, getAssociatedTokenAddressSync } from "@solana/spl-token";
 import { useWalletCompat, useConnectionCompat } from "@/hooks/useWalletCompat";
 import { useSlabState } from "@/components/providers/SlabProvider";
+import { assertKnownProgram } from "@/lib/programAllowlist";
 import { usePositionNft } from "@/hooks/usePositionNft";
 import { sendTx } from "@/lib/tx";
 import { humanizeError } from "@/lib/errorMessages";
@@ -82,6 +83,11 @@ export function useBurnPositionNft(slabAddress: string, override?: PositionNftOv
     setError(null);
 
     try {
+      // Defense-in-depth parity with the other fund/position hooks: assert
+      // the slab's programId is a known Percolator program before deriving
+      // PDAs from it and building a signable tx (see useMintPositionNft).
+      assertKnownProgram(programId);
+
       const nftProgId = PERCOLATOR_NFT_PROGRAM_ID;
       const nftPda = new PublicKey(nftPdaAddress);
       const [mintAuth]    = deriveMintAuthority(nftProgId);

--- a/app/hooks/useMintPositionNft.ts
+++ b/app/hooks/useMintPositionNft.ts
@@ -5,6 +5,7 @@ import { PublicKey, Keypair, TransactionInstruction, SYSVAR_RENT_PUBKEY, SystemP
 import { TOKEN_2022_PROGRAM_ID, getAssociatedTokenAddressSync, ASSOCIATED_TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { useWalletCompat, useConnectionCompat } from "@/hooks/useWalletCompat";
 import { useSlabState } from "@/components/providers/SlabProvider";
+import { assertKnownProgram } from "@/lib/programAllowlist";
 import { sendTx } from "@/lib/tx";
 import { humanizeError } from "@/lib/errorMessages";
 import { useToast } from "@/hooks/useToast";
@@ -34,11 +35,18 @@ export function useMintPositionNft(slabAddress: string) {
       setError("Wallet not connected or market not loaded");
       return;
     }
-
     setLoading(true);
     setError(null);
 
     try {
+      // Defense-in-depth parity with useTrade/useDeposit/useWithdraw: these
+      // NFT hooks derive PDAs from `programId` (useSlabState) and use it as an
+      // account, but relied solely on SlabProvider nulling programId for an
+      // unknown-owner slab. Assert it's a known program before building a
+      // signable tx, so a phishing slab can never reach the tx-build path.
+      // Inside the try so the existing catch surfaces it like any other error.
+      assertKnownProgram(programId);
+
       const slabPk = new PublicKey(slabAddress);
       const nftProgId = PERCOLATOR_NFT_PROGRAM_ID;
       const isV17 = raw != null && raw.length > 0 && isV17Account(raw);


### PR DESCRIPTION
Security sweep finding (Low, defense-in-depth). `useMintPositionNft` and `useBurnPositionNft` derive PDAs from `programId` and use it as a tx account, but - unlike useTrade/useDeposit/useWithdraw/useInsuranceLP - never called `assertKnownProgram`. They relied solely on SlabProvider nulling programId for an unknown-owner slab. Adding the explicit assert (inside each try block, so the existing catch surfaces it) gives them the same second line of defense every other fund/position hook has, so a phishing slab can never reach the tx-build path even if the provider guard regressed. No-op for legit markets (wrapper program is allowlisted).

`useTransferPositionNft` is intentionally unchanged - its programId is the SPL Token program (a TransferChecked of the user's own NFT), not a Percolator CPI.

Tested: tsc clean; programAllowlist suite green (8/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)