### PR TITLE
fix(launch): recover from the confirmation-timeout expiry sub-case (landing-checked)

### DIFF
--- a/app/__tests__/lib/tx.test.ts
+++ b/app/__tests__/lib/tx.test.ts
@@ -7,7 +7,7 @@ vi.mock("@/lib/config", () => ({
 }));
 
 import { TransactionExpiredBlockheightExceededError } from "@solana/web3.js";
-import { sendTx, estimateFees, getClockDriftWarning, isBlockhashExpiredError } from "@/lib/tx";
+import { sendTx, estimateFees, getClockDriftWarning, isBlockhashExpiredError, isConfirmationTimeoutError, checkSignatureLanded } from "@/lib/tx";
 import type { SendTxParams, FeeEstimate } from "@/lib/tx";
 
 describe("sendTx", () => {
@@ -152,6 +152,14 @@ describe("isBlockhashExpiredError", () => {
     expect(isBlockhashExpiredError(new Error("BLOCKHASH NOT FOUND"))).toBe(true);
   });
 
+  it('matches a "has expired" message (consistency with sendTx\'s own predicate)', () => {
+    expect(isBlockhashExpiredError(new Error("Transaction's blockhash has expired"))).toBe(true);
+  });
+
+  it("does NOT match a confirmation timeout (that path may have landed — needs a status check)", () => {
+    expect(isBlockhashExpiredError(new Error("Confirmation timeout (90s) — tx may still land. Check explorer: abc"))).toBe(false);
+  });
+
   // Negative cases — a generic send/simulation failure must NOT trigger the
   // extra re-approval popup; only genuine expiry should.
   it("does not match a generic program error", () => {
@@ -170,5 +178,47 @@ describe("isBlockhashExpiredError", () => {
 
   it("does not match an empty-message Error", () => {
     expect(isBlockhashExpiredError(new Error(""))).toBe(false);
+  });
+});
+
+describe("isConfirmationTimeoutError", () => {
+  it("matches pollConfirmation's timeout message", () => {
+    expect(isConfirmationTimeoutError(new Error("Confirmation timeout (90s) — tx may still land. Check explorer: sig123"))).toBe(true);
+  });
+  it("is case-insensitive", () => {
+    expect(isConfirmationTimeoutError(new Error("CONFIRMATION TIMEOUT"))).toBe(true);
+  });
+  it("does not match a blockhash-expiry error (that path has no signature to check)", () => {
+    expect(isConfirmationTimeoutError(new Error("Blockhash not found"))).toBe(false);
+  });
+  it("does not match generic errors or non-strings", () => {
+    expect(isConfirmationTimeoutError(new Error("custom program error: 0x1"))).toBe(false);
+    expect(isConfirmationTimeoutError(null)).toBe(false);
+    expect(isConfirmationTimeoutError({ x: 1 })).toBe(false);
+  });
+});
+
+describe("checkSignatureLanded", () => {
+  const conn = (value: unknown) =>
+    ({ getSignatureStatuses: vi.fn().mockResolvedValue({ value: [value] }) }) as never;
+
+  it('returns "landed" for a confirmed status with no error', async () => {
+    expect(await checkSignatureLanded(conn({ err: null, confirmationStatus: "confirmed" }), "s")).toBe("landed");
+  });
+  it('returns "landed" for a finalized status', async () => {
+    expect(await checkSignatureLanded(conn({ err: null, confirmationStatus: "finalized" }), "s")).toBe("landed");
+  });
+  it('returns "not-found" for a null status (dropped)', async () => {
+    expect(await checkSignatureLanded(conn(null), "s")).toBe("not-found");
+  });
+  it('returns "unknown" for an on-chain error (a rebuild would just fail again)', async () => {
+    expect(await checkSignatureLanded(conn({ err: { InstructionError: [0, "Custom"] } }), "s")).toBe("unknown");
+  });
+  it('returns "unknown" for processed-but-not-yet-confirmed (indeterminate)', async () => {
+    expect(await checkSignatureLanded(conn({ err: null, confirmationStatus: "processed" }), "s")).toBe("unknown");
+  });
+  it('returns "unknown" when the RPC call throws (fail safe — never rebuild on uncertainty)', async () => {
+    const throwing = { getSignatureStatuses: vi.fn().mockRejectedValue(new Error("rpc down")) } as never;
+    expect(await checkSignatureLanded(throwing, "s")).toBe("unknown");
   });
 });

--- a/app/hooks/useCreateMarket.ts
+++ b/app/hooks/useCreateMarket.ts
@@ -1097,7 +1097,12 @@ async function attemptFreshBatchedLaunch(ctx: FreshBatchContext): Promise<FreshB
           // if it is DEFINITIVELY absent. On "landed" treat as success; on any
           // indeterminate result (RPC error, on-chain failure, processed-not-
           // confirmed) propagate rather than risk re-running a landed createAccount.
-          if (isConfirmationTimeoutError(err) && canRecover) {
+          if (isConfirmationTimeoutError(err)) {
+            // The landing-check is free (one RPC read) and ALWAYS safe, so it
+            // runs regardless of the recovery budget — a tx that already landed
+            // must be reported as success even after the rebuild cap is spent,
+            // otherwise a fully-successful launch gets reported as a failure.
+            // Only the REBUILD leg is gated on `canRecover`.
             const sig = (err as { signature?: string }).signature;
             const landed = sig ? await checkSignatureLanded(connection, sig) : "unknown";
             if (landed === "landed" && sig) {
@@ -1106,14 +1111,15 @@ async function attemptFreshBatchedLaunch(ctx: FreshBatchContext): Promise<FreshB
               );
               return sig; // it's on-chain; treat exactly like a normal success
             }
-            if (landed === "not-found") {
+            if (landed === "not-found" && canRecover) {
               console.warn(
                 `[useCreateMarket] batch: tail step ${idx} timed out and did not land — recovering (attempt ${blockhashRecoveries + 1}/${MAX_BLOCKHASH_RECOVERIES})`,
               );
               await recoverTailFrom(idx);
               continue;
             }
-            // "unknown" → indeterminate; do not rebuild (could double-execute).
+            // "unknown" (indeterminate — never rebuild), or "not-found" with the
+            // recovery budget exhausted → fall through and propagate (resumable).
           }
           throw err;
         }

--- a/app/hooks/useCreateMarket.ts
+++ b/app/hooks/useCreateMarket.ts
@@ -79,6 +79,8 @@ import {
   getFreshBlockhash,
   getPriorityFee,
   isBlockhashExpiredError,
+  isConfirmationTimeoutError,
+  checkSignatureLanded,
 } from "@/lib/tx";
 import { getConfig, getNetwork } from "@/lib/config";
 import { normalizeDexType } from "@/lib/dex-type";
@@ -1077,12 +1079,41 @@ async function attemptFreshBatchedLaunch(ctx: FreshBatchContext): Promise<FreshB
           if (!tx) throw new Error(`Missing signed transaction for tail step ${idx}.`);
           return await broadcastSignedTx(connection, tx);
         } catch (err) {
-          if (isBlockhashExpiredError(err) && blockhashRecoveries < MAX_BLOCKHASH_RECOVERIES) {
+          const canRecover = blockhashRecoveries < MAX_BLOCKHASH_RECOVERIES;
+
+          // Case A — the SEND was rejected as expired (no signature exists, the
+          // tx never landed): safe to rebuild against a fresh blockhash.
+          if (isBlockhashExpiredError(err) && canRecover) {
             console.warn(
               `[useCreateMarket] batch: blockhash expired at tail step ${idx} — recovering (attempt ${blockhashRecoveries + 1}/${MAX_BLOCKHASH_RECOVERIES})`,
             );
             await recoverTailFrom(idx);
             continue; // retry the SAME step with the freshly rebuilt+signed tx
+          }
+
+          // Case B — the tx was SUBMITTED but confirmation timed out at the edge
+          // of the blockhash window; it may still have landed. Status-check the
+          // signature FIRST (mirrors sendTx's R2-S7 landing check) — only rebuild
+          // if it is DEFINITIVELY absent. On "landed" treat as success; on any
+          // indeterminate result (RPC error, on-chain failure, processed-not-
+          // confirmed) propagate rather than risk re-running a landed createAccount.
+          if (isConfirmationTimeoutError(err) && canRecover) {
+            const sig = (err as { signature?: string }).signature;
+            const landed = sig ? await checkSignatureLanded(connection, sig) : "unknown";
+            if (landed === "landed" && sig) {
+              console.warn(
+                `[useCreateMarket] batch: tail step ${idx} confirmation timed out but the tx DID land — continuing`,
+              );
+              return sig; // it's on-chain; treat exactly like a normal success
+            }
+            if (landed === "not-found") {
+              console.warn(
+                `[useCreateMarket] batch: tail step ${idx} timed out and did not land — recovering (attempt ${blockhashRecoveries + 1}/${MAX_BLOCKHASH_RECOVERIES})`,
+              );
+              await recoverTailFrom(idx);
+              continue;
+            }
+            // "unknown" → indeterminate; do not rebuild (could double-execute).
           }
           throw err;
         }

--- a/app/lib/tx.ts
+++ b/app/lib/tx.ts
@@ -729,8 +729,52 @@ export function isBlockhashExpiredError(err: unknown): boolean {
   return (
     lower.includes("blockhash not found") ||
     lower.includes("block height exceeded") ||
-    lower.includes("blockhashnotfound")
+    lower.includes("blockhashnotfound") ||
+    // Consistency with `sendTx`'s own retry predicate above, which also treats
+    // "has expired" as an expiry signal.
+    lower.includes("has expired")
   );
+}
+
+/**
+ * True if `err` is `pollConfirmation`'s "Confirmation timeout" — the tx WAS
+ * submitted (it has a signature) but didn't confirm within MAX_POLL_TIME_MS
+ * (~= the blockhash validity window). Distinct from `isBlockhashExpiredError`:
+ * an expiry error means the send was REJECTED (never accepted, no signature),
+ * whereas a timeout means the tx may have landed and MUST be status-checked
+ * (via `checkSignatureLanded`) before any rebuild — re-broadcasting a rebuilt
+ * tx whose original actually landed would re-run a createAccount that already
+ * succeeded and hard-fail the operation.
+ */
+export function isConfirmationTimeoutError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : typeof err === "string" ? err : "";
+  return msg.toLowerCase().includes("confirmation timeout");
+}
+
+/**
+ * Definitive on-chain status of a submitted signature, for the "did it land
+ * before I rebuild?" check (mirrors `sendTx`'s R2-S7 landing check). Uses
+ * `searchTransactionHistory: true` so a confirmed-but-status-aged tx isn't
+ * mis-reported as missing.
+ *  - "landed"    → confirmed/finalized with no error: treat as success, do NOT rebuild.
+ *  - "not-found" → genuinely absent (dropped): safe to rebuild against a fresh blockhash.
+ *  - "unknown"   → on-chain error, or an RPC failure that leaves it indeterminate:
+ *                  caller must NOT rebuild (could double-execute) and should propagate.
+ */
+export async function checkSignatureLanded(
+  connection: Connection,
+  signature: string,
+): Promise<"landed" | "not-found" | "unknown"> {
+  try {
+    const resp = await connection.getSignatureStatuses([signature], { searchTransactionHistory: true });
+    const st = resp.value[0];
+    if (st?.err) return "unknown"; // failed on-chain — a rebuild would just fail again
+    if (st && (st.confirmationStatus === "confirmed" || st.confirmationStatus === "finalized")) return "landed";
+    if (!st) return "not-found";
+    return "unknown"; // processed-but-not-yet-confirmed — indeterminate, don't rebuild
+  } catch {
+    return "unknown"; // RPC hiccup — indeterminate, fail safe
+  }
 }
 
 // ============================================================================
@@ -853,6 +897,21 @@ export async function broadcastSignedTx(
     }
     throw sendErr;
   }
-  await pollConfirmation(connection, signature, opts.onProgress, opts.abortSignal);
+  try {
+    await pollConfirmation(connection, signature, opts.onProgress, opts.abortSignal);
+  } catch (confirmErr) {
+    // The tx WAS submitted (we have its signature) but confirmation failed —
+    // attach the signature so a caller (the batch pipeline) can status-check it
+    // before deciding to rebuild, instead of blindly re-broadcasting. Only the
+    // send path above (a rejected tx) has no signature to attach.
+    if (confirmErr && typeof confirmErr === "object") {
+      try {
+        (confirmErr as { signature?: string }).signature = signature;
+      } catch {
+        // Frozen/exotic error object — leave it; caller falls back to no-sig handling.
+      }
+    }
+    throw confirmErr;
+  }
   return signature;
 }


### PR DESCRIPTION
## Follow-up to #2394 (adversarial-review MEDIUM finding)

#2394's tail recovery only triggered on `isBlockhashExpiredError` — the dominant `"Blockhash not found"` preflight rejection. But a tx accepted then dropped right at the blockhash-validity edge surfaces from `pollConfirmation` as `"Confirmation timeout — tx may still land"`, which the matcher didn't catch, so that sub-case still hard-failed.

## Fix (conservative)
`broadcastTailTx` now also handles the timeout case, but **only after a landing-check**:
- `broadcastSignedTx` attaches the submitted signature to a confirmation-failure error.
- `checkSignatureLanded` (new) status-checks it with `searchTransactionHistory: true` — mirroring `sendTx`'s proven R2-S7 landing check.
- **`"landed"`** → treat the step as success, never re-broadcast (a rebuilt `createAccount` whose original landed would hard-fail).
- **`"not-found"`** (definitively dropped) → rebuild against a fresh blockhash.
- **`"unknown"`** (RPC error / on-chain failure / processed-not-confirmed) → propagate, do **not** rebuild — same resumable behavior as before for that narrow case, so we never risk double-execution on uncertainty.

Also adds `"has expired"` to `isBlockhashExpiredError` for consistency with `sendTx`'s own retry predicate.

## Test
`__tests__/lib/tx.test.ts`: `"has expired"` + confirmation-timeout-is-not-expiry for `isBlockhashExpiredError`; full positive/negative for `isConfirmationTimeoutError`; and all five `checkSignatureLanded` outcomes incl. the fail-safe `"unknown"` on RPC throw. tsc clean, 41/41 pass. (The recovery orchestration itself can't be unit-tested under jsdom — same `Transaction` signing limitation #2394 documented — so this leans on the landing-check unit tests + review.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)