### PR TITLE
fix(portfolio): make liquidation distance direction-aware

### DIFF
--- a/app/__tests__/lib/liquidation-distance.test.ts
+++ b/app/__tests__/lib/liquidation-distance.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeLiquidationDistancePct } from '@/lib/liquidation-distance';
+
+describe('computeLiquidationDistancePct', () => {
+  it('preserves the canonical warning distance for a short position', () => {
+    const distance = computeLiquidationDistancePct(-1n, 77_000_000n, 110_000_000n);
+
+    // (110 - 77) / 110 * 100 = 30%
+    expect(distance).toBe(30);
+  });
+
+  it('computes the directional distance for a healthy long position', () => {
+    const distance = computeLiquidationDistancePct(1n, 120_000_000n, 90_000_000n);
+
+    // (120 - 90) / 120 * 100 = 25%
+    expect(distance).toBe(25);
+  });
+
+  it('computes the directional distance for a healthy short position', () => {
+    const distance = computeLiquidationDistancePct(-1n, 80_000_000n, 100_000_000n);
+
+    // (100 - 80) / 100 * 100 = 20%
+    expect(distance).toBe(20);
+  });
+
+  it('returns zero when a short mark has crossed its liquidation price', () => {
+    const distance = computeLiquidationDistancePct(-1n, 160_000_000n, 110_000_000n);
+
+    expect(distance).toBe(0);
+  });
+
+  it('returns zero when a long mark has crossed its liquidation price', () => {
+    const distance = computeLiquidationDistancePct(1n, 80_000_000n, 90_000_000n);
+
+    expect(distance).toBe(0);
+  });
+
+  it.each([
+    {
+      name: 'long',
+      positionSize: 1n,
+      markPriceE6: 90_000_000n,
+      liquidationPriceE6: 90_000_000n,
+    },
+    {
+      name: 'short',
+      positionSize: -1n,
+      markPriceE6: 110_000_000n,
+      liquidationPriceE6: 110_000_000n,
+    },
+  ])(
+    'returns zero at the exact $name liquidation boundary',
+    ({ positionSize, markPriceE6, liquidationPriceE6 }) => {
+      expect(computeLiquidationDistancePct(positionSize, markPriceE6, liquidationPriceE6)).toBe(0);
+    },
+  );
+
+  it('uses the supplied fallback when there is no open position', () => {
+    expect(computeLiquidationDistancePct(0n, 100_000_000n, 90_000_000n, 37.5)).toBe(37.5);
+  });
+
+  it.each([
+    {
+      name: 'invalid mark',
+      markPriceE6: 0n,
+      liquidationPriceE6: 90_000_000n,
+    },
+    {
+      name: 'invalid liquidation price',
+      markPriceE6: 100_000_000n,
+      liquidationPriceE6: 0n,
+    },
+  ])('uses the supplied fallback for $name', ({ markPriceE6, liquidationPriceE6 }) => {
+    expect(computeLiquidationDistancePct(1n, markPriceE6, liquidationPriceE6, 64)).toBe(64);
+  });
+
+  it('handles prices above Number.MAX_SAFE_INTEGER without precision conversion', () => {
+    const distance = computeLiquidationDistancePct(
+      1n,
+      10_000_000_000_000_000_000n,
+      9_000_000_000_000_000_000n,
+    );
+
+    expect(distance).toBe(10);
+  });
+});

--- a/app/app/portfolio/page.tsx
+++ b/app/app/portfolio/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import { subscribeSlab, getSnapshot } from "@/lib/priceStore/priceStore";
 import { computeLivePositionPnl } from "@/lib/trading";
+import { computeLiquidationDistancePct } from "@/lib/liquidation-distance";
 import { SlabProvider } from "@/components/providers/SlabProvider";
 import { useClosePosition } from "@/hooks/useClosePosition";
 import { useEngineFreshness } from "@/hooks/useEngineFreshness";
