### PR TITLE
fix(tx): preserve wrapped transaction error details

### DIFF
--- a/app/__tests__/lib/parseMarketError.test.ts
+++ b/app/__tests__/lib/parseMarketError.test.ts
@@ -111,4 +111,72 @@ describe("parseMarketCreationError", () => {
     );
     expect(msg).toContain("code 255");
   });
+
+  // Anchored program-error routing — a successful Tokenkeg CPI in the logs
+  // must NOT hijack an unrelated engine failure into "insufficient token
+  // balance" (old heuristic: includes("custom program error: 0x1") — which
+  // also prefix-matched 0x13 — && includes("TokenkegQ") anywhere).
+  describe("token-program error routing (anchored)", () => {
+    const TOKENKEG = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+    const WRAPPER = "6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P";
+
+    it("routes 0x13 EngineStale to the engine-stale message even with a successful Tokenkeg CPI in the logs", () => {
+      const msg = parseMarketCreationError(new Error(
+        [
+          "Transaction failed: Unexpected error",
+          `Program ${WRAPPER} invoke [1]`,
+          `Program ${TOKENKEG} invoke [2]`,
+          "Program log: Instruction: Transfer",
+          `Program ${TOKENKEG} success`,
+          `Program ${WRAPPER} failed: custom program error: 0x13`,
+        ].join("\n")
+      ));
+      expect(msg).not.toContain("Insufficient token balance");
+      expect(msg).toContain("stale");
+    });
+
+    it("still routes a genuine Tokenkeg 0x1 failure to the insufficient-token-balance message", () => {
+      const msg = parseMarketCreationError(new Error(
+        [
+          `Program ${WRAPPER} invoke [1]`,
+          `Program ${TOKENKEG} invoke [2]`,
+          "Program log: Instruction: Transfer",
+          `Program ${TOKENKEG} failed: custom program error: 0x1`,
+        ].join("\n")
+      ));
+      expect(msg).toContain("Insufficient token balance");
+    });
+
+    it("attributes a bare failing line to the innermost still-open invoke (Tokenkeg)", () => {
+      const msg = parseMarketCreationError(new Error(
+        [
+          `Program ${TOKENKEG} invoke [2]`,
+          "Program failed: custom program error: 0x1",
+        ].join("\n")
+      ));
+      expect(msg).toContain("Insufficient token balance");
+    });
+
+    it("routes a non-token 0x1 failure to the program-error decode path, not token balance", () => {
+      const msg = parseMarketCreationError(new Error(
+        `Program ${WRAPPER} failed: custom program error: 0x1`
+      ));
+      expect(msg).not.toContain("Insufficient token balance");
+      // 0x1 = v17 InvalidVersion override
+      expect(msg).toContain("version mismatch");
+    });
+
+    it("routes exact-code 0x12 (not a 0x1 prefix match) via the hex decode path", () => {
+      const msg = parseMarketCreationError(new Error(
+        [
+          `Program ${TOKENKEG} invoke [2]`,
+          `Program ${TOKENKEG} success`,
+          `Program ${WRAPPER} failed: custom program error: 0x12`,
+        ].join("\n")
+      ));
+      expect(msg).not.toContain("Insufficient token balance");
+      // 0x12 = 18 EngineInvalidLeg
+      expect(msg).toContain("leg");
+    });
+  });
 });

--- a/app/__tests__/lib/tx.test.ts
+++ b/app/__tests__/lib/tx.test.ts
@@ -1,3 +1,10 @@
+// @vitest-environment node
+//
+// Node, not jsdom: sendTx's tx-build path calls
+// ComputeBudgetProgram.requestHeapFrame, whose buffer-layout encoder rejects
+// jsdom's realm-separated Uint8Array ("b must be a Uint8Array") — the same
+// test-environment artifact __tests__/setup.ts documents for tweetnacl.
+// Nothing in this file touches the DOM.
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Keypair } from "@solana/web3.js";
 
