### PR TITLE
fix(chart): stop "Value is null" crash from non-finite candle/price points

### DIFF
--- a/app/__tests__/lib/chart-style.test.ts
+++ b/app/__tests__/lib/chart-style.test.ts
@@ -5,6 +5,8 @@ import {
   candleStyleOptions,
   chartDataKind,
   hasRenderableData,
+  finiteCandles,
+  finitePricePoints,
   DEFAULT_CHART_STYLE,
   CHART_STYLE_LABELS,
   CHART_STYLE_DISPLAY_ORDER,
@@ -197,6 +199,90 @@ describe("hasRenderableData", () => {
       expect(r.ready).toBe(false);
       expect(r.sparse).toBe(true);
     }
+  });
+});
+
+describe("finiteCandles", () => {
+  const c = (o: number, h: number, l: number, cl: number, t = 1_000, v = 5) => ({
+    timestamp: t,
+    open: o,
+    high: h,
+    low: l,
+    close: cl,
+    volume: v,
+  });
+
+  it("keeps candles whose OHLC are all finite (incl. sub-cent values)", () => {
+    const good = [c(0.000613, 0.000614, 0.000612, 0.000613), c(1, 2, 0.5, 1.5)];
+    expect(finiteCandles(good)).toEqual(good);
+  });
+
+  it("drops any candle with a NaN in open/high/low/close", () => {
+    expect(finiteCandles([c(NaN, 1, 1, 1)])).toHaveLength(0);
+    expect(finiteCandles([c(1, NaN, 1, 1)])).toHaveLength(0);
+    expect(finiteCandles([c(1, 1, NaN, 1)])).toHaveLength(0);
+    expect(finiteCandles([c(1, 1, 1, NaN)])).toHaveLength(0);
+  });
+
+  it("drops candles with ±Infinity or a non-finite timestamp", () => {
+    expect(finiteCandles([c(Infinity, 1, 1, 1)])).toHaveLength(0);
+    expect(finiteCandles([c(1, 1, 1, -Infinity)])).toHaveLength(0);
+    expect(finiteCandles([c(1, 1, 1, 1, NaN)])).toHaveLength(0);
+  });
+
+  it("does NOT require volume to be finite — the volume series coerces that itself", () => {
+    const bar = c(1, 1, 1, 1, 1_000, NaN);
+    expect(finiteCandles([bar])).toEqual([bar]);
+  });
+
+  it("an all-NaN batch collapses to empty, so hasRenderableData reports not-ready (no crash path)", () => {
+    // This is the exact regression: a length>=1 batch of whitespace candles
+    // used to pass `ready` and then throw "Value is null" once a price line
+    // was drawn. After filtering, `ready` is false and the empty overlay shows.
+    const allNaN = [c(NaN, NaN, NaN, NaN), c(NaN, NaN, NaN, NaN)];
+    const filtered = finiteCandles(allNaN);
+    expect(filtered).toHaveLength(0);
+    expect(hasRenderableData("candle-solid", filtered, []).ready).toBe(false);
+  });
+
+  it("a mixed batch keeps only the finite candles", () => {
+    const mixed = [c(1, 1, 1, 1), c(NaN, 1, 1, 1), c(2, 2, 2, 2)];
+    expect(finiteCandles(mixed)).toHaveLength(2);
+  });
+
+  it("preserves input order and does not mutate the source array", () => {
+    const src = [c(1, 1, 1, 1, 1), c(NaN, 1, 1, 1, 2), c(3, 3, 3, 3, 3)];
+    const out = finiteCandles(src);
+    expect(out.map((x) => x.timestamp)).toEqual([1, 3]);
+    expect(src).toHaveLength(3); // source untouched
+  });
+});
+
+describe("finitePricePoints", () => {
+  const p = (price: number, timestamp = 1_000) => ({ timestamp, price });
+
+  it("keeps points with a finite price", () => {
+    const good = [p(0.000613), p(1.5)];
+    expect(finitePricePoints(good)).toEqual(good);
+  });
+
+  it("drops NaN / ±Infinity prices and non-finite timestamps", () => {
+    expect(finitePricePoints([p(NaN)])).toHaveLength(0);
+    expect(finitePricePoints([p(Infinity)])).toHaveLength(0);
+    expect(finitePricePoints([p(1, NaN)])).toHaveLength(0);
+  });
+
+  it("an all-NaN batch collapses to empty → line style reports not-ready", () => {
+    const filtered = finitePricePoints([p(NaN), p(NaN)]);
+    expect(filtered).toHaveLength(0);
+    expect(hasRenderableData("line", [], filtered).ready).toBe(false);
+  });
+
+  it("keeps only the finite points in a mixed batch, order preserved", () => {
+    const src = [p(1, 1), p(NaN, 2), p(3, 3)];
+    const out = finitePricePoints(src);
+    expect(out.map((x) => x.timestamp)).toEqual([1, 3]);
+    expect(src).toHaveLength(3);
   });
 });
 

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -51,6 +51,8 @@ import {
   candleStyleOptions,
   chartDataKind,
   hasRenderableData,
+  finiteCandles,
+  finitePricePoints,
   type ChartSeriesKind,
 } from "@/lib/chart-style";
 import { assertNever } from "@/lib/exhaustive";
