### PR TITLE
fix(mobile): make create-market transactions recoverable after blockhash expiry

### DIFF
--- a/app/__tests__/api/mobile-create-market-blockhash-recovery.test.ts
+++ b/app/__tests__/api/mobile-create-market-blockhash-recovery.test.ts
@@ -1,0 +1,278 @@
+// @vitest-environment node
+
+/**
+ * Regression coverage for issue #2400.
+ *
+ * Every transaction returned by the mobile create-market route must remain
+ * recoverable after recentBlockhash expiry without requiring unavailable
+ * server-generated account signatures.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemInstruction,
+  SystemProgram,
+  Transaction,
+} from '@solana/web3.js';
+import { NextRequest } from 'next/server';
+
+const { captureExceptionMock } = vi.hoisted(() => ({
+  captureExceptionMock: vi.fn(),
+}));
+
+vi.mock('@/lib/get-client-ip', () => ({
+  getClientIp: () => '127.0.0.1',
+}));
+
+vi.mock('@/lib/create-market-rate-limit', () => ({
+  checkCreateMarketRateLimit: async () => ({
+    allowed: true,
+    retryAfterSecs: 0,
+  }),
+  CREATE_MARKET_RATE_LIMIT: 5,
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: captureExceptionMock,
+}));
+
+import { POST } from '@/app/api/mobile/create-market/route';
+
+interface MobileCreateMarketResponse {
+  slab_address: string;
+  unsigned_txs: string[];
+  last_valid_block_height: number;
+  registration: {
+    slab_address: string;
+    deployer: string;
+    mint_address: string;
+  };
+}
+
+function findCreateWithSeedInstruction(transaction: Transaction) {
+  return transaction.instructions.find((instruction) => {
+    if (!instruction.programId.equals(SystemProgram.programId)) {
+      return false;
+    }
+
+    try {
+      return SystemInstruction.decodeInstructionType(instruction) === 'CreateWithSeed';
+    } catch {
+      return false;
+    }
+  });
+}
+
+describe('mobile create-market blockhash recovery (#2400)', () => {
+  const originalNetwork = process.env.NEXT_PUBLIC_DEFAULT_NETWORK;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_DEFAULT_NETWORK = 'devnet';
+    captureExceptionMock.mockClear();
+
+    vi.spyOn(Connection.prototype, 'getLatestBlockhash').mockResolvedValue({
+      blockhash: Keypair.generate().publicKey.toBase58(),
+      lastValidBlockHeight: 999_999,
+    });
+
+    vi.spyOn(Connection.prototype, 'getMinimumBalanceForRentExemption').mockResolvedValue(
+      1_000_000,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+
+    if (originalNetwork === undefined) {
+      delete process.env.NEXT_PUBLIC_DEFAULT_NETWORK;
+    } else {
+      process.env.NEXT_PUBLIC_DEFAULT_NETWORK = originalNetwork;
+    }
+  });
+
+  it('allows every transaction to be refreshed and signed by the deployer only', async () => {
+    const deployerKeypair = Keypair.generate();
+    const deployer = deployerKeypair.publicKey.toBase58();
+
+    const mint = Keypair.generate().publicKey.toBase58();
+
+    const request = new NextRequest('http://localhost/api/mobile/create-market', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        deployer,
+        mint,
+        tier: 'small',
+        name: 'Blockhash Recovery Regression',
+        oracle_mode: 'admin',
+        initial_price_e6: '1000000',
+      }),
+    });
+
+    const response = await POST(request);
+    const rawBody = await response.text();
+
+    if (response.status !== 200) {
+      const captured = captureExceptionMock.mock.calls.at(-1)?.[0];
+
+      console.error('\n=== CAPTURED ROUTE ERROR ===');
+
+      if (captured instanceof Error) {
+        console.error(captured.stack ?? captured.message);
+      } else {
+        console.error(captured);
+      }
+
+      console.error('=== END CAPTURED ROUTE ERROR ===\n');
+    }
+
+    expect(response.status, `Unexpected route response: ${rawBody}`).toBe(200);
+
+    const body = JSON.parse(rawBody) as MobileCreateMarketResponse;
+
+    expect(body.unsigned_txs).toHaveLength(4);
+    expect(body.last_valid_block_height).toBe(999_999);
+
+    expect(body.registration.deployer).toBe(deployer);
+    expect(body.registration.mint_address).toBe(mint);
+    expect(body.registration.slab_address).toBe(body.slab_address);
+
+    const transactions = body.unsigned_txs.map((encoded) =>
+      Transaction.from(Buffer.from(encoded, 'base64')),
+    );
+
+    const createdAccounts: string[] = [];
+
+    for (const [index, transaction] of transactions.entries()) {
+      const originalBlockhash = transaction.recentBlockhash;
+
+      const accountKeysBeforeRefresh = transaction
+        .compileMessage()
+        .accountKeys.map((key) => key.toBase58());
+
+      /**
+       * Every transaction must require exactly one signer:
+       * the mobile deployer.
+       */
+      expect(transaction.signatures).toHaveLength(1);
+
+      const [requiredSigner] = transaction.signatures;
+
+      expect(requiredSigner.publicKey.toBase58()).toBe(deployer);
+
+      /**
+       * The route must not pre-populate a server signature.
+       */
+      expect(requiredSigner.signature).toBeNull();
+
+      expect(accountKeysBeforeRefresh).toContain(body.slab_address);
+
+      /**
+       * TX0-TX2 create the slab, LP portfolio, and matcher
+       * context through CreateAccountWithSeed.
+       *
+       * TX3 does not create a new system account.
+       */
+      const createWithSeedInstruction = findCreateWithSeedInstruction(transaction);
+
+      if (index < 3) {
+        expect(createWithSeedInstruction).toBeDefined();
+
+        if (!createWithSeedInstruction) {
+          throw new Error(`TX${index} is missing CreateWithSeed`);
+        }
+
+        const decoded = SystemInstruction.decodeCreateWithSeed(createWithSeedInstruction);
+
+        /**
+         * The deployer is both the funding account and the
+         * base authority. No server account signer is needed.
+         */
+        expect(decoded.fromPubkey.toBase58()).toBe(deployer);
+
+        expect(decoded.basePubkey.toBase58()).toBe(deployer);
+
+        /**
+         * randomBytes(12) produces 24 hex characters.
+         * The prefix identifies each derived account type.
+         */
+        expect(decoded.seed).toMatch(/^[spm]-[0-9a-f]{24}$/);
+
+        expect(Buffer.byteLength(decoded.seed, 'utf8')).toBeLessThanOrEqual(32);
+
+        const expectedPrefix = ['s-', 'p-', 'm-'][index];
+
+        expect(decoded.seed.startsWith(expectedPrefix)).toBe(true);
+
+        /**
+         * Verify that the system instruction creates exactly
+         * the address derived from base + seed + program ID.
+         */
+        const expectedCreatedAddress = await PublicKey.createWithSeed(
+          deployerKeypair.publicKey,
+          decoded.seed,
+          decoded.programId,
+        );
+
+        expect(decoded.newAccountPubkey.toBase58()).toBe(expectedCreatedAddress.toBase58());
+
+        createdAccounts.push(decoded.newAccountPubkey.toBase58());
+      } else {
+        expect(createWithSeedInstruction).toBeUndefined();
+      }
+
+      let refreshedBlockhash = Keypair.generate().publicKey.toBase58();
+
+      while (refreshedBlockhash === originalBlockhash) {
+        refreshedBlockhash = Keypair.generate().publicKey.toBase58();
+      }
+
+      /**
+       * Simulate recovery after the original blockhash
+       * expires.
+       */
+      transaction.recentBlockhash = refreshedBlockhash;
+
+      transaction.sign(deployerKeypair);
+
+      /**
+       * The rebuilt transaction must be fully valid with the
+       * deployer signature alone.
+       */
+      expect(transaction.verifySignatures()).toBe(true);
+
+      expect(transaction.signatures[0].signature).not.toBeNull();
+
+      /**
+       * Refreshing the blockhash must not change any account
+       * address or instruction account.
+       */
+      expect(transaction.compileMessage().accountKeys.map((key) => key.toBase58())).toEqual(
+        accountKeysBeforeRefresh,
+      );
+
+      console.log(`TX${index}: refreshed and signed by deployer only`);
+    }
+
+    /**
+     * Exactly three unique system accounts must be created:
+     * slab, LP portfolio, and matcher context.
+     */
+    expect(createdAccounts).toHaveLength(3);
+    expect(new Set(createdAccounts).size).toBe(3);
+
+    expect(createdAccounts[0]).toBe(body.slab_address);
+
+    /**
+     * No private signer material may be exposed.
+     */
+    expect(body).not.toHaveProperty('signers');
+    expect(body).not.toHaveProperty('private_keys');
+    expect(body).not.toHaveProperty('secret_keys');
+  });
+});