@@ -209,10 +210,12 @@ function PositionCard({
     pos.unrealizedPnl,
     pos.pnlPercent,
   );
-  const liquidationDistancePct =
-    hasPosition && liquidationPriceE6 > 0n && markE6 > 0n
-      ? Math.max(0, Math.min(100, (Math.abs(Number(markE6) - Number(liquidationPriceE6)) / Number(markE6)) * 100))
-      : pos.liquidationDistancePct;
+  const liquidationDistancePct = computeLiquidationDistancePct(
+    posSize,
+    markE6,
+    liquidationPriceE6,
+    pos.liquidationDistancePct,
+  );
   const pnlPositive = pnlTokens >= 0n;
   const severity = getLiquidationSeverity(liquidationDistancePct);
   const livePriceUsd = getSnapshot(pos.slabAddress).priceUsd ?? (markE6 > 0n ? Number(markE6) / 1e6 : null);

--- a/app/hooks/usePortfolio.ts
+++ b/app/hooks/usePortfolio.ts
@@ -28,6 +28,7 @@ import { parseV17RiskParams } from "@/lib/v17-engine-config";
 import { getAllProgramIds, getNetwork } from "@/lib/config";
 import { applyInvert, sanitizePriceE6 } from "@/lib/oraclePrice";
 import { getEntryPrice } from "@/lib/entry-price";
+import { computeLiquidationDistancePct } from "@/lib/liquidation-distance";
 import { discoverMarketsViaProgramDirectory } from "@/lib/market-directory-discovery";
 import { PERCOLATOR_NFT_PROGRAM_ID } from "@/lib/nft-program";
 import { PLAYGROUND_SLAB_META } from "@/lib/playground-slab-meta";
@@ -294,18 +295,11 @@ function buildV17Position(
     ? computePnlPercent(unrealizedPnl, positionInitialMargin)
     : computePnlPercent(unrealizedPnl, account.capital);
 
-  let liquidationDistancePct = 100;
-  if (oraclePriceE6 > 0n && liquidationPriceE6 > 0n && account.positionSize !== 0n) {
-    if (account.positionSize > 0n) {
-      liquidationDistancePct = oraclePriceE6 > liquidationPriceE6
-        ? Number(((oraclePriceE6 - liquidationPriceE6) * 10000n) / oraclePriceE6) / 100
-        : 0;
-    } else {
-      liquidationDistancePct = liquidationPriceE6 > oraclePriceE6
-        ? Number(((liquidationPriceE6 - oraclePriceE6) * 10000n) / liquidationPriceE6) / 100
-        : 0;
-    }
-  }
+  const liquidationDistancePct = computeLiquidationDistancePct(
+    account.positionSize,
+    oraclePriceE6,
+    liquidationPriceE6,
+  );
 
   const absPos = account.positionSize < 0n ? -account.positionSize : account.positionSize;
   let leverage = 0;
@@ -554,20 +548,11 @@ async function fetchPortfolioSnapshot(
               : computePnlPercent(unrealizedPnl, account.capital);
 
             // Liquidation distance percentage
-            let liquidationDistancePct = 100;
-            if (oraclePriceE6 > 0n && liquidationPriceE6 > 0n && account.positionSize !== 0n) {
-              if (account.positionSize > 0n) {
-                // Long: liq price is below oracle
-                liquidationDistancePct = oraclePriceE6 > liquidationPriceE6
-                  ? Number(((oraclePriceE6 - liquidationPriceE6) * 10000n) / oraclePriceE6) / 100
-                  : 0;
-              } else {
-                // Short: liq price is above oracle
-                liquidationDistancePct = liquidationPriceE6 > oraclePriceE6
-                  ? Number(((liquidationPriceE6 - oraclePriceE6) * 10000n) / liquidationPriceE6) / 100
-                  : 0;
-              }
-            }
+            const liquidationDistancePct = computeLiquidationDistancePct(
+              account.positionSize,
+              oraclePriceE6,
+              liquidationPriceE6,
+            );
 
             // Risk leverage = notional / slab account capital.
             const absPos = account.positionSize < 0n ? -account.positionSize : account.positionSize;

--- a/app/lib/liquidation-distance.ts
+++ b/app/lib/liquidation-distance.ts
@@ -1,0 +1,41 @@
+/**
+ * Computes the directional percentage distance from the current mark price
+ * to the position's liquidation price.
+ *
+ * Long positions are liquidated as the mark moves down to the liquidation
+ * price. Short positions are liquidated as the mark moves up to it.
+ *
+ * Returns fallbackDistancePct when the position or prices are unavailable.
+ */
+export function computeLiquidationDistancePct(
+  positionSize: bigint,
+  markPriceE6: bigint,
+  liquidationPriceE6: bigint,
+  fallbackDistancePct = 100,
+): number {
+  if (positionSize === 0n || markPriceE6 <= 0n || liquidationPriceE6 <= 0n) {
+    return fallbackDistancePct;
+  }
+
+  const isLong = positionSize > 0n;
+
+  const crossedLiquidationBoundary = isLong
+    ? markPriceE6 <= liquidationPriceE6
+    : markPriceE6 >= liquidationPriceE6;
+
+  if (crossedLiquidationBoundary) {
+    return 0;
+  }
+
+  const distanceE6 = isLong ? markPriceE6 - liquidationPriceE6 : liquidationPriceE6 - markPriceE6;
+
+  // Preserve the existing canonical denominators:
+  // long  => (mark - liquidation) / mark
+  // short => (liquidation - mark) / liquidation
+  const denominatorE6 = isLong ? markPriceE6 : liquidationPriceE6;
+
+  // Keep two decimal places without converting large prices to Number first.
+  const hundredthsOfPercent = (distanceE6 * 10_000n) / denominatorE6;
+
+  return Math.max(0, Math.min(100, Number(hundredthsOfPercent) / 100));
+}


### PR DESCRIPTION
## Summary

Fixes #2412.

This PR fixes an incorrect live liquidation-distance calculation in the Portfolio position cards.

The previous live calculation used an absolute price delta:

```ts
Math.abs(Number(markE6) - Number(liquidationPriceE6))
  / Number(markE6)
  * 100
```

This removed the direction of the position and allowed the displayed liquidation risk to diverge from the canonical Portfolio snapshot calculation.

In the highest-impact case, a short position whose mark price had already crossed its liquidation price could be classified as `safe` instead of `danger`.

---

## Problem

Liquidation boundaries are directional:

```text
Long:
The position approaches liquidation as mark price decreases.

Short:
The position approaches liquidation as mark price increases.
```

Using `Math.abs()` discards this direction.

After the mark crosses the liquidation boundary, the absolute difference starts increasing again. This can produce a positive liquidation distance even though the correct distance is already `0%`.

The live Portfolio card also used the mark price as the denominator for both position directions, while the existing canonical Portfolio calculation uses:

```text
Long:
(mark - liquidation) / mark

Short:
(liquidation - mark) / liquidation
```

This caused the live card and snapshot-derived Portfolio risk indicators to report different severity levels for the same position.

---

## User Impact

The calculated liquidation distance is used to derive the Portfolio risk state:

```text
distance <= 10%  → danger
distance <= 30%  → warning
distance > 30%   → safe
```

An incorrect value can affect:

- liquidation warning labels;
- position-card border and status styling;
- the perceived urgency of a position;
- the user's decision to add margin, reduce exposure, or close the position.

### Example: crossed short position

```text
Position:          Short
Mark price:        160
Liquidation price: 110
```

Previous live calculation:

```text
abs(160 - 110) / 160 × 100
= 31.25%
= safe
```

Correct result:

```text
mark >= liquidation price
= 0%
= danger
```

This is a high user-impact risk-indication issue, but it does not alter protocol liquidation behavior or on-chain state.

---

## Changes

### 1. Added a shared directional liquidation-distance helper

Added:

```text
app/lib/liquidation-distance.ts
```

The helper applies the canonical direction-aware calculation:

```text
Long:
  mark <= liquidation
    → 0%

  otherwise
    → (mark - liquidation) / mark × 100

Short:
  mark >= liquidation
    → 0%

  otherwise
    → (liquidation - mark) / liquidation × 100
```

It also:

- returns the existing fallback value when the position or prices are unavailable;
- clamps exact and crossed liquidation boundaries to `0%`;
- preserves the canonical short-position denominator;
- performs price arithmetic with `bigint`;
- converts only the final hundredths-of-a-percent result to `number`;
- clamps the final output to the supported `0–100%` range.

### 2. Unified Portfolio consumers

Updated both liquidation-distance paths in:

```text
app/hooks/usePortfolio.ts
```

Updated the live position-card calculation in:

```text
app/app/portfolio/page.tsx
```

All three consumers now use the same shared helper.

The live card continues to use:

```ts
pos.liquidationDistancePct
```

as its fallback when a valid live mark price is not yet available, preserving the existing loading and snapshot behavior.

### 3. Added regression coverage

Added:

```text
app/__tests__/lib/liquidation-distance.test.ts
```

Coverage includes:

- canonical short warning distance;
- healthy long distance;
- healthy short distance;
- crossed long liquidation boundary;
- crossed short liquidation boundary;
- exact long liquidation boundary;
- exact short liquidation boundary;
- zero-position fallback;
- invalid mark-price fallback;
- invalid liquidation-price fallback;
- values above `Number.MAX_SAFE_INTEGER`.

---

## Before and After

| Scenario | Previous result | Correct result |
|---|---:|---:|
| Short: mark `77`, liquidation `110` | `42.857%` / safe | `30%` / warning |
| Short: mark `160`, liquidation `110` | `31.25%` / safe | `0%` / danger |
| Long: mark `80`, liquidation `90` | `12.5%` / warning | `0%` / danger |

---

## Validation

### Targeted and related tests

```bash
cd app

pnpm vitest run \
  __tests__/lib/liquidation-distance.test.ts \
  __tests__/components/Portfolio.test.tsx \
  __tests__/hooks/useTrade.v17-portfolio-selection.test.ts \
  __tests__/lib/lpPortfolio.test.ts \
  --reporter=verbose
```

Result:

```text
Test Files  4 passed
Tests       38 passed
```

The dedicated liquidation-distance suite contains:

```text
11 passed
```

### TypeScript

```bash
cd app
pnpm exec tsc --noEmit
```

Result:

```text
Passed
```

### Formatting

```bash
pnpm exec prettier --check \
  app/lib/liquidation-distance.ts \
  app/__tests__/lib/liquidation-distance.test.ts
```

Result:

```text
All matched files use Prettier code style.
```

The production integration was intentionally kept as a minimal diff to avoid unrelated whole-file formatting changes.

### Production build

```bash
pnpm build:app
```

Result:

```text
Passed
```

### Full application suite baseline comparison

The complete application suite currently contains unrelated pre-existing failures.

The patched branch and a clean `upstream/playground` worktree produced:

```text
101 failed tests
3 unhandled errors
```

The failing-test signatures were identical, and this PR introduced no additional full-suite failure.

---

## Scope

This PR only changes:

```text
app/app/portfolio/page.tsx
app/hooks/usePortfolio.ts
app/lib/liquidation-distance.ts
app/__tests__/lib/liquidation-distance.test.ts
```

No protocol logic, transaction construction, authorization behavior, or on-chain state handling is modified.