@@ -527,7 +529,13 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
   const oracleFiltered = useMemo(
     () => {
       const cutoff = Date.now() - TIMEFRAME_MS[timeframe];
-      return oraclePrices.filter((p) => p.timestamp >= cutoff);
+      // finitePricePoints drops any point whose price parsed to NaN (e.g. a
+      // malformed price_e6 from the indexer) — a non-finite value is a
+      // whitespace point that plots nothing and establishes no price range,
+      // which is what makes an overlay price line throw "Value is null". This
+      // is the single chokepoint feeding both the oracle line fallback and the
+      // aggregated-candle fallback, so sanitising here covers both.
+      return finitePricePoints(oraclePrices.filter((p) => p.timestamp >= cutoff));
     },
     [oraclePrices, timeframe],
   );
@@ -541,17 +549,26 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
   // unrelated state like timeframe-pill hover) creates a new array, which
   // re-fires the indicator hooks' effects and tears down + reallocates the
   // oscillator pane on every WebSocket tick.
+  // finiteCandles / finitePricePoints strip any non-finite point BEFORE it can
+  // reach lightweight-charts' setData. A NaN OHLC/price is silently demoted to
+  // a whitespace point (plots nothing, no price range); a series that ends up
+  // all-whitespace has a null firstValue and any overlay price line drawn on it
+  // throws "Value is null" on paint. Sanitising at the source means every
+  // downstream consumer (the render switch, indicator overlays, the volume
+  // pane, referencePriceUsd) sees only plottable data, and an all-NaN batch
+  // degrades to the empty/building overlay via hasRenderableData instead of
+  // crashing the chart. oracleFiltered is already sanitised above.
   const candleData = useMemo(() => {
-    if (hasPercolatorData) return percolatorCandles;
-    if (hasPythData) return pythCandles as { timestamp: number; open: number; high: number; low: number; close: number; volume: number }[];
-    if (hasExternalData) return externalCandles as { timestamp: number; open: number; high: number; low: number; close: number; volume: number }[];
-    return aggregateCandles(oracleFiltered, CANDLE_INTERVAL_MS);
+    if (hasPercolatorData) return finiteCandles(percolatorCandles);
+    if (hasPythData) return finiteCandles(pythCandles as { timestamp: number; open: number; high: number; low: number; close: number; volume: number }[]);
+    if (hasExternalData) return finiteCandles(externalCandles as { timestamp: number; open: number; high: number; low: number; close: number; volume: number }[]);
+    return finiteCandles(aggregateCandles(oracleFiltered, CANDLE_INTERVAL_MS));
   }, [hasPercolatorData, hasPythData, hasExternalData, percolatorCandles, pythCandles, externalCandles, oracleFiltered]);
 
   const lineData = useMemo(() => {
-    if (hasPercolatorData) return percolatorCandles.map((c) => ({ timestamp: c.timestamp, price: c.close }));
-    if (hasPythData) return pythCandles.map((c) => ({ timestamp: c.timestamp, price: c.close }));
-    if (hasExternalData) return externalCandles.map((c) => ({ timestamp: c.timestamp, price: c.close }));
+    if (hasPercolatorData) return finitePricePoints(percolatorCandles.map((c) => ({ timestamp: c.timestamp, price: c.close })));
+    if (hasPythData) return finitePricePoints(pythCandles.map((c) => ({ timestamp: c.timestamp, price: c.close })));
+    if (hasExternalData) return finitePricePoints(externalCandles.map((c) => ({ timestamp: c.timestamp, price: c.close })));
     return oracleFiltered;
   }, [hasPercolatorData, hasPythData, hasExternalData, percolatorCandles, pythCandles, externalCandles, oracleFiltered]);
 
