### PR TITLE
fix(chart): never cache an empty candle batch — kills stuck-empty timeframes

### DIFF
--- a/app/__tests__/hooks/useTokenChart-empty-cache.test.ts
+++ b/app/__tests__/hooks/useTokenChart-empty-cache.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Regression: a chart timeframe would get stuck showing EMPTY for the whole
+ * session. Root cause — GeckoTerminal rate-limits (~30 req/min), so switching
+ * timeframes quickly makes one or two requests come back empty; the client then
+ * CACHED that empty and repainted it via stale-while-revalidate on every later
+ * visit, so e.g. 1h/1d stayed blank even though the data was available.
+ *
+ * Fix (useTokenChart): never cache an empty batch, and keep last-good candles
+ * when a fetch comes back empty — mirroring the existing keep-last-good error
+ * branch. These tests pin: empty-not-cached (no stuck-empty), success-cached,
+ * and keep-last-good-on-empty.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+
+const MINT = "So11111111111111111111111111111111111111112";
+const CANDLE = { timestamp: 1_700_000_000_000, open: 1, high: 2, low: 0.5, close: 1.5, volume: 10 };
+
+function resp(candles: unknown[], poolAddress: string | null = "Pool111") {
+  return { ok: true, json: async () => ({ candles, poolAddress }) };
+}
+
+describe("useTokenChart — empty responses are not cached (stuck-empty fix)", () => {
+  let useTokenChart: typeof import("@/hooks/useTokenChart").useTokenChart;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.resetModules(); // fresh module-level chartCache per test
+    fetchMock = vi.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    ({ useTokenChart } = await import("@/hooks/useTokenChart"));
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("does NOT get stuck empty: an empty response is not cached, so a later fetch shows data", async () => {
+    fetchMock.mockResolvedValueOnce(resp([])); // first: rate-limited / empty
+    const first = renderHook(() => useTokenChart(MINT, "1h"));
+    await waitFor(() => expect(first.result.current.status).toBe("empty"));
+    expect(first.result.current.candles).toEqual([]);
+    first.unmount();
+
+    // Later: data is available. If the empty had been cached, this key would be
+    // painted "empty" from cache; either way it MUST resolve to the data.
+    fetchMock.mockResolvedValue(resp([CANDLE]));
+    const second = renderHook(() => useTokenChart(MINT, "1h"));
+    await waitFor(() => expect(second.result.current.status).toBe("success"));
+    expect(second.result.current.candles.length).toBe(1);
+    second.unmount();
+  });
+
+  it("caches a SUCCESSFUL batch: a repeat mount paints it synchronously (no blank)", async () => {
+    fetchMock.mockResolvedValue(resp([CANDLE]));
+    const first = renderHook(() => useTokenChart(MINT, "4h"));
+    await waitFor(() => expect(first.result.current.status).toBe("success"));
+    first.unmount();
+
+    // Same (mint,timeframe): stale-while-revalidate serves cached candles
+    // immediately — success on first render, never a "loading"/"empty" flash.
+    const second = renderHook(() => useTokenChart(MINT, "4h"));
+    expect(second.result.current.status).toBe("success");
+    expect(second.result.current.candles.length).toBe(1);
+    second.unmount();
+  });
+
+  it("keeps last-good candles when a subsequent fetch of the same key returns empty", async () => {
+    fetchMock.mockResolvedValueOnce(resp([CANDLE]));
+    const { result } = renderHook(() => useTokenChart(MINT, "1d"));
+    await waitFor(() => expect(result.current.status).toBe("success"));
+    expect(result.current.candles.length).toBe(1);
+
+    // A repoll of the SAME key comes back empty (transient GT 429). The chart
+    // must NOT blank — last-good candles are retained, status stays success.
+    fetchMock.mockResolvedValue(resp([]));
+    await act(async () => {
+      result.current.refresh();
+    });
+    await waitFor(() => {
+      expect(result.current.candles.length).toBe(1);
+      expect(result.current.status).toBe("success");
+    });
+  });
+});

