### PR TITLE
fix(logo): per-market ownership proof replaces broken shared-key auth

### DIFF
--- a/app/__tests__/api/market-logo-ownership-auth.test.ts
+++ b/app/__tests__/api/market-logo-ownership-auth.test.ts
@@ -1,0 +1,258 @@
+// @vitest-environment node
+//
+// This route (and the ed25519 verification it performs via tweetnacl) only
+// ever runs server-side in production — the default jsdom environment's
+// TextEncoder produces a Uint8Array that fails tweetnacl's strict
+// `instanceof Uint8Array` check across jsdom's realm, which would make every
+// signature silently fail verification (a test-environment artifact, not a
+// real bug — Next.js API routes execute in real Node, never jsdom). Forcing
+// `node` here mirrors how this route actually runs.
+
+/**
+ * POST /api/markets/[slab]/logo — per-market wallet ownership proof.
+ *
+ * This route used to gate on `requireAuth()` (a server-only `x-api-key` vs
+ * INDEXER_API_KEY header) — the browser never held that key, so every real
+ * upload from components/create/LogoUpload.tsx 401'd unconditionally, and the
+ * key itself was one shared secret with no per-market scoping. It's been
+ * replaced with a wallet-signed stateless deployer proof (mirroring
+ * app/api/playground/keeper-register/route.ts's H1v2 scheme) checked against
+ * the market's LP-portfolio owner (the durable creator marker — marketauth
+ * rotates away post-launch, see the route's header comment).
+ *
+ * Covers:
+ *   1. Missing deployer/signature (no admin bypass) → 400
+ *   2. Invalid deployer pubkey → 400
+ *   3. Invalid signature (not base64 64 bytes) → 400
+ *   4. Wrong-key signature (well-formed, doesn't verify) → 401
+ *   5. Valid signature but no LP portfolio found for (slab, deployer) → 403
+ *   6. Valid signature, a portfolio is found but it's NOT the LP → 403
+ *   7. Valid signature + a real LP portfolio → auth passes (hits downstream
+ *      503 from the mocked Supabase client, proving auth was NOT what failed)
+ *   8. Admin bypass header skips the wallet-proof requirement entirely
+ *   9. On-chain RPC failure during the ownership scan → 400
+ */
+
+import nacl from "tweetnacl";
+import { PublicKey } from "@solana/web3.js";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/lib/config", () => ({
+  getConfig: vi.fn(() => ({
+    rpcUrl: "https://api.devnet.solana.com",
+    programId: "69VUZ7a2BeXBTpRRManLamF5UWTaNR9B1hy5Se3cdXy9",
+  })),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+const mockGetProgramAccounts = vi.fn();
+vi.mock("@solana/web3.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@solana/web3.js")>();
+  return {
+    ...actual,
+    // A plain `function` (not an arrow) — the route calls `new Connection(...)`,
+    // and only a real constructor function can be invoked via `new` (an arrow
+    // function has no [[Construct]] and throws "is not a constructor").
+    // Explicitly returning an object from a constructor makes `new` use that
+    // object instead of `this`, which is all this mock needs.
+    Connection: vi.fn().mockImplementation(function mockConnection() {
+      return { getProgramAccounts: mockGetProgramAccounts };
+    }),
+  };
+});
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceClient: vi.fn(() => {
+    throw new Error("Storage backend unavailable (mocked)");
+  }),
+}));
+
+const SLAB = "7RXTVmGcJMDqqTCFu5ADQRyLDvVZBi3r5U5WXzoULHJV";
+/** market_group_id offset within a v17 portfolio account. */
+const V17_PF_MARKET_OFF = 16;
+/** Mutable owner offset within a v17 portfolio account. */
+const V17_PF_OWNER_OFF = 116;
+const V17_PORTFOLIO_MAGIC = Buffer.from([0x00, 0x36, 0x31, 0x56, 0x43, 0x52, 0x45, 0x50]);
+
+/** Builds a minimal v17-portfolio-shaped account buffer: magic@0,
+ *  market_group_id@16, owner@116, and (optionally) an enabled trailing
+ *  PortfolioMatcherConfigV16 (the LP discriminator — see lib/lpPortfolio.ts). */
+function makePortfolioBuffer(marketGroupId: PublicKey, owner: PublicKey, isLp: boolean): Buffer {
+  const PORTFOLIO_MATCHER_CONFIG_LEN = 104;
+  const totalLen = 200; // arbitrary, large enough to hold both regions with no overlap
+  const buf = Buffer.alloc(totalLen);
+  V17_PORTFOLIO_MAGIC.copy(buf, 0);
+  marketGroupId.toBuffer().copy(buf, V17_PF_MARKET_OFF);
+  owner.toBuffer().copy(buf, V17_PF_OWNER_OFF);
+  const matcherConfigOffset = buf.length - PORTFOLIO_MATCHER_CONFIG_LEN;
+  buf.writeBigUInt64LE(isLp ? 1n : 0n, matcherConfigOffset + 96);
+  return buf;
+}
+
+function genKeypair() {
+  const kp = nacl.sign.keyPair();
+  return { secretKey: kp.secretKey, publicKey: new PublicKey(kp.publicKey) };
+}
+
+function signProof(slab: string, secretKey: Uint8Array, minuteOffset = 0): string {
+  const unixMinute = Math.floor(Date.now() / 60_000) + minuteOffset;
+  // Mirrors markets-deployer-auth.test.ts's approach (Buffer→Uint8Array, not
+  // TextEncoder) — avoids a jsdom-environment realm mismatch where tweetnacl's
+  // `instanceof Uint8Array` check rejects a TextEncoder-produced array.
+  const msg = new Uint8Array(Buffer.from(`market-logo:${slab}:${unixMinute}`, "utf-8"));
+  return Buffer.from(nacl.sign.detached(msg, secretKey)).toString("base64");
+}
+
+/** Builds a multipart/form-data POST request the route handler can read via
+ *  req.formData(). `includeFile` attaches a dummy `logo` File — needed for
+ *  tests that assert auth PASSED, since without one the route's own
+ *  "No file provided" 400 (checked right after auth) would be
+ *  indistinguishable from an auth failure. */
+function buildRequest(
+  fields: Record<string, string>,
+  headers: Record<string, string> = {},
+  includeFile = false,
+): Request {
+  const form = new FormData();
+  for (const [k, v] of Object.entries(fields)) form.append(k, v);
+  if (includeFile) {
+    form.append("logo", new File([new Uint8Array([1, 2, 3])], "logo.png", { type: "image/png" }));
+  }
+  return new Request(`http://localhost/api/markets/${SLAB}/logo`, {
+    method: "POST",
+    headers,
+    body: form,
+  });
+}
+
+describe("POST /api/markets/[slab]/logo — wallet ownership auth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.ADMIN_API_SECRET;
+  });
+  afterEach(() => {
+    delete process.env.ADMIN_API_SECRET;
+  });
+
+  it("returns 400 when deployer/signature are both missing", async () => {
+    const { POST } = await import("@/app/api/markets/[slab]/logo/route");
+    const req = buildRequest({});
+    // @ts-expect-error - NextRequest wraps Request
+    const res = await POST(req, { params: Promise.resolve({ slab: SLAB }) });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/deployer|signature/i);
+  });
+
+  it("returns 400 for an invalid deployer pubkey", async () => {
+    const { POST } = await import("@/app/api/markets/[slab]/logo/route");
+    const req = buildRequest({ deployer: "not-a-pubkey", signature: "dGVzdA==" });
+    // @ts-expect-error
+    const res = await POST(req, { params: Promise.resolve({ slab: SLAB }) });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/deployer/i);
+  });
+
+  it("returns 400 for a malformed signature (not base64 64 bytes)", async () => {
+    const kp = genKeypair();
+    const { POST } = await import("@/app/api/markets/[slab]/logo/route");
+    const req = buildRequest({ deployer: kp.publicKey.toBase58(), signature: "dGVzdA==" });
+    // @ts-expect-error
+    const res = await POST(req, { params: Promise.resolve({ slab: SLAB }) });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/signature/i);
+  });
+
+  it("returns 401 for a well-formed signature that doesn't verify (wrong key)", async () => {
+    const kp = genKeypair();
+    const wrongKp = genKeypair();
+    const badSig = signProof(SLAB, wrongKp.secretKey);
+    const { POST } = await import("@/app/api/markets/[slab]/logo/route");
+    const req = buildRequest({ deployer: kp.publicKey.toBase58(), signature: badSig });
+    // @ts-expect-error
+    const res = await POST(req, { params: Promise.resolve({ slab: SLAB }) });
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toMatch(/signature/i);
+  });
+
+  it("returns 403 when the signer owns no portfolio on this market", async () => {
+    const kp = genKeypair();
+    const sig = signProof(SLAB, kp.secretKey);
+    mockGetProgramAccounts.mockResolvedValue([]);
+    const { POST } = await import("@/app/api/markets/[slab]/logo/route");
+    const req = buildRequest({ deployer: kp.publicKey.toBase58(), signature: sig });
+    // @ts-expect-error
+    const res = await POST(req, { params: Promise.resolve({ slab: SLAB }) });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toMatch(/not the creator/i);
+  });
+
+  it("returns 403 when the signer owns a portfolio on this market that is NOT the LP", async () => {
+    const kp = genKeypair();
+    const sig = signProof(SLAB, kp.secretKey);
+    const tradingPortfolio = makePortfolioBuffer(new PublicKey(SLAB), kp.publicKey, false);
+    mockGetProgramAccounts.mockResolvedValue([{ pubkey: kp.publicKey, account: { data: tradingPortfolio } }]);
+    const { POST } = await import("@/app/api/markets/[slab]/logo/route");
+    const req = buildRequest({ deployer: kp.publicKey.toBase58(), signature: sig });
+    // @ts-expect-error
+    const res = await POST(req, { params: Promise.resolve({ slab: SLAB }) });
+    expect(res.status).toBe(403);
+  });
+
+  it("passes auth when the signer owns the market's LP portfolio (hits downstream storage-unavailable, not an auth error)", async () => {
+    const kp = genKeypair();
+    const sig = signProof(SLAB, kp.secretKey);
+    const lpPortfolio = makePortfolioBuffer(new PublicKey(SLAB), kp.publicKey, true);
+    mockGetProgramAccounts.mockResolvedValue([{ pubkey: kp.publicKey, account: { data: lpPortfolio } }]);
+    const { POST } = await import("@/app/api/markets/[slab]/logo/route");
+    const req = buildRequest({ deployer: kp.publicKey.toBase58(), signature: sig }, {}, true);
+    // @ts-expect-error
+    const res = await POST(req, { params: Promise.resolve({ slab: SLAB }) });
+    // Auth passed — the mocked getServiceClient() throw surfaces as 503, not 400/401/403.
+    expect(res.status).toBe(503);
+  });
+
+  it("accepts a signature signed a couple minutes in the past (clock-skew tolerance)", async () => {
+    const kp = genKeypair();
+    const sig = signProof(SLAB, kp.secretKey, -3);
+    const lpPortfolio = makePortfolioBuffer(new PublicKey(SLAB), kp.publicKey, true);
+    mockGetProgramAccounts.mockResolvedValue([{ pubkey: kp.publicKey, account: { data: lpPortfolio } }]);
+    const { POST } = await import("@/app/api/markets/[slab]/logo/route");
+    const req = buildRequest({ deployer: kp.publicKey.toBase58(), signature: sig }, {}, true);
+    // @ts-expect-error
+    const res = await POST(req, { params: Promise.resolve({ slab: SLAB }) });
+    expect(res.status).toBe(503);
+  });
+
+  it("admin bypass header skips the wallet-proof requirement entirely", async () => {
+    process.env.ADMIN_API_SECRET = "test-admin-secret";
+    const { POST } = await import("@/app/api/markets/[slab]/logo/route");
+    const req = buildRequest({}, { "x-admin-secret": "test-admin-secret" }, true);
+    // @ts-expect-error
+    const res = await POST(req, { params: Promise.resolve({ slab: SLAB }) });
+    // No deployer/signature at all, yet auth passes — hits the same downstream 503.
+    expect(res.status).toBe(503);
+    expect(mockGetProgramAccounts).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the on-chain ownership scan itself fails (RPC error)", async () => {
+    const kp = genKeypair();
+    const sig = signProof(SLAB, kp.secretKey);
+    mockGetProgramAccounts.mockRejectedValue(new Error("mock RPC failure"));
+    const { POST } = await import("@/app/api/markets/[slab]/logo/route");
+    const req = buildRequest({ deployer: kp.publicKey.toBase58(), signature: sig });
+    // @ts-expect-error
+    const res = await POST(req, { params: Promise.resolve({ slab: SLAB }) });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/verify market ownership/i);
+  });
+});

