### PR TITLE
fix(chart): add ±20% jitter to GeckoTerminal backoff (#2391 fast-follow)

### DIFF
--- a/app/__tests__/lib/gecko-fetch.test.ts
+++ b/app/__tests__/lib/gecko-fetch.test.ts
@@ -71,23 +71,34 @@ describe("geckoFetch — bounded retry for GeckoTerminal", () => {
 });
 
 describe("geckoBackoffMs", () => {
+  // rng = 0.5 → jitter factor 0.8 + 0.4*0.5 = 1.0 (no change), keeping the
+  // base/cap assertions below deterministic.
+  const mid = () => 0.5;
+
   it("honors a numeric Retry-After (seconds) but CAPS it at the max backoff", () => {
     const r = res(429, { "retry-after": "100" }); // GT asks for 100s
-    expect(geckoBackoffMs(r, 0, Date.now())).toBe(GECKO_MAX_BACKOFF_MS); // never 100_000ms
+    expect(geckoBackoffMs(r, 0, Date.now(), mid)).toBe(GECKO_MAX_BACKOFF_MS); // never 100_000ms
   });
 
   it("ignores a non-numeric (HTTP-date) Retry-After and uses exponential backoff", () => {
     const r = res(429, { "retry-after": "Wed, 21 Oct 2026 07:28:00 GMT" });
-    expect(geckoBackoffMs(r, 0, Date.now())).toBe(300); // exponential, not a misparse
+    expect(geckoBackoffMs(r, 0, Date.now(), mid)).toBe(300); // exponential, not a misparse
   });
 
   it("uses exponential 300ms·2^n when there is no Retry-After", () => {
-    expect(geckoBackoffMs(null, 0, Date.now())).toBe(300);
-    expect(geckoBackoffMs(null, 1, Date.now())).toBe(600);
+    expect(geckoBackoffMs(null, 0, Date.now(), mid)).toBe(300);
+    expect(geckoBackoffMs(null, 1, Date.now(), mid)).toBe(600);
   });
 
   it("never returns negative and never sleeps past the deadline", () => {
     // startedAt already past the deadline → remaining is negative → clamps to 0.
-    expect(geckoBackoffMs(null, 2, Date.now() - GECKO_DEADLINE_MS - 5_000)).toBe(0);
+    expect(geckoBackoffMs(null, 2, Date.now() - GECKO_DEADLINE_MS - 5_000, mid)).toBe(0);
+  });
+
+  it("applies ±20% jitter to the base (below the cap) so retries don't align", () => {
+    // attempt 1 base = 600ms; jitter spans [480, 720].
+    expect(geckoBackoffMs(null, 1, Date.now(), () => 0)).toBe(480); // 600 * 0.8
+    expect(geckoBackoffMs(null, 1, Date.now(), () => 1)).toBeCloseTo(720, 5); // 600 * 1.2
+    expect(geckoBackoffMs(null, 1, Date.now(), mid)).toBe(600); // 600 * 1.0
   });
 });

--- a/app/lib/gecko-fetch.ts
+++ b/app/lib/gecko-fetch.ts
@@ -24,13 +24,23 @@ export const GECKO_DEADLINE_MS = 9_000;
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
 /** Backoff before the next attempt: honor a numeric Retry-After (seconds) when
- *  present, else exponential 300ms·2^n — both capped, and never sleeping past
- *  the overall deadline. Exported for unit testing. */
-export function geckoBackoffMs(res: Response | null, attempt: number, startedAt: number): number {
+ *  present, else exponential 300ms·2^n — with ±20% jitter, both capped, and
+ *  never sleeping past the overall deadline. The jitter matters because all
+ *  chart requests share Vercel's single outbound IP, so without it every
+ *  concurrent request retries on the SAME schedule and triples outbound volume
+ *  to GeckoTerminal in the exact instant it's already signaling back-off. `rng`
+ *  is injectable so unit tests stay deterministic. Exported for unit testing. */
+export function geckoBackoffMs(
+  res: Response | null,
+  attempt: number,
+  startedAt: number,
+  rng: () => number = Math.random,
+): number {
   const ra = res?.headers.get("retry-after");
   const base = ra && /^\d+$/.test(ra) ? Number(ra) * 1000 : 300 * 2 ** attempt;
+  const jittered = base * (0.8 + 0.4 * rng()); // ±20%
   const remaining = GECKO_DEADLINE_MS - (Date.now() - startedAt);
-  return Math.max(0, Math.min(base, GECKO_MAX_BACKOFF_MS, remaining));
+  return Math.max(0, Math.min(jittered, GECKO_MAX_BACKOFF_MS, remaining));
 }
 
 /**


### PR DESCRIPTION
Fast-follow to #2391. The bounded retry backed off deterministically, so concurrent requests from Vercel's shared IP retried in lockstep and amplified outbound volume to GT under 429s. Adds ±20% jitter (injectable rng → deterministic tests). Caps/deadline unchanged. The ~18s worst-case latency the review also flagged is within Vercel's 300s default function timeout. tsc clean, 12/12 gecko-fetch tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)