### PR TITLE
fix(logo): authorize on markets.deployer, not the forgeable LP-portfolio scan

### DIFF
--- a/app/__tests__/api/market-logo-ownership-auth.test.ts
+++ b/app/__tests__/api/market-logo-ownership-auth.test.ts
@@ -11,107 +11,76 @@
 /**
  * POST /api/markets/[slab]/logo — per-market wallet ownership proof.
  *
- * This route used to gate on `requireAuth()` (a server-only `x-api-key` vs
- * INDEXER_API_KEY header) — the browser never held that key, so every real
- * upload from components/create/LogoUpload.tsx 401'd unconditionally, and the
- * key itself was one shared secret with no per-market scoping. It's been
- * replaced with a wallet-signed stateless deployer proof (mirroring
- * app/api/playground/keeper-register/route.ts's H1v2 scheme) checked against
- * the market's LP-portfolio owner (the durable creator marker — marketauth
- * rotates away post-launch, see the route's header comment).
+ * This route used to gate on `requireAuth()` (a server-only `x-api-key`) — the
+ * browser never held that key, so every real upload 401'd. It was then rewritten
+ * to a wallet-signed stateless deployer proof; the FIRST rewrite authorised
+ * against the market's on-chain LP portfolio, which is FORGEABLE
+ * (SetMatcherConfig(enabled=1) only checks the caller owns their own portfolio,
+ * not that they created the market — so any wallet could pass). This suite
+ * covers the corrected version, which authorises against the AUTHORITATIVE,
+ * non-forgeable `markets.deployer` column (set at creation against the on-chain
+ * admin + a signed nonce; never rotated).
  *
  * Covers:
  *   1. Missing deployer/signature (no admin bypass) → 400
  *   2. Invalid deployer pubkey → 400
  *   3. Invalid signature (not base64 64 bytes) → 400
  *   4. Wrong-key signature (well-formed, doesn't verify) → 401
- *   5. Valid signature but no LP portfolio found for (slab, deployer) → 403
- *   6. Valid signature, a portfolio is found but it's NOT the LP → 403
- *   7. Valid signature + a real LP portfolio → auth passes (hits downstream
- *      503 from the mocked Supabase client, proving auth was NOT what failed)
- *   8. Admin bypass header skips the wallet-proof requirement entirely
- *   9. On-chain RPC failure during the ownership scan → 400
+ *   5. Market row not found → 404
+ *   6. Valid signature but market has a null deployer (no registered creator) → 403
+ *   7. FORGERY: a different wallet with a VALID self-signature, != the registered
+ *      deployer → 403 (the exact bypass the LP-portfolio version allowed)
+ *   8. Valid signature + deployer === markets.deployer → auth passes (reaches the
+ *      downstream "No file provided" 400, proving auth was NOT what failed)
+ *   9. Clock-skew tolerance (signed a few minutes ago) with a matching deployer
+ *  10. Admin bypass header skips the wallet-proof requirement entirely
+ *  11. Storage backend unavailable (getServiceClient throws) → 503
  */
 
 import nacl from "tweetnacl";
 import { PublicKey } from "@solana/web3.js";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-vi.mock("@/lib/config", () => ({
-  getConfig: vi.fn(() => ({
-    rpcUrl: "https://api.devnet.solana.com",
-    programId: "69VUZ7a2BeXBTpRRManLamF5UWTaNR9B1hy5Se3cdXy9",
-  })),
-}));
-
 vi.mock("@sentry/nextjs", () => ({
   captureMessage: vi.fn(),
   captureException: vi.fn(),
 }));
 