--- a/app/hooks/useTokenChart.ts
+++ b/app/hooks/useTokenChart.ts
@@ -116,12 +116,42 @@ export function useTokenChart(
 
         const fetchedCandles: CandleData[] = json.candles ?? [];
         const pool = json.poolAddress ?? null;
-        const status: ChartDataStatus = fetchedCandles.length > 0 ? "success" : "empty";
-        candlesRef.current = fetchedCandles;
-        setCandles(fetchedCandles);
-        setPoolAddress(pool);
-        setStatus(status);
-        boundedSet(chartCache, key, { candles: fetchedCandles, poolAddress: pool, status }, CACHE_MAX_ENTRIES);
+
+        if (fetchedCandles.length > 0) {
+          candlesRef.current = fetchedCandles;
+          setCandles(fetchedCandles);
+          setPoolAddress(pool);
+          setStatus("success");
+          // Only successful (non-empty) batches are cached — see the empty
+          // branch below for why an empty must never be cached.
+          boundedSet(
+            chartCache,
+            key,
+            { candles: fetchedCandles, poolAddress: pool, status: "success" },
+            CACHE_MAX_ENTRIES,
+          );
+        } else {
+          // Empty response. GeckoTerminal rate-limits (~30 req/min), so an
+          // empty batch is almost always a transient 429 while switching
+          // timeframes quickly — NOT "this token has no chart". Two rules,
+          // mirroring the keep-last-good error branch below:
+          //   1. NEVER cache an empty. A cached empty would be repainted by the
+          //      stale-while-revalidate branch above on every later visit to
+          //      this (mint,timeframe), leaving that one timeframe stuck blank
+          //      for the whole session even though the data is available — the
+          //      exact "1h/1d show empty" bug. Not caching it means the next
+          //      poll / timeframe switch refetches fresh.
+          //   2. If we already have candles for this key, KEEP them (don't
+          //      blank a chart that was populated a moment ago); otherwise
+          //      surface "empty" so the chart falls back to the oracle line,
+          //      and let the 60s poll refill it once GT responds.
+          if (pool) setPoolAddress(pool); // pool can resolve even on an empty batch
+          if (candlesRef.current.length > 0) {
+            setStatus("success");
+          } else {
+            setStatus("empty");
+          }
+        }
       } catch (err) {
         if (fetchKeyRef.current !== key) return;
         console.warn("[useTokenChart] fetch error:", err);


### PR DESCRIPTION
## What (user-reported)

A freshly-launched market's chart showed data on some timeframes (1m/5m/15m/4h) but stayed **permanently empty** on others (1h/1d) — until a hard refresh. Verified against the live API that GeckoTerminal returns **clean data for every timeframe** for that token (1h = 333 bars, 1d = 181), so it was never a missing-data or bad-timeframe problem.

## Root cause

`useTokenChart` caches fetch results, and GeckoTerminal rate-limits (~30 req/min). Switching timeframes quickly makes one or two requests come back **empty** (a transient 429) — and the client **cached that empty result**. The stale-while-revalidate branch then repainted the cached empty on every later visit to that `(mint, timeframe)`, so whichever timeframe happened to catch the rate-limit stayed blank for the whole session. Hard-refresh was the only escape.

## Fix

Treat an empty batch exactly the way the existing **error** branch already treats a failed one:

- **Never cache an empty.** The cache now only ever holds successful batches, so the stale-while-revalidate paint can only serve real data — a transient blip can't become a permanent blank.
- **Keep last-good candles** if we already have them (don't blank a chart that was populated a moment ago); otherwise surface `"empty"` so the chart falls back to the oracle line, and the next 60s poll refills it once GT responds.
- The pool address is still retained on an empty batch (it can resolve independently of candle data).

Net: no code path caches or pins an empty anymore — the exact mechanism behind the stuck 1h/1d.

## Testing

- `npx tsc --noEmit` clean.
- New `useTokenChart-empty-cache` suite (3 cases): empty-not-cached so a later fetch shows data (no stuck-empty); a successful batch **is** cached and repaints synchronously; keep-last-good when a same-key refetch returns empty. Plus `bounded-map` suite — **8/8**.
- Headless render across all timeframes (1d → 1h → 4h → 5m → 1m → 1h → 1d): chart renders on every one, zero JS errors.
- Purely client-side display cache — no security surface (candles/pool come from our own `/api/chart` proxy, which `PublicKey`-validates the mint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
