### PR TITLE
fix(playground): prevent lost updates in registered market writes

### DIFF
--- a/app/__tests__/api/keeper-register-concurrency-race.test.ts
+++ b/app/__tests__/api/keeper-register-concurrency-race.test.ts
@@ -1,0 +1,489 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+/**
+ * Route-level deterministic lost-update PoC.
+ *
+ * Two authenticated keeper-register requests:
+ *
+ *   1. pass route validation,
+ *   2. pass mocked on-chain ownership verification,
+ *   3. both read the same registered-markets snapshot,
+ *   4. both return HTTP 200 / registered: true,
+ *   5. but the second Blob overwrite removes the first market.
+ */
+
+const state = vi.hoisted(() => ({
+  adminSecret: 'route-race-admin-secret',
+  deployer: 'Vote111111111111111111111111111111111111111',
+  programId: 'BPFLoaderUpgradeab1e11111111111111111111111',
+
+  slabA: '11111111111111111111111111111111',
+  slabB: 'So11111111111111111111111111111111111111112',
+
+  poolA: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+  poolB: 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL',
+
+  fakeStore: '[]',
+  fakeEtagVersion: 0,
+
+  registrationReads: 0,
+  readSnapshots: [] as string[],
+  committedWrites: [] as string[][],
+
+  allRegistrationReadsArrived: Promise.resolve(),
+  releaseRegistrationReads: () => {},
+
+  firstWriteCommitted: Promise.resolve(),
+  releaseFirstWrite: () => {},
+}));
+
+const originalEnv = {
+  NEXT_PUBLIC_DEFAULT_NETWORK: process.env.NEXT_PUBLIC_DEFAULT_NETWORK,
+  NEXT_PUBLIC_SOLANA_NETWORK: process.env.NEXT_PUBLIC_SOLANA_NETWORK,
+  ADMIN_API_SECRET: process.env.ADMIN_API_SECRET,
+  MAINNET_RPC_URL: process.env.MAINNET_RPC_URL,
+};
+
+process.env.NEXT_PUBLIC_DEFAULT_NETWORK = 'devnet';
+delete process.env.NEXT_PUBLIC_SOLANA_NETWORK;
+process.env.ADMIN_API_SECRET = state.adminSecret;
+process.env.MAINNET_RPC_URL = 'https://mainnet.test';
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(() => ({
+    rpcUrl: 'https://devnet.test',
+  })),
+
+  getAllProgramIds: vi.fn(() => [state.programId]),
+}));
+
+vi.mock('@solana/web3.js', () => {
+  class PublicKey {
+    private readonly value: string;
+
+    constructor(value: string) {
+      this.value = value;
+    }
+
+    toBase58(): string {
+      return this.value;
+    }
+
+    toBytes(): Uint8Array {
+      return new Uint8Array(32);
+    }
+  }
+
+  class Connection {
+    private readonly endpoint: string;
+
+    constructor(endpoint: string) {
+      this.endpoint = endpoint;
+    }
+
+    async getAccountInfo(): Promise<unknown> {
+      /*
+       * Devnet lookup verifies the playground slab.
+       */
+      if (this.endpoint === 'https://devnet.test') {
+        return {
+          owner: {
+            toBase58: () => state.programId,
+          },
+          data: new Uint8Array(512),
+        };
+      }
+
+      /*
+       * Force classifyPoolByOwner() into its documented dexType
+       * fallback path. The body supplies dexType: "raydium-clmm".
+       */
+      throw new Error('mock mainnet RPC unavailable');
+    }
+  }
+
+  return {
+    Connection,
+    PublicKey,
+  };
+});
+
+vi.mock('@percolatorct/sdk', () => ({
+  V17_HEADER_LEN: 16,
+
+  isV17Account: vi.fn(() => false),
+
+  parseHeader: vi.fn(() => ({
+    admin: {
+      toBase58: () => state.deployer,
+    },
+  })),
+
+  parseWrapperConfigV17: vi.fn(() => ({
+    marketauth: {
+      toBase58: () => state.deployer,
+    },
+  })),
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureMessage: vi.fn(),
+}));
+
+vi.mock('@vercel/blob', () => {
+  class BlobPreconditionFailedError extends Error {
+    constructor() {
+      super('Blob precondition failed');
+      this.name = 'BlobPreconditionFailedError';
+    }
+  }
+
+  const currentEtag = () => `etag-${state.fakeEtagVersion}`;
+
+  const streamFromText = (value: string): ReadableStream<Uint8Array> => {
+    const bytes = new TextEncoder().encode(value);
+
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(bytes);
+        controller.close();
+      },
+    });
+  };
+
+  return {
+    BlobPreconditionFailedError,
+
+    list: vi.fn(async () => ({
+      blobs: [
+        {
+          pathname: 'playground/registered-markets.json',
+          url: 'https://blob.test/playground/registered-markets.json',
+        },
+      ],
+    })),
+
+    get: vi.fn(async () => {
+      /*
+       * Both POST requests initially read the same registry and ETag.
+       * A later retry reads the latest committed registry immediately.
+       */
+      const capturedSnapshot = state.fakeStore;
+      const capturedEtag = currentEtag();
+
+      if (state.registrationReads < 2) {
+        state.registrationReads += 1;
+        state.readSnapshots.push(capturedSnapshot);
+
+        if (state.registrationReads === 2) {
+          state.releaseRegistrationReads();
+        }
+
+        await state.allRegistrationReadsArrived;
+      } else {
+        state.registrationReads += 1;
+        state.readSnapshots.push(capturedSnapshot);
+      }
+
+      return {
+        statusCode: 200,
+        stream: streamFromText(capturedSnapshot),
+        blob: {
+          etag: capturedEtag,
+        },
+      };
+    }),
+
+    put: vi.fn(
+      async (
+        _pathname: string,
+        body: unknown,
+        options: {
+          ifMatch?: string;
+          allowOverwrite?: boolean;
+        } = {},
+      ) => {
+        const nextRegistry = JSON.parse(String(body)) as Array<{
+          slabAddress?: string;
+        }>;
+
+        const slabs = nextRegistry
+          .map((market) => market.slabAddress)
+          .filter((slab): slab is string => typeof slab === 'string');
+
+        const containsA = slabs.includes(state.slabA);
+        const containsB = slabs.includes(state.slabB);
+
+        /*
+         * A commits first. B's stale conditional write conflicts, then the
+         * production retry reads A and persists the merged [A, B] snapshot.
+         */
+        if (containsB && !containsA) {
+          await state.firstWriteCommitted;
+        }
+
+        if (options.ifMatch !== undefined && options.ifMatch !== currentEtag()) {
+          throw new BlobPreconditionFailedError();
+        }
+
+        if (options.allowOverwrite === false && state.fakeStore !== '[]') {
+          throw new BlobPreconditionFailedError();
+        }
+
+        state.fakeStore = JSON.stringify(nextRegistry);
+        state.committedWrites.push(slabs);
+        state.fakeEtagVersion += 1;
+
+        if (containsA && !containsB) {
+          state.releaseFirstWrite();
+        }
+
+        return {
+          url: 'https://blob.test/playground/registered-markets.json',
+          etag: currentEtag(),
+        };
+      },
+    ),
+  };
+});
+
+const { POST } = await import('@/app/api/playground/keeper-register/route');
+
+const { GET: getRegisteredMarkets } = await import('@/app/api/playground/registered-markets/route');
+
+function buildKeeperRegisterRequest(slabAddress: string, suffix: string): NextRequest {
+  return new NextRequest('http://localhost/api/playground/keeper-register', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-admin-secret': state.adminSecret,
+    },
+    body: JSON.stringify({
+      slabAddress,
+      dexPoolAddress: suffix === 'a' ? state.poolA : state.poolB,
+      dexType: 'raydium-clmm',
+      symbol: `RACE-${suffix.toUpperCase()}`,
+      label: `Route race market ${suffix}`,
+      deployer: state.deployer,
+    }),
+  });
+}
+
+function extractMarkets(payload: unknown): Array<{ slabAddress?: string }> {
+  if (Array.isArray(payload)) {
+    return payload as Array<{
+      slabAddress?: string;
+    }>;
+  }
+
+  if (payload && typeof payload === 'object') {
+    const record = payload as Record<string, unknown>;
+
+    for (const key of ['markets', 'registeredMarkets', 'data']) {
+      if (Array.isArray(record[key])) {
+        return record[key] as Array<{
+          slabAddress?: string;
+        }>;
+      }
+    }
+  }
+
+  throw new Error('Registered-markets discovery response did not contain a market array');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  state.fakeStore = '[]';
+  state.fakeEtagVersion = 0;
+  state.registrationReads = 0;
+  state.readSnapshots.length = 0;
+  state.committedWrites.length = 0;
+
+  state.allRegistrationReadsArrived = new Promise<void>((resolve) => {
+    state.releaseRegistrationReads = resolve;
+  });
+
+  state.firstWriteCommitted = new Promise<void>((resolve) => {
+    state.releaseFirstWrite = resolve;
+  });
+
+  globalThis.fetch = vi.fn(async () => {
+    const capturedSnapshot = state.fakeStore;
+
+    /*
+     * The first two reads belong to the two concurrent POST requests.
+     * Capture their snapshots before releasing either request.
+     */
+    if (state.registrationReads < 2) {
+      state.registrationReads += 1;
+      state.readSnapshots.push(capturedSnapshot);
+
+      if (state.registrationReads === 2) {
+        state.releaseRegistrationReads();
+      }
+
+      await Promise.race([
+        state.allRegistrationReadsArrived,
+        new Promise<never>((_, reject) => {
+          setTimeout(() => {
+            reject(
+              new Error(
+                `Registration read barrier timed out: ${state.registrationReads}/2 POST requests reached the registry read`,
+              ),
+            );
+          }, 2_000);
+        }),
+      ]);
+    }
+
+    return new Response(capturedSnapshot, {
+      status: 200,
+      headers: {
+        'content-type': 'application/json',
+      },
+    });
+  }) as typeof fetch;
+});
+
+afterAll(() => {
+  if (originalEnv.NEXT_PUBLIC_DEFAULT_NETWORK === undefined) {
+    delete process.env.NEXT_PUBLIC_DEFAULT_NETWORK;
+  } else {
+    process.env.NEXT_PUBLIC_DEFAULT_NETWORK = originalEnv.NEXT_PUBLIC_DEFAULT_NETWORK;
+  }
+
+  if (originalEnv.NEXT_PUBLIC_SOLANA_NETWORK === undefined) {
+    delete process.env.NEXT_PUBLIC_SOLANA_NETWORK;
+  } else {
+    process.env.NEXT_PUBLIC_SOLANA_NETWORK = originalEnv.NEXT_PUBLIC_SOLANA_NETWORK;
+  }
+
+  if (originalEnv.ADMIN_API_SECRET === undefined) {
+    delete process.env.ADMIN_API_SECRET;
+  } else {
+    process.env.ADMIN_API_SECRET = originalEnv.ADMIN_API_SECRET;
+  }
+
+  if (originalEnv.MAINNET_RPC_URL === undefined) {
+    delete process.env.MAINNET_RPC_URL;
+  } else {
+    process.env.MAINNET_RPC_URL = originalEnv.MAINNET_RPC_URL;
+  }
+});
+
+describe('POST /api/playground/keeper-register concurrency safety', () => {
+  it('preserves both successfully registered markets in discovery', async () => {
+    const requestA = buildKeeperRegisterRequest(state.slabA, 'a');
+
+    const requestB = buildKeeperRegisterRequest(state.slabB, 'b');
+
+    const [responseA, responseB] = await Promise.all([POST(requestA), POST(requestB)]);
+
+    const [bodyA, bodyB] = await Promise.all([responseA.json(), responseB.json()]);
+
+    console.info(
+      '[keeper-register route response preflight]',
+      JSON.stringify(
+        {
+          responseA: {
+            status: responseA.status,
+            body: bodyA,
+          },
+          responseB: {
+            status: responseB.status,
+            body: bodyB,
+          },
+          registrationReads: state.registrationReads,
+        },
+        null,
+        2,
+      ),
+    );
+
+    /*
+     * Discovery must only run after both production POST handlers
+     * have completed successfully. Otherwise discovery itself could
+     * enter the registry-read barrier and obscure the real failure.
+     */
+    expect(responseA.status).toBe(200);
+    expect(responseB.status).toBe(200);
+
+    expect(bodyA).toMatchObject({
+      ok: true,
+      registered: true,
+      slabAddress: state.slabA,
+    });
+
+    expect(bodyB).toMatchObject({
+      ok: true,
+      registered: true,
+      slabAddress: state.slabB,
+    });
+
+    /*
+     * Invoke the real registered-markets discovery route after
+     * both keeper-register requests have reported success.
+     */
+    const discoveryResponse = await Reflect.apply(getRegisteredMarkets, undefined, []);
+
+    const discoveryPayload = await discoveryResponse.json();
+
+    const discoveredMarkets = extractMarkets(discoveryPayload);
+
+    const discoveredSlabs = discoveredMarkets
+      .map((market) => market.slabAddress)
+      .filter((slab): slab is string => typeof slab === 'string')
+      .sort();
+
+    console.info(
+      '[keeper-register route concurrency PoC]',
+      JSON.stringify(
+        {
+          responses: [
+            {
+              status: responseA.status,
+              body: bodyA,
+            },
+            {
+              status: responseB.status,
+              body: bodyB,
+            },
+          ],
+          registrationReads: state.registrationReads,
+          readSnapshots: state.readSnapshots.map((snapshot) => JSON.parse(snapshot)),
+          committedWrites: state.committedWrites,
+          discoveredSlabs,
+        },
+        null,
+        2,
+      ),
+    );
+
+    /*
+     * Both authenticated route calls report successful
+     * registration.
+     */
+    expect(responseA.status).toBe(200);
+    expect(responseB.status).toBe(200);
+
+    expect(bodyA).toMatchObject({
+      ok: true,
+      registered: true,
+      slabAddress: state.slabA,
+    });
+
+    expect(bodyB).toMatchObject({
+      ok: true,
+      registered: true,
+      slabAddress: state.slabB,
+    });
+
+    /*
+     * Safety invariant expected to FAIL on the vulnerable
+     * read-modify-write implementation.
+     */
+    expect(discoveredSlabs).toEqual([state.slabA, state.slabB]);
+  });
+});

