### PR TITLE
fix(trade): clamp close-position % at the source (supersedes #2388)

### DIFF
--- a/app/__tests__/lib/close-percent.test.ts
+++ b/app/__tests__/lib/close-percent.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { clampClosePercent } from "@/lib/trading";
+
+describe("clampClosePercent", () => {
+  it("passes through valid whole percentages unchanged", () => {
+    expect(clampClosePercent(1)).toBe(1);
+    expect(clampClosePercent(25)).toBe(25);
+    expect(clampClosePercent(100)).toBe(100);
+  });
+
+  it("rounds fractional input to a whole number", () => {
+    expect(clampClosePercent(12.5)).toBe(13);
+    expect(clampClosePercent(49.4)).toBe(49);
+  });
+
+  it("clamps above 100 down to 100", () => {
+    expect(clampClosePercent(150)).toBe(100);
+    expect(clampClosePercent(1e9)).toBe(100);
+  });
+
+  it("folds malformed / below-range input to the MINIMUM (1), never a full close", () => {
+    expect(clampClosePercent(0)).toBe(1);
+    expect(clampClosePercent(-5)).toBe(1);
+    expect(clampClosePercent(NaN)).toBe(1);
+    expect(clampClosePercent(Infinity)).toBe(1);
+    expect(clampClosePercent(-Infinity)).toBe(1);
+  });
+});

--- a/app/components/trade/ClosePositionModal.tsx
+++ b/app/components/trade/ClosePositionModal.tsx
@@ -6,7 +6,7 @@ import gsap from "gsap";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
 import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
 import { formatTokenAmount, formatUsdPriceE6 } from "@/lib/format";
-import { computeMarkPnl, computeMarkPnlCollateral } from "@/lib/trading";
+import { computeMarkPnl, computeMarkPnlCollateral, clampClosePercent } from "@/lib/trading";
 
 interface ClosePositionModalProps {
   positionSize: bigint;
@@ -71,6 +71,10 @@ export const ClosePositionModal: FC<ClosePositionModalProps> = ({
   const prefersReduced = usePrefersReducedMotion();
   useLockBodyScroll();
   const [percent, setPercent] = useState(100);
+  // Single clamp source: every write to `percent` goes through here, so the state
+  // is always a valid whole [1,100] and every display/math/confirm site below
+  // agrees by construction — see clampClosePercent in lib/trading.ts.
+  const updatePercent = (value: number) => setPercent(clampClosePercent(value));
 
   // Ref-based callback to prevent WS price ticks from replaying the GSAP animation
   const onCancelRef = useRef(onCancel);
@@ -255,7 +259,7 @@ export const ClosePositionModal: FC<ClosePositionModalProps> = ({
             max={100}
             step={1}
             value={percent}
-            onChange={(e) => setPercent(Number(e.target.value))}
+            onChange={(e) => updatePercent(Number(e.target.value))}
             style={{
               background: `linear-gradient(to right, var(--short) 0%, var(--short) ${percent}%, rgba(255,255,255,0.03) ${percent}%, rgba(255,255,255,0.03) 100%)`,
               backgroundSize: "100% 2px",
@@ -269,7 +273,7 @@ export const ClosePositionModal: FC<ClosePositionModalProps> = ({
             {PRESETS.map((p) => (
               <button
                 key={p}
-                onClick={() => setPercent(p)}
+                onClick={() => updatePercent(p)}
                 className={`flex-1 rounded-none py-1 text-[10px] font-medium transition-colors duration-150 ${
                   percent === p
                     ? "bg-[var(--short)] text-white"

--- a/app/lib/trading.ts
+++ b/app/lib/trading.ts
@@ -180,3 +180,23 @@ export function estimateEntryFromPnl(
   const entry = positionSize > 0n ? oraclePrice - diff : oraclePrice + diff;
   return entry > 0n ? entry : oraclePrice;
 }
+
+/**
+ * Clamp a close-position percentage to a valid whole number in [1, 100].
+ *
+ * The close-position modal's slider (`min=1 max=100 step=1`) and its presets are
+ * integer-safe by construction, so this is defence-in-depth: applied at the single
+ * `setPercent` source, it guarantees the `percent` state is ALWAYS a valid whole
+ * number, so every display/math/confirm site agrees by construction. A non-finite
+ * value would otherwise flow into `BigInt(percent)` sizing math and slip past
+ * `useClosePosition`'s range guard (`percent < 1 || percent > 100` is `false` for
+ * NaN). Malformed / out-of-low-range input folds to the MINIMUM (1), never the
+ * maximum — corrupted state must not silently escalate to a full 100% close.
+ */
+export function clampClosePercent(value: number): number {
+  if (!Number.isFinite(value)) return 1;
+  const rounded = Math.round(value);
+  if (rounded < 1) return 1;
+  if (rounded > 100) return 100;
+  return rounded;
+}


### PR DESCRIPTION
## What
Route every `setPercent` in `ClosePositionModal` through a new `clampClosePercent` (in `lib/trading.ts`), so the `percent` state is always a valid whole `[1,100]`.

## Why
The modal read `percent` at ~6 places — slider label, gradient, preset active-state, the `Close X%` button, `BigInt(percent)` sizing math, and `onConfirm(percent)` — with nothing guaranteeing the state was valid. A non-finite value would **display one number while executing another** in a money-moving flow, and `useClosePosition`'s guard (`percent < 1 || percent > 100`) is `false` for `NaN`. Clamping at the single source means every read site agrees by construction. Malformed / below-range input folds to the **minimum (1)**, never a destructive full 100% close.

This supersedes #2388 (thanks @Bayyan16 for surfacing it) — same intent, but clamped at the source so all sites stay consistent rather than adding a sanitized variable used at only some of them.

## Test
`__tests__/lib/close-percent.test.ts` — valid pass-through, fractional rounding, >100 → 100, and NaN/Infinity/0/negative → 1. `npx tsc --noEmit` clean, `pnpm test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)