@@ -95,7 +102,7 @@ describe("sendTx", () => {
 
 
 describe("extractTxErrorMessage", () => {
-  it("preserves nested transaction logs when a wallet wraps the failure as unexpected", () => {
+  it("preserves nested failing log lines when a wallet wraps the failure as unexpected, filtering noise", () => {
     const err = new Error("Unexpected error") as Error & { cause?: unknown };
     err.cause = {
       logs: [
@@ -107,8 +114,10 @@ describe("extractTxErrorMessage", () => {
     const msg = extractTxErrorMessage(err);
 
     expect(msg).toContain("Unexpected error");
-    expect(msg).toContain("Program log: Instruction: Trade");
     expect(msg).toContain("custom program error: 0x15");
+    // Non-failure log noise must NOT enter the thrown message — it drowns the
+    // failing line and creates substring false positives downstream.
+    expect(msg).not.toContain("Instruction: Trade");
   });
 
   it("preserves nested cause messages from wrapped transaction errors", () => {
@@ -119,6 +128,121 @@ describe("extractTxErrorMessage", () => {
 
     expect(msg).toContain("Unexpected error");
     expect(msg).toContain("custom program error: 0x13");
+  });
+
+  it("drops invoke/success log lines and caps admitted log lines at 12, preserving order", () => {
+    const noisy = Array.from({ length: 30 }, (_, i) => `Program log: step ${i} ok`);
+    const failures = Array.from({ length: 20 }, (_, i) => `Program log: failed check ${i}`);
+    const err = new Error("boom") as Error & { cause?: unknown };
+    err.cause = {
+      logs: [
+        "Program SomeProg1111111111111111111111111111111111 invoke [1]",
+        ...noisy,
+        ...failures,
+        "Program SomeProg1111111111111111111111111111111111 success",
+      ],
+    };
+
+    const msg = extractTxErrorMessage(err);
+    const lines = msg.split("\n");
+
+    expect(msg).not.toContain("invoke [1]");
+    expect(msg).not.toContain("success");
+    expect(msg).not.toContain("step 0 ok");
+    // "boom" + capped 12 failure lines
+    expect(lines.length).toBe(13);
+    expect(lines[1]).toBe("Program log: failed check 0");
+    expect(lines[12]).toBe("Program log: failed check 11");
+  });
+});
+
+describe("sendTx atomic signAndSendTransaction path — error detail preservation", () => {
+  const LIGHTHOUSE_ID = "L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95";
+
+  const makeConn = () =>
+    ({
+      rpcEndpoint: "https://api.devnet.solana.com",
+      getRecentPrioritizationFees: vi.fn().mockResolvedValue([]),
+      getBalance: vi.fn().mockResolvedValue(1_000_000_000),
+      getLatestBlockhash: vi.fn().mockResolvedValue({
+        blockhash: "11111111111111111111111111111111",
+        lastValidBlockHeight: 123,
+      }),
+      simulateTransaction: vi.fn().mockResolvedValue({ value: { err: null, logs: [] } }),
+    }) as any;
+
+  const makeWallet = (sendErr: unknown) => ({
+    publicKey: Keypair.generate().publicKey,
+    signAndSendTransaction: vi.fn().mockRejectedValue(sendErr),
+  });
+
+  it("throws the EXTRACTED message (nested cause detail) instead of the wallet's generic wrapper", async () => {
+    // Privy-style: generic top-level message, real detail buried in cause.logs.
+    const privyErr = new Error("Unexpected error") as Error & { cause?: unknown };
+    privyErr.cause = {
+      logs: [
+        "Program log: Instruction: Deposit",
+        "Program 6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P failed: custom program error: 0x13",
+      ],
+    };
+
+    let caught: unknown;
+    try {
+      await sendTx({ connection: makeConn(), wallet: makeWallet(privyErr), instructions: [] });
+    } catch (e) {
+      caught = e;
+    }
+
+    const err = caught as Error;
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toContain("Unexpected error");
+    expect(err.message).toContain("custom program error: 0x13");
+    // Original wallet error preserved for debugging.
+    expect(err.cause).toBe(privyErr);
+  });
+
+  it("does NOT show the wallet-security message for a PASSING Lighthouse assertion + unrelated 0x31 failure", async () => {
+    const privyErr = new Error("Unexpected error") as Error & { cause?: unknown };
+    privyErr.cause = {
+      logs: [
+        `Program ${LIGHTHOUSE_ID} invoke [1]`,
+        `Program ${LIGHTHOUSE_ID} success`,
+        "Program 6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P invoke [1]",
+        "Program 6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P failed: custom program error: 0x31",
+      ],
+    };
+
+    let caught: unknown;
+    try {
+      await sendTx({ connection: makeConn(), wallet: makeWallet(privyErr), instructions: [] });
+    } catch (e) {
+      caught = e;
+    }
+
+    const err = caught as Error;
+    expect(err.message).not.toContain("wallet security");
+    expect(err.message).toContain("custom program error: 0x31");
+  });
+
+  it("shows the wallet-security message for a GENUINE Lighthouse 0x1900 failure", async () => {
+    const privyErr = new Error("Unexpected error") as Error & { cause?: unknown };
+    privyErr.cause = {
+      logs: [
+        `Program ${LIGHTHOUSE_ID} invoke [1]`,
+        `Program ${LIGHTHOUSE_ID} failed: custom program error: 0x1900`,
+      ],
+    };
+
+    let caught: unknown;
+    try {
+      await sendTx({ connection: makeConn(), wallet: makeWallet(privyErr), instructions: [] });
+    } catch (e) {
+      caught = e;
+    }
+
+    const err = caught as Error;
+    expect(err.message).toContain("Transaction blocked by wallet security");
+    expect(err.cause).toBe(privyErr);
   });
 });
 

--- a/app/__tests__/lib/tx.test.ts
+++ b/app/__tests__/lib/tx.test.ts
@@ -7,7 +7,7 @@ vi.mock("@/lib/config", () => ({
 }));
 
 import { TransactionExpiredBlockheightExceededError } from "@solana/web3.js";
-import { sendTx, estimateFees, getClockDriftWarning, isBlockhashExpiredError, isConfirmationTimeoutError, checkSignatureLanded } from "@/lib/tx";
+import { sendTx, estimateFees, getClockDriftWarning, isBlockhashExpiredError, isConfirmationTimeoutError, checkSignatureLanded, extractTxErrorMessage } from "@/lib/tx";
 import type { SendTxParams, FeeEstimate } from "@/lib/tx";
 
 describe("sendTx", () => {
@@ -57,10 +57,16 @@ describe("sendTx", () => {
     const conn = {
       rpcEndpoint: "https://api.devnet.solana.com",
       getGenesisHash,
+      getRecentPrioritizationFees: vi.fn().mockResolvedValue([]),
+      getBalance: vi.fn().mockResolvedValue(10_000_000),
+      getLatestBlockhash: vi.fn().mockResolvedValue({
+        blockhash: "11111111111111111111111111111111",
+        lastValidBlockHeight: 123,
+      }),
     } as any;
     const wallet = {
       publicKey: Keypair.generate().publicKey,
-      signTransaction: vi.fn(),
+      signTransaction: vi.fn().mockRejectedValue(new Error("mock wallet stop")),
     };
 
     let caught: unknown;
@@ -84,6 +90,35 @@ describe("sendTx", () => {
     };
     expect(params.computeUnits).toBe(200_000);
     expect(params.maxRetries).toBe(2);
+  });
+});
+
+
+describe("extractTxErrorMessage", () => {
+  it("preserves nested transaction logs when a wallet wraps the failure as unexpected", () => {
+    const err = new Error("Unexpected error") as Error & { cause?: unknown };
+    err.cause = {
+      logs: [
+        "Program log: Instruction: Trade",
+        "Program failed: custom program error: 0x15",
+      ],
+    };
+
+    const msg = extractTxErrorMessage(err);
+
+    expect(msg).toContain("Unexpected error");
+    expect(msg).toContain("Program log: Instruction: Trade");
+    expect(msg).toContain("custom program error: 0x15");
+  });
+
+  it("preserves nested cause messages from wrapped transaction errors", () => {
+    const err = new Error("Unexpected error") as Error & { cause?: unknown };
+    err.cause = new Error("Transaction simulation failed: Error processing Instruction 0: custom program error: 0x13");
+
+    const msg = extractTxErrorMessage(err);
+
+    expect(msg).toContain("Unexpected error");
+    expect(msg).toContain("custom program error: 0x13");
   });
 });
 

--- a/app/lib/parseMarketError.ts
+++ b/app/lib/parseMarketError.ts
@@ -47,6 +47,57 @@ const LAUNCH_ERROR_OVERRIDES: Record<number, string> = {
   21: "Engine lock is active on this market (a close or recovery hasn't finished). If this doesn't clear after a retry or two, the market may need a full re-seed rather than simply waiting — contact a maintainer.",
 };
 
+const SPL_TOKEN_PROGRAM_ID = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+
+/**
+ * Anchored parse of the FIRST failing program-error log line in `msg`
+ * (innermost failure — outer programs re-log the same failure afterwards).
+ * Returns the exact hex code and the failing program's identity: the id named
+ * on the failing line itself ("Program <id> failed: custom program error:…"),
+ * or, when the failing line doesn't name one, the innermost still-open
+ * "Program <id> invoke" tracked via an invoke/success stack.
+ *
+ * This replaces the old substring heuristic
+ * `includes("custom program error: 0x1") && includes("TokenkegQ")`, which
+ * (a) prefix-matched 0x1 against 0x13/0x1a/…, and (b) attributed the failure
+ * to the token program if a Tokenkeg line appeared ANYWHERE in the logs —
+ * including a successful token CPI preceding an unrelated engine failure.
+ */
+function findFailingProgramError(msg: string): { code: number; program: string | null } | null {
+  const invokeStack: string[] = [];
+  for (const raw of msg.split(/\r?\n/)) {
+    // Tolerate lines embedded as JSON array elements (leading/trailing quotes).
+    const line = raw.trim().replace(/^"/, "").replace(/",?$/, "");
+    const failMatch = line.match(/failed: custom program error: (0x[0-9a-fA-F]+)/);
+    if (failMatch) {
+      const idMatch = line.match(/Program ([1-9A-HJ-NP-Za-km-z]{32,44}) failed:/);
+      return {
+        code: parseInt(failMatch[1], 16),
+        program: idMatch ? idMatch[1] : invokeStack[invokeStack.length - 1] ?? null,
+      };
+    }
+    const invokeMatch = line.match(/^Program ([1-9A-HJ-NP-Za-km-z]{32,44}) invoke/);
+    if (invokeMatch) {
+      invokeStack.push(invokeMatch[1]);
+      continue;
+    }
+    if (/^Program ([1-9A-HJ-NP-Za-km-z]{32,44}) success/.test(line)) {
+      invokeStack.pop();
+    }
+  }
+  return null;
+}
+
+/**
+ * SPL Token "insufficient funds" is custom error 1 (0x1) thrown BY the token
+ * program. Route to the token-balance message only when the failing line's
+ * code is exactly 0x1 AND its program context is Tokenkeg.
+ */
+function isTokenProgramInsufficientFunds(msg: string): boolean {
+  const failing = findFailingProgramError(msg);
+  return failing !== null && failing.code === 0x1 && failing.program === SPL_TOKEN_PROGRAM_ID;
+}
+
 export function parseMarketCreationError(error: unknown): string {
   const msg = error instanceof Error ? error.message : String(error);
 
@@ -66,7 +117,7 @@ export function parseMarketCreationError(error: unknown): string {
   if (
     msg.includes("insufficient funds for transfer") ||
     (msg.includes("insufficient funds") && !msg.includes("lamports") && !msg.includes("for rent")) ||
-    (msg.includes("custom program error: 0x1") && msg.includes("TokenkegQ"))
+    isTokenProgramInsufficientFunds(msg)
   ) {
     return "Insufficient token balance. Your wallet doesn't have enough collateral tokens to complete this step. On devnet, refresh the page and retry — the faucet will top up your balance.";
   }

--- a/app/lib/tx.ts
+++ b/app/lib/tx.ts
@@ -55,6 +55,60 @@ const PRIORITY_FEE_FALLBACK = Number(process.env.NEXT_PUBLIC_PRIORITY_FEE ?? 100
 const PRIORITY_FEE_CACHE_MS = 45_000;
 let cachedPriorityFee: { fee: number; ts: number } | null = null;
 
+function pushTxErrorString(out: string[], value: unknown) {
+  if (typeof value !== "string") return;
+  const trimmed = value.trim();
+  if (trimmed) out.push(trimmed);
+}
+
+function pushTxErrorLogs(out: string[], value: unknown) {
+  if (!Array.isArray(value)) return;
+  for (const line of value) {
+    pushTxErrorString(out, typeof line === "string" ? line : String(line));
+  }
+}
+
+export function extractTxErrorMessage(error: unknown): string {
+  const out: string[] = [];
+  const seen = new Set<object>();
+
+  const visit = (value: unknown, depth = 0) => {
+    if (value == null || depth > 4) return;
+
+    if (typeof value === "string") {
+      pushTxErrorString(out, value);
+      return;
+    }
+
+    if (typeof value !== "object") {
+      pushTxErrorString(out, String(value));
+      return;
+    }
+
+    if (seen.has(value)) return;
+    seen.add(value);
+
+    if (value instanceof Error) {
+      pushTxErrorString(out, value.message);
+    }
+
+    const record = value as Record<string, unknown>;
+    pushTxErrorString(out, record.message);
+    pushTxErrorString(out, record.transactionMessage);
+    pushTxErrorLogs(out, record.logs);
+    pushTxErrorLogs(out, record.transactionLogs);
+
+    visit(record.cause, depth + 1);
+    visit(record.error, depth + 1);
+    visit(record.err, depth + 1);
+  };
+
+  visit(error);
+
+  const unique = Array.from(new Set(out));
+  return unique.length > 0 ? unique.join("\n") : "Unexpected error";
+}
+
 /**
  * Get dynamic priority fee based on recent network conditions.
  * Cached for PRIORITY_FEE_CACHE_MS; falls back to hardcoded value if the RPC
@@ -537,7 +591,7 @@ export async function sendTx({
           // Privy returns raw signature bytes (64 bytes). Convert to base58.
           lastSignature = bs58.encode(sigBytes);
         } catch (sendErr) {
-          const sendMsg = sendErr instanceof Error ? sendErr.message : String(sendErr);
+          const sendMsg = extractTxErrorMessage(sendErr);
           // Check for Lighthouse-specific errors and provide user-friendly message
           if (
             sendMsg.includes(LIGHTHOUSE_PROGRAM_ID) ||
@@ -592,7 +646,7 @@ export async function sendTx({
             maxRetries: 5,
           });
         } catch (sendErr) {
-          const sendMsg = sendErr instanceof Error ? sendErr.message : String(sendErr);
+          const sendMsg = extractTxErrorMessage(sendErr);
           const isBatchError =
             sendMsg.includes("Missing response from batch") ||
             sendMsg.includes("failed to get recent blockhash") ||
@@ -880,6 +934,7 @@ export async function broadcastSignedTx(
       maxRetries: 5,
     });
   } catch (sendErr) {
+    const sendMsg = extractTxErrorMessage(sendErr);
     if (sendErr instanceof SendTransactionError) {
       try {
         const logs = await sendErr.getLogs(connection);
@@ -895,7 +950,7 @@ export async function broadcastSignedTx(
         if (logsErr instanceof Error && logsErr.message !== sendErr.message) throw logsErr;
       }
     }
-    throw sendErr;
+    throw new Error(sendMsg);
   }
   try {
     await pollConfirmation(connection, signature, opts.onProgress, opts.abortSignal);

--- a/app/lib/tx.ts
+++ b/app/lib/tx.ts
@@ -61,10 +61,34 @@ function pushTxErrorString(out: string[], value: unknown) {
   if (trimmed) out.push(trimmed);
 }
 
+/** Only log lines carrying a failure signal belong in a thrown message —
+ *  success/invoke noise ("Program X invoke [1]", "Program X success",
+ *  "Program log: Instruction: Trade") drowns the failing line AND creates
+ *  false positives in downstream substring classifiers (e.g. a PASSING
+ *  Lighthouse assertion's invoke line must not trigger the wallet-security
+ *  message, and a successful Tokenkeg CPI line must not route an unrelated
+ *  engine error to "insufficient token balance"). */
+const TX_ERROR_LOG_LINE_RE =
+  /error|failed|failure|panicked|insufficient|exceeded|denied|custom program error/i;
+/** Hard cap on log lines admitted into a thrown message. */
+const TX_ERROR_LOG_LINE_CAP = 12;
+
+/** Keep only failure-relevant log lines (order preserved, capped). */
+function filterTxErrorLogLines(lines: readonly unknown[]): string[] {
+  const out: string[] = [];
+  for (const raw of lines) {
+    const line = (typeof raw === "string" ? raw : String(raw)).trim();
+    if (!line || !TX_ERROR_LOG_LINE_RE.test(line)) continue;
+    out.push(line);
+    if (out.length >= TX_ERROR_LOG_LINE_CAP) break;
+  }
+  return out;
+}
+
 function pushTxErrorLogs(out: string[], value: unknown) {
   if (!Array.isArray(value)) return;
-  for (const line of value) {
-    pushTxErrorString(out, typeof line === "string" ? line : String(line));
+  for (const line of filterTxErrorLogLines(value)) {
+    out.push(line);
   }
 }
 
@@ -107,6 +131,57 @@ export function extractTxErrorMessage(error: unknown): string {
 
   const unique = Array.from(new Set(out));
   return unique.length > 0 ? unique.join("\n") : "Unexpected error";
+}
+
+/**
+ * True only when the extracted message carries an actual Lighthouse FAILURE
+ * signal:
+ *  - a line with exactly error code 0x1900 (Anchor ConstraintAddress — the
+ *    code Lighthouse assertions fail with), or
+ *  - a line naming Lighthouse alongside a failure word, or
+ *  - a line where the Lighthouse program id itself appears with a failure word.
+ *
+ * Mere PRESENCE of the Lighthouse program id anywhere in the message is not
+ * enough: nested transaction logs legitimately contain "Program L2TExM…
+ * invoke"/"success" lines for PASSING assertions, and attributing an unrelated
+ * program failure to "wallet security" would hide the real error.
+ */
+function isLighthouseFailureMessage(msg: string): boolean {
+  for (const rawLine of msg.split("\n")) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    // \b keeps 0x1900 from matching longer codes (e.g. 0x19001).
+    if (/custom program error:\s*0x1900\b/i.test(line)) return true;
+    if (/Lighthouse/i.test(line) && /error|failed|failure|blocked|denied/i.test(line)) return true;
+    if (line.includes(LIGHTHOUSE_PROGRAM_ID) && /error|failed|failure/i.test(line)) return true;
+  }
+  return false;
+}
+
+/**
+ * Final thrown message for a failed sendRawTransaction: the filtered extract
+ * of everything already on the error object, plus — for SendTransactionError,
+ * whose logs sometimes only materialize via getLogs() — any failure-relevant
+ * log lines the extract didn't already surface. Line-wise deduped so the
+ * message carries ONE copy of each failing log line (previously the same
+ * failing lines could appear up to three times: embedded in web3.js's own
+ * message, again via the error's log array, and a third time via a manual
+ * "relevant logs" append).
+ */
+async function buildSendErrorMessage(connection: Connection, sendErr: unknown): Promise<string> {
+  const sendMsg = extractTxErrorMessage(sendErr);
+  if (!(sendErr instanceof SendTransactionError)) return sendMsg;
+  try {
+    const logs = await sendErr.getLogs(connection);
+    if (logs && logs.length > 0) {
+      const seen = new Set(sendMsg.split("\n").map((l) => l.trim()));
+      const fresh = filterTxErrorLogLines(logs).filter((l) => !seen.has(l));
+      if (fresh.length > 0) return `${sendMsg}\n${fresh.join("\n")}`;
+    }
+  } catch {
+    // Best-effort log fetch — the extract alone is already informative.
+  }
+  return sendMsg;
 }
 
 /**
@@ -592,20 +667,24 @@ export async function sendTx({
           lastSignature = bs58.encode(sigBytes);
         } catch (sendErr) {
           const sendMsg = extractTxErrorMessage(sendErr);
-          // Check for Lighthouse-specific errors and provide user-friendly message
-          if (
-            sendMsg.includes(LIGHTHOUSE_PROGRAM_ID) ||
-            sendMsg.includes("0x1900") ||
-            sendMsg.includes("Lighthouse")
-          ) {
+          // Lighthouse-specific failure → user-friendly message. Gated on an
+          // actual failure signal, not mere program-id presence: nested logs
+          // can contain PASSING Lighthouse assertion lines while the real
+          // failure lives elsewhere.
+          if (isLighthouseFailureMessage(sendMsg)) {
             throw new Error(
               "Transaction blocked by wallet security (Blowfish/Lighthouse). " +
               "Your wallet's transaction guard flagged this as unknown. " +
               "Try disabling transaction simulation in your wallet settings, " +
-              "or use a different wallet. This is a known issue for new DeFi programs."
+              "or use a different wallet. This is a known issue for new DeFi programs.",
+              { cause: sendErr }
             );
           }
-          throw sendErr;
+          // Throw the EXTRACTED message: wallets (notably Privy) wrap program
+          // failures in a generic "Unexpected error" whose real detail lives
+          // in nested cause/logs — rethrowing sendErr verbatim discarded it.
+          // The original error rides along as `cause` for debugging.
+          throw new Error(sendMsg, { cause: sendErr });
         }
       } else if (wallet.signTransaction) {
         // Fallback: signTransaction + sendRawTransaction (legacy path)
@@ -657,25 +736,11 @@ export async function sendTx({
               `[sendTx] Batch RPC error (attempt ${attempt + 1}); will retry.`
             );
             throw sendErr;
-          } else if (sendErr instanceof SendTransactionError) {
-            try {
-              const logs = await sendErr.getLogs(connection);
-              if (logs && logs.length > 0) {
-                const relevantLogs = logs
-                  .filter((l: string) =>
-                    l.includes("Error") || l.includes("failed") || l.includes("Program log:")
-                  )
-                  .slice(-5)
-                  .join("\n");
-                throw new Error(`${sendMsg}${relevantLogs ? `\n${relevantLogs}` : ""}`);
-              }
-            } catch (logsErr) {
-              if (logsErr instanceof Error && logsErr.message !== sendMsg) throw logsErr;
-            }
-            throw sendErr;
-          } else {
-            throw sendErr;
           }
+          // One source of log lines: the filtered extract (+ getLogs() lines
+          // it couldn't see), deduped — see buildSendErrorMessage. Original
+          // error preserved as `cause`.
+          throw new Error(await buildSendErrorMessage(connection, sendErr), { cause: sendErr });
         }
       } else {
         throw new Error("Wallet not connected — no sign method available");
@@ -934,23 +999,9 @@ export async function broadcastSignedTx(
       maxRetries: 5,
     });
   } catch (sendErr) {
-    const sendMsg = extractTxErrorMessage(sendErr);
-    if (sendErr instanceof SendTransactionError) {
-      try {
-        const logs = await sendErr.getLogs(connection);
-        if (logs && logs.length > 0) {
-          const relevantLogs = logs
-            .filter((l: string) => l.includes("Error") || l.includes("failed") || l.includes("Program log:"))
-            .slice(-5)
-            .join("\n");
-          const sendMsg = sendErr instanceof Error ? sendErr.message : String(sendErr);
-          throw new Error(`${sendMsg}${relevantLogs ? `\n${relevantLogs}` : ""}`);
-        }
-      } catch (logsErr) {
-        if (logsErr instanceof Error && logsErr.message !== sendErr.message) throw logsErr;
-      }
-    }
-    throw new Error(sendMsg);
+    // Same semantics as sendTx's legacy send path: filtered extracted message
+    // (single deduped source of log lines), original error kept as `cause`.
+    throw new Error(await buildSendErrorMessage(connection, sendErr), { cause: sendErr });
   }
   try {
     await pollConfirmation(connection, signature, opts.onProgress, opts.abortSignal);


### PR DESCRIPTION
## Summary

This PR improves transaction error handling in the shared `sendTx` / broadcast flow by preserving actionable details from wrapped wallet/RPC errors.

Previously, when a wallet or RPC layer wrapped a failed transaction as a generic `Unexpected error`, the UI could surface only:

`Transaction failed: Unexpected error`

This made trade/withdraw failures difficult to understand, especially when the original error still contained useful nested transaction logs, program errors, or cause messages.

## Changes

- Added `extractTxErrorMessage()` in `app/lib/tx.ts`.
- Preserves useful nested transaction failure details from:
  - `message`
  - `transactionMessage`
  - `logs`
  - `transactionLogs`
  - `cause`
  - `error`
  - `err`
- Reuses the extracted message in transaction broadcast failure paths instead of dropping back to a generic wrapped error.
- Added regression coverage in `app/__tests__/lib/tx.test.ts` for:
  - wrapped wallet errors with nested transaction logs
  - wrapped transaction errors with nested cause messages

## User Impact

Users should now receive more actionable transaction failure messages instead of a generic `Unexpected error` when trade or withdraw transactions fail through a wrapped wallet/RPC error path.

This helps users and maintainers diagnose whether the failure came from a program error, transaction log, stale market state, RPC issue, or another transaction-layer problem.

## Scope

This PR does not change market logic, trade sizing, withdraw logic, deposit behavior, or on-chain execution flow.

The change is limited to preserving transaction error details before they reach the UI.

## Files Changed

- `app/lib/tx.ts`
- `app/__tests__/lib/tx.test.ts`