--- a/app/__tests__/lib/lpPortfolio.test.ts
+++ b/app/__tests__/lib/lpPortfolio.test.ts
@@ -1,0 +1,43 @@
+/**
+ * lib/lpPortfolio.ts — extracted from lib/userAccountScan.ts (2026-07-13) so
+ * SERVER routes (app/api/markets/[slab]/logo/route.ts) can import
+ * `isLpPortfolio` without pulling in a `"use client"` module. This test
+ * imports directly from the new module (not the userAccountScan re-export,
+ * which app/__tests__/lib/userAccountScan.test.ts already covers) to confirm
+ * the extraction is self-contained and importable from a plain (server-safe)
+ * context.
+ */
+import { describe, it, expect } from "vitest";
+import { isLpPortfolio, PORTFOLIO_MATCHER_CONFIG_LEN } from "@/lib/lpPortfolio";
+
+function makePortfolioBuffer(enabled: boolean, totalLen = 200): Buffer {
+  const buf = Buffer.alloc(totalLen);
+  const matcherConfigOffset = buf.length - PORTFOLIO_MATCHER_CONFIG_LEN;
+  buf.writeBigUInt64LE(enabled ? 1n : 0n, matcherConfigOffset + 96);
+  return buf;
+}
+
+describe("lib/lpPortfolio — isLpPortfolio", () => {
+  it("PORTFOLIO_MATCHER_CONFIG_LEN is sizeof(PortfolioMatcherConfigV16) = 104", () => {
+    expect(PORTFOLIO_MATCHER_CONFIG_LEN).toBe(104);
+  });
+
+  it("returns true when the trailing PortfolioMatcherConfigV16.enabled == 1", () => {
+    expect(isLpPortfolio(makePortfolioBuffer(true))).toBe(true);
+  });
+
+  it("returns false when the trailing PortfolioMatcherConfigV16.enabled == 0", () => {
+    expect(isLpPortfolio(makePortfolioBuffer(false))).toBe(false);
+  });
+
+  it("returns false for a buffer shorter than the trailing config (can't be an LP)", () => {
+    expect(isLpPortfolio(Buffer.alloc(1))).toBe(false);
+    expect(isLpPortfolio(Buffer.alloc(PORTFOLIO_MATCHER_CONFIG_LEN - 1))).toBe(false);
+  });
+
+  it("also accepts a plain Uint8Array (not just Buffer) — server routes get raw Uint8Array from getProgramAccounts", () => {
+    const buf = makePortfolioBuffer(true);
+    const plain = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+    expect(isLpPortfolio(plain)).toBe(true);
+  });
+});