-const mockGetProgramAccounts = vi.fn();
-vi.mock("@solana/web3.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@solana/web3.js")>();
-  return {
-    ...actual,
-    // A plain `function` (not an arrow) — the route calls `new Connection(...)`,
-    // and only a real constructor function can be invoked via `new` (an arrow
-    // function has no [[Construct]] and throws "is not a constructor").
-    // Explicitly returning an object from a constructor makes `new` use that
-    // object instead of `this`, which is all this mock needs.
-    Connection: vi.fn().mockImplementation(function mockConnection() {
-      return { getProgramAccounts: mockGetProgramAccounts };
-    }),
-  };
+// Controllable Supabase mock. `mockSingle` resolves the markets lookup
+// (`{ data: { slab_address, deployer }, error }`); `mockGetServiceClient`
+// returns a client exposing exactly the `.from().select().eq().single()` chain
+// the route uses, and can be made to throw to exercise the 503 path.
+const { mockGetServiceClient, mockSingle } = vi.hoisted(() => {
+  const mockSingle = vi.fn();
+  const mockGetServiceClient = vi.fn(() => ({
+    from: () => ({ select: () => ({ eq: () => ({ single: mockSingle }) }) }),
+  }));
+  return { mockGetServiceClient, mockSingle };
 });
-
-vi.mock("@/lib/supabase", () => ({
-  getServiceClient: vi.fn(() => {
-    throw new Error("Storage backend unavailable (mocked)");
-  }),
-}));
+vi.mock("@/lib/supabase", () => ({ getServiceClient: mockGetServiceClient }));
 
 const SLAB = "7RXTVmGcJMDqqTCFu5ADQRyLDvVZBi3r5U5WXzoULHJV";
-/** market_group_id offset within a v17 portfolio account. */
-const V17_PF_MARKET_OFF = 16;
-/** Mutable owner offset within a v17 portfolio account. */
-const V17_PF_OWNER_OFF = 116;
-const V17_PORTFOLIO_MAGIC = Buffer.from([0x00, 0x36, 0x31, 0x56, 0x43, 0x52, 0x45, 0x50]);
-
-/** Builds a minimal v17-portfolio-shaped account buffer: magic@0,
- *  market_group_id@16, owner@116, and (optionally) an enabled trailing
- *  PortfolioMatcherConfigV16 (the LP discriminator — see lib/lpPortfolio.ts). */
-function makePortfolioBuffer(marketGroupId: PublicKey, owner: PublicKey, isLp: boolean): Buffer {
-  const PORTFOLIO_MATCHER_CONFIG_LEN = 104;
-  const totalLen = 200; // arbitrary, large enough to hold both regions with no overlap
-  const buf = Buffer.alloc(totalLen);
-  V17_PORTFOLIO_MAGIC.copy(buf, 0);
-  marketGroupId.toBuffer().copy(buf, V17_PF_MARKET_OFF);
-  owner.toBuffer().copy(buf, V17_PF_OWNER_OFF);
-  const matcherConfigOffset = buf.length - PORTFOLIO_MATCHER_CONFIG_LEN;
-  buf.writeBigUInt64LE(isLp ? 1n : 0n, matcherConfigOffset + 96);
-  return buf;
-}
 
 function genKeypair() {
   const kp = nacl.sign.keyPair();
   return { secretKey: kp.secretKey, publicKey: new PublicKey(kp.publicKey) };
 }
 
+/** The wallet recorded as this market's creator in the DB. */
+const REGISTERED = genKeypair();
+
 function signProof(slab: string, secretKey: Uint8Array, minuteOffset = 0): string {
   const unixMinute = Math.floor(Date.now() / 60_000) + minuteOffset;
-  // Mirrors markets-deployer-auth.test.ts's approach (Buffer→Uint8Array, not
-  // TextEncoder) — avoids a jsdom-environment realm mismatch where tweetnacl's
-  // `instanceof Uint8Array` check rejects a TextEncoder-produced array.
+  // Buffer→Uint8Array (not TextEncoder) — avoids a realm mismatch where
+  // tweetnacl's `instanceof Uint8Array` check rejects a TextEncoder array.
   const msg = new Uint8Array(Buffer.from(`market-logo:${slab}:${unixMinute}`, "utf-8"));
   return Buffer.from(nacl.sign.detached(msg, secretKey)).toString("base64");
 }
 