--- a/app/__tests__/api/keeper-register-concurrency-race.test.ts
+++ b/app/__tests__/api/keeper-register-concurrency-race.test.ts
@@ -141,17 +141,6 @@ vi.mock('@vercel/blob', () => {
 
   const currentEtag = () => `etag-${state.fakeEtagVersion}`;
 
-  const streamFromText = (value: string): ReadableStream<Uint8Array> => {
-    const bytes = new TextEncoder().encode(value);
-
-    return new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(bytes);
-        controller.close();
-      },
-    });
-  };
-
   return {
     BlobPreconditionFailedError,
 
@@ -163,37 +152,6 @@ vi.mock('@vercel/blob', () => {
         },
       ],
     })),
-
-    get: vi.fn(async () => {
-      /*
-       * Both POST requests initially read the same registry and ETag.
-       * A later retry reads the latest committed registry immediately.
-       */
-      const capturedSnapshot = state.fakeStore;
-      const capturedEtag = currentEtag();
-
-      if (state.registrationReads < 2) {
-        state.registrationReads += 1;
-        state.readSnapshots.push(capturedSnapshot);
-
-        if (state.registrationReads === 2) {
-          state.releaseRegistrationReads();
-        }
-
-        await state.allRegistrationReadsArrived;
-      } else {
-        state.registrationReads += 1;
-        state.readSnapshots.push(capturedSnapshot);
-      }
-
-      return {
-        statusCode: 200,
-        stream: streamFromText(capturedSnapshot),
-        blob: {
-          etag: capturedEtag,
-        },
-      };
-    }),
 
     put: vi.fn(
       async (
@@ -311,10 +269,11 @@ beforeEach(() => {
 
   globalThis.fetch = vi.fn(async () => {
     const capturedSnapshot = state.fakeStore;
+    const capturedEtag = `etag-${state.fakeEtagVersion}`;
 
     /*
      * The first two reads belong to the two concurrent POST requests.
-     * Capture their snapshots before releasing either request.
+     * Capture their snapshot+ETag pairs before releasing either request.
      */
     if (state.registrationReads < 2) {
       state.registrationReads += 1;
@@ -342,6 +301,7 @@ beforeEach(() => {
       status: 200,
       headers: {
         'content-type': 'application/json',
+        etag: capturedEtag,
       },
     });
   }) as typeof fetch;

--- a/app/__tests__/lib/playground-registered-markets-cap.test.ts
+++ b/app/__tests__/lib/playground-registered-markets-cap.test.ts
@@ -25,17 +25,10 @@ function currentEtag(): string {
   return `etag-${fakeEtagVersion}`;
 }
 
-function streamFromText(value: string): ReadableStream<Uint8Array> {
-  const bytes = new TextEncoder().encode(value);
-
-  return new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(bytes);
-      controller.close();
-    },
-  });
-}
-
+/*
+ * Mutation reads go through list() + an origin-fresh fetch (etag taken from
+ * the response headers), so the fetch fixture below is the read layer.
+ */
 vi.mock('@vercel/blob', () => ({
   BlobPreconditionFailedError,
 
@@ -51,38 +44,6 @@ vi.mock('@vercel/blob', () => ({
           url: FAKE_BLOB_URL,
         },
       ],
-    };
-  }),
-
-  get: vi.fn(async () => {
-    if (fakeStore === null) {
-      return null;
-    }
-
-    /*
-     * Delegate reads to the existing fetch fixture so the fail-closed
-     * tests can continue simulating non-OK, network and malformed reads.
-     */
-    const response = await global.fetch(FAKE_BLOB_URL);
-
-    if (!response.ok) {
-      return {
-        statusCode: response.status || 500,
-        stream: null,
-        blob: {
-          etag: currentEtag(),
-        },
-      };
-    }
-
-    const payload = await response.json();
-
-    return {
-      statusCode: 200,
-      stream: streamFromText(JSON.stringify(payload)),
-      blob: {
-        etag: currentEtag(),
-      },
     };
   }),
 
@@ -118,6 +79,7 @@ beforeEach(() => {
   fakeStore = null;
   global.fetch = vi.fn(async () => ({
     ok: true,
+    headers: new Headers({ etag: currentEtag() }),
     json: async () => JSON.parse(fakeStore ?? '[]'),
   })) as unknown as typeof fetch;
 });

--- a/app/__tests__/lib/playground-registered-markets-cap.test.ts
+++ b/app/__tests__/lib/playground-registered-markets-cap.test.ts
@@ -7,32 +7,124 @@
  * @vercel/blob is mocked with an in-memory store so this runs without real
  * Blob credentials.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 let fakeStore: string | null = null;
-const FAKE_BLOB_URL = "http://fake-blob/playground/registered-markets.json";
+const FAKE_BLOB_URL = 'http://fake-blob/playground/registered-markets.json';
 
-vi.mock("@vercel/blob", () => ({
+let fakeEtagVersion = 0;
+
+class BlobPreconditionFailedError extends Error {
+  constructor() {
+    super('Blob precondition failed');
+    this.name = 'BlobPreconditionFailedError';
+  }
+}
+
+function currentEtag(): string {
+  return `etag-${fakeEtagVersion}`;
+}
+
+function streamFromText(value: string): ReadableStream<Uint8Array> {
+  const bytes = new TextEncoder().encode(value);
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}
+
+vi.mock('@vercel/blob', () => ({
+  BlobPreconditionFailedError,
+
   list: vi.fn(async () => {
-    if (fakeStore === null) return { blobs: [] };
-    return { blobs: [{ pathname: "playground/registered-markets.json", url: FAKE_BLOB_URL }] };
+    if (fakeStore === null) {
+      return { blobs: [] };
+    }
+
+    return {
+      blobs: [
+        {
+          pathname: 'playground/registered-markets.json',
+          url: FAKE_BLOB_URL,
+        },
+      ],
+    };
   }),
-  put: vi.fn(async (_pathname: string, body: string) => {
-    fakeStore = body;
-    return { url: FAKE_BLOB_URL };
+
+  get: vi.fn(async () => {
+    if (fakeStore === null) {
+      return null;
+    }
+
+    /*
+     * Delegate reads to the existing fetch fixture so the fail-closed
+     * tests can continue simulating non-OK, network and malformed reads.
+     */
+    const response = await global.fetch(FAKE_BLOB_URL);
+
+    if (!response.ok) {
+      return {
+        statusCode: response.status || 500,
+        stream: null,
+        blob: {
+          etag: currentEtag(),
+        },
+      };
+    }
+
+    const payload = await response.json();
+
+    return {
+      statusCode: 200,
+      stream: streamFromText(JSON.stringify(payload)),
+      blob: {
+        etag: currentEtag(),
+      },
+    };
   }),
+
+  put: vi.fn(
+    async (
+      _pathname: string,
+      body: unknown,
+      options: {
+        ifMatch?: string;
+        allowOverwrite?: boolean;
+      } = {},
+    ) => {
+      if (options.ifMatch !== undefined && options.ifMatch !== currentEtag()) {
+        throw new BlobPreconditionFailedError();
+      }
+
+      if (options.allowOverwrite === false && fakeStore !== null) {
+        throw new BlobPreconditionFailedError();
+      }
+
+      fakeStore = String(body);
+      fakeEtagVersion += 1;
+
+      return {
+        url: FAKE_BLOB_URL,
+      };
+    },
+  ),
 }));
 
 beforeEach(() => {
+  fakeEtagVersion = 0;
   fakeStore = null;
   global.fetch = vi.fn(async () => ({
     ok: true,
-    json: async () => JSON.parse(fakeStore ?? "[]"),
+    json: async () => JSON.parse(fakeStore ?? '[]'),
   })) as unknown as typeof fetch;
 });
 
 // Imported after the mock so the module under test picks up the mocked @vercel/blob.
-const { upsertRegisteredMarket, MAX_REGISTERED_MARKETS } = await import("@/lib/playground-registered-markets");
+const { upsertRegisteredMarket, MAX_REGISTERED_MARKETS } =
+  await import('@/lib/playground-registered-markets');
 type RegisteredMarket = Awaited<ReturnType<typeof upsertRegisteredMarket>>[number];
 
 function makeEntry(i: number, registeredAt: number): RegisteredMarket {
@@ -40,17 +132,17 @@ function makeEntry(i: number, registeredAt: number): RegisteredMarket {
     slabAddress: `SLAB_${i}`,
     marketAddress: `SLAB_${i}`,
     poolAddress: `POOL_${i}`,
-    dexType: "raydium-clmm",
+    dexType: 'raydium-clmm',
     symbol: null,
     label: `label-${i}`,
     mainnetCA: null,
-    collateral: "COLLATERAL_MINT",
+    collateral: 'COLLATERAL_MINT',
     registeredAt,
   };
 }
 
-describe("H1: registered-markets registry cap", () => {
-  it("caps at MAX_REGISTERED_MARKETS, evicting the oldest entry first", async () => {
+describe('H1: registered-markets registry cap', () => {
+  it('caps at MAX_REGISTERED_MARKETS, evicting the oldest entry first', async () => {
     let result: RegisteredMarket[] = [];
     for (let i = 0; i < MAX_REGISTERED_MARKETS; i++) {
       result = await upsertRegisteredMarket(makeEntry(i, i));
@@ -58,13 +150,15 @@ describe("H1: registered-markets registry cap", () => {
     expect(result).toHaveLength(MAX_REGISTERED_MARKETS);
 
     // One more registration beyond the cap should evict the oldest (SLAB_0).
-    result = await upsertRegisteredMarket(makeEntry(MAX_REGISTERED_MARKETS, MAX_REGISTERED_MARKETS));
+    result = await upsertRegisteredMarket(
+      makeEntry(MAX_REGISTERED_MARKETS, MAX_REGISTERED_MARKETS),
+    );
     expect(result).toHaveLength(MAX_REGISTERED_MARKETS);
-    expect(result.find((m) => m.slabAddress === "SLAB_0")).toBeUndefined();
+    expect(result.find((m) => m.slabAddress === 'SLAB_0')).toBeUndefined();
     expect(result.find((m) => m.slabAddress === `SLAB_${MAX_REGISTERED_MARKETS}`)).toBeDefined();
   });
 
-  it("updating an existing slab does not grow the registry or evict anything", async () => {
+  it('updating an existing slab does not grow the registry or evict anything', async () => {
     let result: RegisteredMarket[] = [];
     for (let i = 0; i < 5; i++) {
       result = await upsertRegisteredMarket(makeEntry(i, i));
@@ -74,6 +168,6 @@ describe("H1: registered-markets registry cap", () => {
     // Re-register SLAB_2 with a fresh timestamp — updates in place, doesn't grow.
     result = await upsertRegisteredMarket(makeEntry(2, 1000));
     expect(result).toHaveLength(5);
-    expect(result.find((m) => m.slabAddress === "SLAB_2")?.registeredAt).toBe(1000);
+    expect(result.find((m) => m.slabAddress === 'SLAB_2')?.registeredAt).toBe(1000);
   });
 });

--- a/app/__tests__/lib/playground-registered-markets-cas-retry.test.ts
+++ b/app/__tests__/lib/playground-registered-markets-cas-retry.test.ts
@@ -1,0 +1,209 @@
+/**
+ * CAS retry behaviors that the barrier-based race tests do not cover:
+ *
+ * 1. CDN staleness: @vercel/blob `get(..., { useCache: false })` is a silent
+ *    no-op on a PUBLIC store (the SDK only appends its cache-buster for
+ *    private access), so a CDN edge can keep serving the SAME stale
+ *    content+etag pair for up to ~60s after a write. A retry loop without
+ *    backoff burns every attempt against that identical stale pair in
+ *    milliseconds and deterministically exhausts — even for strictly
+ *    sequential registrations. The fix (origin-fresh `?ts=` reads + backoff
+ *    between attempts) must instead converge once a fresh read lands.
+ *
+ * 2. Initial-create race: the very first registration (blob not created yet)
+ *    writes with `allowOverwrite: false`. If a concurrent request creates the
+ *    blob in between, the create fails with a generic (non-precondition)
+ *    error; the loop must confirm the race by re-reading and then retry the
+ *    merge via ifMatch — preserving BOTH entries.
+ *
+ * @vercel/blob is mocked with an in-memory store, same convention as the
+ * sibling registered-markets tests.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let fakeStore: string | null = null;
+const FAKE_BLOB_URL = 'http://fake-blob/playground/registered-markets.json';
+
+let fakeEtagVersion = 0;
+
+/** When set, the NEXT create-only put simulates a concurrent creator winning first. */
+const createRace = { entryJson: null as string | null };
+
+class BlobPreconditionFailedError extends Error {
+  constructor() {
+    super('Blob precondition failed');
+    this.name = 'BlobPreconditionFailedError';
+  }
+}
+
+function currentEtag(): string {
+  return `etag-${fakeEtagVersion}`;
+}
+
+vi.mock('@vercel/blob', () => ({
+  BlobPreconditionFailedError,
+
+  list: vi.fn(async () => {
+    if (fakeStore === null) {
+      return { blobs: [] };
+    }
+
+    return {
+      blobs: [
+        {
+          pathname: 'playground/registered-markets.json',
+          url: FAKE_BLOB_URL,
+        },
+      ],
+    };
+  }),
+
+  put: vi.fn(
+    async (
+      _pathname: string,
+      body: unknown,
+      options: {
+        ifMatch?: string;
+        allowOverwrite?: boolean;
+      } = {},
+    ) => {
+      if (options.ifMatch !== undefined && options.ifMatch !== currentEtag()) {
+        throw new BlobPreconditionFailedError();
+      }
+
+      if (options.allowOverwrite === false) {
+        if (createRace.entryJson !== null) {
+          // A concurrent request creates the blob between this caller's
+          // read (which saw nothing) and its create-only write.
+          fakeStore = `[${createRace.entryJson}]`;
+          fakeEtagVersion += 1;
+          createRace.entryJson = null;
+          throw new Error('blob already exists');
+        }
+
+        if (fakeStore !== null) {
+          throw new Error('blob already exists');
+        }
+      }
+
+      fakeStore = String(body);
+      fakeEtagVersion += 1;
+
+      return {
+        url: FAKE_BLOB_URL,
+      };
+    },
+  ),
+}));
+
+beforeEach(() => {
+  fakeEtagVersion = 0;
+  fakeStore = null;
+  createRace.entryJson = null;
+});
+
+const { upsertRegisteredMarket } = await import('@/lib/playground-registered-markets');
+type RegisteredMarket = Awaited<ReturnType<typeof upsertRegisteredMarket>>[number];
+
+function makeEntry(i: number): RegisteredMarket {
+  return {
+    slabAddress: `SLAB_${i}`,
+    marketAddress: `SLAB_${i}`,
+    poolAddress: `POOL_${i}`,
+    dexType: 'raydium-clmm',
+    symbol: null,
+    label: `label-${i}`,
+    mainnetCA: null,
+    collateral: 'COLLATERAL_MINT',
+    registeredAt: i,
+  };
+}
+
+function healthyFetch(): typeof fetch {
+  return vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    headers: new Headers({ etag: currentEtag() }),
+    json: async () => JSON.parse(fakeStore ?? '[]'),
+  })) as unknown as typeof fetch;
+}
+
+describe('registered-markets CAS retry behaviors', () => {
+  it('recovers from stale CDN reads: retries back off and re-read until a fresh etag+content pair lands', async () => {
+    // Seed two registrations; store is now [SLAB_1, SLAB_2] at etag-2.
+    global.fetch = healthyFetch();
+    await upsertRegisteredMarket(makeEntry(1));
+    await upsertRegisteredMarket(makeEntry(2));
+    expect(currentEtag()).toBe('etag-2');
+
+    // The CDN edge keeps serving the pre-SLAB_2 snapshot (WITH its matching
+    // stale etag) for the first two mutation reads, then origin freshness
+    // kicks in. Every stale attempt must fail the ifMatch write and retry.
+    const staleSnapshot = JSON.stringify([makeEntry(1)]);
+    let reads = 0;
+    global.fetch = vi.fn(async () => {
+      reads += 1;
+      if (reads <= 2) {
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers({ etag: 'etag-1' }),
+          json: async () => JSON.parse(staleSnapshot),
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers({ etag: currentEtag() }),
+        json: async () => JSON.parse(fakeStore ?? '[]'),
+      };
+    }) as unknown as typeof fetch;
+
+    const startedAt = Date.now();
+    const result = await upsertRegisteredMarket(makeEntry(3));
+    const elapsedMs = Date.now() - startedAt;
+
+    // Succeeded on the third (first fresh) read without losing SLAB_2.
+    expect(reads).toBe(3);
+    expect(result.map((m) => m.slabAddress).sort()).toEqual(['SLAB_1', 'SLAB_2', 'SLAB_3']);
+    expect(
+      (JSON.parse(fakeStore!) as RegisteredMarket[]).map((m) => m.slabAddress).sort(),
+    ).toEqual(['SLAB_1', 'SLAB_2', 'SLAB_3']);
+
+    // Backoff actually waited between the two failed attempts
+    // (jitter floor is 50% of 150ms + 300ms = 225ms; allow timer slop).
+    expect(elapsedMs).toBeGreaterThanOrEqual(200);
+  });
+
+  it('initial-create race: create-only write loses, confirms via re-read, then merges with ifMatch — both entries survive', async () => {
+    global.fetch = healthyFetch();
+
+    // Blob does not exist yet; another request wins the create with SLAB_9
+    // between our read (saw nothing) and our allowOverwrite:false put.
+    createRace.entryJson = JSON.stringify(makeEntry(9));
+
+    const result = await upsertRegisteredMarket(makeEntry(1));
+
+    expect(result.map((m) => m.slabAddress).sort()).toEqual(['SLAB_1', 'SLAB_9']);
+    expect(
+      (JSON.parse(fakeStore!) as RegisteredMarket[]).map((m) => m.slabAddress).sort(),
+    ).toEqual(['SLAB_1', 'SLAB_9']);
+  });
+
+  it('fails closed when the origin response carries no ETag (cannot CAS without a token)', async () => {
+    global.fetch = healthyFetch();
+    await upsertRegisteredMarket(makeEntry(1));
+
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: new Headers({}),
+      json: async () => JSON.parse(fakeStore!),
+    })) as unknown as typeof fetch;
+
+    await expect(upsertRegisteredMarket(makeEntry(2))).rejects.toThrow();
+    expect((JSON.parse(fakeStore!) as RegisteredMarket[]).map((m) => m.slabAddress)).toEqual([
+      'SLAB_1',
+    ]);
+  });
+});

--- a/app/__tests__/lib/playground-registered-markets-concurrency-race.test.ts
+++ b/app/__tests__/lib/playground-registered-markets-concurrency-race.test.ts
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Deterministic lost-update PoC.
+ *
+ * Both concurrent registrations are forced to read the same registry snapshot.
+ * Their writes are then committed in a deterministic A -> B order.
+ *
+ * A correct implementation must preserve both registrations.
+ * The current read-modify-write implementation instead allows B to overwrite A.
+ */
+
+const state = vi.hoisted(() => ({
+  fakeStore: '[]',
+  fakeEtagVersion: 0,
+  readArrivals: 0,
+  readSnapshots: [] as string[],
+  writeBodies: [] as string[][],
+
+  allReadsArrived: Promise.resolve(),
+  releaseReads: () => {},
+
+  firstWriteDone: Promise.resolve(),
+  releaseFirstWrite: () => {},
+}));
+
+vi.mock('@vercel/blob', () => {
+  class BlobPreconditionFailedError extends Error {
+    constructor() {
+      super('Blob precondition failed');
+      this.name = 'BlobPreconditionFailedError';
+    }
+  }
+
+  const currentEtag = () => `etag-${state.fakeEtagVersion}`;
+
+  const streamFromText = (value: string): ReadableStream<Uint8Array> => {
+    const bytes = new TextEncoder().encode(value);
+
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(bytes);
+        controller.close();
+      },
+    });
+  };
+
+  return {
+    BlobPreconditionFailedError,
+
+    list: vi.fn(async () => ({
+      blobs: [
+        {
+          pathname: 'playground/registered-markets.json',
+          url: 'https://blob.test/playground/registered-markets.json',
+        },
+      ],
+    })),
+
+    get: vi.fn(async () => {
+      /*
+       * Force both initial mutation reads to observe the same content and ETag.
+       * Retry reads are allowed through immediately and observe the latest state.
+       */
+      const capturedSnapshot = state.fakeStore;
+      const capturedEtag = currentEtag();
+
+      if (state.readArrivals < 2) {
+        state.readArrivals += 1;
+        state.readSnapshots.push(capturedSnapshot);
+
+        if (state.readArrivals === 2) {
+          state.releaseReads();
+        }
+
+        await state.allReadsArrived;
+      } else {
+        state.readSnapshots.push(capturedSnapshot);
+      }
+
+      return {
+        statusCode: 200,
+        stream: streamFromText(capturedSnapshot),
+        blob: {
+          etag: capturedEtag,
+        },
+      };
+    }),
+
+    put: vi.fn(
+      async (
+        _pathname: string,
+        body: unknown,
+        options: {
+          ifMatch?: string;
+          allowOverwrite?: boolean;
+        } = {},
+      ) => {
+        const nextRegistry = JSON.parse(String(body)) as Array<{
+          slabAddress?: string;
+        }>;
+
+        const slabs = nextRegistry
+          .map((entry) => entry.slabAddress)
+          .filter((slab): slab is string => typeof slab === 'string');
+
+        const containsA = slabs.includes('race-market-a');
+        const containsB = slabs.includes('race-market-b');
+
+        /*
+         * Deterministically let A commit first. B's stale first attempt then
+         * reaches the conditional write only after A changed the ETag.
+         */
+        if (containsB && !containsA) {
+          await state.firstWriteDone;
+        }
+
+        if (options.ifMatch !== undefined && options.ifMatch !== currentEtag()) {
+          throw new BlobPreconditionFailedError();
+        }
+
+        if (options.allowOverwrite === false && state.fakeStore !== '[]') {
+          throw new BlobPreconditionFailedError();
+        }
+
+        state.fakeStore = JSON.stringify(nextRegistry);
+        state.writeBodies.push(slabs);
+        state.fakeEtagVersion += 1;
+
+        if (containsA && !containsB) {
+          state.releaseFirstWrite();
+        }
+
+        return {
+          url: 'https://blob.test/playground/registered-markets.json',
+          etag: currentEtag(),
+        };
+      },
+    ),
+  };
+});
+
+const { upsertRegisteredMarket } = await import('@/lib/playground-registered-markets');
+
+type RegisteredMarket = Parameters<typeof upsertRegisteredMarket>[0];
+
+function makeEntry(slabAddress: string): RegisteredMarket {
+  const suffix = slabAddress.endsWith('-a') ? 'a' : 'b';
+
+  return {
+    slabAddress,
+    marketAddress: slabAddress,
+    poolAddress: `race-pool-${suffix}`,
+    dexType: 'raydium-clmm',
+    symbol: `RACE-${suffix.toUpperCase()}`,
+    label: `Race market ${suffix}`,
+    mainnetCA: null,
+    collateral: 'race-collateral',
+    registeredAt: suffix === 'a' ? 1 : 2,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  state.fakeStore = '[]';
+  state.fakeEtagVersion = 0;
+  state.readArrivals = 0;
+  state.readSnapshots.length = 0;
+  state.writeBodies.length = 0;
+
+  state.allReadsArrived = new Promise<void>((resolve) => {
+    state.releaseReads = resolve;
+  });
+
+  state.firstWriteDone = new Promise<void>((resolve) => {
+    state.releaseFirstWrite = resolve;
+  });
+
+  global.fetch = vi.fn(async () => {
+    /*
+     * Capture the snapshot before waiting at the barrier.
+     * Therefore both requests deterministically retain the same stale value.
+     */
+    const capturedSnapshot = state.fakeStore;
+
+    state.readSnapshots.push(capturedSnapshot);
+    state.readArrivals += 1;
+
+    if (state.readArrivals === 2) {
+      state.releaseReads();
+    }
+
+    await state.allReadsArrived;
+
+    return {
+      ok: true,
+      status: 200,
+      json: async () => JSON.parse(capturedSnapshot),
+    } as Response;
+  });
+});
+
+describe('registered-markets concurrent upsert safety', () => {
+  it('preserves both registrations when concurrent requests read the same snapshot', async () => {
+    await Promise.all([
+      upsertRegisteredMarket(makeEntry('race-market-a')),
+      upsertRegisteredMarket(makeEntry('race-market-b')),
+    ]);
+
+    const finalRegistry = JSON.parse(state.fakeStore) as Array<{
+      slabAddress?: string;
+    }>;
+
+    const finalSlabs = finalRegistry
+      .map((entry) => entry.slabAddress)
+      .filter((slab): slab is string => typeof slab === 'string')
+      .sort();
+
+    console.info(
+      '[registered-markets concurrency PoC]',
+      JSON.stringify(
+        {
+          readsObserved: state.readArrivals,
+          readSnapshots: state.readSnapshots.map((snapshot) => JSON.parse(snapshot)),
+          committedWrites: state.writeBodies,
+          finalRegistry: finalSlabs,
+        },
+        null,
+        2,
+      ),
+    );
+
+    /*
+     * Safety invariant:
+     * every successful concurrent registration must remain discoverable.
+     *
+     * This assertion is expected to FAIL on the vulnerable implementation
+     * because the second overwrite removes race-market-a.
+     */
+    expect(finalSlabs).toEqual(['race-market-a', 'race-market-b']);
+  });
+});

--- a/app/__tests__/lib/playground-registered-markets-concurrency-race.test.ts
+++ b/app/__tests__/lib/playground-registered-markets-concurrency-race.test.ts
@@ -34,17 +34,6 @@ vi.mock('@vercel/blob', () => {
 
   const currentEtag = () => `etag-${state.fakeEtagVersion}`;
 
-  const streamFromText = (value: string): ReadableStream<Uint8Array> => {
-    const bytes = new TextEncoder().encode(value);
-
-    return new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(bytes);
-        controller.close();
-      },
-    });
-  };
-
   return {
     BlobPreconditionFailedError,
 
@@ -56,36 +45,6 @@ vi.mock('@vercel/blob', () => {
         },
       ],
     })),
-
-    get: vi.fn(async () => {
-      /*
-       * Force both initial mutation reads to observe the same content and ETag.
-       * Retry reads are allowed through immediately and observe the latest state.
-       */
-      const capturedSnapshot = state.fakeStore;
-      const capturedEtag = currentEtag();
-
-      if (state.readArrivals < 2) {
-        state.readArrivals += 1;
-        state.readSnapshots.push(capturedSnapshot);
-
-        if (state.readArrivals === 2) {
-          state.releaseReads();
-        }
-
-        await state.allReadsArrived;
-      } else {
-        state.readSnapshots.push(capturedSnapshot);
-      }
-
-      return {
-        statusCode: 200,
-        stream: streamFromText(capturedSnapshot),
-        blob: {
-          etag: capturedEtag,
-        },
-      };
-    }),
 
     put: vi.fn(
       async (
@@ -179,10 +138,11 @@ beforeEach(() => {
 
   global.fetch = vi.fn(async () => {
     /*
-     * Capture the snapshot before waiting at the barrier.
-     * Therefore both requests deterministically retain the same stale value.
+     * Capture the snapshot AND its ETag before waiting at the barrier.
+     * Therefore both requests deterministically retain the same stale pair.
      */
     const capturedSnapshot = state.fakeStore;
+    const capturedEtag = `etag-${state.fakeEtagVersion}`;
 
     state.readSnapshots.push(capturedSnapshot);
     state.readArrivals += 1;
@@ -196,6 +156,7 @@ beforeEach(() => {
     return {
       ok: true,
       status: 200,
+      headers: new Headers({ etag: capturedEtag }),
       json: async () => JSON.parse(capturedSnapshot),
     } as Response;
   });

--- a/app/__tests__/lib/playground-registered-markets-fail-closed.test.ts
+++ b/app/__tests__/lib/playground-registered-markets-fail-closed.test.ts
@@ -32,17 +32,11 @@ function currentEtag(): string {
   return `etag-${fakeEtagVersion}`;
 }
 
-function streamFromText(value: string): ReadableStream<Uint8Array> {
-  const bytes = new TextEncoder().encode(value);
-
-  return new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(bytes);
-      controller.close();
-    },
-  });
-}
-
+/*
+ * Mutation reads now go through list() + an origin-fresh fetch (etag taken
+ * from the response headers) — no more @vercel/blob get(). The fetch fixtures
+ * below simulate healthy, non-OK, network-throw and malformed reads.
+ */
 vi.mock('@vercel/blob', () => ({
   BlobPreconditionFailedError,
 
@@ -58,38 +52,6 @@ vi.mock('@vercel/blob', () => ({
           url: FAKE_BLOB_URL,
         },
       ],
-    };
-  }),
-
-  get: vi.fn(async () => {
-    if (fakeStore === null) {
-      return null;
-    }
-
-    /*
-     * Delegate reads to the existing fetch fixture so the fail-closed
-     * tests can continue simulating non-OK, network and malformed reads.
-     */
-    const response = await global.fetch(FAKE_BLOB_URL);
-
-    if (!response.ok) {
-      return {
-        statusCode: response.status || 500,
-        stream: null,
-        blob: {
-          etag: currentEtag(),
-        },
-      };
-    }
-
-    const payload = await response.json();
-
-    return {
-      statusCode: 200,
-      stream: streamFromText(JSON.stringify(payload)),
-      blob: {
-        etag: currentEtag(),
-      },
     };
   }),
 
@@ -147,6 +109,7 @@ describe('J: playground-registered-markets fails CLOSED on a read failure', () =
   it('baseline: a healthy read + upsert round-trips normally', async () => {
     global.fetch = vi.fn(async () => ({
       ok: true,
+      headers: new Headers({ etag: currentEtag() }),
       json: async () => JSON.parse(fakeStore ?? '[]'),
     })) as any;
     await upsertRegisteredMarket(makeEntry(1));
@@ -158,6 +121,7 @@ describe('J: playground-registered-markets fails CLOSED on a read failure', () =
     // Seed the blob with 3 existing registrations via a healthy read/write.
     global.fetch = vi.fn(async () => ({
       ok: true,
+      headers: new Headers({ etag: currentEtag() }),
       json: async () => JSON.parse(fakeStore ?? '[]'),
     })) as any;
     await upsertRegisteredMarket(makeEntry(1));
@@ -191,6 +155,7 @@ describe('J: playground-registered-markets fails CLOSED on a read failure', () =
   it('upsertRegisteredMarket ABORTS on a network-level fetch throw', async () => {
     global.fetch = vi.fn(async () => ({
       ok: true,
+      headers: new Headers({ etag: currentEtag() }),
       json: async () => JSON.parse(fakeStore ?? '[]'),
     })) as any;
     await upsertRegisteredMarket(makeEntry(1));
@@ -208,6 +173,7 @@ describe('J: playground-registered-markets fails CLOSED on a read failure', () =
   it('upsertRegisteredMarket ABORTS on malformed (non-array) blob content', async () => {
     global.fetch = vi.fn(async () => ({
       ok: true,
+      headers: new Headers({ etag: currentEtag() }),
       json: async () => JSON.parse(fakeStore ?? '[]'),
     })) as any;
     await upsertRegisteredMarket(makeEntry(1));
@@ -216,6 +182,7 @@ describe('J: playground-registered-markets fails CLOSED on a read failure', () =
     fakeStore = JSON.stringify({ not: 'an array' });
     global.fetch = vi.fn(async () => ({
       ok: true,
+      headers: new Headers({ etag: currentEtag() }),
       json: async () => JSON.parse(fakeStore!),
     })) as any;
 

--- a/app/__tests__/lib/playground-registered-markets-fail-closed.test.ts
+++ b/app/__tests__/lib/playground-registered-markets-fail-closed.test.ts
@@ -14,29 +14,119 @@
  * @vercel/blob is mocked with an in-memory store, same convention as the
  * existing __tests__/lib/playground-registered-markets-cap.test.ts.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 let fakeStore: string | null = null;
-const FAKE_BLOB_URL = "http://fake-blob/playground/registered-markets.json";
+const FAKE_BLOB_URL = 'http://fake-blob/playground/registered-markets.json';
 
-vi.mock("@vercel/blob", () => ({
+let fakeEtagVersion = 0;
+
+class BlobPreconditionFailedError extends Error {
+  constructor() {
+    super('Blob precondition failed');
+    this.name = 'BlobPreconditionFailedError';
+  }
+}
+
+function currentEtag(): string {
+  return `etag-${fakeEtagVersion}`;
+}
+
+function streamFromText(value: string): ReadableStream<Uint8Array> {
+  const bytes = new TextEncoder().encode(value);
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}
+
+vi.mock('@vercel/blob', () => ({
+  BlobPreconditionFailedError,
+
   list: vi.fn(async () => {
-    if (fakeStore === null) return { blobs: [] };
-    return { blobs: [{ pathname: "playground/registered-markets.json", url: FAKE_BLOB_URL }] };
+    if (fakeStore === null) {
+      return { blobs: [] };
+    }
+
+    return {
+      blobs: [
+        {
+          pathname: 'playground/registered-markets.json',
+          url: FAKE_BLOB_URL,
+        },
+      ],
+    };
   }),
-  put: vi.fn(async (_pathname: string, body: string) => {
-    fakeStore = body;
-    return { url: FAKE_BLOB_URL };
+
+  get: vi.fn(async () => {
+    if (fakeStore === null) {
+      return null;
+    }
+
+    /*
+     * Delegate reads to the existing fetch fixture so the fail-closed
+     * tests can continue simulating non-OK, network and malformed reads.
+     */
+    const response = await global.fetch(FAKE_BLOB_URL);
+
+    if (!response.ok) {
+      return {
+        statusCode: response.status || 500,
+        stream: null,
+        blob: {
+          etag: currentEtag(),
+        },
+      };
+    }
+
+    const payload = await response.json();
+
+    return {
+      statusCode: 200,
+      stream: streamFromText(JSON.stringify(payload)),
+      blob: {
+        etag: currentEtag(),
+      },
+    };
   }),
+
+  put: vi.fn(
+    async (
+      _pathname: string,
+      body: unknown,
+      options: {
+        ifMatch?: string;
+        allowOverwrite?: boolean;
+      } = {},
+    ) => {
+      if (options.ifMatch !== undefined && options.ifMatch !== currentEtag()) {
+        throw new BlobPreconditionFailedError();
+      }
+
+      if (options.allowOverwrite === false && fakeStore !== null) {
+        throw new BlobPreconditionFailedError();
+      }
+
+      fakeStore = String(body);
+      fakeEtagVersion += 1;
+
+      return {
+        url: FAKE_BLOB_URL,
+      };
+    },
+  ),
 }));
 
 beforeEach(() => {
+  fakeEtagVersion = 0;
   fakeStore = null;
 });
 
-const { readRegisteredMarkets, upsertRegisteredMarket } = await import(
-  "@/lib/playground-registered-markets"
-);
+const { readRegisteredMarkets, upsertRegisteredMarket } =
+  await import('@/lib/playground-registered-markets');
 type RegisteredMarket = Awaited<ReturnType<typeof upsertRegisteredMarket>>[number];
 
 function makeEntry(i: number): RegisteredMarket {
@@ -44,26 +134,32 @@ function makeEntry(i: number): RegisteredMarket {
     slabAddress: `SLAB_${i}`,
     marketAddress: `SLAB_${i}`,
     poolAddress: `POOL_${i}`,
-    dexType: "raydium-clmm",
+    dexType: 'raydium-clmm',
     symbol: null,
     label: `label-${i}`,
     mainnetCA: null,
-    collateral: "COLLATERAL_MINT",
+    collateral: 'COLLATERAL_MINT',
     registeredAt: i,
   };
 }
 
-describe("J: playground-registered-markets fails CLOSED on a read failure", () => {
-  it("baseline: a healthy read + upsert round-trips normally", async () => {
-    global.fetch = vi.fn(async () => ({ ok: true, json: async () => JSON.parse(fakeStore ?? "[]") })) as any;
+describe('J: playground-registered-markets fails CLOSED on a read failure', () => {
+  it('baseline: a healthy read + upsert round-trips normally', async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => JSON.parse(fakeStore ?? '[]'),
+    })) as any;
     await upsertRegisteredMarket(makeEntry(1));
     const result = await upsertRegisteredMarket(makeEntry(2));
     expect(result).toHaveLength(2);
   });
 
-  it("upsertRegisteredMarket ABORTS (throws) on a non-OK blob read, instead of overwriting with a partial list", async () => {
+  it('upsertRegisteredMarket ABORTS (throws) on a non-OK blob read, instead of overwriting with a partial list', async () => {
     // Seed the blob with 3 existing registrations via a healthy read/write.
-    global.fetch = vi.fn(async () => ({ ok: true, json: async () => JSON.parse(fakeStore ?? "[]") })) as any;
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => JSON.parse(fakeStore ?? '[]'),
+    })) as any;
     await upsertRegisteredMarket(makeEntry(1));
     await upsertRegisteredMarket(makeEntry(2));
     await upsertRegisteredMarket(makeEntry(3));
@@ -72,49 +168,76 @@ describe("J: playground-registered-markets fails CLOSED on a read failure", () =
 
     // Now simulate a transient CDN/read failure (non-OK response) on the NEXT
     // registration attempt.
-    global.fetch = vi.fn(async () => ({ ok: false, status: 503, json: async () => { throw new Error("should not parse"); } })) as any;
+    global.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 503,
+      json: async () => {
+        throw new Error('should not parse');
+      },
+    })) as any;
 
     await expect(upsertRegisteredMarket(makeEntry(4))).rejects.toThrow();
 
     // The blob must be UNTOUCHED — not overwritten with a single-entry array.
     const after = JSON.parse(fakeStore!);
     expect(after).toHaveLength(3);
-    expect(after.map((m: RegisteredMarket) => m.slabAddress).sort()).toEqual(["SLAB_1", "SLAB_2", "SLAB_3"]);
+    expect(after.map((m: RegisteredMarket) => m.slabAddress).sort()).toEqual([
+      'SLAB_1',
+      'SLAB_2',
+      'SLAB_3',
+    ]);
   });
 
-  it("upsertRegisteredMarket ABORTS on a network-level fetch throw", async () => {
-    global.fetch = vi.fn(async () => ({ ok: true, json: async () => JSON.parse(fakeStore ?? "[]") })) as any;
+  it('upsertRegisteredMarket ABORTS on a network-level fetch throw', async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => JSON.parse(fakeStore ?? '[]'),
+    })) as any;
     await upsertRegisteredMarket(makeEntry(1));
     await upsertRegisteredMarket(makeEntry(2));
 
-    global.fetch = vi.fn(async () => { throw new Error("network blip"); }) as any;
+    global.fetch = vi.fn(async () => {
+      throw new Error('network blip');
+    }) as any;
     await expect(upsertRegisteredMarket(makeEntry(3))).rejects.toThrow();
 
     const after = JSON.parse(fakeStore!);
     expect(after).toHaveLength(2); // untouched
   });
 
-  it("upsertRegisteredMarket ABORTS on malformed (non-array) blob content", async () => {
-    global.fetch = vi.fn(async () => ({ ok: true, json: async () => JSON.parse(fakeStore ?? "[]") })) as any;
+  it('upsertRegisteredMarket ABORTS on malformed (non-array) blob content', async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => JSON.parse(fakeStore ?? '[]'),
+    })) as any;
     await upsertRegisteredMarket(makeEntry(1));
 
     // Corrupt the stored payload directly (simulates a partial/garbled write elsewhere).
-    fakeStore = JSON.stringify({ not: "an array" });
-    global.fetch = vi.fn(async () => ({ ok: true, json: async () => JSON.parse(fakeStore!) })) as any;
+    fakeStore = JSON.stringify({ not: 'an array' });
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => JSON.parse(fakeStore!),
+    })) as any;
 
     await expect(upsertRegisteredMarket(makeEntry(2))).rejects.toThrow();
     // Still the corrupted (untouched) content — not silently replaced.
-    expect(JSON.parse(fakeStore!)).toEqual({ not: "an array" });
+    expect(JSON.parse(fakeStore!)).toEqual({ not: 'an array' });
   });
 
-  it("readRegisteredMarkets() (the lenient GET-route path) still degrades to [] on the SAME failures — never throws", async () => {
-    global.fetch = vi.fn(async () => ({ ok: false, status: 503, json: async () => { throw new Error("nope"); } })) as any;
+  it('readRegisteredMarkets() (the lenient GET-route path) still degrades to [] on the SAME failures — never throws', async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 503,
+      json: async () => {
+        throw new Error('nope');
+      },
+    })) as any;
     // list() reports a blob exists (fakeStore starts non-null after a prior seed
     // in a real scenario) — here we just confirm no throw and an empty result.
     await expect(readRegisteredMarkets()).resolves.toEqual([]);
   });
 
-  it("a genuinely not-yet-created blob (no prior registrations) is a real empty state, not a failure", async () => {
+  it('a genuinely not-yet-created blob (no prior registrations) is a real empty state, not a failure', async () => {
     // fakeStore is null (beforeEach) -> list() returns no blobs -> genuinely empty.
     global.fetch = vi.fn() as any; // must not even be called
     const result = await upsertRegisteredMarket(makeEntry(1));

--- a/app/lib/playground-registered-markets.ts
+++ b/app/lib/playground-registered-markets.ts
@@ -16,7 +16,7 @@
  * it's the only place that carries `poolAddress`/`dexType` alongside the devnet
  * `marketAddress`.
  */
-import { BlobPreconditionFailedError, get, list, put } from '@vercel/blob';
+import { BlobPreconditionFailedError, list, put } from '@vercel/blob';
 
 /** Fixed, non-random-suffixed pathname — there is exactly one blob for this store. */
 export const REGISTERED_MARKETS_BLOB_PATHNAME = 'playground/registered-markets.json';
@@ -87,36 +87,75 @@ interface RegisteredMarketsMutationReadResult {
   ok: boolean;
 }
 
-interface RegisteredMarketsWriteOptions {
-  /**
-   * Existing-blob optimistic concurrency token.
-   * Blob requires overwrite mode whenever `ifMatch` is supplied.
-   */
-  ifMatch?: string;
-
-  /**
-   * False on the initial-create path so another concurrent creator
-   * cannot be overwritten.
-   */
-  allowOverwrite?: boolean;
-}
+/**
+ * Write guard: every write MUST be conditional — either an existing-blob
+ * optimistic-concurrency token (`ifMatch`) or a create-only write
+ * (`allowOverwrite: false`). There is deliberately no unconditional-overwrite
+ * variant: this union (plus the function no longer being exported) makes a
+ * CAS-bypassing "just put()" write unrepresentable.
+ */
+type RegisteredMarketsWriteOptions =
+  | {
+      /**
+       * Existing-blob optimistic concurrency token.
+       * Blob requires overwrite mode whenever `ifMatch` is supplied.
+       */
+      ifMatch: string;
+    }
+  | {
+      /**
+       * False on the initial-create path so another concurrent creator
+       * cannot be overwritten.
+       */
+      allowOverwrite: false;
+    };
 
 const REGISTERED_MARKETS_WRITE_MAX_ATTEMPTS = 5;
+const REGISTERED_MARKETS_RETRY_BASE_DELAY_MS = 150;
+const REGISTERED_MARKETS_RETRY_MAX_DELAY_MS = 2_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 /**
- * Read registry content and its ETag from the same Blob response.
+ * Exponential backoff with jitter between CAS attempts: 150ms base, doubling,
+ * capped at 2s, jittered to 50-100% of the computed delay. Without this, a
+ * precondition_failed retry loop re-reads immediately and (behind a CDN edge
+ * that can serve the same stale snapshot for up to ~60s after a write) burns
+ * all attempts in milliseconds against the identical stale content+etag pair.
+ */
+function casRetryDelayMs(attempt: number): number {
+  const exp = Math.min(
+    REGISTERED_MARKETS_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1),
+    REGISTERED_MARKETS_RETRY_MAX_DELAY_MS,
+  );
+  return Math.floor(exp / 2 + Math.random() * (exp / 2));
+}
+
+/**
+ * Read registry content AND its ETag from one origin-fresh response, so the
+ * CAS token always belongs to the exact bytes that were merged against.
  *
- * Mutation reads bypass the CDN so retries always merge against the
- * latest origin version.
+ * Why not `get(..., { useCache: false })`: on a PUBLIC blob store the SDK's
+ * `useCache: false` is a silent no-op (its cache-busting query is only added
+ * for `access: 'private'`), so `get()` reads go through the CDN and can be
+ * stale for up to ~60s after a write — every retry would then re-read the same
+ * stale content+etag pair and deterministically exhaust. Instead we `list()`
+ * for the blob URL and fetch it with a unique `?ts=` query (plus
+ * `cache: 'no-store'`), which forces a fresh origin read, taking both the body
+ * and the `etag` response header from that same response.
  */
 async function readRegisteredMarketsForMutation(): Promise<RegisteredMarketsMutationReadResult> {
   try {
-    const result = await get(REGISTERED_MARKETS_BLOB_PATHNAME, {
-      access: 'public',
-      useCache: false,
+    const { blobs } = await list({
+      prefix: REGISTERED_MARKETS_BLOB_PATHNAME,
+      limit: 1,
     });
+    const found = blobs.find((b) => b.pathname === REGISTERED_MARKETS_BLOB_PATHNAME);
 
-    if (result === null) {
+    // Genuinely not created yet — the caller takes the create-only write path.
+    if (!found) {
       return {
         markets: [],
         etag: null,
@@ -124,8 +163,12 @@ async function readRegisteredMarketsForMutation(): Promise<RegisteredMarketsMuta
       };
     }
 
-    if (result.statusCode !== 200 || result.stream === null) {
-      console.error('[playground-registered-markets] unexpected Blob GET response');
+    const resp = await fetch(`${found.url}?ts=${Date.now()}`, { cache: 'no-store' });
+
+    if (!resp.ok) {
+      console.error(
+        `[playground-registered-markets] blob fetch ${resp.status} — mutation read failed`,
+      );
 
       return {
         markets: [],
@@ -134,7 +177,23 @@ async function readRegisteredMarketsForMutation(): Promise<RegisteredMarketsMuta
       };
     }
 
-    const data: unknown = await new Response(result.stream).json();
+    // Strip a weak-validator prefix if an intermediary added one; ifMatch
+    // must carry the token exactly as the Blob store knows it.
+    const etag = resp.headers.get('etag')?.replace(/^W\//, '') ?? null;
+
+    if (etag === null) {
+      console.error(
+        '[playground-registered-markets] blob response carried no ETag — cannot CAS, mutation read failed',
+      );
+
+      return {
+        markets: [],
+        etag: null,
+        ok: false,
+      };
+    }
+
+    const data: unknown = await resp.json();
 
     if (!Array.isArray(data)) {
       console.error(
@@ -150,7 +209,7 @@ async function readRegisteredMarketsForMutation(): Promise<RegisteredMarketsMuta
 
     return {
       markets: data.filter(isRegisteredMarket),
-      etag: result.blob.etag,
+      etag,
       ok: true,
     };
   } catch (err) {
@@ -221,23 +280,24 @@ export async function readRegisteredMarkets(): Promise<RegisteredMarket[]> {
 }
 
 /**
- * Persist a complete registry snapshot.
- *
- * Existing snapshots may be guarded by `ifMatch`. Initial creation may
- * disable overwrite so a concurrent creator cannot be silently replaced.
+ * Persist a complete registry snapshot. NOT exported: all writes must go
+ * through `upsertRegisteredMarket`'s read-merge-CAS loop, and the options
+ * union makes an unconditional overwrite unrepresentable — existing
+ * snapshots are guarded by `ifMatch`, initial creation disables overwrite
+ * so a concurrent creator cannot be silently replaced.
  */
-export async function writeRegisteredMarkets(
+async function writeRegisteredMarkets(
   markets: RegisteredMarket[],
-  options: RegisteredMarketsWriteOptions = {},
+  options: RegisteredMarketsWriteOptions,
 ): Promise<void> {
-  const ifMatch = options.ifMatch;
+  const ifMatch = 'ifMatch' in options ? options.ifMatch : undefined;
 
   await put(REGISTERED_MARKETS_BLOB_PATHNAME, JSON.stringify(markets), {
     access: 'public',
     addRandomSuffix: false,
     contentType: 'application/json',
 
-    allowOverwrite: ifMatch !== undefined ? true : (options.allowOverwrite ?? true),
+    allowOverwrite: ifMatch !== undefined,
 
     ...(ifMatch !== undefined ? { ifMatch } : {}),
 
@@ -282,9 +342,10 @@ function applyRegisteredMarketUpsert(
 /**
  * Upsert a registered market using Blob optimistic concurrency.
  *
- * A stale ETag causes the operation to read the newest registry,
- * recompute the merge and retry. A failed initial create is retried only
- * when a follow-up read confirms another request created the blob.
+ * A stale ETag causes the operation to back off (exponential + jitter),
+ * read the newest registry, recompute the merge and retry. A failed
+ * initial create is retried only when a follow-up read confirms another
+ * request created the blob.
  */
 export async function upsertRegisteredMarket(entry: RegisteredMarket): Promise<RegisteredMarket[]> {
   let lastConflict: unknown;
@@ -318,6 +379,7 @@ export async function upsertRegisteredMarket(entry: RegisteredMarket): Promise<R
       if (snapshot.etag !== null) {
         if (err instanceof BlobPreconditionFailedError) {
           lastConflict = err;
+          await sleep(casRetryDelayMs(attempt));
           continue;
         }
 
@@ -332,6 +394,7 @@ export async function upsertRegisteredMarket(entry: RegisteredMarket): Promise<R
 
       if (afterCreateFailure.ok && afterCreateFailure.etag !== null) {
         lastConflict = err;
+        await sleep(casRetryDelayMs(attempt));
         continue;
       }
 

--- a/app/lib/playground-registered-markets.ts
+++ b/app/lib/playground-registered-markets.ts
@@ -16,10 +16,10 @@
  * it's the only place that carries `poolAddress`/`dexType` alongside the devnet
  * `marketAddress`.
  */
-import { list, put } from "@vercel/blob";
+import { BlobPreconditionFailedError, get, list, put } from '@vercel/blob';
 
 /** Fixed, non-random-suffixed pathname — there is exactly one blob for this store. */
-export const REGISTERED_MARKETS_BLOB_PATHNAME = "playground/registered-markets.json";
+export const REGISTERED_MARKETS_BLOB_PATHNAME = 'playground/registered-markets.json';
 
 /**
  * H1 hardening: cap the registry so an unbounded stream of registrations (the
@@ -48,16 +48,16 @@ export interface RegisteredMarket {
 }
 
 function isRegisteredMarket(value: unknown): value is RegisteredMarket {
-  if (typeof value !== "object" || value === null) return false;
+  if (typeof value !== 'object' || value === null) return false;
   const v = value as Record<string, unknown>;
   return (
-    typeof v.slabAddress === "string" &&
-    typeof v.marketAddress === "string" &&
-    typeof v.poolAddress === "string" &&
-    typeof v.dexType === "string" &&
-    typeof v.label === "string" &&
-    typeof v.collateral === "string" &&
-    typeof v.registeredAt === "number"
+    typeof v.slabAddress === 'string' &&
+    typeof v.marketAddress === 'string' &&
+    typeof v.poolAddress === 'string' &&
+    typeof v.dexType === 'string' &&
+    typeof v.label === 'string' &&
+    typeof v.collateral === 'string' &&
+    typeof v.registeredAt === 'number'
   );
 }
 
@@ -77,6 +77,96 @@ interface RegisteredMarketsReadResult {
   ok: boolean;
 }
 
+interface RegisteredMarketsMutationReadResult {
+  markets: RegisteredMarket[];
+  /**
+   * ETag belonging to the exact content returned in `markets`.
+   * Null means that the registry blob has not been created yet.
+   */
+  etag: string | null;
+  ok: boolean;
+}
+
+interface RegisteredMarketsWriteOptions {
+  /**
+   * Existing-blob optimistic concurrency token.
+   * Blob requires overwrite mode whenever `ifMatch` is supplied.
+   */
+  ifMatch?: string;
+
+  /**
+   * False on the initial-create path so another concurrent creator
+   * cannot be overwritten.
+   */
+  allowOverwrite?: boolean;
+}
+
+const REGISTERED_MARKETS_WRITE_MAX_ATTEMPTS = 5;
+
+/**
+ * Read registry content and its ETag from the same Blob response.
+ *
+ * Mutation reads bypass the CDN so retries always merge against the
+ * latest origin version.
+ */
+async function readRegisteredMarketsForMutation(): Promise<RegisteredMarketsMutationReadResult> {
+  try {
+    const result = await get(REGISTERED_MARKETS_BLOB_PATHNAME, {
+      access: 'public',
+      useCache: false,
+    });
+
+    if (result === null) {
+      return {
+        markets: [],
+        etag: null,
+        ok: true,
+      };
+    }
+
+    if (result.statusCode !== 200 || result.stream === null) {
+      console.error('[playground-registered-markets] unexpected Blob GET response');
+
+      return {
+        markets: [],
+        etag: null,
+        ok: false,
+      };
+    }
+
+    const data: unknown = await new Response(result.stream).json();
+
+    if (!Array.isArray(data)) {
+      console.error(
+        '[playground-registered-markets] blob content is not an array — mutation read failed',
+      );
+
+      return {
+        markets: [],
+        etag: null,
+        ok: false,
+      };
+    }
+
+    return {
+      markets: data.filter(isRegisteredMarket),
+      etag: result.blob.etag,
+      ok: true,
+    };
+  } catch (err) {
+    console.error(
+      '[playground-registered-markets] mutation read failed:',
+      err instanceof Error ? err.message : String(err),
+    );
+
+    return {
+      markets: [],
+      etag: null,
+      ok: false,
+    };
+  }
+}
+
 async function readRegisteredMarketsInternal(): Promise<RegisteredMarketsReadResult> {
   try {
     const { blobs } = await list({
@@ -91,24 +181,22 @@ async function readRegisteredMarketsInternal(): Promise<RegisteredMarketsReadRes
     // plain fetch (even `no-store`) can return a stale copy — which would silently
     // drop registrations in the read-modify-write upsert and hide markets from the
     // keeper. A unique query forces a fresh origin read every time.
-    const resp = await fetch(`${found.url}?ts=${Date.now()}`, { cache: "no-store" });
+    const resp = await fetch(`${found.url}?ts=${Date.now()}`, { cache: 'no-store' });
     if (!resp.ok) {
-      console.warn(
-        `[playground-registered-markets] blob fetch ${resp.status} — read failed`,
-      );
+      console.warn(`[playground-registered-markets] blob fetch ${resp.status} — read failed`);
       return { markets: [], ok: false };
     }
     const data: unknown = await resp.json();
     // A found-but-non-array blob is corrupted data, not "empty" — treat as a
     // failure so an upsert can't silently overwrite it with a partial list.
     if (!Array.isArray(data)) {
-      console.warn("[playground-registered-markets] blob content is not an array — read failed");
+      console.warn('[playground-registered-markets] blob content is not an array — read failed');
       return { markets: [], ok: false };
     }
     return { markets: data.filter(isRegisteredMarket), ok: true };
   } catch (err) {
     console.warn(
-      "[playground-registered-markets] read failed:",
+      '[playground-registered-markets] read failed:',
       err instanceof Error ? err.message : String(err),
     );
     return { markets: [], ok: false };
@@ -133,74 +221,128 @@ export async function readRegisteredMarkets(): Promise<RegisteredMarket[]> {
 }
 
 /**
- * Overwrite the registered-markets blob with `markets`.
- * Throws on failure — callers are expected to catch and return a clear 502.
+ * Persist a complete registry snapshot.
+ *
+ * Existing snapshots may be guarded by `ifMatch`. Initial creation may
+ * disable overwrite so a concurrent creator cannot be silently replaced.
  */
 export async function writeRegisteredMarkets(
   markets: RegisteredMarket[],
+  options: RegisteredMarketsWriteOptions = {},
 ): Promise<void> {
+  const ifMatch = options.ifMatch;
+
   await put(REGISTERED_MARKETS_BLOB_PATHNAME, JSON.stringify(markets), {
-    access: "public",
+    access: 'public',
     addRandomSuffix: false,
-    contentType: "application/json",
-    // Fixed pathname + upsert semantics: every registration overwrites the single
-    // registry blob. Without this, only the first-ever registration succeeds and
-    // every subsequent one 502s ("blob already exists").
-    allowOverwrite: true,
-    // This blob mutates on every registration — don't let the CDN serve a stale copy.
+    contentType: 'application/json',
+
+    allowOverwrite: ifMatch !== undefined ? true : (options.allowOverwrite ?? true),
+
+    ...(ifMatch !== undefined ? { ifMatch } : {}),
+
     cacheControlMaxAge: 0,
   });
 }
 
 /**
- * Upsert a single market by `slabAddress` (dedup — replace if present, else append)
- * and persist the result. Caps the registry at MAX_REGISTERED_MARKETS, evicting the
- * oldest entries (by `registeredAt`) first when a fresh registration would exceed it
- * — re-registering an existing slab refreshes its `registeredAt` (see the route),
- * which keeps actively-used markets from aging out ahead of stale ones. Returns the
- * updated array.
- *
- * J: this is a read-modify-write, so it MUST fail closed on a read failure. The
- * previous version called the lenient `readRegisteredMarkets()`, which returns `[]`
- * for BOTH "genuinely nothing registered yet" AND "the read just failed" (network
- * blip, CDN hiccup, malformed JSON) — indistinguishable to this function. On a
- * transient read failure it would proceed anyway, treat the blob as empty, and
- * `writeRegisteredMarkets` a SINGLE-entry array over the top, destroying up to
- * `MAX_REGISTERED_MARKETS` (100) existing market↔pool bindings. Using the stricter
- * `readRegisteredMarketsInternal` (which reports `ok: false` only for a genuine
- * failure, never for a legitimate empty/not-yet-created blob) lets this function
- * throw and abort instead — the caller (keeper-register route) already catches and
- * returns a 502, so this is a safe, visible failure instead of silent data loss.
+ * Apply deduplication, insertion and registry-cap eviction without
+ * mutating the snapshot that was read.
  */
-export async function upsertRegisteredMarket(
+function applyRegisteredMarketUpsert(
+  current: RegisteredMarket[],
   entry: RegisteredMarket,
-): Promise<RegisteredMarket[]> {
-  const { markets: existing, ok } = await readRegisteredMarketsInternal();
-  if (!ok) {
-    throw new Error(
-      "Failed to read the registered-markets blob before upsert — aborting without writing, " +
-      "to avoid overwriting existing registrations with a partial list. Retry the registration.",
-    );
-  }
-  const idx = existing.findIndex((m) => m.slabAddress === entry.slabAddress);
-  if (idx >= 0) {
-    existing[idx] = entry;
+): RegisteredMarket[] {
+  const next = [...current];
+
+  const index = next.findIndex((market) => market.slabAddress === entry.slabAddress);
+
+  if (index >= 0) {
+    next[index] = entry;
   } else {
-    existing.push(entry);
+    next.push(entry);
   }
 
-  let capped = existing;
-  if (capped.length > MAX_REGISTERED_MARKETS) {
-    const overflow = capped.length - MAX_REGISTERED_MARKETS;
-    const evictSlabs = new Set(
-      [...capped]
-        .sort((a, b) => a.registeredAt - b.registeredAt)
-        .slice(0, overflow)
-        .map((m) => m.slabAddress),
-    );
-    capped = capped.filter((m) => !evictSlabs.has(m.slabAddress));
+  if (next.length <= MAX_REGISTERED_MARKETS) {
+    return next;
   }
 
-  await writeRegisteredMarkets(capped);
-  return capped;
+  const overflow = next.length - MAX_REGISTERED_MARKETS;
+
+  const evictSlabs = new Set(
+    [...next]
+      .sort((left, right) => left.registeredAt - right.registeredAt)
+      .slice(0, overflow)
+      .map((market) => market.slabAddress),
+  );
+
+  return next.filter((market) => !evictSlabs.has(market.slabAddress));
+}
+
+/**
+ * Upsert a registered market using Blob optimistic concurrency.
+ *
+ * A stale ETag causes the operation to read the newest registry,
+ * recompute the merge and retry. A failed initial create is retried only
+ * when a follow-up read confirms another request created the blob.
+ */
+export async function upsertRegisteredMarket(entry: RegisteredMarket): Promise<RegisteredMarket[]> {
+  let lastConflict: unknown;
+
+  for (let attempt = 1; attempt <= REGISTERED_MARKETS_WRITE_MAX_ATTEMPTS; attempt += 1) {
+    const snapshot = await readRegisteredMarketsForMutation();
+
+    if (!snapshot.ok) {
+      throw new Error(
+        'Failed to read the registered-markets blob before upsert — ' +
+          'aborting without writing to avoid overwriting existing ' +
+          'registrations with a partial list. Retry the registration.',
+      );
+    }
+
+    const next = applyRegisteredMarketUpsert(snapshot.markets, entry);
+
+    try {
+      if (snapshot.etag === null) {
+        await writeRegisteredMarkets(next, {
+          allowOverwrite: false,
+        });
+      } else {
+        await writeRegisteredMarkets(next, {
+          ifMatch: snapshot.etag,
+        });
+      }
+
+      return next;
+    } catch (err) {
+      if (snapshot.etag !== null) {
+        if (err instanceof BlobPreconditionFailedError) {
+          lastConflict = err;
+          continue;
+        }
+
+        throw err;
+      }
+
+      /*
+       * Blob SDK 2.6.1 does not expose a dedicated already-exists
+       * exception. Confirm an initial-create race by reading again.
+       */
+      const afterCreateFailure = await readRegisteredMarketsForMutation();
+
+      if (afterCreateFailure.ok && afterCreateFailure.etag !== null) {
+        lastConflict = err;
+        continue;
+      }
+
+      throw err;
+    }
+  }
+
+  const conflictDetail =
+    lastConflict instanceof Error ? ` Last conflict: ${lastConflict.message}` : '';
+
+  throw new Error(
+    `Failed to update the registered-markets blob after ${REGISTERED_MARKETS_WRITE_MAX_ATTEMPTS} optimistic-concurrency attempts.${conflictDetail}`,
+  );
 }


### PR DESCRIPTION
## Summary

This PR fixes a lost-update race condition in the Playground registered-markets registry when multiple authenticated market registrations are processed concurrently.

The registry is persisted as a single JSON document in Vercel Blob:

```text
playground/registered-markets.json
```

The previous implementation used an unguarded read-modify-write sequence:

1. Read the current registered-markets array.
2. Merge or append the requested market in memory.
3. Overwrite the fixed Blob pathname.
4. Return a successful registration response.

When two requests read the same registry snapshot before either write completes, both requests independently produce a valid replacement document from stale state. The later write can therefore overwrite the earlier write and silently remove a market that was already acknowledged as successfully registered.

This PR replaces the unconditional overwrite flow with bounded optimistic concurrency control using the Blob ETag and conditional `ifMatch` writes.

Fixes #2410

---

## Problem

The Playground registered-markets registry is shared by all market registration requests.

The vulnerable persistence flow was effectively:

```text
read registry
→ update local array
→ overwrite complete Blob document
```

This operation was not atomic.

Two concurrent requests could execute the following interleaving:

```text
Initial registry: R

Request A reads R
Request B reads R

Request A computes R + market A
Request B computes R + market B

Request A writes R + market A
Request B writes R + market B
```

The final persisted registry becomes:

```text
R + market B
```

`market A` disappears even though Request A returned a successful registration response.

At the route level, both requests could return:

```json
{
  "ok": true,
  "registered": true
}
```

while only one market remained present in subsequent registered-markets discovery reads.

---

## Affected components

- `app/lib/playground-registered-markets.ts`
- `POST /api/playground/keeper-register`
- `GET /api/playground/registered-markets`
- Playground market discovery consumers
- Keeper polling that consumes the registered-markets registry
- Registry-cap and fail-closed storage behavior

---

## User impact

A successfully acknowledged market registration could be silently removed from persistent storage.

This could cause:

- newly launched markets to disappear from Playground discovery;
- keeper polling to miss a market that was reported as registered;
- inconsistent state between the registration response and later registry reads;
- users to repeat a registration that had already returned success;
- incomplete market listings under concurrent registration activity;
- silent data loss without either request failing at the HTTP layer.

The failure was especially dangerous because the API response could report success even though the registration was no longer durable.

---

## Root cause

`upsertRegisteredMarket()` previously performed a read-modify-write operation without validating that the Blob had remained unchanged between the read and write phases.

The implementation:

1. read the current registry;
2. modified the returned array;
3. wrote the entire array back to the same fixed Blob pathname;
4. enabled overwriting of the existing Blob.

The write did not carry a version token from the preceding read.

Because the registered-markets registry is stored as one shared JSON document, every writer replaces the complete registry snapshot. A writer operating on stale state could therefore replace a newer registry version without detecting the conflict.

The existing fail-closed behavior protected against transient read failures, but it did not protect against multiple valid writers reading the same valid snapshot.

---

## Solution

The mutation path now uses optimistic concurrency control based on the Blob ETag.

Each mutation attempt follows this sequence:

```text
read latest registry content and ETag
→ apply the requested upsert in memory
→ write conditionally against the observed ETag
→ retry if another writer changed the Blob
```

A stale writer can no longer overwrite a newer committed registry version.

---

## Implementation details

### 1. Origin-backed mutation reads

The mutation path now reads the registry using the Vercel Blob `get()` API.

The mutation reader returns both the registry content and the ETag belonging to that exact Blob response:

```ts
interface RegisteredMarketsMutationReadResult {
  markets: RegisteredMarket[];
  etag: string | null;
  ok: boolean;
}
```

Mutation reads explicitly disable cache usage:

```ts
useCache: false
```

This ensures every retry merges against the latest origin state rather than a stale CDN representation.

The mutation reader validates:

- whether the Blob exists;
- whether the Blob response status is `200`;
- whether a readable response stream is present;
- whether the stream can be parsed as JSON;
- whether the parsed value is an array;
- whether each retained entry satisfies the registered-market shape;
- whether the ETag can be carried into the conditional write.

Unexpected statuses, missing streams, malformed JSON, non-array payloads, and network failures return `ok: false`.

---

### 2. Public reads remain lenient

The existing public `readRegisteredMarkets()` contract remains unchanged.

Public discovery consumers still degrade to an empty array when the registry cannot be read.

This behavior is intentionally separated from mutation reads.

A public GET request may safely degrade to an empty result, but a read-modify-write mutation must never interpret a transient read failure as an empty registry because doing so could overwrite all existing registrations with a partial list.

---

### 3. Conditional write support

`writeRegisteredMarkets()` now accepts write options:

```ts
interface RegisteredMarketsWriteOptions {
  ifMatch?: string;
  allowOverwrite?: boolean;
}
```

For an existing Blob snapshot, the write uses:

```ts
{
  allowOverwrite: true,
  ifMatch: snapshot.etag
}
```

The write succeeds only when the current Blob ETag still matches the ETag observed during the mutation read.

When another request updates the registry first, the stale writer receives:

```ts
BlobPreconditionFailedError
```

The stale replacement document is rejected before it can overwrite the latest state.

---

### 4. Initial-creation protection

A missing Blob has no ETag.

The initial creation path therefore uses:

```ts
{
  allowOverwrite: false
}
```

This prevents two concurrent first registrations from both treating the registry as absent and silently replacing one another.

The expected initial-create race now behaves as follows:

```text
Request A observes no Blob
Request B observes no Blob

Request A creates the Blob
Request B attempts creation with overwrite disabled
Request B receives a conflict

Request B re-reads the newly created registry
Request B merges its market into the latest state
Request B retries with the current ETag
```

This protects both:

- concurrent updates to an existing registry;
- concurrent creation of the first registry document.

---

### 5. Immutable registry mutation

Registry mutation is applied through a dedicated in-memory helper.

The helper:

- clones the current registry;
- identifies entries by `slabAddress`;
- replaces an existing registration in place;
- appends a previously unknown registration;
- prevents duplicate slab entries;
- preserves the registry capacity limit;
- evicts the oldest entries by `registeredAt` when the cap is exceeded.

The read snapshot is not mutated directly.

This is required because every retry must recompute the resulting registry from the latest committed Blob state.

---

### 6. Bounded compare-and-swap retry loop

`upsertRegisteredMarket()` now performs a bounded retry loop:

```ts
const REGISTERED_MARKETS_WRITE_MAX_ATTEMPTS = 5;
```

The operation is conceptually:

```text
for each attempt:
    read the latest registry and ETag
    validate the mutation snapshot
    apply the market upsert in memory

    if no Blob exists:
        attempt creation with overwrite disabled
    else:
        attempt write with If-Match: current ETag

    if write succeeds:
        return the updated registry

    if write fails because the ETag changed:
        re-read the latest registry
        recompute the merge
        retry

    if write fails for another reason:
        abort immediately
```

The retry budget prevents unbounded loops under sustained contention.

When all attempts are exhausted, the mutation fails visibly instead of returning a false success.

---

### 7. Conflict-specific retry behavior

Only optimistic concurrency conflicts are retried.

The retry branch specifically handles:

```ts
error instanceof BlobPreconditionFailedError
```

The following failures are not retried as concurrency conflicts:

- network failures;
- authentication failures;
- Blob service failures;
- malformed registry content;
- missing response streams;
- unexpected Blob response statuses;
- invalid registry structure;
- unrelated persistence errors.

These failures propagate to the existing route-level persistence error handling.

This prevents infrastructure failures from being incorrectly masked as ordinary write contention.

---

## Concurrency behavior after the fix

Two requests reading the same registry version now execute safely:

```text
Initial registry: R
Current ETag: E0

Request A reads R with ETag E0
Request B reads R with ETag E0

Request A computes R + market A
Request B computes R + market B

Request A writes with If-Match: E0
Request A succeeds
Blob ETag becomes E1

Request B writes with If-Match: E0
Request B receives BlobPreconditionFailedError

Request B reads R + market A with ETag E1
Request B recomputes R + market A + market B
Request B writes with If-Match: E1
Request B succeeds
```

The final persisted registry becomes:

```text
R + market A + market B
```

Neither successfully registered market is lost.

---

## Fail-closed behavior

The mutation path continues to fail closed.

No write is performed when:

- the Blob read returns a non-success status;
- the Blob response does not contain a stream;
- the registry JSON cannot be parsed;
- the parsed payload is not an array;
- the origin read throws;
- the current registry version cannot be verified.

This prevents the destructive sequence:

```text
transient read failure
→ treat the registry as empty
→ write only the current registration
→ remove all previous registrations
```

The existing registry remains untouched when the current state cannot be safely read.

---

## PoC: library-level lost-update race

A deterministic library-level regression test reproduces the original lost-update condition directly against `upsertRegisteredMarket()`.

Test file:

```text
app/__tests__/lib/playground-registered-markets-concurrency-race.test.ts
```

The test launches two concurrent upserts:

```ts
await Promise.all([
  upsertRegisteredMarket(marketA),
  upsertRegisteredMarket(marketB)
]);
```

The Blob mock uses synchronization barriers so both operations are forced to read the same registry snapshot before either write is committed.

The physical write order is then controlled deterministically.

### Vulnerable behavior

Without conditional writes:

```text
A reads []
B reads []

A computes [A]
B computes [B]

A writes [A]
B writes [B]
```

Observed final registry:

```text
[B]
```

Expected final registry:

```text
[A, B]
```

The second write silently removes the first registration.

### Fixed behavior

With ETag-based optimistic concurrency:

```text
A reads [] with ETag E0
B reads [] with ETag E0

A writes [A] with If-Match E0
A succeeds

B writes [B] with If-Match E0
B receives a precondition failure

B re-reads [A] with ETag E1
B computes [A, B]
B writes [A, B] with If-Match E1
B succeeds
```

The test verifies:

- both operations initially observe the same registry state;
- both registrations participate in the same deterministic race;
- the first write commits successfully;
- the stale second write is rejected;
- the conflicted writer performs another registry read;
- the retry merges against the latest committed registry;
- both `slabAddress` values remain present;
- the final registry does not contain duplicate entries;
- no successful registration is silently discarded.

---

## PoC: authenticated route-level race

A second deterministic regression test exercises the complete authenticated registration route.

Test file:

```text
app/__tests__/api/keeper-register-concurrency-race.test.ts
```

The test sends two concurrent requests to:

```text
POST /api/playground/keeper-register
```

Each request registers a different market.

The fixture controls the Blob read and write order so both requests initially operate on the same registry snapshot.

The test validates the complete flow:

```text
concurrent HTTP requests
→ admin-secret authentication
→ request body validation
→ registry mutation read
→ ETag-guarded Blob write
→ precondition conflict
→ latest-state re-read
→ merge retry
→ persisted registry discovery
```

Assertions verify that:

- both requests pass authentication;
- both request payloads are accepted;
- both requests initially read the same registry version;
- one request commits first;
- the other request encounters a conditional-write conflict;
- the conflicted request re-reads the newest registry;
- the retry includes the already committed market;
- both route responses return HTTP `200`;
- both route response bodies report `registered: true`;
- each response contains its expected `slabAddress`;
- the registered-markets discovery route contains both markets after completion.

This proves the fix at the actual route boundary rather than only inside the storage helper.

---

## Regression coverage

Existing registered-markets fixtures were updated to model the Blob contract required by the mutation reader.

The mocks now support:

- `list()`;
- `get()`;
- readable response streams;
- Blob ETags;
- `put()`;
- `ifMatch`;
- `allowOverwrite`;
- `BlobPreconditionFailedError`;
- deterministic write conflicts.

Regression coverage includes:

- initial registry creation;
- existing registry updates;
- replacement of an existing slab;
- deduplication by `slabAddress`;
- registry cap enforcement;
- oldest-entry eviction;
- non-OK Blob read failures;
- network-level Blob failures;
- malformed registry payloads;
- lenient public discovery reads;
- legitimate not-yet-created Blob state;
- initial-create conflict recovery;
- existing-registry ETag conflict recovery;
- bounded retry behavior;
- authenticated route-level concurrent registration;
- final discovery containing both registrations;
- generic Blob persistence failure handling;
- keeper-register error response behavior.

---

## Files changed

### Production implementation

```text
app/lib/playground-registered-markets.ts
```

Main changes:

- import `get` from `@vercel/blob`;
- import `BlobPreconditionFailedError`;
- add strict mutation-read result metadata;
- retain the Blob ETag from the same response as the registry content;
- bypass CDN cache during mutation reads;
- add conditional write options;
- protect initial creation with `allowOverwrite: false`;
- protect existing updates with `ifMatch`;
- add immutable registry mutation logic;
- add bounded optimistic-concurrency retries;
- preserve fail-closed mutation behavior.

### Updated tests

```text
app/__tests__/lib/playground-registered-markets-cap.test.ts
app/__tests__/lib/playground-registered-markets-fail-closed.test.ts
```

These tests were updated so the Blob mocks expose the `get()`, stream, ETag, conditional-write, and conflict behavior used by the production implementation.

### New tests

```text
app/__tests__/lib/playground-registered-markets-concurrency-race.test.ts
app/__tests__/api/keeper-register-concurrency-race.test.ts
```

These tests deterministically reproduce the library-level and route-level lost-update race.

---

## Validation

### Concurrency race tests

```text
Test Files  2 passed
Tests       2 passed
Exit code   0
```

### Registered-markets regression suites

```text
Test Files  7 passed
Tests       18 passed
Exit code   0
```

### Legacy Blob mock compatibility

```text
Test Files  4 passed
Tests       10 passed
Exit code   0
```

### Formatting

```text
All matched files use Prettier code style
Exit code: 0
```

### Diff integrity

```text
git diff --check
Exit code: 0
```

### TypeScript

```text
TypeScript exit code: 0
```

### Production build

```text
Compiled successfully
Build exit code: 0
```

### Full-suite baseline comparison

The repository-wide unit suite contains unrelated pre-existing failures.

The patched branch was compared against a clean Playground baseline using normalized failure signatures.

Result:

```text
New full-suite failure signatures introduced by this patch: 0
```

The patch therefore introduces no additional unrelated full-suite failure signatures.

---

## Before

```text
read registry snapshot
→ merge registration locally
→ overwrite complete Blob
→ stale writer may remove an earlier successful registration
```

## After

```text
read latest origin registry and ETag
→ merge registration locally
→ conditionally write using If-Match
→ detect stale writer
→ re-read the latest registry
→ recompute the merge
→ retry against the new ETag
```

---

## Compatibility

This PR does not change:

- the registered-market JSON schema;
- the fixed Blob pathname;
- the keeper-register request format;
- the successful keeper-register response shape;
- the public registered-markets response shape;
- registry identity based on `slabAddress`;
- the registry capacity limit;
- the existing oldest-entry eviction behavior;
- downstream discovery consumers.

The change is limited to mutation correctness, Blob concurrency control, test fixture compatibility, and deterministic regression coverage.

---

## Result

Concurrent authenticated market registrations can no longer silently overwrite one another.

Every successful registration is now either:

- persisted together with other concurrent registrations; or
- rejected with a visible persistence failure after the bounded retry budget is exhausted.

This removes the false-success condition where the registration API reports success even though the market has disappeared from the persisted registered-markets registry.