### PR TITLE
fix(ui): stop .bg-grid overlay from pushing page content ~192px down

### DIFF
--- a/app/app/globals.css
+++ b/app/app/globals.css
@@ -471,9 +471,14 @@ body::before {
 }
 
 /* ─── Grid Background ─── */
-.bg-grid {
-  position: relative;
-}
+/* `.bg-grid` deliberately sets NO `position` of its own. Every usage in the app
+   applies it as an ABSOLUTE overlay (`absolute inset-x-0 top-0 h-48 bg-grid …`),
+   and that `absolute` already establishes the containing block the `::before`
+   needs. A previous `.bg-grid { position: relative }` here (unlayered, so it beat
+   Tailwind's layered `.absolute` utility) forced the overlay into normal flow —
+   turning the 192px-tall grid into a real block that shoved page content ~192px
+   down on portfolio/earn/wallet/dashboard/etc. Removing it lets the element's own
+   `absolute` take effect so the overlay is out of flow again. */
 .bg-grid::before {
   content: "";
   position: absolute;


### PR DESCRIPTION
## Problem

On `/portfolio`, `/earn`, `/dashboard`, `/wallet` (and every other `.bg-grid`
page) the page heading sat far below the header with a large empty gap — on
mobile you had to scroll down just to reach the content.

## Root cause

`.bg-grid` is used everywhere as an **absolute overlay** — all 23 usages are
`absolute inset-x-0 top-0 h-48 bg-grid …`. But the class also declared
`position: relative`, and because that rule is **unlayered**, it beat Tailwind's
layered `.absolute` utility. So the element's computed `position` was `relative`,
not `absolute` — which dropped the **192px-tall (`h-48`) grid overlay into normal
flow as a real block**, pushing all page content ~192px down the viewport.

## Fix

`.bg-grid` no longer sets a `position` of its own. The element's `absolute`
utility takes effect (out of flow again), and that `absolute` already provides
the containing block the `.bg-grid::before` overlay needs — so the grid still
renders identically. One line, fixes every affected page at the source.

## Testing

- Headless measurement: the `/portfolio` eyebrow/heading moved from **289px →
  97px** from the top — now exactly the intended `py-10` (40px) below the header.
  Same on `/earn`, `/dashboard`, `/wallet`.
- Confirmed the grid still draws as the faded top overlay (screenshot below —
  no visual regression).
- `npx tsc --noEmit` clean.
- No usage relies on `.bg-grid` being a non-positioned container, so nothing
  else regresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