--- a/app/__tests__/setup.ts
+++ b/app/__tests__/setup.ts
@@ -4,19 +4,31 @@ import '@testing-library/jest-dom';
 
 // jsdom doesn't implement window.matchMedia — mock it so hooks like
 // usePrefersReducedMotion don't throw during component tests.
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: vi.fn((query: string) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  })),
-});
+//
+// Guarded by `typeof window !== 'undefined'`: this setup file runs for EVERY
+// test file regardless of that file's own `@vitest-environment` docblock
+// (setupFiles is a global config, not per-environment). A handful of
+// server-route tests (e.g. __tests__/api/market-logo-ownership-auth.test.ts)
+// opt into `@vitest-environment node` — real Next.js API routes only ever
+// run in Node, and jsdom's realm-separated `TextEncoder`/`Uint8Array` makes
+// tweetnacl's `instanceof Uint8Array` check spuriously fail there (a
+// test-environment artifact, not a product bug) — so `window` doesn't exist
+// for them.
+if (typeof window !== 'undefined') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
 
 // Cleanup after each test
 afterEach(() => {

--- a/app/app/api/markets/[slab]/logo/route.ts
+++ b/app/app/api/markets/[slab]/logo/route.ts
@@ -1,16 +1,142 @@
 import { Buffer } from "node:buffer";
+import { timingSafeEqual } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
+import { Connection, PublicKey } from "@solana/web3.js";
+import nacl from "tweetnacl";
+import * as Sentry from "@sentry/nextjs";
 import { getServiceClient } from "@/lib/supabase";
-import { PublicKey } from "@solana/web3.js";
 import { validateSlabParam } from "@/lib/route-validators";
-import { requireAuth, UNAUTHORIZED } from "@/lib/api-auth";
 import { detectRasterImage } from "@/lib/raster-image-bytes";
+import { isLpPortfolio } from "@/lib/lpPortfolio";
+import { getConfig } from "@/lib/config";
 
 export const dynamic = "force-dynamic";
 
 // Rate limit: simple in-memory tracker (resets on cold start, good enough for Vercel)
 const uploadTimestamps = new Map<string, number>();
 const RATE_LIMIT_MS = 30_000; // 1 upload per 30s per slab
+
+/**
+ * POST /api/markets/[slab]/logo — Upload logo file to Supabase Storage.
+ *
+ * AUTHENTICATION (rewritten 2026-07-13 — was broken for every real user):
+ * this route used to gate on `requireAuth()` (a server-only `x-api-key` vs
+ * INDEXER_API_KEY header). The browser can't hold that key — it's meant for
+ * the indexer service — so every upload from components/create/LogoUpload.tsx
+ * 401'd unconditionally. Worse, `x-api-key` is one secret shared across every
+ * caller of that key, so a leak would let anyone overwrite ANY market's logo;
+ * it was never a *per-market* ownership check to begin with.
+ *
+ * Replaced with a per-market wallet-ownership proof, mirroring
+ * app/api/playground/keeper-register/route.ts's H1v2 stateless deployer proof
+ * (ed25519 signature over a message binding the signer to a unix-minute
+ * window, verified independently by the server — no nonce, no shared state
+ * between requests):
+ *   1. Client signs `market-logo:<slabAddress>:<unix-minute>` and POSTs it
+ *      as `deployer` + `signature` FORM FIELDS alongside the `logo` file
+ *      (multipart/form-data, not JSON — this route always was, and the
+ *      logo file itself has to travel the same way).
+ *   2. The server reconstructs that message for a small window of minutes
+ *      around its own clock and verifies the ed25519 signature.
+ *
+ * CRITICAL DIFFERENCE from keeper-register: keeper-register checks
+ * `deployer == slab.marketauth`. That check is USELESS here, because logo
+ * upload happens POST-launch — from LaunchSuccess.tsx right after a
+ * completed launch, and from CreatorMarketRow.tsx on the creator dashboard —
+ * and by then `marketauth` has already ROTATED away from the creator to the
+ * stake-pool PDA (percolator-stake's StakeInitPool does this irreversibly;
+ * see hooks/useCreatedMarkets.ts's header comment for the same discovery).
+ * A PDA has no private key, so checking marketauth would make every
+ * completed launch permanently unable to prove ownership.
+ *
+ * Instead this binds to the DURABLE creator marker: the market's LP
+ * PORTFOLIO — the AMM counterparty account created by the wizard via
+ * InitUser with the CREATOR's wallet as its mutable owner (offset 116), and
+ * never rotated afterward (see lib/lpPortfolio.ts's isLpPortfolio doc and
+ * hooks/useCreatedMarkets.ts). After the signature verifies for `deployer`,
+ * this route runs a `getProgramAccounts` scan (magic@0 + market_group_id@16
+ * == this slab + owner@116 == deployer) and accepts only if at least one
+ * returned account is the market's actual LP (isLpPortfolio — trailing
+ * PortfolioMatcherConfigV16.enabled == 1), not just any portfolio the wallet
+ * happens to own on this market.
+ *
+ * Admin bypass: header `x-admin-secret` matching ADMIN_API_SECRET (same
+ * convention as keeper-register / /api/oracle/set-price-cap), timing-safe,
+ * fails closed when unset.
+ */
+
+/** Timing-safe admin-bypass check — same secret/header convention as
+ *  /api/playground/keeper-register and /api/oracle/set-price-cap. Empty/unset
+ *  ADMIN_API_SECRET always denies. */
+function isAdminBypass(req: NextRequest): boolean {
+  const secret = (process.env.ADMIN_API_SECRET ?? "").trim();
+  if (!secret) return false;
+  const provided = req.headers.get("x-admin-secret") ?? "";
+  const a = Buffer.from(provided, "utf8");
+  const b = Buffer.from(secret, "utf8");
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+/** Stateless deployer proof — see the file header for why this mirrors
+ *  keeper-register's H1v2 scheme instead of a nonce+claim flow. No
+ *  server-stored state: the message is fully determined by (slabAddress,
+ *  unix-minute), so any lambda instance can verify it. */
+const STATELESS_PROOF_PREFIX = "market-logo";
+/** Tolerance window: candidate minutes tried are [now - BACK, now + FWD]. */
+const STATELESS_PROOF_WINDOW_BACK_MIN = 5;
+const STATELESS_PROOF_WINDOW_FWD_MIN = 1;
+
+function statelessProofMessage(slabAddress: string, unixMinute: number): Uint8Array {
+  return new TextEncoder().encode(`${STATELESS_PROOF_PREFIX}:${slabAddress}:${unixMinute}`);
+}
+
+/** Verify `signatureBytes` is a valid ed25519 signature by `deployerPubkeyBytes`
+ *  over `market-logo:<slabAddress>:<unix-minute>` for some minute within the
+ *  tolerance window of the server's own clock. */
+function verifyStatelessDeployerProof(
+  slabAddress: string,
+  deployerPubkeyBytes: Uint8Array,
+  signatureBytes: Uint8Array,
+): boolean {
+  const nowMinute = Math.floor(Date.now() / 60_000);
+  for (let d = -STATELESS_PROOF_WINDOW_BACK_MIN; d <= STATELESS_PROOF_WINDOW_FWD_MIN; d++) {
+    const msg = statelessProofMessage(slabAddress, nowMinute + d);
+    try {
+      if (nacl.sign.detached.verify(msg, signatureBytes, deployerPubkeyBytes)) return true;
+    } catch {
+      // Malformed input for this candidate — try the next one.
+    }
+  }
+  return false;
+}
+
+/** v17 portfolio account magic (PERCV16\0), base64 for the memcmp filter. */
+const V17_PORTFOLIO_MAGIC_B64 = Buffer.from([
+  0x00, 0x36, 0x31, 0x56, 0x43, 0x52, 0x45, 0x50,
+]).toString("base64");
+/** market_group_id — the slab a portfolio belongs to. */
+const V17_PF_MARKET_OFF = 16;
+/** Mutable owner (SDK PF_OWNER_OFF) — NOT provenance@80. */
+const V17_PF_OWNER_OFF = 116;
+
+/**
+ * True iff `deployer` owns the market's LP portfolio on `slabAddress` — the
+ * durable creator marker (see file header). Scans the wrapper program for
+ * portfolios matching (magic + this slab + this owner) and accepts if any of
+ * the (0–2) results is the market's actual LP (isLpPortfolio).
+ */
+async function verifyMarketOwnership(slabAddress: string, deployer: string): Promise<boolean> {
+  const cfg = getConfig();
+  const connection = new Connection(cfg.rpcUrl, "confirmed");
+  const accounts = await connection.getProgramAccounts(new PublicKey(cfg.programId), {
+    filters: [
+      { memcmp: { offset: 0, bytes: V17_PORTFOLIO_MAGIC_B64, encoding: "base64" } },
+      { memcmp: { offset: V17_PF_MARKET_OFF, bytes: slabAddress } },
+      { memcmp: { offset: V17_PF_OWNER_OFF, bytes: deployer } },
+    ],
+  });
+  return accounts.some(({ account }) => isLpPortfolio(account.data));
+}
 
 // GET /api/markets/[slab]/logo
 export async function GET(
@@ -56,10 +182,6 @@ export async function POST(
   req: NextRequest,
   { params }: { params: Promise<{ slab: string }> }
 ) {
-  if (!requireAuth(req)) {
-    return UNAUTHORIZED;
-  }
-
   const { slab } = await params;
 
   // Validate slab address
@@ -69,13 +191,86 @@ export async function POST(
   }
   const validSlab = new PublicKey(validation.slab).toBase58();
 
+  // multipart/form-data — the logo file AND the wallet ownership proof
+  // (`deployer`, `signature`) all travel as form fields on the same request.
+  const formData = await req.formData();
+  const deployer = formData.get("deployer");
+  const signature = formData.get("signature");
+
+  // AUTH: per-market wallet ownership proof (or admin bypass) — see file
+  // header for why this replaced the broken shared-key `requireAuth` gate.
+  if (!isAdminBypass(req)) {
+    if (typeof deployer !== "string" || typeof signature !== "string" || !deployer || !signature) {
+      return NextResponse.json(
+        {
+          error:
+            "Missing required fields: deployer, signature. " +
+            `Sign the message "market-logo:${validSlab}:<unix-minute>" (UTF-8, ` +
+            "unix-minute = Math.floor(Date.now()/60000)) with the market creator's " +
+            "wallet and include the base64 signature as form fields alongside 'logo'.",
+        },
+        { status: 400 },
+      );
+    }
+
+    let deployerPubkeyBytes: Uint8Array;
+    try {
+      deployerPubkeyBytes = new PublicKey(deployer).toBytes();
+    } catch {
+      return NextResponse.json({ error: "Invalid deployer: must be a valid Solana public key" }, { status: 400 });
+    }
+
+    let signatureBytes: Uint8Array;
+    try {
+      signatureBytes = Buffer.from(signature, "base64");
+      if (signatureBytes.length !== 64) throw new Error("Signature must be 64 bytes");
+    } catch {
+      return NextResponse.json(
+        { error: "Invalid signature: must be a base64-encoded 64-byte ed25519 signature" },
+        { status: 400 },
+      );
+    }
+
+    const sigValid = verifyStatelessDeployerProof(validSlab, deployerPubkeyBytes, signatureBytes);
+    if (!sigValid) {
+      Sentry.captureMessage("[markets/logo] Deployer signature verification failed", {
+        level: "warning",
+        tags: { endpoint: "/api/markets/[slab]/logo", auth: "sig-fail" },
+        extra: { deployer, slabAddress: validSlab },
+      });
+      return NextResponse.json(
+        {
+          error:
+            'Signature verification failed. Ensure you signed "market-logo:<slabAddress>:<unix-minute>" ' +
+            "with the market creator's wallet within the last few minutes.",
+        },
+        { status: 401 },
+      );
+    }
+
+    // Cryptographic proof of the deployer key alone isn't enough — verify that
+    // key actually owns THIS market's LP portfolio (the durable creator
+    // marker; marketauth can't be used here — see file header for why).
+    try {
+      const owns = await verifyMarketOwnership(validSlab, deployer);
+      if (!owns) {
+        return NextResponse.json({ error: "Signer is not the creator of this market" }, { status: 403 });
+      }
+    } catch (err) {
+      console.error(
+        "[markets/logo] Market ownership check failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+      return NextResponse.json({ error: "Failed to verify market ownership" }, { status: 400 });
+    }
+  }
+
   // Rate limit
   const lastUpload = uploadTimestamps.get(validSlab) ?? 0;
   if (Date.now() - lastUpload < RATE_LIMIT_MS) {
     return NextResponse.json({ error: "Rate limited. Try again in 30s." }, { status: 429 });
   }
 
-  const formData = await req.formData();
   const file = formData.get("logo") as File | null;
 
   if (!file) {

--- a/app/components/create/LogoUpload.tsx
+++ b/app/components/create/LogoUpload.tsx
@@ -2,6 +2,7 @@
 
 import { FC, useCallback, useEffect, useRef, useState } from "react";
 import { MarketLogo } from "@/components/market/MarketLogo";
+import { useWalletCompat } from "@/hooks/useWalletCompat";
 
 interface LogoUploadProps {
   /** Upload by slab address (market must exist) */
@@ -25,6 +26,7 @@ export const LogoUpload: FC<LogoUploadProps> = ({ slabAddress, mintAddress, main
   const [logoUrl, setLogoUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
+  const wallet = useWalletCompat();
 
   const endpoint = mintAddress
     ? `/api/tokens/${mintAddress}/logo`
@@ -47,6 +49,31 @@ export const LogoUpload: FC<LogoUploadProps> = ({ slabAddress, mintAddress, main
         return;
       }
 
+      // Market (slab) logos are gated by a per-market wallet ownership proof
+      // (see app/api/markets/[slab]/logo/route.ts) — sign it up front so a
+      // wallet that can't (no connection, or signMessage unsupported) fails
+      // fast with an actionable message instead of a confusing 400/401 from
+      // the server. The mintAddress (faucet) path is unauthenticated and
+      // untouched — out of scope here.
+      let deployer: string | undefined;
+      let signature: string | undefined;
+      if (slabAddress) {
+        if (!wallet.publicKey || !wallet.signMessage) {
+          setError("Connect the creator wallet to upload a logo.");
+          return;
+        }
+        try {
+          const unixMinute = Math.floor(Date.now() / 60_000);
+          const proofMsg = new TextEncoder().encode(`market-logo:${slabAddress}:${unixMinute}`);
+          const sig = await wallet.signMessage(proofMsg);
+          deployer = wallet.publicKey.toBase58();
+          signature = Buffer.from(sig).toString("base64");
+        } catch (sigErr) {
+          setError(sigErr instanceof Error ? sigErr.message : "Wallet signature declined");
+          return;
+        }
+      }
+
       setPreview(URL.createObjectURL(file));
       setError(null);
       setUploading(true);
@@ -54,6 +81,10 @@ export const LogoUpload: FC<LogoUploadProps> = ({ slabAddress, mintAddress, main
       try {
         const form = new FormData();
         form.append("logo", file);
+        if (deployer && signature) {
+          form.append("deployer", deployer);
+          form.append("signature", signature);
+        }
 
         const res = await fetch(endpoint, { method: "POST", body: form });
         const data = await res.json();
@@ -71,7 +102,7 @@ export const LogoUpload: FC<LogoUploadProps> = ({ slabAddress, mintAddress, main
         setUploading(false);
       }
     },
-    [endpoint]
+    [endpoint, slabAddress, wallet]
   );
 
   // Cleanup preview URL to prevent memory leaks

--- a/app/lib/lpPortfolio.ts
+++ b/app/lib/lpPortfolio.ts
@@ -1,0 +1,62 @@
+/**
+ * LP-portfolio exclusion helper.
+ *
+ * Extracted from lib/userAccountScan.ts (2026-07-13) so SERVER routes (e.g.
+ * app/api/markets/[slab]/logo/route.ts) can import `isLpPortfolio` without
+ * pulling in a `"use client"` module. userAccountScan.ts re-exports both
+ * names from here so its existing client call sites (useUserAccount,
+ * usePositionNft, useNftWrappedPosition, useMintPositionNft, usePortfolio,
+ * useDeposit, useWithdraw, useClosePosition, useTrade, useInitUser,
+ * useCreatedMarkets) don't need to change.
+ *
+ * WHY this exists (verified on-chain, 2026-07-12): the wizard creates a
+ * market's LP portfolio (the AMM counterparty holding the market's seeded
+ * liquidity, e.g. 1000 sim-USDC) via InitUser with the market CREATOR's own
+ * wallet as its mutable owner (offset 116) — see useCreateMarket. Every "find
+ * MY trading account on this market" owner-scan across the app filters ONLY
+ * on (magic + market_group_id@16 + owner@116), with no LP exclusion. For a
+ * market's CREATOR specifically, that means these scans return the LP
+ * portfolio as if it were the creator's own trading account:
+ *   - the trade page shows the market's LP liquidity as the creator's own
+ *     "available to trade" balance;
+ *   - a creator's DEPOSIT would top up the LP instead of creating their own
+ *     portfolio;
+ *   - a creator's TRADE would resolve accountA (taker) == accountB (LP,
+ *     matcher-enabled) — the same account on both sides, nonsense/fails
+ *     on-chain;
+ *   - withdraw/close/portfolio/NFT-mint paths are similarly contaminated.
+ * Non-creators are unaffected (the LP's owner is a different wallet).
+ *
+ * A portfolio IS the LP iff its trailing PortfolioMatcherConfigV16 has
+ * `enabled == 1` — SetMatcherConfig is only ever called on the LP side (see
+ * useTrade.ts's readPortfolioMatcherConfig / lib/lp-portfolio.ts's
+ * isMatcherEnabled, which this mirrors byte-for-byte). Every scan whose
+ * purpose is "the CALLER's own trading account" must call this AFTER fetch
+ * (memcmp can't express "enabled != 1") and drop any match — BEFORE the
+ * existing pubkey-sort/[0]-pick and before the owner re-verification result
+ * is used. Do NOT apply this to scans that explicitly WANT the LP: useTrade's
+ * accountB discovery (resolveV17TradeAccounts), lib/lp-portfolio.ts's capital
+ * reads (market vault_balance display), or useCreateMarket's own LP setup.
+ *
+ * SERVER USE (new, 2026-07-13): POST /api/markets/[slab]/logo uses this same
+ * signal, in the OPPOSITE direction, as its per-market ownership proof — a
+ * wallet-signed request is accepted only if the signer owns a portfolio on
+ * this slab that satisfies isLpPortfolio (i.e. IS the market's LP), because
+ * that LP portfolio's owner is the durable creator marker (see that route's
+ * header comment for why marketauth can't be used post-launch).
+ */
+export const PORTFOLIO_MATCHER_CONFIG_LEN = 104; // sizeof(PortfolioMatcherConfigV16)
+
+/**
+ * True if `data` is a v17 portfolio account acting as a market's LP (its
+ * trailing PortfolioMatcherConfigV16.enabled == 1). See the module comment
+ * above for why every "this is MY trading account" scan must exclude these.
+ */
+export function isLpPortfolio(data: Buffer | Uint8Array): boolean {
+  if (data.length < PORTFOLIO_MATCHER_CONFIG_LEN) return false;
+  const off = data.length - PORTFOLIO_MATCHER_CONFIG_LEN;
+  const dv = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  // enabled (u64 LE) sits at the last 8 bytes of the 104-byte trailing config
+  // (matcher_program[32] | matcher_context[32] | matcher_delegate[32] | enabled[8]).
+  return dv.getBigUint64(off + 96, true) === 1n;
+}

--- a/app/lib/userAccountScan.ts
+++ b/app/lib/userAccountScan.ts
@@ -75,6 +75,7 @@ import {
   type PortfolioLegV17,
   type PortfolioV17,
 } from "@percolatorct/sdk";
+import { isLpPortfolio } from "@/lib/lpPortfolio";
 
 // ---------------------------------------------------------------------------
 // Shared UserAccountInfo shape + v17→legacy Account mapper.
@@ -170,49 +171,15 @@ const V17_PF_OWNER_OFF = 116;
 // ---------------------------------------------------------------------------
 // LP-portfolio exclusion helper.
 //
-// WHY this exists (verified on-chain, 2026-07-12): the wizard creates a
-// market's LP portfolio (the AMM counterparty holding the market's seeded
-// liquidity, e.g. 1000 sim-USDC) via InitUser with the market CREATOR's own
-// wallet as its mutable owner (offset 116) — see useCreateMarket. Every "find
-// MY trading account on this market" owner-scan across the app filters ONLY
-// on (magic + market_group_id@16 + owner@116), with no LP exclusion. For a
-// market's CREATOR specifically, that means these scans return the LP
-// portfolio as if it were the creator's own trading account:
-//   - the trade page shows the market's LP liquidity as the creator's own
-//     "available to trade" balance;
-//   - a creator's DEPOSIT would top up the LP instead of creating their own
-//     portfolio;
-//   - a creator's TRADE would resolve accountA (taker) == accountB (LP,
-//     matcher-enabled) — the same account on both sides, nonsense/fails
-//     on-chain;
-//   - withdraw/close/portfolio/NFT-mint paths are similarly contaminated.
-// Non-creators are unaffected (the LP's owner is a different wallet).
-//
-// A portfolio IS the LP iff its trailing PortfolioMatcherConfigV16 has
-// `enabled == 1` — SetMatcherConfig is only ever called on the LP side (see
-// useTrade.ts's readPortfolioMatcherConfig / lib/lp-portfolio.ts's
-// isMatcherEnabled, which this mirrors byte-for-byte). Every scan whose
-// purpose is "the CALLER's own trading account" must call this AFTER fetch
-// (memcmp can't express "enabled != 1") and drop any match — BEFORE the
-// existing pubkey-sort/[0]-pick and before the owner re-verification result
-// is used. Do NOT apply this to scans that explicitly WANT the LP: useTrade's
-// accountB discovery (resolveV17TradeAccounts), lib/lp-portfolio.ts's capital
-// reads (market vault_balance display), or useCreateMarket's own LP setup.
-const PORTFOLIO_MATCHER_CONFIG_LEN = 104; // sizeof(PortfolioMatcherConfigV16)
-
-/**
- * True if `data` is a v17 portfolio account acting as a market's LP (its
- * trailing PortfolioMatcherConfigV16.enabled == 1). See the module comment
- * above for why every "this is MY trading account" scan must exclude these.
- */
-export function isLpPortfolio(data: Buffer | Uint8Array): boolean {
-  if (data.length < PORTFOLIO_MATCHER_CONFIG_LEN) return false;
-  const off = data.length - PORTFOLIO_MATCHER_CONFIG_LEN;
-  const dv = new DataView(data.buffer, data.byteOffset, data.byteLength);
-  // enabled (u64 LE) sits at the last 8 bytes of the 104-byte trailing config
-  // (matcher_program[32] | matcher_context[32] | matcher_delegate[32] | enabled[8]).
-  return dv.getBigUint64(off + 96, true) === 1n;
-}
+// Moved to lib/lpPortfolio.ts (2026-07-13) — that module carries the full
+// "why" doc comment (creator LP-mistaken-for-own-account bug, plus the new
+// server-side use by app/api/markets/[slab]/logo/route.ts) — so it's a plain
+// (non `"use client"`) module a server route can import directly. Re-exported
+// here so every existing call site in this file (and useMintPositionNft,
+// usePortfolio, useDeposit, useWithdraw, useClosePosition, useTrade,
+// useInitUser, useCreatedMarkets) keeps working unchanged.
+// ---------------------------------------------------------------------------
+export { PORTFOLIO_MATCHER_CONFIG_LEN, isLpPortfolio } from "@/lib/lpPortfolio";
 
 /** Raw scan result: the owned portfolio's own account pubkey + full parsed
  *  state. Kept in this richer shape (rather than just the mapped `Account`)


### PR DESCRIPTION
## The bug

`POST /api/markets/[slab]/logo` gated on `requireAuth()` — a server-only `x-api-key` header checked against `INDEXER_API_KEY`. The browser never holds that key (it's meant for the indexer service), so every real upload from `components/create/LogoUpload.tsx` (a plain `fetch(endpoint, { method: "POST", body: form })`, no such header) 401'd unconditionally — logo upload was fully broken for every user. Worse, `x-api-key` is one secret shared across every legitimate caller of that key, with zero per-market scoping — a leak would let anyone overwrite ANY market's logo.

## The fix

Replaced the `requireAuth` gate with a per-market wallet-signed ownership proof, mirroring `app/api/playground/keeper-register/route.ts`'s already-battle-tested H1v2 stateless deployer proof: the client signs `market-logo:<slabAddress>:<unix-minute>` (ed25519, `tweetnacl`) and POSTs `deployer` + `signature` as extra multipart form fields alongside the `logo` file; the server independently reconstructs that message within a small clock-skew tolerance window (-5/+1 min) and verifies the signature — no server-stored nonce, no shared state between requests.

**Why not `deployer == slab.marketauth`** (what keeper-register checks): logo upload happens **post-launch** — from `LaunchSuccess.tsx` right after a completed launch, and from `CreatorMarketRow.tsx` on the creator dashboard — and by then `marketauth` has already been **irreversibly rotated** from the creator wallet to the stake-pool PDA by percolator-stake's `StakeInitPool` (see `hooks/useCreatedMarkets.ts`'s header comment for the same discovery, verified on-chain). A PDA has no private key, so checking marketauth here would make every completed launch permanently unable to prove ownership.

Instead the proof binds to the **durable creator marker**: the market's **LP portfolio** — created by the wizard via `InitUser` with the creator's wallet as its mutable owner (offset 116), and never rotated afterward. After the signature verifies, the route runs one `getProgramAccounts` scan (magic@0 + `market_group_id`@16 == this slab + owner@116 == the signer) and accepts only if at least one returned account is the market's actual LP — `isLpPortfolio`, the trailing `PortfolioMatcherConfigV16.enabled == 1` discriminator, not just any portfolio the signer happens to own on this market (e.g. their own trading position). Distinct error codes throughout: 400 for malformed input, 401 for a signature that doesn't verify (+ a Sentry warning, mirroring keeper-register), 403 "Signer is not the creator of this market" when no LP portfolio is found, 400 "Failed to verify market ownership" if the on-chain read itself fails. The admin bypass (`x-admin-secret` vs `ADMIN_API_SECRET`, timing-safe) is kept as an alternative path, same convention as keeper-register / `/api/oracle/set-price-cap`.

`isLpPortfolio` (+ its `PORTFOLIO_MATCHER_CONFIG_LEN` constant) lived in `lib/userAccountScan.ts`, a `"use client"` module — a server route can't import that. Extracted both into a new plain module, `lib/lpPortfolio.ts`, with the full doc comment preserved; `userAccountScan.ts` now re-exports both names so its ~9 existing client call sites (`useUserAccount`, `usePositionNft`, `useMintPositionNft`, `usePortfolio`, `useDeposit`, `useWithdraw`, `useClosePosition`, `useTrade`, `useInitUser`, `useCreatedMarkets`) are unaffected.

`components/create/LogoUpload.tsx` now pulls `useWalletCompat()` and signs the proof before POSTing (only for the slab-address path — the `mintAddress` faucet upload path is untouched, out of scope). If the wallet isn't connected or can't sign messages, it shows "Connect the creator wallet to upload a logo." instead of firing a doomed request.

## Deviations from spec

- `__tests__/setup.ts`: had to guard the jsdom-only `window.matchMedia` mock behind `typeof window !== 'undefined'`. The new route test opts into `@vitest-environment node` because jsdom's realm-separated `TextEncoder` makes `tweetnacl`'s `instanceof Uint8Array` check spuriously throw (verified with a standalone repro) — a test-environment artifact only, since real Next.js API routes always execute in actual Node, never jsdom. This is a one-line, backward-compatible guard; every existing jsdom test is unaffected (`window` still exists there).
- Added a route-level test (`__tests__/api/market-logo-ownership-auth.test.ts`, 10 cases) in addition to the extracted-helper test (`__tests__/lib/lpPortfolio.test.ts`, 5 cases) — the spec allowed falling back to just the helper test if route mocking was impractical, but `__tests__/api/markets-deployer-auth.test.ts` already established a working `Connection`-mocking pattern for this exact kind of route, so full route coverage was practical.

## Test evidence

`cd app && npx tsc --noEmit` → 0 errors.

New/relevant tests, plus the full suite to confirm no regressions (a large pre-existing set of ~101 failures across ~30 unrelated files — waitlist, chart-drawing hooks, stake hooks, wallet/Privy components, `tx.test.ts` blockhash — was independently verified via `git stash` to be present on `origin/playground` **before** this change too, byte-for-byte identical failure count):

```
✓ __tests__/api/market-logo-ownership-auth.test.ts (10 tests)
✓ __tests__/lib/lpPortfolio.test.ts (5 tests)
✓ __tests__/lib/userAccountScan.test.ts (23 tests)
✓ __tests__/api/markets-deployer-auth.test.ts (9 tests)
✓ __tests__/lib/market-registration-auth.test.ts (15 tests)

Full suite: 2479 passed | 101 failed (pre-existing, unrelated) | 16 skipped (2596 total)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)