--- a/app/app/api/mobile/create-market/route.ts
+++ b/app/app/api/mobile/create-market/route.ts
@@ -3,9 +3,8 @@
  *
  * Server-assisted transaction builder for mobile market creation (GH #80).
  *
- * Problem: Mobile cannot execute the 5-step on-chain deployment flow that the web
- * wizard does client-side. The slab and matcher-context keypairs must co-sign TX0
- * and TX2 respectively, which requires server-side key generation.
+ * The slab, LP portfolio, and matcher-context accounts are derived from
+ * the deployer so every transaction requires only the deployer signature.
  *
  * Flow:
  *  1. Client posts { deployer, mint, tier, name, oracle_mode, initial_price_e6 }
@@ -16,14 +15,14 @@
  *  5. Mobile signs each tx with MWA (adds deployer signature) and sends in order
  *  6. Mobile calls POST /api/markets to register the new market in the dashboard DB
  *
- * Security: server keypairs are ephemeral (never persisted). The deployer field is
- * validated as a valid Solana pubkey. The endpoint uses an allowlist guard — only
+ * Security: no account private keys are generated or persisted. The deployer field
+ * is validated as a valid Solana pubkey. The endpoint uses an allowlist guard — only
  * NEXT_PUBLIC_DEFAULT_NETWORK (or NEXT_PUBLIC_SOLANA_NETWORK) === "devnet" is
  * accepted; all other values (mainnet, staging, unset) return 403 (GH#1950).
  */
+import { randomBytes } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
 import {
-  Keypair,
   PublicKey,
   SystemProgram,
   Transaction,
@@ -241,10 +240,27 @@ export async function POST(req: NextRequest) {
     const { blockhash, lastValidBlockHeight } =
       await connection.getLatestBlockhash("confirmed");
 
-    // ── Ephemeral keypairs (server-side only, never persisted) ────────────────
-    const slabKp = Keypair.generate();
-    const matcherCtxKp = Keypair.generate();
-    const slabPk = slabKp.publicKey;
+    // ── Refreshable deployer-derived accounts ────────────────
+  // Unique, non-secret seeds allow every account-creation transaction
+  // to be authorized and refreshed using the deployer signature only.
+  const accountNonce = randomBytes(12).toString("hex");
+  const slabSeed = `s-${accountNonce}`;
+  const lpPortfolioSeed = `p-${accountNonce}`;
+  const matcherCtxSeed = `m-${accountNonce}`;
+
+  const [slabPk, lpPortfolioPk, matcherCtxPk] = await Promise.all([
+    PublicKey.createWithSeed(deployerPk, slabSeed, programId),
+    PublicKey.createWithSeed(
+      deployerPk,
+      lpPortfolioSeed,
+      programId,
+    ),
+    PublicKey.createWithSeed(
+      deployerPk,
+      matcherCtxSeed,
+      matcherProgramId,
+    ),
+  ]);
 
     // ── PDAs & associated accounts ────────────────────────────────────────────
     const [vaultPda] = deriveVaultAuthority(programId, slabPk);
@@ -259,11 +275,13 @@ export async function POST(req: NextRequest) {
 
     // ═══════════════════════════════════════════════════════════════════════════
     // TX 0: createAccount(slab) + createATA(vaultAta) + seedTransfer + initMarket
-    // Partially signed by: slabKp (server), deployer (mobile)
+    // Signed by: deployer only
     // ═══════════════════════════════════════════════════════════════════════════
-    const createSlabIx = SystemProgram.createAccount({
-      fromPubkey: deployerPk,
-      newAccountPubkey: slabPk,
+  const createSlabIx = SystemProgram.createAccountWithSeed({
+    fromPubkey: deployerPk,
+    basePubkey: deployerPk,
+    seed: slabSeed,
+    newAccountPubkey: slabPk,
       lamports: slabRent,
       space: slabDataSize,
       programId,
@@ -328,24 +346,23 @@ export async function POST(req: NextRequest) {
     tx0.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
     tx0.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }));
     tx0.add(createSlabIx, createVaultAtaIx, seedTransferIx, initMarketIx);
-    tx0.partialSign(slabKp); // server co-signs as the new slab account
 
     // ═══════════════════════════════════════════════════════════════════════════
     // TX 1: LP Portfolio Init (v17 replacement for pre-LP crank)
     // v17: PermissionlessCrank needs a portfolio at accounts[2] — which doesn't exist
     // before InitPortfolio. TX1 now creates the LP portfolio account + runs InitPortfolio.
-    // The portfolio keypair is ephemeral (server-side only, never persisted).
-    // Partially signed by: lpPortfolioKp (server), deployer (mobile)
+    // The portfolio address is derived from the deployer and a unique seed.
+    // Signed by: deployer only
     // ═══════════════════════════════════════════════════════════════════════════
-    const lpPortfolioKp = Keypair.generate();
-    const lpPortfolioPk = lpPortfolioKp.publicKey;
     // Full portfolio length (9347): InitPortfolio reallocs up to it and adds no lamports, so an
     // undersized createAccount leaves the account below rent-exempt → InsufficientFundsForRent.
     const portfolioRent = await connection.getMinimumBalanceForRentExemption(V17_PORTFOLIO_ACCOUNT_LEN);
 
-    const createPortfolioIx = SystemProgram.createAccount({
-      fromPubkey: deployerPk,
-      newAccountPubkey: lpPortfolioPk,
+  const createPortfolioIx = SystemProgram.createAccountWithSeed({
+    fromPubkey: deployerPk,
+    basePubkey: deployerPk,
+    seed: lpPortfolioSeed,
+    newAccountPubkey: lpPortfolioPk,
       lamports: portfolioRent,
       space: V17_PORTFOLIO_ACCOUNT_LEN,
       programId,
@@ -366,24 +383,25 @@ export async function POST(req: NextRequest) {
     tx1.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
     tx1.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }));
     tx1.add(createPortfolioIx, initPortfolioIx);
-    tx1.partialSign(lpPortfolioKp); // server co-signs as the new portfolio account
 
     // ═══════════════════════════════════════════════════════════════════════════
     // TX 2: createAccount(matcherCtx) + matcher init passive + SetMatcherConfig
     // v17: encodeInitLP (tag 2) is REMOVED — throws removedInstruction().
     // Replacement: create matcher context account + call matcher program (InitPassive) +
     // call wrapper SetMatcherConfig (tag 68) on the LP portfolio created in TX1.
-    // Partially signed by: matcherCtxKp (server), deployer (mobile)
+    // Signed by: deployer only
     // ═══════════════════════════════════════════════════════════════════════════
 
     // Derive matcher delegate PDA: seeds = ["matcher", market, lpPortfolio, lpOwner, matcherProg, ctx]
     const [delegatePk] = deriveMatcherDelegate(
-      programId, slabPk, lpPortfolioPk, deployerPk, matcherProgramId, matcherCtxKp.publicKey,
+      programId, slabPk, lpPortfolioPk, deployerPk, matcherProgramId, matcherCtxPk,
     );
 
-    const createCtxIx = SystemProgram.createAccount({
-      fromPubkey: deployerPk,
-      newAccountPubkey: matcherCtxKp.publicKey,
+  const createCtxIx = SystemProgram.createAccountWithSeed({
+    fromPubkey: deployerPk,
+    basePubkey: deployerPk,
+    seed: matcherCtxSeed,
+    newAccountPubkey: matcherCtxPk,
       lamports: matcherCtxRent,
       space: MATCHER_CTX_SIZE,
       programId: matcherProgramId,
@@ -394,7 +412,7 @@ export async function POST(req: NextRequest) {
       programId: matcherProgramId,
       keys: [
         { pubkey: delegatePk, isSigner: false, isWritable: false },
-        { pubkey: matcherCtxKp.publicKey, isSigner: false, isWritable: true },
+        { pubkey: matcherCtxPk, isSigner: false, isWritable: true },
       ],
       data: Buffer.from(encodeMatcherInitPassive({ maxFillAbs: BigInt("340282366920938463463374607431768211455") })),
     });
@@ -408,7 +426,7 @@ export async function POST(req: NextRequest) {
         slabPk,
         lpPortfolioPk,
         matcherProgramId,
-        matcherCtxKp.publicKey,
+        matcherCtxPk,
         delegatePk,
       ]),
       data: encodeSetMatcherConfig({ enabled: 1 }),
@@ -421,7 +439,6 @@ export async function POST(req: NextRequest) {
     tx2.add(ComputeBudgetProgram.requestHeapFrame({ bytes: 131072 }));
     tx2.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }));
     tx2.add(createCtxIx, matcherInitIx, setMatcherConfigIx);
-    tx2.partialSign(matcherCtxKp); // server co-signs as the new matcher context account
 
     // ═══════════════════════════════════════════════════════════════════════════
     // TX 3: DepositCollateral + TopUpInsurance + PermissionlessCrank (final)
@@ -488,7 +505,7 @@ export async function POST(req: NextRequest) {
     // ═══════════════════════════════════════════════════════════════════════════
     return NextResponse.json({
       slab_address: slabPk.toBase58(),
-      /** Base64-encoded partially-signed transactions. Mobile adds deployer signature. */
+      /** Base64-encoded unsigned transactions. Mobile adds the deployer signature. */
       unsigned_txs: [tx0, tx1, tx2, tx3].map(txToBase64),
       /** Config for the POST /api/markets registration call after all txs succeed. */
       registration: {


### PR DESCRIPTION
## Summary

This PR fixes the mobile market-creation recovery failure reported in #2400.

`POST /api/mobile/create-market` previously returned four dependent transactions (`TX0`–`TX3`) that shared one `recentBlockhash`.

The first three transactions also depended on signatures from ephemeral server-generated account keypairs:

- `TX0` → slab account keypair
- `TX1` → LP portfolio account keypair
- `TX2` → matcher-context account keypair

Those keypairs existed only during the API request and were discarded immediately after the response was produced.

If the shared blockhash expired before the mobile client completed the full transaction sequence, replacing `recentBlockhash` changed the signed transaction message and invalidated the server signatures. The client could not recreate those signatures because it never possessed the corresponding private keys.

This PR removes that unrecoverable server-signer dependency.

The slab, LP portfolio, and matcher-context accounts are now derived with `PublicKey.createWithSeed()`, and their System Program creation instructions use `SystemProgram.createAccountWithSeed()` with the deployer as both:

- `fromPubkey`
- `basePubkey`

As a result, every returned transaction requires only the deployer signature and can be rebuilt with a fresh blockhash without generating new account addresses or requiring unavailable server-side private keys.

Closes #2400

## Problem

The mobile endpoint generated three ephemeral account keypairs:

```ts
const slabKp = Keypair.generate();
const lpPortfolioKp = Keypair.generate();
const matcherCtxKp = Keypair.generate();
```

The server then partially signed the first three market-creation transactions:

```ts
tx0.partialSign(slabKp);
tx1.partialSign(lpPortfolioKp);
tx2.partialSign(matcherCtxKp);
```

All four sequential transactions used the same short-lived blockhash:

```ts
const { blockhash, lastValidBlockHeight } =
  await connection.getLatestBlockhash("confirmed");
```

```ts
const tx0 = new Transaction({
  recentBlockhash: blockhash,
  feePayer: deployerPk,
});

const tx1 = new Transaction({
  recentBlockhash: blockhash,
  feePayer: deployerPk,
});

const tx2 = new Transaction({
  recentBlockhash: blockhash,
  feePayer: deployerPk,
});

const tx3 = new Transaction({
  recentBlockhash: blockhash,
  feePayer: deployerPk,
});
```

The endpoint returned the serialized transactions and block-height expiry:

```ts
unsigned_txs: [tx0, tx1, tx2, tx3].map(txToBase64),
last_valid_block_height: lastValidBlockHeight,
```

However, it did not persist or expose the ephemeral private keys.

After blockhash expiry, the mobile client could not safely refresh `TX0`, `TX1`, or `TX2`:

1. Replacing `recentBlockhash` changes the serialized transaction message.
2. The existing server signature no longer verifies against the modified message.
3. The client does not have the ephemeral server private key.
4. Calling the endpoint again generates different account addresses instead of resuming the original market.

This could leave the original creation flow partially completed after ordinary wallet latency, application suspension, RPC delay, temporary connectivity loss, or network congestion.

## Root Cause

The failure was caused by the combination of:

1. A multi-step transaction batch using one shared blockhash lifetime.
2. Server-generated account keypairs required by `TX0`–`TX2`.
3. Server signatures embedded before returning the transactions.
4. No server-side session or signer persistence.
5. No mechanism for the client to rebuild the same accounts after expiry.

The shared blockhash alone was not the unrecoverable component.

The critical recovery constraint was that refreshing the transaction message required signatures from account private keys that had already been discarded.

## Fix

### Deployer-derived account addresses

The route now generates unique, non-secret account seeds using server-side cryptographic randomness:

```ts
const accountNonce = randomBytes(12).toString("hex");

const slabSeed = `s-${accountNonce}`;
const lpPortfolioSeed = `p-${accountNonce}`;
const matcherCtxSeed = `m-${accountNonce}`;
```

The three account addresses are derived from:

- the deployer public key;
- a unique seed;
- the destination program ID.

```ts
const [slabPk, lpPortfolioPk, matcherCtxPk] =
  await Promise.all([
    PublicKey.createWithSeed(
      deployerPk,
      slabSeed,
      programId,
    ),
    PublicKey.createWithSeed(
      deployerPk,
      lpPortfolioSeed,
      programId,
    ),
    PublicKey.createWithSeed(
      deployerPk,
      matcherCtxSeed,
      matcherProgramId,
    ),
  ]);
```

### System Program account creation

The route now creates those accounts through `createAccountWithSeed()`:

```ts
SystemProgram.createAccountWithSeed({
  fromPubkey: deployerPk,
  basePubkey: deployerPk,
  seed: slabSeed,
  newAccountPubkey: slabPk,
  lamports: slabRent,
  space: slabDataSize,
  programId,
});
```

Equivalent seeded account creation is used for:

- the LP portfolio;
- the matcher context.

Because `fromPubkey` and `basePubkey` are both the deployer, no separate account keypair signature is required.

### Removed ephemeral server signatures

The following server-side signatures were removed:

```ts
tx0.partialSign(slabKp);
tx1.partialSign(lpPortfolioKp);
tx2.partialSign(matcherCtxKp);
```

The route no longer imports or uses `Keypair` for account generation.

All four transactions are returned unsigned and require only the mobile deployer's signature.

## Transaction Behavior

### Before

| Transaction | Purpose | Required signers before mobile signing |
|---|---|---|
| `TX0` | Create slab, vault setup, initialize market | Deployer + ephemeral `slabKp` |
| `TX1` | Create and initialize LP portfolio | Deployer + ephemeral `lpPortfolioKp` |
| `TX2` | Create matcher context and configure matcher | Deployer + ephemeral `matcherCtxKp` |
| `TX3` | Deposit collateral, top up insurance, crank | Deployer |

After blockhash replacement, the server signatures in `TX0`–`TX2` became invalid and could not be recreated by the client.

### After

| Transaction | Purpose | Required signer |
|---|---|---|
| `TX0` | Create seeded slab, vault setup, initialize market | Deployer |
| `TX1` | Create seeded LP portfolio and initialize it | Deployer |
| `TX2` | Create seeded matcher context and configure matcher | Deployer |
| `TX3` | Deposit collateral, top up insurance, crank | Deployer |

The client can now:

1. deserialize an expired transaction;
2. replace `recentBlockhash`;
3. sign the updated message with the deployer wallet;
4. submit the transaction while preserving the same account addresses.

## Why `createAccountWithSeed` Is Appropriate

The Percolator instructions do not require the slab, LP portfolio, or matcher-context accounts themselves to sign their program instructions.

They are writable accounts created before initialization, while the deployer or LP owner remains the authority signer.

Using `createAccountWithSeed()` preserves those account semantics while removing the need for separate generated account private keys.

The account address remains deterministically bound to:

```text
base public key + seed + owner program ID
```

The seed is unique per API request but is not secret key material.

## Security Properties

This change improves the transaction builder by ensuring that:

- no account private keys are generated by the server;
- no account private keys are persisted;
- no account private keys are returned to the client;
- no account private keys can be accidentally logged;
- every account-creation transaction is authorized by the deployer;
- blockhash refresh does not require an unavailable signer;
- refreshed transactions preserve the original account addresses;
- the existing devnet-only network guard remains unchanged;
- the API response does not expose signer or secret-key material.

The generated seeds use 12 random bytes, represented as 24 hexadecimal characters with an account-type prefix:

```text
s-<24 hex characters>
p-<24 hex characters>
m-<24 hex characters>
```

Each seed remains below the System Program's 32-byte UTF-8 seed limit.

## API Compatibility

The response structure remains compatible with the existing mobile flow.

The endpoint still returns:

```ts
{
  slab_address,
  unsigned_txs,
  registration,
  last_valid_block_height,
}
```

No existing response field was removed or renamed.

The transaction order remains unchanged:

```text
TX0 → TX1 → TX2 → TX3
```

The market instructions, account layouts, compute-budget instructions, deposit flow, insurance top-up, and final crank remain unchanged.

The meaningful behavior change is that the returned transactions no longer contain server-generated account signatures.

## Regression Coverage

Added:

```text
app/__tests__/api/mobile-create-market-blockhash-recovery.test.ts
```

The regression test invokes the real mobile create-market route while mocking RPC reads only.

It verifies that:

1. The route returns four transactions.
2. The response retains the expected registration metadata.
3. Every transaction requires exactly one signer.
4. The required signer is the deployer.
5. The server does not pre-populate any signature.
6. `TX0`, `TX1`, and `TX2` contain a System Program `CreateWithSeed` instruction.
7. `TX3` does not create a new System Program account.
8. `fromPubkey` is the deployer.
9. `basePubkey` is the deployer.
10. Every seed follows the expected account-type prefix.
11. Every seed remains within the 32-byte limit.
12. Every created address matches `PublicKey.createWithSeed()` using the decoded base, seed, and program ID.
13. The slab, LP portfolio, and matcher-context accounts are unique.
14. The slab created by `TX0` matches `slab_address` in the API response.
15. Replacing the blockhash does not alter transaction account addresses.
16. Every refreshed transaction verifies successfully after signing with the deployer only.
17. No signer or private-key material is exposed in the response.

## Test Results

### Targeted API and regression tests

```bash
pnpm --filter @percolator/app exec vitest run \
  __tests__/api/mobile-create-market-blockhash-recovery.test.ts \
  __tests__/api/create-market-network-guard.test.ts \
  __tests__/api/create-market-name.test.ts \
  --reporter=verbose
```

Result:

```text
Test Files  3 passed (3)
Tests       16 passed (16)
```

The recovery test confirms:

```text
TX0: refreshed and signed by deployer only
TX1: refreshed and signed by deployer only
TX2: refreshed and signed by deployer only
TX3: refreshed and signed by deployer only
```

### Type checking

```bash
pnpm --filter @percolator/app exec tsc --noEmit
```

Result:

```text
Passed
```

### Production build

```bash
cd app

NEXT_PUBLIC_API_URL=http://localhost:4000 \
NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co \
NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy \
NEXT_PUBLIC_PRIVY_APP_ID=cltestappid00000000000000 \
pnpm exec next build
```

Result:

```text
Compiled successfully
Generated static pages successfully
Build completed successfully
```

### Formatting

```bash
pnpm exec prettier --check \
  app/__tests__/api/mobile-create-market-blockhash-recovery.test.ts
```

Result:

```text
All matched files use Prettier code style!
```

### Diff validation

```bash
git diff --cached --check
```

Result:

```text
Passed with no whitespace errors
```

## Full App Test Baseline

The repository-wide app test command currently reports pre-existing failures in unrelated stake-hook and transaction utility tests:

```text
Stake pool account owner mismatch
connection.getLatestBlockhash is not a function
```

The same failures were reproduced against a clean `upstream/playground` baseline with the #2400 changes stashed.

Baseline:

```text
Test Files  30 failed | 220 passed | 1 skipped
Tests       101 failed | 2514 passed | 16 skipped
Errors      3
```

With this PR:

```text
Test Files  30 failed | 221 passed | 1 skipped
Tests       101 failed | 2515 passed | 16 skipped
Errors      3
```

This PR adds one passing test file and one passing test without introducing additional failures or unhandled errors.

Those baseline failures are outside the scope of #2400 and are not modified by this PR.

## Files Changed

```text
app/app/api/mobile/create-market/route.ts
app/__tests__/api/mobile-create-market-blockhash-recovery.test.ts
```

## Scope

This PR makes the transaction batch **recoverable and refreshable** after blockhash expiry.

It does not:

- eliminate Solana blockhash expiration;
- automatically fetch a fresh blockhash in the mobile client;
- automatically resubmit expired transactions;
- change transaction confirmation handling;
- change market registration behavior;
- modify the web create-market flow.

The mobile client must still detect expiry, replace `recentBlockhash`, and request a new deployer signature.

The important difference is that this recovery is now cryptographically possible without access to discarded server-side private keys.

## Result

The mobile create-market flow no longer depends on ephemeral server account signatures.

Every returned transaction can be refreshed and signed using the deployer wallet alone while preserving the original slab, LP portfolio, matcher-context, and instruction account addresses.