### PR TITLE
fix(security): parseHumanAmount returns 0n for invalid input (honors contract)

### DIFF
--- a/app/__tests__/lib/parseAmount.test.ts
+++ b/app/__tests__/lib/parseAmount.test.ts
@@ -42,6 +42,14 @@ describe("parseHumanAmount", () => {
     expect(parseHumanAmount("1.2.3", 6)).toBe(0n);
   });
 
+  it("returns 0n for non-numeric input instead of throwing (documented contract)", () => {
+    // Previously these reached BigInt(...) and threw, contradicting the JSDoc
+    // (`"abc" -> 0n`) and risking an unhandled throw in a live-input caller.
+    for (const bad of ["abc", "1e6", "0x5", "1,000", "12.3a", "--5", "1 000", "NaN", "Infinity"]) {
+      expect(parseHumanAmount(bad, 6)).toBe(0n);
+    }
+  });
+
   it("throws if too many decimal places", () => {
     expect(() => parseHumanAmount("1.1234567", 6)).toThrow(/Input has 7 decimals/);
   });

--- a/app/lib/parseAmount.ts
+++ b/app/lib/parseAmount.ts
@@ -35,7 +35,14 @@ export function parseHumanAmount(input: string, decimals: number): bigint {
   if (parts.length > 2) return 0n; // reject "1.2.3"
   const whole = parts[0] || "0";
   const fracPart = parts[1] || "";
-  
+
+  // Honor the documented "invalid input -> 0n" contract. `whole`/`fracPart`
+  // must be pure digit strings; anything else ("abc", "1e6", "0x5", "1,000")
+  // would otherwise reach `BigInt(...)` below and THROW, contradicting the
+  // JSDoc and risking an unhandled throw in a caller that parses live input.
+  // (The decimals-exceed case below is a genuine, documented @throws.)
+  if (!/^\d+$/.test(whole) || !/^\d*$/.test(fracPart)) return 0n;
+
   // M1: Throw error if decimals exceed token precision
   if (fracPart.length > decimals) {
     throw new Error(`Input has ${fracPart.length} decimals, but token only supports ${decimals}`);


### PR DESCRIPTION
## Security-sweep finding (Low, robustness)

`parseHumanAmount`'s JSDoc promises invalid input returns `0n` (`"abc" → 0n`), but non-numeric whole/fraction parts reached `BigInt(...)` and **threw** — contradicting the contract and risking an unhandled throw in a caller that parses live user input (amount fields).

## Fix

A digit-shape guard (`/^\d+$/` on the whole part, `/^\d*$/` on the fraction) returns `0n` for `abc` / `1e6` / `0x5` / `1,000` / `12.3a` / etc. The documented decimals-exceed `@throws` is preserved.

## Testing

- `npx tsc --noEmit` clean.
- parseAmount suite **27/27** — new invalid-input cases plus all existing valid / negative / decimals-throw cases unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
