### PR TITLE
fix(parse): guard malformed decimals on the input-parsing path (#2389 fast-follow)

### DIFF
--- a/app/__tests__/lib/parseAmount.test.ts
+++ b/app/__tests__/lib/parseAmount.test.ts
@@ -119,3 +119,23 @@ describe("formatHumanAmount", () => {
     expect(formatted).toBe("123.456789");
   });
 });
+
+describe("malformed decimals are guarded (do not throw a raw BigInt/padStart error)", () => {
+  it("parseHumanAmount folds NaN/Infinity/negative decimals to whole-unit parsing", () => {
+    // NaN → 0 decimals: "100" parses as 100 whole units; no BigInt(NaN) throw.
+    expect(parseHumanAmount("100", NaN)).toBe(100n);
+    expect(parseHumanAmount("100", Infinity)).toBe(100n);
+    expect(parseHumanAmount("100", -5)).toBe(100n);
+  });
+
+  it("formatHumanAmount folds malformed decimals to whole-unit formatting", () => {
+    expect(formatHumanAmount(100n, NaN)).toBe("100");
+    expect(formatHumanAmount(100n, Infinity)).toBe("100");
+    expect(formatHumanAmount(100n, -5)).toBe("100");
+  });
+
+  it("valid decimals are unchanged (no display/parse regression)", () => {
+    expect(parseHumanAmount("1.5", 6)).toBe(1_500_000n);
+    expect(formatHumanAmount(1_500_000n, 6)).toBe("1.5");
+  });
+});

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -61,7 +61,7 @@ import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab, getMockUserAccountIdle } from "@/lib/mock-trade-data";
 import { sanitizeSymbol } from "@/lib/symbol-utils";
 import { useMarketInfo } from "@/hooks/useMarketInfo";
-import { formatTokenAmount, formatUsdPriceE6, toE6 } from "@/lib/format";
+import { formatTokenAmount, formatUsdPriceE6, toE6, normalizeTokenDecimals } from "@/lib/format";
 import { saveEntryPrice, getEntryPrice, clearEntryPrice } from "@/lib/entry-price";
 import { isSentinelValue } from "@/lib/health";
 import { DepositWithdrawCard } from "@/components/trade/DepositWithdrawCard";
@@ -82,7 +82,8 @@ function sanitizeDecimalInput(value: string): string {
 
 
 
-function parsePercToNative(input: string, decimals = 6): bigint {
+function parsePercToNative(input: string, decimalsRaw = 6): bigint {
+  const decimals = normalizeTokenDecimals(decimalsRaw); // guard NaN/Infinity/negative before BigInt/padEnd
   const parts = input.split(".");
   if (parts.length > 2) return 0n;
   const whole = parts[0] || "0";

--- a/app/lib/parseAmount.ts
+++ b/app/lib/parseAmount.ts
@@ -1,3 +1,5 @@
+import { normalizeTokenDecimals } from "@/lib/format";
+
 /**
  * Parse a human-readable decimal string into native token units (smallest units).
  * Converts user input like "100.5" into blockchain-native format like 100_500_000n (for 6-decimal token).
@@ -23,7 +25,11 @@
  * parseHumanAmount("abc", 6) // -> 0n (invalid input)
  * parseHumanAmount("0.0000001", 6) // -> throws (too many decimals)
  */
-export function parseHumanAmount(input: string, decimals: number): bigint {
+export function parseHumanAmount(input: string, decimalsRaw: number): bigint {
+  // Guard malformed decimals (NaN/Infinity/negative/fractional) before they
+  // reach BigInt exponentiation or String.padEnd — same fix as the display
+  // formatters in lib/format.ts (#2389), extended to this input-parsing path.
+  const decimals = normalizeTokenDecimals(decimalsRaw);
   const trimmed = input.trim();
   if (!trimmed || trimmed === ".") return 0n;
 
@@ -75,9 +81,10 @@ export function parseHumanAmount(input: string, decimals: number): bigint {
  * formatHumanAmount(0n, 6) // -> "0"
  * formatHumanAmount(100000000n, 6) // -> "100" (trailing zeros stripped)
  */
-export function formatHumanAmount(raw: bigint, decimals: number): string {
+export function formatHumanAmount(raw: bigint, decimalsRaw: number): string {
   if (raw === 0n) return "0";
 
+  const decimals = normalizeTokenDecimals(decimalsRaw);
   const negative = raw < 0n;
   const abs = negative ? -raw : raw;
   const divisor = 10n ** BigInt(decimals);


### PR DESCRIPTION
Fast-follow to #2389. That PR guarded the display formatters; this extends the same `normalizeTokenDecimals` guard to the input-parsing path (`parseHumanAmount`/`formatHumanAmount` and `OrderTicket`'s `parsePercToNative`), which still did raw `BigInt(decimals)`/`padEnd`/`padStart` and would throw on a malformed `decimals`. Folds malformed input to whole-unit handling (format.ts precedent); valid input unchanged. tsc clean, 30/30 parseAmount tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)