### PR TITLE
fix(chart): bounded GeckoTerminal retry so a new market's first fetch survives a 429

### DIFF
--- a/app/__tests__/lib/gecko-fetch.test.ts
+++ b/app/__tests__/lib/gecko-fetch.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  geckoFetch,
+  geckoBackoffMs,
+  GECKO_ATTEMPTS,
+  GECKO_MAX_BACKOFF_MS,
+  GECKO_DEADLINE_MS,
+} from "@/lib/gecko-fetch";
+
+/** Build a Response with a given status (and optional headers). 429/5xx allow a body. */
+function res(status: number, headers?: Record<string, string>) {
+  return new Response("{}", { status, headers });
+}
+
+describe("geckoFetch — bounded retry for GeckoTerminal", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("returns immediately on success — one call, no retry", async () => {
+    fetchMock.mockResolvedValue(res(200));
+    const r = await geckoFetch("https://x/y");
+    expect(r?.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT retry a genuine 4xx (404 no-such-token) — returns it on the first call", async () => {
+    fetchMock.mockResolvedValue(res(404));
+    const r = await geckoFetch("https://x/y");
+    expect(r?.status).toBe(404);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a 429 and returns the eventual success", async () => {
+    fetchMock.mockResolvedValueOnce(res(429)).mockResolvedValueOnce(res(200));
+    const r = await geckoFetch("https://x/y");
+    expect(r?.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a 5xx and returns the eventual success", async () => {
+    fetchMock.mockResolvedValueOnce(res(503)).mockResolvedValueOnce(res(200));
+    const r = await geckoFetch("https://x/y");
+    expect(r?.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up after GECKO_ATTEMPTS on a persistent 429 (returns the last failure, not null)", async () => {
+    fetchMock.mockResolvedValue(res(429));
+    const r = await geckoFetch("https://x/y");
+    expect(r?.status).toBe(429);
+    expect(fetchMock).toHaveBeenCalledTimes(GECKO_ATTEMPTS);
+  });
+
+  it("retries a thrown network/timeout error, then succeeds", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("timeout")).mockResolvedValueOnce(res(200));
+    const r = await geckoFetch("https://x/y");
+    expect(r?.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns null when a network error persists across all attempts", async () => {
+    fetchMock.mockRejectedValue(new Error("network"));
+    const r = await geckoFetch("https://x/y");
+    expect(r).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(GECKO_ATTEMPTS);
+  });
+});
+
+describe("geckoBackoffMs", () => {
+  it("honors a numeric Retry-After (seconds) but CAPS it at the max backoff", () => {
+    const r = res(429, { "retry-after": "100" }); // GT asks for 100s
+    expect(geckoBackoffMs(r, 0, Date.now())).toBe(GECKO_MAX_BACKOFF_MS); // never 100_000ms
+  });
+
+  it("ignores a non-numeric (HTTP-date) Retry-After and uses exponential backoff", () => {
+    const r = res(429, { "retry-after": "Wed, 21 Oct 2026 07:28:00 GMT" });
+    expect(geckoBackoffMs(r, 0, Date.now())).toBe(300); // exponential, not a misparse
+  });
+
+  it("uses exponential 300ms·2^n when there is no Retry-After", () => {
+    expect(geckoBackoffMs(null, 0, Date.now())).toBe(300);
+    expect(geckoBackoffMs(null, 1, Date.now())).toBe(600);
+  });
+
+  it("never returns negative and never sleeps past the deadline", () => {
+    // startedAt already past the deadline → remaining is negative → clamps to 0.
+    expect(geckoBackoffMs(null, 2, Date.now() - GECKO_DEADLINE_MS - 5_000)).toBe(0);
+  });
+});

--- a/app/app/api/chart/[mint]/route.ts
+++ b/app/app/api/chart/[mint]/route.ts
@@ -29,6 +29,7 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { PublicKey } from "@solana/web3.js";
 import { boundedSet } from "@/lib/bounded-map";
+import { geckoFetch } from "@/lib/gecko-fetch";
 
 export const dynamic = "force-dynamic";
 
@@ -44,8 +45,6 @@ export interface CandleData {
 }
 
 const GECKOTERMINAL_BASE = "https://api.geckoterminal.com/api/v2/networks/solana";
-const FETCH_TIMEOUT_MS = 8_000;
-const GECKO_HEADERS = { Accept: "application/json", "User-Agent": "percolator-chart-proxy/1.0" };
 
 const CACHE_HEADERS = {
   "Cache-Control": "public, s-maxage=60, stale-while-revalidate=120",
@@ -140,11 +139,8 @@ async function resolveTopPool(mint: string): Promise<string | null> {
 
 async function resolveTopPoolUncached(mint: string): Promise<string | null> {
   try {
-    const res = await fetch(`${GECKOTERMINAL_BASE}/tokens/${mint}?include=top_pools`, {
-      headers: GECKO_HEADERS,
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    });
-    if (!res.ok) return null;
+    const res = await geckoFetch(`${GECKOTERMINAL_BASE}/tokens/${mint}?include=top_pools`);
+    if (!res || !res.ok) return null;
     const json = await res.json();
 
     const topIds: string[] = (json?.data?.relationships?.top_pools?.data ?? [])
@@ -180,8 +176,8 @@ async function fetchCandles(
     const url =
       `${GECKOTERMINAL_BASE}/pools/${encodeURIComponent(pool)}/ohlcv/${timeframe}` +
       `?aggregate=${encodeURIComponent(aggregate)}&limit=${encodeURIComponent(limit)}`;
-    const res = await fetch(url, { headers: GECKO_HEADERS, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
-    if (!res.ok) return [];
+    const res = await geckoFetch(url);
+    if (!res || !res.ok) return [];
     const json = await res.json();
     const bars = json?.data?.attributes?.ohlcv_list as GeckoOhlcvBar[] | undefined;
     if (!Array.isArray(bars) || bars.length === 0) return [];

--- a/app/lib/gecko-fetch.ts
+++ b/app/lib/gecko-fetch.ts
@@ -1,0 +1,74 @@
+/**
+ * Bounded retry wrapper for GeckoTerminal calls (used by the chart route).
+ *
+ * All users' chart requests exit through Vercel's SHARED IP, so GeckoTerminal
+ * rate-limits (429) that IP under load — and a brand-new market's FIRST fetch
+ * has no previously-cached good batch to fall back on, so a single 429 returns
+ * an empty chart. A small retry lets that first fetch survive a transient
+ * 429 / 5xx / network blip.
+ *
+ * Hard-bounded so a waiting client is never left hanging: at most
+ * GECKO_ATTEMPTS tries, each timeout clamped to the remaining total budget,
+ * backoff capped at GECKO_MAX_BACKOFF_MS, and the whole call abandoned once
+ * GECKO_DEADLINE_MS elapses. Retries ONLY transient failures (429, 5xx, thrown
+ * network/timeout) — never a genuine 4xx (e.g. 404 "no such token"), where
+ * retrying can't help.
+ */
+const GECKO_HEADERS = { Accept: "application/json", "User-Agent": "percolator-chart-proxy/1.0" };
+
+export const GECKO_ATTEMPTS = 3; // 1 initial + 2 retries
+export const GECKO_ATTEMPT_TIMEOUT_MS = 5_000;
+export const GECKO_MAX_BACKOFF_MS = 1_500;
+export const GECKO_DEADLINE_MS = 9_000;
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/** Backoff before the next attempt: honor a numeric Retry-After (seconds) when
+ *  present, else exponential 300ms·2^n — both capped, and never sleeping past
+ *  the overall deadline. Exported for unit testing. */
+export function geckoBackoffMs(res: Response | null, attempt: number, startedAt: number): number {
+  const ra = res?.headers.get("retry-after");
+  const base = ra && /^\d+$/.test(ra) ? Number(ra) * 1000 : 300 * 2 ** attempt;
+  const remaining = GECKO_DEADLINE_MS - (Date.now() - startedAt);
+  return Math.max(0, Math.min(base, GECKO_MAX_BACKOFF_MS, remaining));
+}
+
+/**
+ * Fetch a GeckoTerminal URL with the bounded retry described above. Returns the
+ * first usable Response, the last failed Response when out of attempts, or
+ * null on a network/timeout error with no attempts left. Never throws.
+ */
+export async function geckoFetch(url: string): Promise<Response | null> {
+  const startedAt = Date.now();
+  for (let attempt = 0; attempt < GECKO_ATTEMPTS; attempt++) {
+    // Hard-bound each attempt's timeout by the remaining total budget so the
+    // whole call can never exceed ~GECKO_DEADLINE_MS, no matter how the
+    // attempts time out. Attempt 0 always gets the full per-attempt timeout
+    // (the budget is fresh).
+    const remaining = GECKO_DEADLINE_MS - (Date.now() - startedAt);
+    if (attempt > 0 && remaining <= 0) break;
+    const attemptTimeout = Math.min(GECKO_ATTEMPT_TIMEOUT_MS, Math.max(1, remaining));
+    try {
+      const res = await fetch(url, {
+        headers: GECKO_HEADERS,
+        signal: AbortSignal.timeout(attemptTimeout),
+      });
+      // Success, or a non-retryable 4xx (400/404/…): hand back as-is.
+      if (res.ok || (res.status < 500 && res.status !== 429)) return res;
+      // 429 / 5xx: back off and retry if we still can, else return the failure.
+      if (attempt < GECKO_ATTEMPTS - 1) {
+        await sleep(geckoBackoffMs(res, attempt, startedAt));
+        continue;
+      }
+      return res;
+    } catch {
+      // Network error / timeout — retry if attempts and time budget remain.
+      if (attempt < GECKO_ATTEMPTS - 1 && Date.now() - startedAt < GECKO_DEADLINE_MS) {
+        await sleep(geckoBackoffMs(null, attempt, startedAt));
+        continue;
+      }
+      return null;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## What

Closes the "new market, first load shows an empty chart" gap at the source. All users' chart requests exit through Vercel's **shared** IP, so GeckoTerminal rate-limits (429) that IP under load — and a brand-new market's **first** fetch has no previously-cached good batch to fall back on, so a single transient 429 returned an empty chart.

## Fix

Both GT calls (`mint→pool` resolve, `pool→candles`) now go through a small **bounded retry** (`lib/gecko-fetch.ts`):

- Retries **only transient failures** — HTTP **429**, **5xx**, and thrown **network/timeout** errors. A genuine **4xx** (e.g. 404 "no such token") is returned immediately — retrying can't help.
- Honors a numeric **`Retry-After`** (capped at 1.5s so we never hang), otherwise exponential `300ms·2^n`.
- **Hard-bounded** so a waiting client is never left hanging: at most 3 attempts, each timeout clamped to the remaining budget, whole call abandoned once a **9s deadline** elapses. `geckoFetch` never throws; callers already treat `null` / `!ok` as "no data".

Net: a transient blip on a first load recovers within ~1s instead of returning empty; **success is still a single call** (no latency regression); sustained rate-limiting still fails fast (429s are quick) and the client falls back to the oracle line + refetches, as before. Complements the client-side fix ("never cache an empty", #2390) — the server retries the blip, the client never freezes on one.

Extracted to `lib/gecko-fetch.ts` because a Next route file can't cleanly export non-handler symbols for testing.

## Testing

- `npx tsc --noEmit` clean.
- New `gecko-fetch` suite — **11 cases**: success = 1 call (no retry), 404 not retried, 429→success retried, 5xx→success, persistent-429 gives up after 3 returning the last failure, network-error retried-then-succeeds, persistent-network → null; backoff honors + **caps** `Retry-After`, ignores an HTTP-date, exponential default, never negative / past deadline. Plus `chart-mint-validation` — **16/16**.
- Live route: SOL 1h returns 100 bars in ~1.4s (single call); an invalid mint still **400s fast** (validation runs before any GT fetch — no retry storm).
- No security surface: URL still built only from validated inputs (`PublicKey`-checked mint, GT-sourced pool, whitelisted timeframe, `^\d+$` aggregate, clamped limit); `Retry-After` parsed only as `^\d+$` and capped; no new hosts.

**Note:** touches the same chart `route.ts` as the open cache-cap PR (#2379) — different regions, so whichever merges second is a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
