### PR TITLE
fix(security): stop echoing raw blob error detail to keeper-register callers

### DIFF
--- a/app/__tests__/api/keeper-register-no-error-echo.test.ts
+++ b/app/__tests__/api/keeper-register-no-error-echo.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * SEC: the playground keeper-register route must not echo raw upstream
+ * (@vercel/blob) error text to the caller — those strings can name internal
+ * store IDs / paths (info-leak). The raw error is logged server-side; the
+ * client gets only a generic message.
+ */
+describe("keeper-register does not leak raw error detail", () => {
+  const src = readFileSync(
+    resolve(__dirname, "../../app/api/playground/keeper-register/route.ts"),
+    "utf8",
+  );
+
+  it("no `detail` field is returned in a JSON response", () => {
+    // The raw err.message must not be surfaced to the client under any key.
+    // (It remains in console.error server-side.)
+    expect(src).not.toMatch(/\bdetail\s*[:,]/);
+  });
+
+  it("the blob-write failure still returns a generic error message", () => {
+    expect(src).toContain("Failed to persist market registration to Blob store");
+  });
+});

--- a/app/app/api/playground/keeper-register/route.ts
+++ b/app/app/api/playground/keeper-register/route.ts
@@ -382,14 +382,19 @@ export async function POST(req: NextRequest) {
   try {
     await upsertRegisteredMarket(entry);
   } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
-    console.error("[playground/keeper-register] Blob write failed:", detail);
+    // SEC: log the raw upstream error server-side only. Echoing it to the
+    // caller (the previous `detail` field) leaked internal infra text — the
+    // @vercel/blob error strings can name store IDs / paths and are an
+    // info-leak smell. The generic `error` message is all the client needs.
+    console.error(
+      "[playground/keeper-register] Blob write failed:",
+      err instanceof Error ? err.message : String(err),
+    );
     return NextResponse.json(
       {
         ok: false,
         registered: false,
         error: "Failed to persist market registration to Blob store",
-        detail,
       },
       { status: 502 },
     );


### PR DESCRIPTION
## Security-sweep finding (Low, info-leak)

On a Blob-write failure the playground `keeper-register` route returned `detail: err.message` to the caller. `@vercel/blob` error strings can name internal store IDs / paths — an info-leak smell. The raw error is already logged server-side; the client only needs the generic message.

## Fix

Removed the `detail` field from the 502 response (kept the `console.error`). The generic `"Failed to persist market registration to Blob store"` message is retained.

## Testing

- `npx tsc --noEmit` clean.
- New source-assertion test: no `detail` field returned in any JSON response; generic message retained. 2/2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
