### PR TITLE
fix(trade): sanitize close position percentage

### DIFF
--- a/app/components/trade/ClosePositionModal.tsx
+++ b/app/components/trade/ClosePositionModal.tsx
@@ -72,6 +72,12 @@ export const ClosePositionModal: FC<ClosePositionModalProps> = ({
   useLockBodyScroll();
   const [percent, setPercent] = useState(100);
 
+function sanitizeClosePercent(value: number): number {
+  if (!Number.isFinite(value)) return 100;
+
+  return Math.min(100, Math.max(1, Math.trunc(value)));
+}
+
   // Ref-based callback to prevent WS price ticks from replaying the GSAP animation
   const onCancelRef = useRef(onCancel);
   onCancelRef.current = onCancel;
@@ -150,10 +156,12 @@ export const ClosePositionModal: FC<ClosePositionModalProps> = ({
   const colSym = collateralSymbol ?? symbol;
   const absPosition = abs(positionSize);
 
+  const safePercent = sanitizeClosePercent(percent);
+
   const preview = useMemo(() => {
-    const closeAbs = percent >= 100
+    const closeAbs = safePercent >= 100
       ? absPosition
-      : (absPosition * BigInt(percent)) / 100n;
+      : (absPosition * BigInt(safePercent)) / 100n;
     const remainingAbs = absPosition - closeAbs;
 
     // Compute PnL on the close portion. computeMarkPnl returns coin-margined
@@ -167,9 +175,9 @@ export const ClosePositionModal: FC<ClosePositionModalProps> = ({
     const pnl = currentPrice > 0n ? computeMarkPnlCollateral(pnlNative, currentPrice) : 0n;
 
     // Proportional capital for the close portion
-    const closeCapital = percent >= 100
+    const closeCapital = safePercent >= 100
       ? capital
-      : (capital * BigInt(percent)) / 100n;
+      : (capital * BigInt(safePercent)) / 100n;
 
     // B-3: Compute the trading fee charged on close (notional * feeBps / 10_000).
     // Without this, "Est. Receive" overstates what the user actually receives on-chain.
@@ -363,7 +371,7 @@ export const ClosePositionModal: FC<ClosePositionModalProps> = ({
             Cancel
           </button>
           <button
-            onClick={() => onConfirm(percent)}
+            onClick={() => onConfirm(safePercent)}
             disabled={loading || oracleStale}
             className="flex-1 rounded-none bg-[var(--short)] py-2.5 text-[11px] font-medium uppercase tracking-[0.1em] text-white transition-[filter,opacity] duration-150 hover:brightness-110 disabled:opacity-50"
           >


### PR DESCRIPTION
## Summary

This PR hardens the close position modal by sanitizing the close percentage before it is used in preview calculations and confirmation.

The close position modal calculates close size and proportional capital using `BigInt(percent)`. If the `percent` state ever becomes a fractional or invalid number, for example `12.5`, JavaScript throws when converting it to `BigInt()`. This can break the close position preview/render path and interrupt the user flow inside the trade UI.

Although the current slider uses integer steps, this patch makes the close-position flow safer by normalizing the percentage before it reaches any `BigInt()` calculation or confirm action.

## Problem

`ClosePositionModal.tsx` previously used the raw `percent` state directly in several close-position calculation paths:

- close amount calculation
- proportional capital calculation
- close confirmation payload

The risky pattern was `BigInt(percent)`.

This is unsafe if `percent` is ever non-integer, `NaN`, infinite, or outside the expected range.

For example, `BigInt(12.5)` throws:

`The number 12.5 cannot be converted to a BigInt because it is not an integer`

That means an invalid percentage state can cause the modal render/preview path to fail instead of safely normalizing the value before calculation.

## Changes

This PR adds a small defensive percentage sanitizer and uses the sanitized value consistently across the close-position flow.

Implemented changes:

- Added a `sanitizeClosePercent` helper.
- Clamps close percentage to the valid `1–100` range.
- Truncates fractional values before using them in `BigInt()` calculations.
- Uses the sanitized percentage in close preview calculations.
- Uses the sanitized percentage when calling `onConfirm`.
- Removes direct unsafe usage of `BigInt(percent)`.

## User Impact

This improves the stability of the close position modal.

The normal slider behavior remains unchanged for regular users, but the preview and confirmation paths are now more defensive against invalid, fractional, or out-of-range percentage state.

This prevents the trade UI from breaking if the close percentage becomes unsafe before being used in `BigInt()` arithmetic.

## Validation

- Verified that `BigInt(12.5)` throws in Node, confirming the original crash risk.
- Verified the modal no longer uses `BigInt(percent)` directly.
- Verified the close confirmation path now uses the sanitized percentage.
- Verified `git diff --check` passes.
- Confirmed the patch only changes `app/components/trade/ClosePositionModal.tsx`.

## Build Note

`pnpm build` currently fails on the base branch due to a missing `resend` dependency in waitlist API routes.

Affected base-branch files:

- `app/app/api/admin/waitlist/backfill-emails/route.ts`
- `app/app/api/waitlist/signup/route.ts`

The same failure is reproducible on the base branch, and this PR does not touch those files.