### PR TITLE
fix(markets): bind deployer signature to registration payload

### DIFF
--- a/app/__tests__/api/markets-deployer-auth.test.ts
+++ b/app/__tests__/api/markets-deployer-auth.test.ts
@@ -42,6 +42,10 @@ vi.mock("@solana/web3.js", async (importOriginal) => {
 
 import { getServiceClient } from "@/lib/supabase";
 
+import {
+  buildMarketRegistrationMessage,
+  type MarketRegistrationPayload,
+} from "@/lib/market-registration-auth";
 /** Generate a fresh ed25519 keypair for testing */
 function genKeypair() {
   const kp = nacl.sign.keyPair();
@@ -52,11 +56,27 @@ function genKeypair() {
   };
 }
 
-/** Sign a nonce string with a secret key */
-function signNonce(nonce: string, secretKey: Uint8Array): string {
-  const nonceBytes = new Uint8Array(Buffer.from(nonce, "utf-8"));
-  const sig = nacl.sign.detached(nonceBytes, secretKey);
-  return Buffer.from(sig).toString("base64");
+/** Sign one exact market registration payload. */
+function signRegistration(
+  body: MarketRegistrationPayload,
+  secretKey: Uint8Array,
+  nonce = NONCE,
+): string {
+  const message =
+    buildMarketRegistrationMessage({
+      nonce,
+      deployer: String(body.deployer),
+      payload: body,
+    });
+
+  const signature = nacl.sign.detached(
+    message,
+    secretKey,
+  );
+
+  return Buffer.from(
+    signature,
+  ).toString("base64");
 }
 
 const NONCE = "550e8400-e29b-41d4-a716-446655440000";
@@ -140,7 +160,7 @@ describe("POST /api/markets — PERC-8332 deployer auth", () => {
     // claimCount=0 → DB found no matching unused, unexpired nonce for this deployer
     (getServiceClient as ReturnType<typeof vi.fn>).mockReturnValue(buildMockSupabase(0));
     const { POST } = await import("@/app/api/markets/route");
-    const sig = signNonce(NONCE, kp.secretKey);
+    const sig = signRegistration(baseBody, kp.secretKey, NONCE);
     const req = new Request("http://localhost/api/markets", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -157,7 +177,7 @@ describe("POST /api/markets — PERC-8332 deployer auth", () => {
     // Expired nonce: DB's .gt("expires_at", now) filter excludes it → count=0
     (getServiceClient as ReturnType<typeof vi.fn>).mockReturnValue(buildMockSupabase(0));
     const { POST } = await import("@/app/api/markets/route");
-    const sig = signNonce(NONCE, kp.secretKey);
+    const sig = signRegistration(baseBody, kp.secretKey, NONCE);
     const req = new Request("http://localhost/api/markets", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -175,7 +195,7 @@ describe("POST /api/markets — PERC-8332 deployer auth", () => {
     // Already-used nonce: DB's .is("used_at", null) filter excludes it → count=0
     (getServiceClient as ReturnType<typeof vi.fn>).mockReturnValue(buildMockSupabase(0));
     const { POST } = await import("@/app/api/markets/route");
-    const sig = signNonce(NONCE, kp.secretKey);
+    const sig = signRegistration(baseBody, kp.secretKey, NONCE);
     const req = new Request("http://localhost/api/markets", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -195,7 +215,10 @@ describe("POST /api/markets — PERC-8332 deployer auth", () => {
     const { POST } = await import("@/app/api/markets/route");
     // Sign with a different keypair
     const wrongKp = nacl.sign.keyPair();
-    const sig = Buffer.from(nacl.sign.detached(new Uint8Array(Buffer.from(NONCE, "utf-8")), wrongKp.secretKey)).toString("base64");
+    const sig = signRegistration(
+      baseBody,
+      wrongKp.secretKey,
+    );
     const req = new Request("http://localhost/api/markets", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -208,12 +231,75 @@ describe("POST /api/markets — PERC-8332 deployer auth", () => {
     expect(body.error).toMatch(/signature/i);
   });
 
+  it("returns 401 before nonce claim when a signed registration payload is modified", async () => {
+    const mockSupa =
+      buildMockSupabase(1);
+
+    (
+      getServiceClient as ReturnType<
+        typeof vi.fn
+      >
+    ).mockReturnValue(mockSupa);
+
+    const { POST } = await import(
+      "@/app/api/markets/route"
+    );
+
+    const signature = signRegistration(
+      baseBody,
+      kp.secretKey,
+    );
+
+    const tamperedBody = {
+      ...baseBody,
+      symbol: "TAMPERED-PERP",
+    };
+
+    const request = new Request(
+      "http://localhost/api/markets",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type":
+            "application/json",
+        },
+        body: JSON.stringify({
+          ...tamperedBody,
+          nonce: NONCE,
+          signature,
+        }),
+      },
+    );
+
+    // @ts-ignore - NextRequest wraps Request
+    const response = await POST(
+      request as any,
+    );
+
+    const responseBody =
+      await response.json();
+
+    expect(response.status).toBe(401);
+
+    expect(
+      responseBody.error,
+    ).toMatch(/signature/i);
+
+    /*
+     * Payload verification must fail before the route performs
+     * the atomic market_challenges nonce update.
+     */
+    expect(
+      mockSupa.from,
+    ).not.toHaveBeenCalled();
+  });
+
   it("passes auth check with valid signature (hits on-chain step after)", async () => {
     // Valid nonce, valid sig → auth passes, hits on-chain slab check (which fails with 400)
     const mockSupa = buildMockSupabase(1);
     (getServiceClient as ReturnType<typeof vi.fn>).mockReturnValue(mockSupa);
     const { POST } = await import("@/app/api/markets/route");
-    const sig = signNonce(NONCE, kp.secretKey);
+    const sig = signRegistration(baseBody, kp.secretKey, NONCE);
     const req = new Request("http://localhost/api/markets", {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/app/__tests__/hooks/useCreateMarket-fresh-batched-registration.test.ts
+++ b/app/__tests__/hooks/useCreateMarket-fresh-batched-registration.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const hookSource = readFileSync(
+  resolve(process.cwd(), "hooks/useCreateMarket.ts"),
+  "utf8",
+);
+
+const functionStart = hookSource.indexOf(
+  "async function attemptFreshBatchedLaunch",
+);
+const functionEnd = hookSource.indexOf(
+  "\nconst STEP_LABELS",
+  functionStart,
+);
+
+describe("useCreateMarket fresh batched registration", () => {
+  it("signs the canonical registration payload and posts that same payload", () => {
+    expect(functionStart).toBeGreaterThanOrEqual(0);
+    expect(functionEnd).toBeGreaterThan(functionStart);
+
+    const freshBatchSource = hookSource.slice(functionStart, functionEnd);
+
+    expect(freshBatchSource).toMatch(
+      /const registrationPayload:\s*MarketRegistrationPayload\s*=\s*\{/,
+    );
+
+    expect(freshBatchSource).toContain(
+      "const deployerStr: string = walletPk.toBase58();",
+    );
+
+    expect(freshBatchSource).toMatch(
+      /buildMarketRegistrationMessage\(\{\s*nonce:\s*marketsNonce,\s*deployer:\s*deployerStr,\s*payload:\s*registrationPayload,\s*\}\)/s,
+    );
+
+    expect(freshBatchSource).toContain(
+      "wallet.signMessage(signingMessage)",
+    );
+
+    expect(freshBatchSource).not.toContain(
+      "new TextEncoder().encode(marketsNonce)",
+    );
+
+    const registrationStart = freshBatchSource.indexOf(
+      "const marketsRegisterPromise",
+    );
+    const registrationEnd = freshBatchSource.indexOf(
+      "const keeperRegisterPromise",
+      registrationStart,
+    );
+
+    expect(registrationStart).toBeGreaterThanOrEqual(0);
+    expect(registrationEnd).toBeGreaterThan(registrationStart);
+
+    const registrationRequestSource = freshBatchSource.slice(
+      registrationStart,
+      registrationEnd,
+    );
+
+    expect(registrationRequestSource).toMatch(
+      /body:\s*JSON\.stringify\(\{\s*\.\.\.registrationPayload,/s,
+    );
+
+    expect(registrationRequestSource).toMatch(
+      /\.\.\.\(marketsNonce\s*&&\s*marketsSignature\s*\?\s*\{\s*nonce:\s*marketsNonce,\s*signature:\s*marketsSignature\s*\}/s,
+    );
+
+    // Prevent the POST body from drifting back to a separately duplicated
+    // market-registration object.
+    expect(registrationRequestSource).not.toMatch(/\bslab_address\s*:/);
+    expect(registrationRequestSource).not.toMatch(/\bmint_address\s*:/);
+    expect(registrationRequestSource).not.toMatch(/\bdeployer\s*:/);
+  });
+});

--- a/app/__tests__/lib/market-registration-auth.test.ts
+++ b/app/__tests__/lib/market-registration-auth.test.ts
@@ -1,0 +1,216 @@
+import nacl from "tweetnacl";
+import {
+  buildMarketRegistrationMessage,
+  canonicalizeMarketRegistrationPayload,
+  MARKET_REGISTRATION_AUTH_DOMAIN,
+  MARKET_REGISTRATION_AUTH_METHOD,
+  MARKET_REGISTRATION_AUTH_PATH,
+  type MarketRegistrationPayload,
+} from "@/lib/market-registration-auth";
+import {
+  describe,
+  expect,
+  it,
+} from "vitest";
+
+const NONCE =
+  "550e8400-e29b-41d4-a716-446655440000";
+
+const DEPLOYER =
+  "11111111111111111111111111111111";
+
+function buildPayload(
+  overrides:
+    MarketRegistrationPayload = {},
+): MarketRegistrationPayload {
+  return {
+    slab_address:
+      "7eubYRwJiQdJgXsw1VdaNQ7YHvHbgChe7wbPNQw74S23",
+    mint_address:
+      "So11111111111111111111111111111111111111112",
+    deployer: DEPLOYER,
+    symbol: "TEST-PERP",
+    name: "Test Market",
+    decimals: 6,
+    oracle_mode: "admin",
+    oracle_authority: DEPLOYER,
+    dex_pool_address: null,
+    mainnet_ca: null,
+    initial_price_e6: "1000000",
+    max_leverage: 5,
+    trading_fee_bps: 10,
+    logo_url: null,
+    ...overrides,
+  };
+}
+
+describe(
+  "market registration authorization",
+  () => {
+    it(
+      "is deterministic regardless of object insertion order",
+      () => {
+        const first = buildPayload();
+
+        const reversed =
+          Object.fromEntries(
+            Object.entries(first).reverse(),
+          );
+
+        expect(
+          canonicalizeMarketRegistrationPayload(
+            reversed,
+          ),
+        ).toBe(
+          canonicalizeMarketRegistrationPayload(
+            first,
+          ),
+        );
+      },
+    );
+
+    it(
+      "excludes only nonce and signature from the request envelope",
+      () => {
+        const original = buildPayload();
+
+        expect(
+          canonicalizeMarketRegistrationPayload({
+            ...original,
+            nonce: NONCE,
+            signature: "base64-signature",
+          }),
+        ).toBe(
+          canonicalizeMarketRegistrationPayload(
+            original,
+          ),
+        );
+      },
+    );
+
+    it(
+      "includes domain, method, route, nonce, deployer and payload",
+      () => {
+        const message =
+          buildMarketRegistrationMessage({
+            nonce: NONCE,
+            deployer: DEPLOYER,
+            payload: buildPayload(),
+          });
+
+        const decoded =
+          new TextDecoder().decode(message);
+
+        expect(decoded).toContain(
+          `${MARKET_REGISTRATION_AUTH_DOMAIN}\n`,
+        );
+
+        expect(decoded).toContain(
+          `\n${MARKET_REGISTRATION_AUTH_METHOD}\n`,
+        );
+
+        expect(decoded).toContain(
+          `\n${MARKET_REGISTRATION_AUTH_PATH}\n`,
+        );
+
+        expect(decoded).toContain(
+          `\n${NONCE}\n${DEPLOYER}\n`,
+        );
+
+        expect(decoded).toContain(
+          '"symbol":"TEST-PERP"',
+        );
+      },
+    );
+
+    it.each([
+      ["symbol", "ALTERED-PERP"],
+      ["name", "Altered Market"],
+      ["oracle_mode", "keeper"],
+      [
+        "oracle_authority",
+        "So11111111111111111111111111111111111111112",
+      ],
+      [
+        "dex_pool_address",
+        "So11111111111111111111111111111111111111112",
+      ],
+      [
+        "mainnet_ca",
+        "So11111111111111111111111111111111111111112",
+      ],
+      ["initial_price_e6", "999000000"],
+      ["max_leverage", 99],
+      ["trading_fee_bps", 999],
+      [
+        "logo_url",
+        "https://example.invalid/logo.png",
+      ],
+    ])(
+      "changing %s changes the signed message",
+      (field, replacement) => {
+        const original =
+          buildMarketRegistrationMessage({
+            nonce: NONCE,
+            deployer: DEPLOYER,
+            payload: buildPayload(),
+          });
+
+        const modified =
+          buildMarketRegistrationMessage({
+            nonce: NONCE,
+            deployer: DEPLOYER,
+            payload: buildPayload({
+              [field]: replacement,
+            }),
+          });
+
+        expect(modified).not.toEqual(
+          original,
+        );
+      },
+    );
+
+    it(
+      "returns bytes accepted directly by TweetNaCl",
+      () => {
+        const keyPair =
+          nacl.sign.keyPair();
+
+        const message =
+          buildMarketRegistrationMessage({
+            nonce: NONCE,
+            deployer: DEPLOYER,
+            payload: buildPayload(),
+          });
+
+        expect(
+          message,
+        ).toBeInstanceOf(Uint8Array);
+
+        expect(() =>
+          nacl.sign.detached(
+            message,
+            keyPair.secretKey,
+          ),
+        ).not.toThrow();
+      },
+    );
+
+    it(
+      "rejects mismatched envelope and payload deployers",
+      () => {
+        expect(() =>
+          buildMarketRegistrationMessage({
+            nonce: NONCE,
+            deployer: DEPLOYER,
+            payload: buildPayload({
+              deployer:
+                "So11111111111111111111111111111111111111112",
+            }),
+          }),
+        ).toThrow(/deployer/i);
+      },
+    );
+  },
+);

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -23,6 +23,10 @@ import { sanitizeLogoUrl } from "@/lib/token-metadata-validators";
 import { computeMarketHealthFromStats } from "@/lib/health";
 import { BLOCKED_SLAB_ADDRESSES } from "@/lib/blocklist";
 import { SLUG_ALIASES } from "@/lib/symbol-utils";
+import {
+  buildMarketRegistrationMessage,
+  type MarketRegistrationPayload,
+} from "@/lib/market-registration-auth";
 
 /**
  * GH#1526: Map frontend oracle_mode filter values to DB-stored values.
@@ -1424,11 +1428,38 @@ export async function POST(req: NextRequest) {
     // Previously, nonce was consumed first, then signature checked — allowing an attacker
     // to burn a victim's nonces by submitting invalid signatures. Now we verify the
     // cryptographic proof first (cheap, no DB write) so invalid signatures never touch nonces.
-    const nonceBytes = new Uint8Array(Buffer.from(nonce, "utf-8"));
+    /*
+     * Bind authorization to the complete registration payload.
+     * The shared helper excludes only nonce and signature from
+     * the authentication envelope.
+     */
+    let signingMessage: Uint8Array;
+
+    try {
+      signingMessage =
+        buildMarketRegistrationMessage({
+          nonce,
+          deployer,
+          payload:
+            body as MarketRegistrationPayload,
+        });
+    } catch {
+      return NextResponse.json(
+        {
+          error:
+            "Invalid market registration authorization payload.",
+        },
+        { status: 400 },
+      );
+    }
     const sigBytes = new Uint8Array(signatureBytes);
     let sigValid = false;
     try {
-      sigValid = nacl.sign.detached.verify(nonceBytes, sigBytes, deployerPubkeyBytes);
+      sigValid = nacl.sign.detached.verify(
+      signingMessage,
+      sigBytes,
+      deployerPubkeyBytes,
+    );
     } catch {
       // nacl throws on invalid input lengths — treat as signature failure
       sigValid = false;
@@ -1445,7 +1476,7 @@ export async function POST(req: NextRequest) {
         }
       );
       return NextResponse.json(
-        { error: "Signature verification failed. Ensure you signed the nonce bytes with the deployer keypair." },
+        { error: "Signature verification failed. Ensure you signed the exact market-registration payload with the deployer keypair." },
         { status: 401 }
       );
     }

--- a/app/hooks/useCreateMarket.ts
+++ b/app/hooks/useCreateMarket.ts
@@ -93,6 +93,10 @@ import {
   clearInFlightMarket,
   loadLastInFlightMarket,
 } from "@/lib/inFlightMarket";
+import {
+  buildMarketRegistrationMessage,
+  type MarketRegistrationPayload,
+} from "@/lib/market-registration-auth";
 // v17: max assets per portfolio (= the market's asset-slot capacity); program cap = 14.
 // The slab MUST be sized to exactly match this capacity or InitMarket reverts (dynamic-len validation).
 export const V17_MAX_PORTFOLIO_ASSETS = 14;
@@ -627,12 +631,49 @@ async function attemptFreshBatchedLaunch(ctx: FreshBatchContext): Promise<FreshB
     //    both proofs tolerate the ~15-30s the pipeline takes to actually use
     //    them (markets nonce has a 5-min TTL; the keeper proof window is
     //    -5min/+1min server-side — see keeper-register/route.ts).
+    // Build the registration payload once so the wallet signs the exact
+    // market data later submitted to POST /api/markets.
+    const deployerStr: string = walletPk.toBase58();
+    const registrationPayload: MarketRegistrationPayload = {
+      slab_address: slabPk.toBase58(),
+      mint_address: params.mint.toBase58(),
+      symbol: params.symbol ?? "UNKNOWN",
+      name: params.name ?? "Unknown Token",
+      decimals: params.decimals ?? 6,
+      deployer: deployerStr,
+      oracle_mode: oracleMode,
+      dex_pool_address: params.dexPoolAddress ?? null,
+      oracle_authority: isAdminOracle
+        ? isDevnetEnv && getConfig().crankWallet
+          ? getConfig().crankWallet
+          : walletPk.toBase58()
+        : null,
+      initial_price_e6: params.initialPriceE6.toString(),
+      max_leverage:
+        params.initialMarginBps > 0
+          ? Math.floor(
+              10000 /
+                flooredInitialMarginBps(params.initialMarginBps),
+            )
+          : 1,
+      trading_fee_bps: Number(params.tradingFeeBps),
+      lp_collateral: params.lpCollateral.toString(),
+      mainnet_ca: params.mainnetCA ?? null,
+    };
+
     let marketsSignature: string | null = null;
     if (marketsNonce && wallet.signMessage) {
       try {
-        const sigBytes = await wallet.signMessage(new TextEncoder().encode(marketsNonce));
+        const signingMessage = buildMarketRegistrationMessage({
+          nonce: marketsNonce,
+          deployer: deployerStr,
+          payload: registrationPayload,
+        });
+        const sigBytes = await wallet.signMessage(signingMessage);
         marketsSignature = Buffer.from(sigBytes).toString("base64");
-      } catch { /* non-fatal — mirrors the sequential path's own try/catch */ }
+      } catch {
+        /* non-fatal — mirrors the sequential path's own try/catch */
+      }
     }
     let keeperProofSignature: string | null = null;
     if (isKeeperOracle && params.dexPoolAddress && wallet.signMessage) {
@@ -938,25 +979,10 @@ async function attemptFreshBatchedLaunch(ctx: FreshBatchContext): Promise<FreshB
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            slab_address: slabPk.toBase58(),
-            mint_address: params.mint.toBase58(),
-            symbol: params.symbol ?? "UNKNOWN",
-            name: params.name ?? "Unknown Token",
-            decimals: params.decimals ?? 6,
-            deployer: walletPk.toBase58(),
-            oracle_mode: oracleMode,
-            dex_pool_address: params.dexPoolAddress ?? null,
-            oracle_authority: isAdminOracle
-              ? (isDevnetEnv && getConfig().crankWallet ? getConfig().crankWallet : walletPk.toBase58())
-              : null,
-            initial_price_e6: params.initialPriceE6.toString(),
-            max_leverage: params.initialMarginBps > 0
-              ? Math.floor(10000 / flooredInitialMarginBps(params.initialMarginBps))
-              : 1,
-            trading_fee_bps: Number(params.tradingFeeBps),
-            lp_collateral: params.lpCollateral.toString(),
-            mainnet_ca: params.mainnetCA ?? null,
-            ...(marketsNonce && marketsSignature ? { nonce: marketsNonce, signature: marketsSignature } : {}),
+            ...registrationPayload,
+            ...(marketsNonce && marketsSignature
+              ? { nonce: marketsNonce, signature: marketsSignature }
+              : {}),
           }),
         });
       } catch {
@@ -2557,13 +2583,36 @@ export function useCreateMarket() {
         // PERC-8332: Attach nonce + ed25519 signature so the POST handler can verify
         // deployer ownership without Supabase. Flow:
         //   1. GET /api/markets/challenge?deployer=<pubkey> → { nonce }
-        //   2. Sign nonce bytes with wallet.signMessage (ed25519)
+        // 2. Sign the canonical market-registration payload with wallet.signMessage (ed25519)
         //   3. POST with { nonce, signature: base64 }
         if (startStep <= 4) {
           try {
             const deployerStr = wallet.publicKey.toBase58();
 
             // Step 1: fetch nonce challenge
+            const registrationPayload: MarketRegistrationPayload = {
+              slab_address: slabPk.toBase58(),
+              mint_address: params.mint.toBase58(),
+              symbol: params.symbol ?? "UNKNOWN",
+              name: params.name ?? "Unknown Token",
+              decimals: params.decimals ?? 6,
+              deployer: deployerStr,
+              oracle_mode: oracleMode,
+              dex_pool_address: params.dexPoolAddress ?? null,
+              oracle_authority: isAdminOracle
+                                ? (isDevnetEnv && getConfig().crankWallet ? getConfig().crankWallet : deployerStr)
+                                : null,
+              initial_price_e6: params.initialPriceE6.toString(),
+              // BUG 16 fix: advertise the FLOORED margin (what's actually enforced
+                              // on-chain), not the raw requested bps — see flooredInitialMarginBps doc.
+                              max_leverage: params.initialMarginBps > 0
+                                ? Math.floor(10000 / flooredInitialMarginBps(params.initialMarginBps))
+                                : 1,
+              trading_fee_bps: Number(params.tradingFeeBps),
+              lp_collateral: params.lpCollateral.toString(),
+              mainnet_ca: params.mainnetCA ?? null
+            };
+
             let nonce: string | null = null;
             let signature: string | null = null;
             if (wallet.signMessage) {
@@ -2574,13 +2623,18 @@ export function useCreateMarket() {
                 if (challengeResp.ok) {
                   const { nonce: n } = await challengeResp.json() as { nonce: string };
                   nonce = n;
-                  // Step 2: sign the nonce bytes
-                  const nonceBytes = new TextEncoder().encode(nonce);
-                  const sigBytes = await wallet.signMessage(nonceBytes);
+                  // Step 2: sign the canonical market-registration payload
+                  const signingMessage =
+                    buildMarketRegistrationMessage({
+                      nonce,
+                      deployer: deployerStr,
+                      payload: registrationPayload,
+                    });
+                  const sigBytes = await wallet.signMessage(signingMessage);
                   signature = Buffer.from(sigBytes).toString("base64");
                 }
               } catch (sigErr) {
-                console.warn("[useCreateMarket] Nonce challenge/sign failed (non-fatal):", sigErr);
+                console.warn("[useCreateMarket] Market-registration challenge/sign failed (non-fatal):", sigErr);
                 // Fall through — POST will 400 if nonce/signature missing, but market is on-chain.
               }
             }
@@ -2589,29 +2643,10 @@ export function useCreateMarket() {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({
-                slab_address: slabPk.toBase58(),
-                mint_address: params.mint.toBase58(),
-                symbol: params.symbol ?? "UNKNOWN",
-                name: params.name ?? "Unknown Token",
-                decimals: params.decimals ?? 6,
-                deployer: deployerStr,
-                oracle_mode: oracleMode,
-                dex_pool_address: params.dexPoolAddress ?? null,
-                oracle_authority: isAdminOracle
-                  ? (isDevnetEnv && getConfig().crankWallet ? getConfig().crankWallet : deployerStr)
-                  : null,
-                initial_price_e6: params.initialPriceE6.toString(),
-                // BUG 16 fix: advertise the FLOORED margin (what's actually enforced
-                // on-chain), not the raw requested bps — see flooredInitialMarginBps doc.
-                max_leverage: params.initialMarginBps > 0
-                  ? Math.floor(10000 / flooredInitialMarginBps(params.initialMarginBps))
-                  : 1,
-                trading_fee_bps: Number(params.tradingFeeBps),
-                lp_collateral: params.lpCollateral.toString(),
-                mainnet_ca: params.mainnetCA ?? null,
-                // PERC-8332: nonce + signature for deployer proof
-                ...(nonce && signature ? { nonce, signature } : {}),
-              }),
+                  ...registrationPayload,
+                  // PERC-8332: nonce + signature for deployer proof
+                                  ...(nonce && signature ? { nonce, signature } : {})
+                }),
             });
           } catch {
             // Non-fatal — market is on-chain even if DB write fails

--- a/app/lib/market-registration-auth.ts
+++ b/app/lib/market-registration-auth.ts
@@ -1,0 +1,221 @@
+/**
+ * Payload-bound authorization for POST /api/markets.
+ *
+ * The browser client and server must build exactly the same
+ * domain-separated message from the challenge nonce and complete
+ * registration payload.
+ */
+
+export const MARKET_REGISTRATION_AUTH_DOMAIN =
+  "percolator-launch:markets:create:v1";
+
+export const MARKET_REGISTRATION_AUTH_METHOD =
+  "POST";
+
+export const MARKET_REGISTRATION_AUTH_PATH =
+  "/api/markets";
+
+export type MarketRegistrationPayload =
+  Record<string, unknown>;
+
+export interface MarketRegistrationAuthorization {
+  nonce: string;
+  deployer: string;
+  payload: MarketRegistrationPayload;
+}
+
+const AUTHENTICATION_FIELDS = new Set([
+  "nonce",
+  "signature",
+]);
+
+/**
+ * Deterministic JSON encoding.
+ *
+ * Object keys are sorted lexicographically. Undefined object
+ * properties are omitted, while undefined array entries become null,
+ * matching JSON.stringify behavior.
+ */
+function encodeCanonicalJson(
+  value: unknown,
+  arrayEntry = false,
+): string | undefined {
+  if (value === null) {
+    return "null";
+  }
+
+  if (typeof value === "string") {
+    return JSON.stringify(value);
+  }
+
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+
+  if (typeof value === "number") {
+    return Number.isFinite(value)
+      ? JSON.stringify(value)
+      : "null";
+  }
+
+  if (
+    value === undefined ||
+    typeof value === "function" ||
+    typeof value === "symbol"
+  ) {
+    return arrayEntry ? "null" : undefined;
+  }
+
+  if (typeof value === "bigint") {
+    throw new TypeError(
+      "BigInt is not supported in market registration payloads",
+    );
+  }
+
+  if (Array.isArray(value)) {
+    const entries = value.map(
+      (entry) =>
+        encodeCanonicalJson(entry, true) ?? "null",
+    );
+
+    return `[${entries.join(",")}]`;
+  }
+
+  if (typeof value === "object") {
+    const prototype = Object.getPrototypeOf(value);
+
+    if (
+      prototype !== Object.prototype &&
+      prototype !== null
+    ) {
+      throw new TypeError(
+        "Market registration payload must contain plain JSON objects",
+      );
+    }
+
+    const record =
+      value as Record<string, unknown>;
+
+    const entries: string[] = [];
+
+    for (const key of Object.keys(record).sort()) {
+      const encoded =
+        encodeCanonicalJson(record[key]);
+
+      if (encoded === undefined) {
+        continue;
+      }
+
+      entries.push(
+        `${JSON.stringify(key)}:${encoded}`,
+      );
+    }
+
+    return `{${entries.join(",")}}`;
+  }
+
+  throw new TypeError(
+    "Unsupported market registration payload value",
+  );
+}
+
+/**
+ * Remove authentication-envelope fields before canonicalization.
+ *
+ * The client signs the registration object before nonce/signature are
+ * appended. The server receives them in the same JSON request, so only
+ * these envelope fields are excluded.
+ */
+export function canonicalizeMarketRegistrationPayload(
+  payload: MarketRegistrationPayload,
+): string {
+  if (
+    payload === null ||
+    typeof payload !== "object" ||
+    Array.isArray(payload)
+  ) {
+    throw new TypeError(
+      "Market registration payload must be an object",
+    );
+  }
+
+  const registrationPayload:
+    MarketRegistrationPayload = {};
+
+  for (const [key, value] of Object.entries(
+    payload,
+  )) {
+    if (AUTHENTICATION_FIELDS.has(key)) {
+      continue;
+    }
+
+    registrationPayload[key] = value;
+  }
+
+  const canonical =
+    encodeCanonicalJson(registrationPayload);
+
+  if (canonical === undefined) {
+    throw new TypeError(
+      "Unable to canonicalize market registration payload",
+    );
+  }
+
+  return canonical;
+}
+
+/**
+ * Signing message:
+ *
+ * percolator-launch:markets:create:v1
+ * POST
+ * /api/markets
+ * <nonce>
+ * <deployer>
+ * <canonical registration JSON>
+ */
+export function buildMarketRegistrationMessage(
+  authorization: MarketRegistrationAuthorization,
+): Uint8Array {
+  const {
+    nonce,
+    deployer,
+    payload,
+  } = authorization;
+
+  if (!nonce || !deployer) {
+    throw new Error(
+      "Market registration nonce and deployer are required",
+    );
+  }
+
+  if (payload.deployer !== deployer) {
+    throw new Error(
+      "Market registration payload deployer does not match authorization deployer",
+    );
+  }
+
+  const canonicalPayload =
+    canonicalizeMarketRegistrationPayload(
+      payload,
+    );
+
+  const message = [
+    MARKET_REGISTRATION_AUTH_DOMAIN,
+    MARKET_REGISTRATION_AUTH_METHOD,
+    MARKET_REGISTRATION_AUTH_PATH,
+    nonce,
+    deployer,
+    canonicalPayload,
+  ].join("\n");
+
+  /*
+   * TextEncoder can return a Uint8Array associated with another
+   * JavaScript realm in some test/browser environments. TweetNaCl
+   * performs a strict instanceof Uint8Array check, so copy the encoded
+   * bytes into the active runtime's Uint8Array constructor.
+   */
+  return Uint8Array.from(
+    new TextEncoder().encode(message),
+  );
+}


### PR DESCRIPTION
## Summary

This PR fixes the authorization weakness reported in #2380 by binding the deployer wallet signature to the complete market-registration payload submitted to `POST /api/markets`.

Previously, the client signed only the challenge nonce:

```text
Ed25519.sign(UTF8(nonce), deployerPrivateKey)
```

The server verified that nonce-only signature independently from the registration body. Because the market parameters were not included in the signed message, a valid unused signature could authenticate a materially modified registration payload.

This PR introduces a shared, deterministic, and domain-separated authorization message that covers:

- authorization domain and message version;
- HTTP method;
- API path;
- challenge nonce;
- deployer public key;
- canonical market-registration payload.

The client signs this complete authorization message, while the server reconstructs the same message from the received request body and verifies it before claiming the nonce.

Fixes #2380.

---

## Problem

The previous registration authorization flow was effectively:

```text
GET /api/markets/challenge?deployer=<wallet>
  -> nonce

wallet.signMessage(UTF8(nonce))
  -> signature

POST /api/markets
{
  ...registrationPayload,
  nonce,
  signature
}
```

The server authenticated only:

```text
Ed25519.verify(
  UTF8(nonce),
  signature,
  deployerPublicKey
)
```

The market-registration payload was processed separately from the signed message.

This meant the signature proved that the deployer approved the challenge nonce, but did not prove that the deployer approved the exact payload received by the server.

Security-relevant registration fields were therefore not cryptographically committed by the wallet signature, including fields such as:

- `slab_address`
- `mint_address`
- `deployer`
- `symbol`
- `name`
- `decimals`
- `oracle_mode`
- `oracle_authority`
- `dex_pool_address`
- `mainnet_ca`
- `initial_price_e6`
- `max_leverage`
- `trading_fee_bps`
- `lp_collateral`
- `logo_url`

A valid nonce signature could consequently be paired with different registration metadata without invalidating the signature.

---

## Root cause

The challenge nonce provided freshness and replay protection, but it was cryptographically independent from the request contents.

Previous authorization message:

```text
nonce
```

Previous signature construction:

```text
signature = Ed25519.sign(
  UTF8(nonce),
  deployerPrivateKey
)
```

The route then consumed the registration fields directly from the JSON body after validating the nonce signature.

This created a gap between:

```text
the action authorized by the wallet
```

and:

```text
the registration payload processed by the server
```

---

## Fix

A shared authorization helper now creates the same deterministic signing message on both the browser client and the server.

The new message format is:

```text
percolator-launch:markets:create:v1
POST
/api/markets
<nonce>
<deployer>
<canonical-registration-json>
```

Conceptually:

```text
authorizationMessage =
  domain
  + HTTP method
  + API path
  + challenge nonce
  + deployer public key
  + canonical registration payload
```

The client signs:

```text
signature = Ed25519.sign(
  authorizationMessage,
  deployerPrivateKey
)
```

The server reconstructs:

```text
expectedMessage =
  buildMarketRegistrationMessage({
    nonce,
    deployer,
    payload: requestBody
  })
```

The server then verifies:

```text
Ed25519.verify(
  expectedMessage,
  signature,
  deployerPublicKey
)
```

Any modification to a signed registration field changes the authorization message and invalidates the signature.

---

## Shared authorization helper

A new shared helper was added:

```text
app/lib/market-registration-auth.ts
```

The helper is used by both:

```text
app/hooks/useCreateMarket.ts
app/app/api/markets/route.ts
```

This prevents the client and server from maintaining separate serialization or signing implementations.

The helper is responsible for:

1. validating the authorization inputs;
2. validating that the payload deployer matches the envelope deployer;
3. removing only authentication-envelope fields;
4. canonicalizing the remaining registration payload;
5. applying domain separation;
6. binding the message to `POST /api/markets`;
7. returning TweetNaCl-compatible message bytes.

---

## Canonicalization rules

The authorization helper uses deterministic JSON encoding so the client and server derive identical signing bytes.

Canonicalization follows these rules:

1. Object keys are sorted lexicographically.
2. Nested plain objects are canonicalized recursively.
3. Array order is preserved.
4. `undefined` object properties are omitted.
5. `undefined` array entries are represented as `null`.
6. Non-finite numeric values are represented consistently with JSON serialization.
7. Unsupported non-JSON values are rejected.
8. `bigint` values are rejected.
9. Non-plain object values are rejected.
10. Only the authentication-envelope fields are excluded:
    - `nonce`
    - `signature`

All registration fields remain part of the signed payload.

The helper also requires:

```text
payload.deployer === authorization.deployer
```

This prevents the deployer identity used in the authorization envelope from differing from the deployer stored in the registration payload.

---

## Domain separation

The signed message includes a versioned authorization domain:

```text
percolator-launch:markets:create:v1
```

The message also binds the signature to:

```text
POST
/api/markets
```

This prevents a signature generated for market creation from being reused as authorization for another endpoint, HTTP method, or unrelated message format.

The version suffix allows future authorization-message changes to be introduced explicitly.

---

## Client changes

`app/hooks/useCreateMarket.ts` now constructs one `registrationPayload` object and reuses the same object for signing and submission.

Updated flow:

```text
construct registrationPayload
  ↓
request challenge nonce
  ↓
build canonical authorization message
  ↓
sign authorization message with wallet.signMessage
  ↓
POST the same registrationPayload with nonce and signature
```

Previous client behavior:

```text
wallet.signMessage(
  new TextEncoder().encode(nonce)
)
```

New client behavior:

```text
const signingMessage =
  buildMarketRegistrationMessage({
    nonce,
    deployer: deployerStr,
    payload: registrationPayload,
  });

const signatureBytes =
  await wallet.signMessage(signingMessage);
```

The request then submits:

```text
{
  ...registrationPayload,
  nonce,
  signature
}
```

Constructing the payload once ensures the object being signed is the same object being posted.

---

## Server changes

`app/app/api/markets/route.ts` now rebuilds the authorization message from the received request body.

Updated server order:

```text
parse request body
  ↓
validate authentication envelope
  ↓
build canonical authorization message
  ↓
verify payload-bound Ed25519 signature
  ↓
claim challenge nonce
  ↓
perform existing on-chain validation
  ↓
continue registration
```

The route no longer verifies:

```text
detached.verify(
  nonceBytes,
  signatureBytes,
  deployerPublicKeyBytes
)
```

It now verifies:

```text
detached.verify(
  signingMessage,
  signatureBytes,
  deployerPublicKeyBytes
)
```

The signature is verified before the nonce is claimed.

Therefore, a modified or invalid request:

- returns `HTTP 401`;
- does not consume the challenge nonce;
- does not reach downstream registration logic;
- does not perform nonce persistence.

---

## Error handling

Malformed authorization payloads are rejected before signature verification with:

```text
HTTP 400
Invalid market registration authorization payload.
```

A payload that does not match the supplied signature is rejected with:

```text
HTTP 401
Signature verification failed.
```

Existing invalid-nonce and wrong-wallet controls remain unchanged.

---

## Security properties after this change

A successful market-registration authorization now proves approval of:

- the exact challenge nonce;
- the deployer identity;
- the target HTTP method;
- the target API path;
- the complete market-registration payload.

The patch preserves the existing controls for:

- missing nonce;
- missing signature;
- unknown nonce;
- expired nonce;
- already-used nonce;
- wrong-wallet signature;
- nonce replay prevention;
- on-chain slab lookup;
- known-program owner validation;
- on-chain deployer/admin equality;
- collateral-mint equality;
- oracle-authority validation;
- existing registration validation and rate limits.

---

## Regression coverage

### Canonical authorization tests

Added:

```text
app/__tests__/lib/market-registration-auth.test.ts
```

Coverage includes:

- deterministic canonicalization regardless of object insertion order;
- exclusion of only `nonce` and `signature`;
- authorization-domain inclusion;
- HTTP-method inclusion;
- API-path inclusion;
- nonce inclusion;
- deployer inclusion;
- payload inclusion;
- deployer mismatch rejection;
- TweetNaCl-compatible `Uint8Array` output;
- message changes when signed fields are modified.

Mutation coverage verifies that changes to the following fields produce different signing messages:

```text
symbol
name
oracle_mode
oracle_authority
dex_pool_address
mainnet_ca
initial_price_e6
max_leverage
trading_fee_bps
logo_url
```

### Route authentication tests

Updated:

```text
app/__tests__/api/markets-deployer-auth.test.ts
```

Existing authorization tests now sign the complete registration payload rather than only the nonce.

The new payload-substitution regression test:

1. creates a valid deployer keypair;
2. builds an original registration payload;
3. signs the original payload;
4. modifies the payload after signing;
5. submits the modified payload with the original signature;
6. expects `HTTP 401`;
7. verifies that the nonce persistence layer was not called.

The wrong-wallet negative control remains covered and continues to return `HTTP 401`.

---

## Validation

### TypeScript validation

Command:

```bash
pnpm exec tsc --noEmit
```

Result:

```text
PASS
```

### Targeted authorization tests

Command:

```bash
pnpm exec vitest run \
  __tests__/lib/market-registration-auth.test.ts \
  __tests__/api/markets-deployer-auth.test.ts \
  --reporter=verbose
```

Result:

```text
Test Files  2 passed
Tests       24 passed
```

Confirmed behavior:

```text
PASS valid payload-bound signature reaches downstream validation
PASS wrong-wallet signature is rejected
PASS modified payload is rejected with HTTP 401
PASS modified payload is rejected before nonce claim
PASS canonical message bytes are accepted by TweetNaCl
```

### Related regression tests

Executed test files:

```text
__tests__/lib/market-registration-auth.test.ts
__tests__/api/markets-deployer-auth.test.ts
__tests__/api/create-market-name.test.ts
__tests__/api/create-market-network-guard.test.ts
__tests__/api/create-market-rate-limit.test.ts
__tests__/hooks/useCreateMarket-keeper-register.test.ts
__tests__/hooks/useCreateMarket.v17-matcher-recovery.test.ts
__tests__/hooks/useCreateMarket.v17-matcher-resume.test.ts
```

Result:

```text
Test Files  8 passed
Tests       57 passed
```

### Production build

Command:

```bash
pnpm run build
```

Result:

```text
PASS
```

### Diff validation

Commands:

```bash
git diff --check
git diff --cached --check
```

Result:

```text
PASS
```

### Repository scope

The final patch contains exactly five files:

```text
app/__tests__/api/markets-deployer-auth.test.ts
app/__tests__/lib/market-registration-auth.test.ts
app/app/api/markets/route.ts
app/hooks/useCreateMarket.ts
app/lib/market-registration-auth.ts
```

No generated build files, local machine paths, private keys, disposable keypairs, or PoC evidence are included.

---

## Compatibility note

This intentionally changes the market-registration authorization format from nonce-only signing to payload-bound signing.

The browser client and server route are updated together in this PR.

Signatures generated using the previous nonce-only format will no longer pass the updated server verifier. This behavior is required to close the authorization gap.

The challenge nonce still provides freshness and replay protection, while the registration payload now provides authorization integrity.

---

## Scope

This PR is limited to deployer authorization for:

```text
POST /api/markets
```

This PR does not change:

- on-chain market ownership rules;
- slab account parsing;
- collateral-mint validation;
- deployer/admin validation;
- program allowlists;
- risk-parameter validation;
- nonce expiration policy;
- nonce storage implementation;
- database schema;
- unrelated market discovery flows;
- trading or position-management behavior.

---

## Checklist

- [x] Added shared canonical authorization helper
- [x] Added versioned domain separation
- [x] Bound the signature to the HTTP method
- [x] Bound the signature to the API path
- [x] Bound the signature to the challenge nonce
- [x] Bound the signature to the deployer identity
- [x] Bound the signature to the complete registration payload
- [x] Ensured the client signs and posts the same payload object
- [x] Ensured the server reconstructs the message from the received request
- [x] Kept signature verification before nonce claiming
- [x] Added payload-substitution regression coverage
- [x] Confirmed modified payloads return `HTTP 401`
- [x] Confirmed modified payloads do not consume the nonce
- [x] Confirmed wrong-wallet signatures remain rejected
- [x] Confirmed valid payload-bound signatures pass authentication
- [x] Passed TypeScript validation
- [x] Passed targeted authorization tests
- [x] Passed related regression tests
- [x] Passed production build
- [x] Passed final diff validation
- [x] Preserved a focused five-file scope

Fixes #2380