@@ -748,7 +765,9 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
       // (this effect no longer depends on priceUsd; the "Live tick -> chart"
       // effect keeps this line fresh via applyOptions() afterward).
       const initialPriceUsd = getSnapshot(slabAddress).priceUsd;
-      if (initialPriceUsd != null) {
+      // Finite-guard mirrors the Liq/Entry lines below: a NaN mark price would
+      // pass `!= null` yet feed a non-finite price into createPriceLine.
+      if (initialPriceUsd != null && Number.isFinite(initialPriceUsd)) {
         priceLineRef.current = s.createPriceLine({
           price: initialPriceUsd,
           color: "rgba(255,255,255,0.6)",
@@ -1021,7 +1040,11 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
     if (!slabAddress) return;
     return subscribeSlab(slabAddress, () => {
       const snap = getSnapshot(slabAddress);
-      if (snap.priceUsd == null) return;
+      // Reject a non-finite tick too, not just null: a NaN would corrupt the
+      // last bar/point via series.update() below, re-introducing a whitespace
+      // point on an already-rendered series and reviving the "Value is null"
+      // crash after the initial safe paint.
+      if (snap.priceUsd == null || !Number.isFinite(snap.priceUsd)) return;
       const finishSpan = startPerfSpan("chart-tick-to-paint");
       const usd = snap.priceUsd;
 

--- a/app/lib/chart-style.ts
+++ b/app/lib/chart-style.ts
@@ -152,6 +152,56 @@ export function hasRenderableData(
   return { ready: len >= 1, sparse: len < 2 };
 }
 
+/** Full numeric OHLC shape the finite-filter reads (superset of `OhlcLike`,
+ *  which only carries `timestamp` for the length-based readiness check). */
+interface OhlcValues {
+  readonly timestamp: number;
+  readonly open: number;
+  readonly high: number;
+  readonly low: number;
+  readonly close: number;
+}
+
+/** Single-value point shape the finite-filter reads. */
+interface PriceValue {
+  readonly timestamp: number;
+  readonly price: number;
+}
+
+/** Drop any candle lightweight-charts would treat as a WHITESPACE point.
+ *
+ *  A point whose value isn't a finite number (NaN / ±Infinity) is silently
+ *  demoted by lightweight-charts to a "whitespace" item: it still reserves the
+ *  time slot but plots nothing and contributes NO price range. A series whose
+ *  points are ALL whitespace has a null `firstValue`/`priceRange`, and drawing
+ *  any price line (Mark / Liq / Entry) onto it makes the library throw
+ *  "Value is null" on the next paint (the TradingChart error boundary then
+ *  shows "something broke"). That state is reachable when the oracle-aggregated
+ *  fallback runs over price points that parsed to NaN (e.g. a malformed
+ *  `price_e6` from the indexer on a brand-new market) — the candle sources are
+ *  otherwise clean. Filtering here keeps `hasRenderableData`'s length check
+ *  honest: a "ready" array now always has >= 1 point that will genuinely plot,
+ *  so an all-NaN batch degrades to the empty/building overlay instead of a
+ *  crash. Volume is intentionally NOT required finite — the volume series
+ *  already coerces a non-finite bar to 0 at its own setData site. */
+export function finiteCandles<T extends OhlcValues>(candles: readonly T[]): T[] {
+  return candles.filter(
+    (c) =>
+      Number.isFinite(c.timestamp) &&
+      Number.isFinite(c.open) &&
+      Number.isFinite(c.high) &&
+      Number.isFinite(c.low) &&
+      Number.isFinite(c.close),
+  );
+}
+
+/** Single-value counterpart to `finiteCandles` for line/area + oracle points.
+ *  Same rationale — a non-finite `price` is a whitespace point that plots
+ *  nothing and establishes no price range. */
+export function finitePricePoints<T extends PriceValue>(points: readonly T[]): T[] {
+  return points.filter((p) => Number.isFinite(p.timestamp) && Number.isFinite(p.price));
+}
+
 /** Build the `addCandlestickSeries` option preset for a given candle variant.
  *
  *  - `candle-solid`: filled bodies in trend color (the default lightweight-charts look)


### PR DESCRIPTION
## What (user-reported)

A brand-new sub-cent market ($chicken, ~$0.000613) crashed the chart — the
TradingChart error boundary showed **"something broke in TradingChart. Value is
null"**. This is a hard crash, **distinct** from the empty-chart issue (that was
GeckoTerminal rate-limiting; #2390/#2391). This PR fixes the crash.

## Root cause

lightweight-charts silently demotes any data point whose value is **non-finite**
(`NaN` / `±Infinity`) to a **"whitespace" point** — it reserves the time slot but
plots nothing and contributes **no price range**. A series whose points are *all*
whitespace has a `null` `firstValue`/`priceRange`, and drawing any overlay price
line (**Mark / Liq / Entry**) onto it makes the library throw `"Value is null"`
(`ensureNotNull(firstValue)` / `ensureNotNull(priceRange)`) on the next paint.

The gap: `hasRenderableData` gates the render switch on array **length** (`>= 1`),
not on whether any point will actually plot. The candle sources
(Percolator / Pyth / GeckoTerminal) return clean finite numbers — I verified
$chicken's GT OHLCV is finite on **every** timeframe. But the oracle-aggregated
**fallback** (`aggregateCandles(oracleFiltered)`) runs over price points parsed as
`parseInt(price_e6) / 1e6`, which is `NaN` if the indexer hands back a malformed
`price_e6` on a market it just learned about. That NaN candle passed the length
check, and because the user had an **open position** (so Mark/Liq/Entry lines
draw), the price line threw on paint. This is exactly the rate-limited **1h/1d**
path the user hit (GT empty → oracle fallback engages).

## Fix — defense at the lightweight-charts boundary

- New pure helpers **`finiteCandles` / `finitePricePoints`** (`lib/chart-style.ts`,
  next to `hasRenderableData`) drop any point with a non-finite OHLC/price.
  Volume is intentionally **not** required finite — the volume series already
  coerces a non-finite bar to `0` at its own `setData` site.
- TradingChart sanitises **at the source**: `oracleFiltered` (the single chokepoint
  for both the oracle line and the aggregated-candle fallbacks) and the
  `candleData` / `lineData` memos all pass through the filters. Every downstream
  consumer (render switch, indicator overlays, volume pane, `referencePriceUsd`)
  now sees only plottable data, and an all-NaN batch **degrades to the
  empty/building overlay** via `hasRenderableData` instead of crashing.
- The **Mark** price line now finite-guards `initialPriceUsd` (mirrors the existing
  Liq/Entry guards) so a NaN mark can't feed `createPriceLine`.
- The **live-tick** effect rejects a non-finite tick, not just null — a NaN would
  corrupt the last bar/point via `series.update()` and revive the crash on an
  already-rendered series after the initial safe paint.

Net: for all real (finite) data the arrays are **identical** to before — no
behavioural change on healthy markets. The only difference is an all-NaN batch
now shows the empty overlay instead of throwing. Memoisation is preserved (filters
run inside the existing `useMemo` on the same deps), so **no extra renders**.

## Testing

- `npx tsc --noEmit` clean.
- `chart-style` suite **41/41** (11 new): finite/NaN/±Infinity/non-finite-timestamp
  cases, volume-not-required, mixed-batch, order-preserving, no-mutation, and the
  key regression — an all-NaN batch collapses so `hasRenderableData` reports
  **not-ready** (the exact crash path is now unreachable).
- Confirmed against the **live GeckoTerminal API** that $chicken's OHLCV is finite
  on 1m/1h/1d — proving the crash was never bad candle data, but the oracle
  fallback path.
- **No security surface:** the helpers are pure `Number.isFinite` filters, strictly
  more restrictive, adding no new inputs or network calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