-/** Builds a multipart/form-data POST request the route handler can read via
- *  req.formData(). `includeFile` attaches a dummy `logo` File — needed for
- *  tests that assert auth PASSED, since without one the route's own
- *  "No file provided" 400 (checked right after auth) would be
- *  indistinguishable from an auth failure. */
+/** Builds a multipart/form-data POST request the route reads via req.formData().
+ *  `includeFile` attaches a dummy `logo` File — omit it for auth-PASS tests so
+ *  the route's own "No file provided" 400 (checked right after auth) cleanly
+ *  proves auth passed rather than failed. */
 function buildRequest(
   fields: Record<string, string>,
   headers: Record<string, string> = {},
@@ -122,17 +91,21 @@ function buildRequest(
   if (includeFile) {
     form.append("logo", new File([new Uint8Array([1, 2, 3])], "logo.png", { type: "image/png" }));
   }
-  return new Request(`http://localhost/api/markets/${SLAB}/logo`, {
-    method: "POST",
-    headers,
-    body: form,
-  });
+  return new Request(`http://localhost/api/markets/${SLAB}/logo`, { method: "POST", headers, body: form });
 }
 
 describe("POST /api/markets/[slab]/logo — wallet ownership auth", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     delete process.env.ADMIN_API_SECRET;
+    // Default: the market exists and its registered creator is REGISTERED.
+    mockGetServiceClient.mockImplementation(() => ({
+      from: () => ({ select: () => ({ eq: () => ({ single: mockSingle }) }) }),
+    }));
+    mockSingle.mockResolvedValue({
+      data: { slab_address: SLAB, deployer: REGISTERED.publicKey.toBase58() },
+      error: null,
+    });
   });
   afterEach(() => {
     delete process.env.ADMIN_API_SECRET;
@@ -144,8 +117,7 @@ describe("POST /api/markets/[slab]/logo — wallet ownership auth", () => {
     // @ts-expect-error - NextRequest wraps Request
     const res = await POST(req, { params: Promise.resolve({ slab: SLAB }) });
     expect(res.status).toBe(400);
-    const body = await res.json();
-    expect(body.error).toMatch(/deployer|signature/i);
+    expect((await res.json()).error).toMatch(/deployer|signature/i);
   });
 
   it("returns 400 for an invalid deployer pubkey", async () => {
@@ -154,8 +126,7 @@ describe("POST /api/markets/[slab]/logo — wallet ownership auth", () => {
     // @ts-expect-error
     const res = await POST(req, { params: Promise.resolve({ slab: SLAB }) });
     expect(res.status).toBe(400);
-    const body = await res.json();
-    expect(body.error).toMatch(/deployer/i);
+    expect((await res.json()).error).toMatch(/deployer/i);
   });
 
   it("returns 400 for a malformed signature (not base64 64 bytes)", async () => {
@@ -165,8 +136,7 @@ describe("POST /api/markets/[slab]/logo — wallet ownership auth", () => {
     // @ts-expect-error
     const res = await POST(req, { params: Promise.resolve({ slab: SLAB }) });
     expect(res.status).toBe(400);
-    const body = await res.json();
-    expect(body.error).toMatch(/signature/i);
+    expect((await res.json()).error).toMatch(/signature/i);
   });
 
   it("returns 401 for a well-formed signature that doesn't verify (wrong key)", async () => {
@@ -178,81 +148,85 @@ describe("POST /api/markets/[slab]/logo — wallet ownership auth", () => {
     // @ts-expect-error
     const res = await POST(req, { params: Promise.resolve({ slab: SLAB }) });
     expect(res.status).toBe(401);
-    const body = await res.json();
-    expect(body.error).toMatch(/signature/i);
+    expect((await res.json()).error).toMatch(/signature/i);
   });
 
-  it("returns 403 when the signer owns no portfolio on this market", async () => {
+  it("returns 404 when the market row does not exist", async () => {
+    mockSingle.mockResolvedValue({ data: null, error: { message: "not found" } });
+    const sig = signProof(SLAB, REGISTERED.secretKey);
+    const { POST } = await import("@/app/api/markets/[slab]/logo/route");
+    const req = buildRequest({ deployer: REGISTERED.publicKey.toBase58(), signature: sig });
+    // @ts-expect-error
+    const res = await POST(req, { params: Promise.resolve({ slab: SLAB }) });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when the market has no registered creator (null deployer)", async () => {
+    mockSingle.mockResolvedValue({ data: { slab_address: SLAB, deployer: null }, error: null });
     const kp = genKeypair();
     const sig = signProof(SLAB, kp.secretKey);
-    mockGetProgramAccounts.mockResolvedValue([]);
     const { POST } = await import("@/app/api/markets/[slab]/logo/route");
     const req = buildRequest({ deployer: kp.publicKey.toBase58(), signature: sig });
     // @ts-expect-error
     const res = await POST(req, { params: Promise.resolve({ slab: SLAB }) });
     expect(res.status).toBe(403);
-    const body = await res.json();
-    expect(body.error).toMatch(/not the creator/i);
+    expect((await res.json()).error).toMatch(/no registered creator/i);
   });
 
-  it("returns 403 when the signer owns a portfolio on this market that is NOT the LP", async () => {
-    const kp = genKeypair();
-    const sig = signProof(SLAB, kp.secretKey);
-    const tradingPortfolio = makePortfolioBuffer(new PublicKey(SLAB), kp.publicKey, false);
-    mockGetProgramAccounts.mockResolvedValue([{ pubkey: kp.publicKey, account: { data: tradingPortfolio } }]);
+  it("FORGERY: a different wallet with a VALID self-signature is rejected (not the registered deployer)", async () => {
+    // Attacker generates their own keypair and signs the proof correctly FOR
+    // THAT KEY — the signature verifies, but the key is not markets.deployer.
+    // This is the exact case the forgeable LP-portfolio check let through.
+    const attacker = genKeypair();
+    const sig = signProof(SLAB, attacker.secretKey);
     const { POST } = await import("@/app/api/markets/[slab]/logo/route");
-    const req = buildRequest({ deployer: kp.publicKey.toBase58(), signature: sig });
+    const req = buildRequest({ deployer: attacker.publicKey.toBase58(), signature: sig });
     // @ts-expect-error
     const res = await POST(req, { params: Promise.resolve({ slab: SLAB }) });
     expect(res.status).toBe(403);
+    expect((await res.json()).error).toMatch(/not the creator/i);
   });
 
-  it("passes auth when the signer owns the market's LP portfolio (hits downstream storage-unavailable, not an auth error)", async () => {
-    const kp = genKeypair();
-    const sig = signProof(SLAB, kp.secretKey);
-    const lpPortfolio = makePortfolioBuffer(new PublicKey(SLAB), kp.publicKey, true);
-    mockGetProgramAccounts.mockResolvedValue([{ pubkey: kp.publicKey, account: { data: lpPortfolio } }]);
+  it("passes auth when the signer IS the registered deployer (reaches the no-file 400)", async () => {
+    const sig = signProof(SLAB, REGISTERED.secretKey);
     const { POST } = await import("@/app/api/markets/[slab]/logo/route");
-    const req = buildRequest({ deployer: kp.publicKey.toBase58(), signature: sig }, {}, true);
+    const req = buildRequest({ deployer: REGISTERED.publicKey.toBase58(), signature: sig }); // no file
     // @ts-expect-error
     const res = await POST(req, { params: Promise.resolve({ slab: SLAB }) });
-    // Auth passed — the mocked getServiceClient() throw surfaces as 503, not 400/401/403.
-    expect(res.status).toBe(503);
+    // Auth passed → downstream file check fires; message distinguishes it from an auth 400.
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/no file provided/i);
   });
 
   it("accepts a signature signed a couple minutes in the past (clock-skew tolerance)", async () => {
-    const kp = genKeypair();
-    const sig = signProof(SLAB, kp.secretKey, -3);
-    const lpPortfolio = makePortfolioBuffer(new PublicKey(SLAB), kp.publicKey, true);
-    mockGetProgramAccounts.mockResolvedValue([{ pubkey: kp.publicKey, account: { data: lpPortfolio } }]);
+    const sig = signProof(SLAB, REGISTERED.secretKey, -3);
     const { POST } = await import("@/app/api/markets/[slab]/logo/route");
-    const req = buildRequest({ deployer: kp.publicKey.toBase58(), signature: sig }, {}, true);
+    const req = buildRequest({ deployer: REGISTERED.publicKey.toBase58(), signature: sig });
     // @ts-expect-error
     const res = await POST(req, { params: Promise.resolve({ slab: SLAB }) });
-    expect(res.status).toBe(503);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/no file provided/i);
   });
 
   it("admin bypass header skips the wallet-proof requirement entirely", async () => {
     process.env.ADMIN_API_SECRET = "test-admin-secret";
     const { POST } = await import("@/app/api/markets/[slab]/logo/route");
-    const req = buildRequest({}, { "x-admin-secret": "test-admin-secret" }, true);
-    // @ts-expect-error
-    const res = await POST(req, { params: Promise.resolve({ slab: SLAB }) });
-    // No deployer/signature at all, yet auth passes — hits the same downstream 503.
-    expect(res.status).toBe(503);
-    expect(mockGetProgramAccounts).not.toHaveBeenCalled();
-  });
-
-  it("returns 400 when the on-chain ownership scan itself fails (RPC error)", async () => {
-    const kp = genKeypair();
-    const sig = signProof(SLAB, kp.secretKey);
-    mockGetProgramAccounts.mockRejectedValue(new Error("mock RPC failure"));
-    const { POST } = await import("@/app/api/markets/[slab]/logo/route");
-    const req = buildRequest({ deployer: kp.publicKey.toBase58(), signature: sig });
+    const req = buildRequest({}, { "x-admin-secret": "test-admin-secret" }); // no deployer/sig, no file
     // @ts-expect-error
     const res = await POST(req, { params: Promise.resolve({ slab: SLAB }) });
     expect(res.status).toBe(400);
-    const body = await res.json();
-    expect(body.error).toMatch(/verify market ownership/i);
+    expect((await res.json()).error).toMatch(/no file provided/i);
+  });
+
+  it("returns 503 when the storage backend is unavailable", async () => {
+    mockGetServiceClient.mockImplementation(() => {
+      throw new Error("Storage backend unavailable (mocked)");
+    });
+    const sig = signProof(SLAB, REGISTERED.secretKey);
+    const { POST } = await import("@/app/api/markets/[slab]/logo/route");
+    const req = buildRequest({ deployer: REGISTERED.publicKey.toBase58(), signature: sig });
+    // @ts-expect-error
+    const res = await POST(req, { params: Promise.resolve({ slab: SLAB }) });
+    expect(res.status).toBe(503);
   });
 });

--- a/app/app/api/markets/[slab]/logo/route.ts
+++ b/app/app/api/markets/[slab]/logo/route.ts
@@ -1,14 +1,12 @@
 import { Buffer } from "node:buffer";
 import { timingSafeEqual } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
-import { Connection, PublicKey } from "@solana/web3.js";
+import { PublicKey } from "@solana/web3.js";
 import nacl from "tweetnacl";
 import * as Sentry from "@sentry/nextjs";
 import { getServiceClient } from "@/lib/supabase";
 import { validateSlabParam } from "@/lib/route-validators";
 import { detectRasterImage } from "@/lib/raster-image-bytes";
-import { isLpPortfolio } from "@/lib/lpPortfolio";
-import { getConfig } from "@/lib/config";
 
 export const dynamic = "force-dynamic";
 
@@ -49,16 +47,26 @@ const RATE_LIMIT_MS = 30_000; // 1 upload per 30s per slab
  * A PDA has no private key, so checking marketauth would make every
  * completed launch permanently unable to prove ownership.
  *
- * Instead this binds to the DURABLE creator marker: the market's LP
- * PORTFOLIO — the AMM counterparty account created by the wizard via
- * InitUser with the CREATOR's wallet as its mutable owner (offset 116), and
- * never rotated afterward (see lib/lpPortfolio.ts's isLpPortfolio doc and
- * hooks/useCreatedMarkets.ts). After the signature verifies for `deployer`,
- * this route runs a `getProgramAccounts` scan (magic@0 + market_group_id@16
- * == this slab + owner@116 == deployer) and accepts only if at least one
- * returned account is the market's actual LP (isLpPortfolio — trailing
- * PortfolioMatcherConfigV16.enabled == 1), not just any portfolio the wallet
- * happens to own on this market.
+ * So after the signature verifies for `deployer`, ownership is authorised
+ * against the `markets.deployer` column — the AUTHORITATIVE, durable creator
+ * marker. It's written once at market creation (POST /api/markets, "R2-S8")
+ * after that route independently proves the deployer both signed a nonce AND
+ * matched the slab's on-chain admin while marketauth was still the creator,
+ * and it is never rotated afterward. The route requires
+ * `deployer === markets.deployer`.
+ *
+ * DO NOT authorise on the market's LP portfolio (an earlier version did, via a
+ * getProgramAccounts scan for isLpPortfolio): that signal is FORGEABLE. The
+ * on-chain SetMatcherConfig(enabled=1) handler that sets the isLpPortfolio
+ * discriminator only checks the caller owns the portfolio being modified — NOT
+ * that they created the market — so any wallet can InitUser + SetMatcherConfig
+ * a portfolio on someone else's slab and pass an LP-based check, reopening the
+ * "anyone can overwrite any market's logo" hole this route exists to close.
+ * `useCreatedMarkets` uses the same signal harmlessly (a false positive only
+ * shows an attacker their OWN row); as an auth boundary it must not be trusted.
+ * The DB `deployer` column has no such forgery path. Markets with a null
+ * `deployer` (legacy / failed registration) have no authenticated creator on
+ * record and are reachable only via the admin bypass.
  *
  * Admin bypass: header `x-admin-secret` matching ADMIN_API_SECRET (same
  * convention as keeper-register / /api/oracle/set-price-cap), timing-safe,
@@ -108,34 +116,6 @@ function verifyStatelessDeployerProof(
     }
   }
   return false;
-}
-
-/** v17 portfolio account magic (PERCV16\0), base64 for the memcmp filter. */
-const V17_PORTFOLIO_MAGIC_B64 = Buffer.from([
-  0x00, 0x36, 0x31, 0x56, 0x43, 0x52, 0x45, 0x50,
-]).toString("base64");
-/** market_group_id — the slab a portfolio belongs to. */
-const V17_PF_MARKET_OFF = 16;
-/** Mutable owner (SDK PF_OWNER_OFF) — NOT provenance@80. */
-const V17_PF_OWNER_OFF = 116;
-
-/**
- * True iff `deployer` owns the market's LP portfolio on `slabAddress` — the
- * durable creator marker (see file header). Scans the wrapper program for
- * portfolios matching (magic + this slab + this owner) and accepts if any of
- * the (0–2) results is the market's actual LP (isLpPortfolio).
- */
-async function verifyMarketOwnership(slabAddress: string, deployer: string): Promise<boolean> {
-  const cfg = getConfig();
-  const connection = new Connection(cfg.rpcUrl, "confirmed");
-  const accounts = await connection.getProgramAccounts(new PublicKey(cfg.programId), {
-    filters: [
-      { memcmp: { offset: 0, bytes: V17_PORTFOLIO_MAGIC_B64, encoding: "base64" } },
-      { memcmp: { offset: V17_PF_MARKET_OFF, bytes: slabAddress } },
-      { memcmp: { offset: V17_PF_OWNER_OFF, bytes: deployer } },
-    ],
-  });
-  return accounts.some(({ account }) => isLpPortfolio(account.data));
 }
 
 // GET /api/markets/[slab]/logo
@@ -197,6 +177,25 @@ export async function POST(
   const deployer = formData.get("deployer");
   const signature = formData.get("signature");
 
+  // Resolve the storage client + market row up front. `markets.deployer` is the
+  // authoritative creator marker used to authorise the upload below (see file
+  // header), and this same lookup doubles as the "market exists" check for both
+  // the wallet-proof and admin-bypass paths.
+  let supabase: ReturnType<typeof getServiceClient>;
+  try {
+    supabase = getServiceClient();
+  } catch {
+    return NextResponse.json({ error: "Storage backend unavailable" }, { status: 503 });
+  }
+  const { data: market, error: marketError } = await supabase
+    .from("markets")
+    .select("slab_address, deployer")
+    .eq("slab_address", validSlab)
+    .single();
+  if (marketError || !market) {
+    return NextResponse.json({ error: "Market not found" }, { status: 404 });
+  }
+
   // AUTH: per-market wallet ownership proof (or admin bypass) — see file
   // header for why this replaced the broken shared-key `requireAuth` gate.
   if (!isAdminBypass(req)) {
@@ -248,20 +247,19 @@ export async function POST(
       );
     }
 
-    // Cryptographic proof of the deployer key alone isn't enough — verify that
-    // key actually owns THIS market's LP portfolio (the durable creator
-    // marker; marketauth can't be used here — see file header for why).
-    try {
-      const owns = await verifyMarketOwnership(validSlab, deployer);
-      if (!owns) {
-        return NextResponse.json({ error: "Signer is not the creator of this market" }, { status: 403 });
-      }
-    } catch (err) {
-      console.error(
-        "[markets/logo] Market ownership check failed:",
-        err instanceof Error ? err.message : String(err),
+    // Cryptographic proof of the deployer key alone isn't enough — authorise
+    // it against the market's AUTHORITATIVE creator (markets.deployer, set at
+    // creation against the on-chain admin + a signed nonce; never rotated). Do
+    // NOT use the on-chain LP-portfolio signal here — it's forgeable (see file
+    // header). Null deployer = no authenticated creator on record → admin only.
+    if (!market.deployer) {
+      return NextResponse.json(
+        { error: "This market has no registered creator on record; a maintainer must set its logo." },
+        { status: 403 },
       );
-      return NextResponse.json({ error: "Failed to verify market ownership" }, { status: 400 });
+    }
+    if (market.deployer !== deployer) {
+      return NextResponse.json({ error: "Signer is not the creator of this market" }, { status: 403 });
     }
   }
 
@@ -289,24 +287,6 @@ export async function POST(
   // Max 2MB
   if (file.size > 2 * 1024 * 1024) {
     return NextResponse.json({ error: "File too large. Max 2MB." }, { status: 400 });
-  }
-
-  let supabase: ReturnType<typeof getServiceClient>;
-  try {
-    supabase = getServiceClient();
-  } catch {
-    return NextResponse.json({ error: "Storage backend unavailable" }, { status: 503 });
-  }
-
-  // Check market exists
-  const { data: market, error: marketError } = await supabase
-    .from("markets")
-    .select("slab_address")
-    .eq("slab_address", validSlab)
-    .single();
-
-  if (marketError || !market) {
-    return NextResponse.json({ error: "Market not found" }, { status: 404 });
   }
 
   try {


### PR DESCRIPTION
## Security fix (follow-up to #2393)

Adversarial review of #2393 found a **CRITICAL false-accept**: it authorized logo uploads by scanning the market's LP portfolio (`isLpPortfolio` = trailing `PortfolioMatcherConfigV16.enabled == 1`). That signal is **forgeable** — the on-chain `SetMatcherConfig(enabled=1)` handler only checks the caller owns the portfolio being modified, **not** that they created the market. So any wallet could `InitUser` + `SetMatcherConfig` a portfolio on *someone else's* slab and pass the check, reopening the exact "overwrite anyone's logo" hole the rewrite was meant to close. (Devnet-only, logo-defacement, no funds — but wrong.)

## Fix
After the ed25519 deployer proof verifies, authorize against **`markets.deployer`** — the authoritative creator marker, written once at creation against the on-chain admin + a signed nonce (`/api/markets` R2-S8, further hardened by #2387) and never rotated. Strictly stronger than the LP scan, and it **removes the `getProgramAccounts` RPC round-trip** — also closing the MEDIUM RPC-amplification finding from the same review. Markets with a `null` deployer (legacy / failed registration) have no authenticated creator and are reachable only via the admin bypass.

`useCreatedMarkets` keeps using the LP signal harmlessly (a false positive only shows an attacker their *own* row); it just must never be an auth boundary. `lib/lpPortfolio.ts` stays (still used client-side).

## Test
The prior suite asserted a *random keypair passes* — which is how the forgery shipped un-caught. Rewritten to authorize against `markets.deployer`, and adds an explicit **forgery-rejection** case: a different wallet with a valid self-signature → 403. 11/11 pass, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)