### PR TITLE
fix(oracle): prevent unbounded cache growth and cap resolver concurrency

### DIFF
--- a/app/__tests__/api/oracle-publishers-cache-bounds.test.ts
+++ b/app/__tests__/api/oracle-publishers-cache-bounds.test.ts
@@ -1,0 +1,221 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { NextRequest } from "next/server";
+
+const cacheMock = vi.hoisted(() => ({
+  options: null as {
+    maxEntries: number;
+    ttlMs: number;
+  } | null,
+  get: vi.fn(),
+  set: vi.fn(),
+}));
+
+vi.mock("@/lib/bounded-ttl-cache", () => ({
+  BoundedTtlCache: class MockBoundedTtlCache {
+    constructor(options: {
+      maxEntries: number;
+      ttlMs: number;
+    }) {
+      cacheMock.options = options;
+    }
+
+    get(key: string) {
+      return cacheMock.get(key);
+    }
+
+    set(key: string, value: unknown) {
+      cacheMock.set(key, value);
+    }
+  },
+}));
+
+import { GET } from "@/app/api/oracle/publishers/route";
+
+const VALID_AUTHORITY =
+  "4RVFNKH15CxFSYdoNBJJGggjszuTKmpFs4PGwuXSNaK7";
+
+const SYSTEM_PROGRAM_ID =
+  "11111111111111111111111111111111";
+
+function makeRequest(
+  params: Record<string, string>,
+): NextRequest {
+  const url = new URL(
+    "http://localhost:3000/api/oracle/publishers",
+  );
+
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+
+  return new NextRequest(url);
+}
+
+describe("GET /api/oracle/publishers cache resource bounds", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    cacheMock.get.mockReset();
+    cacheMock.set.mockReset();
+    fetchMock.mockReset();
+
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("configures a bounded five-minute publisher cache", () => {
+    expect(cacheMock.options).toEqual({
+      maxEntries: 128,
+      ttlMs: 5 * 60 * 1000,
+    });
+  });
+
+  it("returns a valid admin response without using the cache", async () => {
+    const response = await GET(
+      makeRequest({
+        mode: "admin",
+        authority: VALID_AUTHORITY,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+
+    await expect(response.json()).resolves.toMatchObject({
+      mode: "admin",
+      publisherCount: 1,
+      publisherTotal: 1,
+      publishers: [
+        {
+          key: VALID_AUTHORITY,
+          status: "active",
+        },
+      ],
+    });
+
+    expect(cacheMock.get).not.toHaveBeenCalled();
+    expect(cacheMock.set).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves the empty admin state without cache allocation", async () => {
+    const response = await GET(
+      makeRequest({
+        mode: "admin",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+
+    await expect(response.json()).resolves.toEqual({
+      mode: "admin",
+      publisherCount: 0,
+      publisherTotal: 0,
+      publishers: [],
+    });
+
+    expect(cacheMock.get).not.toHaveBeenCalled();
+    expect(cacheMock.set).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves the system-program placeholder empty state", async () => {
+    const response = await GET(
+      makeRequest({
+        mode: "admin",
+        authority: SYSTEM_PROGRAM_ID,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+
+    await expect(response.json()).resolves.toEqual({
+      mode: "admin",
+      publisherCount: 0,
+      publisherTotal: 0,
+      publishers: [],
+    });
+
+    expect(cacheMock.get).not.toHaveBeenCalled();
+    expect(cacheMock.set).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an oversized attacker-controlled authority", async () => {
+    const response = await GET(
+      makeRequest({
+        mode: "admin",
+        authority: "A".repeat(2_048),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid admin authority",
+    });
+
+    expect(cacheMock.get).not.toHaveBeenCalled();
+    expect(cacheMock.set).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed admin authority", async () => {
+    const response = await GET(
+      makeRequest({
+        mode: "admin",
+        authority: "not-a-valid-solana-public-key",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid admin authority",
+    });
+
+    expect(cacheMock.get).not.toHaveBeenCalled();
+    expect(cacheMock.set).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("serves an externally resolved mode from the bounded cache", async () => {
+    const cachedResult = {
+      mode: "hyperp",
+      publisherCount: null,
+      publisherTotal: null,
+      publishers: [],
+    };
+
+    cacheMock.get.mockReturnValueOnce(cachedResult);
+
+    const response = await GET(
+      makeRequest({
+        mode: "hyperp",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, max-age=300",
+    );
+
+    await expect(response.json()).resolves.toEqual(cachedResult);
+
+    expect(cacheMock.get).toHaveBeenCalledWith("hyperp:");
+    expect(cacheMock.set).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/app/__tests__/api/oracle-resolver-cache-bounds.test.ts
+++ b/app/__tests__/api/oracle-resolver-cache-bounds.test.ts
@@ -1,0 +1,357 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { PublicKey } from "@solana/web3.js";
+import { NextRequest } from "next/server";
+
+const cacheMock = vi.hoisted(() => ({
+  options: null as {
+    maxEntries: number;
+    ttlMs: number;
+  } | null,
+  get: vi.fn(),
+  set: vi.fn(),
+}));
+
+vi.mock("@/lib/bounded-ttl-cache", () => ({
+  BoundedTtlCache: class MockBoundedTtlCache {
+    constructor(options: {
+      maxEntries: number;
+      ttlMs: number;
+    }) {
+      cacheMock.options = options;
+    }
+
+    get(key: string) {
+      return cacheMock.get(key);
+    }
+
+    set(key: string, value: unknown) {
+      cacheMock.set(key, value);
+    }
+  },
+}));
+
+import { GET } from "@/app/api/oracle/resolve/[ca]/route";
+
+const VALID_MINT =
+  "So11111111111111111111111111111111111111112";
+
+function uniqueValidMint(index: number): string {
+  const bytes = new Uint8Array(32);
+
+  // Keep every generated key valid and deterministically unique.
+  bytes[0] = 1;
+  bytes[30] = (index >> 8) & 0xff;
+  bytes[31] = index & 0xff;
+
+  return new PublicKey(bytes).toBase58();
+}
+
+function makeRequest(): NextRequest {
+  return new NextRequest(
+    `http://localhost:3000/api/oracle/resolve/${VALID_MINT}`,
+  );
+}
+
+function makeContext(ca = VALID_MINT) {
+  return {
+    params: Promise.resolve({ ca }),
+  };
+}
+
+function jupiterResponse() {
+  return new Response(
+    JSON.stringify({
+      data: {
+        [VALID_MINT]: {
+          id: VALID_MINT,
+          type: "derivedPrice",
+          price: "150.25",
+        },
+      },
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  );
+}
+
+function dexScreenerEmptyResponse() {
+  return new Response(
+    JSON.stringify({
+      pairs: [],
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  );
+}
+
+describe("GET /api/oracle/resolve/[ca] resource bounds", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    cacheMock.get.mockReset();
+    cacheMock.set.mockReset();
+    fetchMock.mockReset();
+
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("configures a bounded five-minute resolver cache", () => {
+    expect(cacheMock.options).toEqual({
+      maxEntries: 256,
+      ttlMs: 5 * 60 * 1000,
+    });
+  });
+
+  it("returns a fresh bounded-cache hit without upstream requests", async () => {
+    const cachedResult = {
+      feedId: null,
+      symbol: "SOL",
+      price: 150.25,
+      source: "jupiter",
+      dexPoolAddress: null,
+      dexType: null,
+      oracleMode: "admin",
+    };
+
+    cacheMock.get.mockReturnValueOnce(cachedResult);
+
+    const response = await GET(
+      makeRequest(),
+      makeContext(),
+    );
+
+    expect(response.status).toBe(200);
+
+    await expect(response.json()).resolves.toEqual({
+      ...cachedResult,
+      cached: true,
+    });
+
+    expect(cacheMock.get).toHaveBeenCalledWith(VALID_MINT);
+    expect(cacheMock.set).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates concurrent upstream lookups for the same mint", async () => {
+    cacheMock.get.mockReturnValue(undefined);
+
+    let resolveJupiter:
+      | ((response: Response) => void)
+      | undefined;
+    let resolveDexScreener:
+      | ((response: Response) => void)
+      | undefined;
+
+    const jupiterPromise = new Promise<Response>((resolve) => {
+      resolveJupiter = resolve;
+    });
+
+    const dexScreenerPromise = new Promise<Response>((resolve) => {
+      resolveDexScreener = resolve;
+    });
+
+    fetchMock.mockImplementation((input: string | URL | Request) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      if (url.includes("jup.ag")) {
+        return jupiterPromise;
+      }
+
+      if (url.includes("dexscreener.com")) {
+        return dexScreenerPromise;
+      }
+
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    const firstRequest = GET(makeRequest(), makeContext());
+    const secondRequest = GET(makeRequest(), makeContext());
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    resolveJupiter?.(jupiterResponse());
+    resolveDexScreener?.(dexScreenerEmptyResponse());
+
+    const [firstResponse, secondResponse] = await Promise.all([
+      firstRequest,
+      secondRequest,
+    ]);
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+
+    const [firstBody, secondBody] = await Promise.all([
+      firstResponse.json(),
+      secondResponse.json(),
+    ]);
+
+    expect(firstBody).toEqual(secondBody);
+
+    /*
+     * `cached` is HTTP response metadata and is intentionally not
+     * stored in the bounded domain cache.
+     */
+    const {
+      cached: firstCached,
+      ...firstCacheValue
+    } = firstBody;
+
+    const {
+      cached: secondCached,
+      ...secondCacheValue
+    } = secondBody;
+
+    expect(firstCached).toBe(false);
+    expect(secondCached).toBe(false);
+    expect(firstCacheValue).toEqual(secondCacheValue);
+
+    /*
+     * One Jupiter request and one DexScreener request total.
+     * Without in-flight deduplication this would be four fetch calls.
+     */
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    expect(cacheMock.set).toHaveBeenCalledTimes(2);
+    expect(cacheMock.set).toHaveBeenNthCalledWith(
+      1,
+      VALID_MINT,
+      firstCacheValue,
+    );
+    expect(cacheMock.set).toHaveBeenNthCalledWith(
+      2,
+      VALID_MINT,
+      secondCacheValue,
+    );
+  });
+
+  it("removes completed operations from the in-flight registry", async () => {
+    cacheMock.get.mockReturnValue(undefined);
+
+    fetchMock
+      .mockResolvedValueOnce(jupiterResponse())
+      .mockResolvedValueOnce(dexScreenerEmptyResponse())
+      .mockResolvedValueOnce(jupiterResponse())
+      .mockResolvedValueOnce(dexScreenerEmptyResponse());
+
+    const firstResponse = await GET(
+      makeRequest(),
+      makeContext(),
+    );
+
+    expect(firstResponse.status).toBe(200);
+
+    const secondResponse = await GET(
+      makeRequest(),
+      makeContext(),
+    );
+
+    expect(secondResponse.status).toBe(200);
+
+    /*
+     * Because the first operation completed and was removed, the second
+     * sequential cache miss creates a new pair of upstream requests.
+     */
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("rejects malformed mint input before cache or upstream access", async () => {
+    const response = await GET(
+      makeRequest(),
+      makeContext("not-a-valid-solana-mint"),
+    );
+
+    expect(response.status).toBe(400);
+
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid Solana mint address",
+    });
+
+    expect(cacheMock.get).not.toHaveBeenCalled();
+    expect(cacheMock.set).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+  it("rejects a new unique lookup when in-flight capacity is saturated", async () => {
+    cacheMock.get.mockReturnValue(undefined);
+
+    /*
+     * Keep every upstream operation unresolved so all 64 unique resolver
+     * entries remain registered as in-flight.
+     */
+    const unresolvedResponse = new Promise<Response>(() => {
+      // Intentionally unresolved.
+    });
+
+    fetchMock.mockReturnValue(unresolvedResponse);
+
+    const pendingRequests = Array.from(
+      { length: 64 },
+      (_, index) =>
+        GET(
+          makeRequest(),
+          makeContext(uniqueValidMint(index)),
+        ),
+    );
+
+    /*
+     * Every unique resolver operation starts one Jupiter request and one
+     * DexScreener request: 64 operations x 2 fetches = 128 fetch calls.
+     */
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(128);
+    });
+
+    const overflowMint = uniqueValidMint(64);
+
+    const response = await GET(
+      makeRequest(),
+      makeContext(overflowMint),
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("1");
+
+    await expect(response.json()).resolves.toEqual({
+      error: "Oracle resolver is busy. Retry shortly.",
+    });
+
+    /*
+     * The rejected 65th unique operation must not initiate additional
+     * upstream traffic or write anything into the response cache.
+     */
+    expect(fetchMock).toHaveBeenCalledTimes(128);
+    expect(cacheMock.set).not.toHaveBeenCalled();
+
+    /*
+     * Retain local references for the duration of the test. These promises
+     * intentionally remain pending to model saturated in-flight capacity.
+     */
+    expect(pendingRequests).toHaveLength(64);
+  });
+
+});

--- a/app/__tests__/lib/bounded-ttl-cache.test.ts
+++ b/app/__tests__/lib/bounded-ttl-cache.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+
+import { BoundedTtlCache } from "@/lib/bounded-ttl-cache";
+
+describe("BoundedTtlCache", () => {
+  it("returns a fresh value before its TTL expires", () => {
+    let now = 1_000;
+
+    const cache = new BoundedTtlCache<string, string>({
+      maxEntries: 2,
+      ttlMs: 100,
+      now: () => now,
+    });
+
+    cache.set("market-a", "value-a");
+    now = 1_099;
+
+    expect(cache.get("market-a")).toBe("value-a");
+    expect(cache.size).toBe(1);
+  });
+
+  it("deletes and no longer returns an expired entry", () => {
+    let now = 1_000;
+
+    const cache = new BoundedTtlCache<string, string>({
+      maxEntries: 2,
+      ttlMs: 100,
+      now: () => now,
+    });
+
+    cache.set("market-a", "value-a");
+    now = 1_100;
+
+    expect(cache.get("market-a")).toBeUndefined();
+    expect(cache.size).toBe(0);
+  });
+
+  it("removes expired entries before inserting a new value", () => {
+    let now = 1_000;
+
+    const cache = new BoundedTtlCache<string, string>({
+      maxEntries: 2,
+      ttlMs: 100,
+      now: () => now,
+    });
+
+    cache.set("expired-a", "value-a");
+    cache.set("expired-b", "value-b");
+
+    now = 1_101;
+    cache.set("fresh-c", "value-c");
+
+    expect(cache.size).toBe(1);
+    expect(cache.get("expired-a")).toBeUndefined();
+    expect(cache.get("expired-b")).toBeUndefined();
+    expect(cache.get("fresh-c")).toBe("value-c");
+  });
+
+  it("never grows beyond its configured maximum cardinality", () => {
+    const cache = new BoundedTtlCache<string, string>({
+      maxEntries: 2,
+      ttlMs: 1_000,
+    });
+
+    cache.set("market-a", "value-a");
+    cache.set("market-b", "value-b");
+    cache.set("market-c", "value-c");
+
+    expect(cache.size).toBe(2);
+    expect(cache.get("market-a")).toBeUndefined();
+    expect(cache.get("market-b")).toBe("value-b");
+    expect(cache.get("market-c")).toBe("value-c");
+  });
+
+  it("evicts the least-recently-used entry after a cache hit", () => {
+    const cache = new BoundedTtlCache<string, string>({
+      maxEntries: 2,
+      ttlMs: 1_000,
+    });
+
+    cache.set("market-a", "value-a");
+    cache.set("market-b", "value-b");
+
+    // Refresh market-a recency, making market-b the LRU entry.
+    expect(cache.get("market-a")).toBe("value-a");
+
+    cache.set("market-c", "value-c");
+
+    expect(cache.get("market-b")).toBeUndefined();
+    expect(cache.get("market-a")).toBe("value-a");
+    expect(cache.get("market-c")).toBe("value-c");
+    expect(cache.size).toBe(2);
+  });
+
+  it("refreshes the value, TTL, and LRU position when replacing a key", () => {
+    let now = 1_000;
+
+    const cache = new BoundedTtlCache<string, string>({
+      maxEntries: 2,
+      ttlMs: 100,
+      now: () => now,
+    });
+
+    cache.set("market-a", "old-a");
+    cache.set("market-b", "value-b");
+
+    now = 1_050;
+    cache.set("market-a", "new-a");
+
+    cache.set("market-c", "value-c");
+
+    expect(cache.get("market-b")).toBeUndefined();
+    expect(cache.get("market-a")).toBe("new-a");
+
+    now = 1_149;
+    expect(cache.get("market-a")).toBe("new-a");
+
+    now = 1_150;
+    expect(cache.get("market-a")).toBeUndefined();
+  });
+
+  it("supports explicit deletion and clearing", () => {
+    const cache = new BoundedTtlCache<string, string>({
+      maxEntries: 3,
+      ttlMs: 1_000,
+    });
+
+    cache.set("market-a", "value-a");
+    cache.set("market-b", "value-b");
+
+    expect(cache.delete("market-a")).toBe(true);
+    expect(cache.delete("missing")).toBe(false);
+    expect(cache.get("market-a")).toBeUndefined();
+
+    cache.clear();
+
+    expect(cache.size).toBe(0);
+    expect(cache.get("market-b")).toBeUndefined();
+  });
+
+  it("rejects invalid resource-bound configuration", () => {
+    expect(
+      () =>
+        new BoundedTtlCache({
+          maxEntries: 0,
+          ttlMs: 1_000,
+        }),
+    ).toThrow("maxEntries must be a positive safe integer");
+
+    expect(
+      () =>
+        new BoundedTtlCache({
+          maxEntries: 10,
+          ttlMs: 0,
+        }),
+    ).toThrow("ttlMs must be a positive finite number");
+  });
+});

--- a/app/app/api/oracle/publishers/route.ts
+++ b/app/app/api/oracle/publishers/route.ts
@@ -1,4 +1,7 @@
+import { PublicKey } from "@solana/web3.js";
 import { NextRequest, NextResponse } from "next/server";
+
+import { BoundedTtlCache } from "@/lib/bounded-ttl-cache";
 
 const PYTHNET_RPC =
   process.env.PYTHNET_RPC_URL || "https://pythnet.rpcpool.com";
@@ -23,14 +26,20 @@ const KNOWN_PYTH_PUBLISHERS: Record<string, string> = {
   "4RVFNKH15CxFSYdoNBJJGggjszuTKmpFs4PGwuXSNaK7": "Raydium",
 };
 
-/** Max age for cached publisher data (5 minutes) */
+/** Max age for cached publisher data (5 minutes). */
 const CACHE_TTL_MS = 5 * 60 * 1000;
 
-interface CacheEntry {
-  data: PublishersResponse;
-  timestamp: number;
-}
-const cache = new Map<string, CacheEntry>();
+/**
+ * Publisher responses have a small expected key space.
+ * Keep the process-local cache strictly bounded so request-controlled
+ * inputs cannot create persistent unbounded memory retention.
+ */
+const MAX_CACHE_ENTRIES = 128;
+
+const cache = new BoundedTtlCache<string, PublishersResponse>({
+  maxEntries: MAX_CACHE_ENTRIES,
+  ttlMs: CACHE_TTL_MS,
+});
 
 interface PublisherInfo {
   key: string;
@@ -65,11 +74,35 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "Missing mode parameter" }, { status: 400 });
   }
 
-  // Check cache
-  const cacheKey = `${mode}:${feedId || authority || ""}`;
+  /*
+   * Admin output is generated locally and is intentionally excluded
+   * from the shared cache. This prevents attacker-controlled authority
+   * values from increasing cache cardinality.
+   */
+  if (mode === "admin") {
+    const validation = validateAdminAuthority(authority);
+
+    if (!validation.ok) {
+      return NextResponse.json(
+        { error: validation.error },
+        { status: 400 },
+      );
+    }
+
+    return NextResponse.json(
+      getAdminPublishers(validation.authority),
+      {
+        headers: { "Cache-Control": "no-store" },
+      },
+    );
+  }
+
+  // Check the bounded cache for externally resolved publisher modes.
+  const cacheKey = `${mode}:${feedId || ""}`;
   const cached = cache.get(cacheKey);
-  if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
-    return NextResponse.json(cached.data, {
+
+  if (cached) {
+    return NextResponse.json(cached, {
       headers: { "Cache-Control": "public, max-age=300" },
     });
   }
@@ -99,16 +132,13 @@ export async function GET(req: NextRequest) {
         result = await fetchHyperpPublishers();
         break;
 
-      case "admin":
-        result = getAdminPublishers(authority);
-        break;
 
       default:
         return NextResponse.json({ error: `Unknown mode: ${mode}` }, { status: 400 });
     }
 
-    // Update cache
-    cache.set(cacheKey, { data: result, timestamp: Date.now() });
+    // Store only externally resolved modes in the bounded cache.
+    cache.set(cacheKey, result);
 
     return NextResponse.json(result, {
       headers: { "Cache-Control": "public, max-age=300" },
@@ -300,8 +330,45 @@ async function fetchHyperpPublishers(): Promise<PublishersResponse> {
 // Admin: Single oracle authority
 // ---------------------------------------------------------------------------
 
+const SYSTEM_PROGRAM_ID = "11111111111111111111111111111111";
+
+type AdminAuthorityValidation =
+  | { ok: true; authority: string | null }
+  | { ok: false; error: string };
+
+function validateAdminAuthority(
+  authority: string | null,
+): AdminAuthorityValidation {
+  /*
+   * Preserve the existing empty-state behavior when no authority is
+   * configured or the system-program placeholder is supplied.
+   */
+  if (!authority || authority === SYSTEM_PROGRAM_ID) {
+    return { ok: true, authority };
+  }
+
+  if (authority.length < 32 || authority.length > 44) {
+    return { ok: false, error: "Invalid admin authority" };
+  }
+
+  try {
+    const canonicalAuthority = new PublicKey(authority).toBase58();
+
+    if (canonicalAuthority !== authority) {
+      return { ok: false, error: "Invalid admin authority" };
+    }
+
+    return {
+      ok: true,
+      authority: canonicalAuthority,
+    };
+  } catch {
+    return { ok: false, error: "Invalid admin authority" };
+  }
+}
+
 function getAdminPublishers(authority: string | null): PublishersResponse {
-  if (!authority || authority === "11111111111111111111111111111111") {
+  if (!authority || authority === SYSTEM_PROGRAM_ID) {
     return {
       mode: "admin",
       publisherCount: 0,

--- a/app/app/api/oracle/resolve/[ca]/route.ts
+++ b/app/app/api/oracle/resolve/[ca]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { PublicKey } from "@solana/web3.js";
 import { SUPPORTED_DEX_IDS } from "@/lib/dex-constants";
+import { BoundedTtlCache } from "@/lib/bounded-ttl-cache";
 
 export const dynamic = "force-dynamic";
 
@@ -77,15 +78,22 @@ const MINT_TO_PYTH: Record<string, { feedId: string; symbol: string }> = {
 };
 
 // ---------------------------------------------------------------------------
-// Simple in-memory cache (TTL 5 minutes)
 // ---------------------------------------------------------------------------
-
-interface CacheEntry {
-  data: OracleResolveResult;
-  expiresAt: number;
-}
-const cache = new Map<string, CacheEntry>();
+// Bounded resolver cache and in-flight request state
+// ---------------------------------------------------------------------------
 const CACHE_TTL_MS = 5 * 60 * 1000;
+const MAX_CACHE_ENTRIES = 256;
+const MAX_IN_FLIGHT_REQUESTS = 64;
+
+const cache = new BoundedTtlCache<string, OracleResolveResult>({
+  maxEntries: MAX_CACHE_ENTRIES,
+  ttlMs: CACHE_TTL_MS,
+});
+
+const inFlight = new Map<
+  string,
+  ReturnType<typeof fetchOracleSources>
+>();
 
 interface OracleResolveResult {
   feedId: string | null;
@@ -191,6 +199,13 @@ async function fetchDexScreenerInfo(
   }
 }
 
+function fetchOracleSources(ca: string) {
+  return Promise.all([
+    fetchJupiterPrice(ca),
+    fetchDexScreenerInfo(ca),
+  ] as const);
+}
+
 // ---------------------------------------------------------------------------
 // Route handler
 // ---------------------------------------------------------------------------
@@ -217,20 +232,45 @@ export async function GET(
     );
   }
 
-  // Cache hit
+  // Return a fresh value from the bounded TTL/LRU cache.
   const cached = cache.get(ca);
-  if (cached && Date.now() < cached.expiresAt) {
-    return NextResponse.json({ ...cached.data, cached: true });
+
+  if (cached) {
+    return NextResponse.json({
+      ...cached,
+      cached: true,
+    });
   }
 
   // --- 1. Check static Pyth feed map ---
   const pythEntry = MINT_TO_PYTH[ca];
 
-  // Fetch price in parallel from both Jupiter and DexScreener
-  const [jupResult, dexResult] = await Promise.all([
-    fetchJupiterPrice(ca),
-    fetchDexScreenerInfo(ca),
-  ]);
+  /*
+   * Reuse one upstream operation for concurrent requests targeting
+   * the same mint. New unique operations are rejected once the hard
+   * in-flight capacity is reached.
+   */
+  let sourceLookup = inFlight.get(ca);
+
+  if (!sourceLookup) {
+    if (inFlight.size >= MAX_IN_FLIGHT_REQUESTS) {
+      return NextResponse.json(
+        { error: "Oracle resolver is busy. Retry shortly." },
+        {
+          status: 503,
+          headers: { "Retry-After": "1" },
+        },
+      );
+    }
+
+    sourceLookup = fetchOracleSources(ca).finally(() => {
+      inFlight.delete(ca);
+    });
+
+    inFlight.set(ca, sourceLookup);
+  }
+
+  const [jupResult, dexResult] = await sourceLookup;
 
   // Best price: prefer DexScreener for memecoins, Jupiter as fallback
   const priceSource = dexResult ?? jupResult;
@@ -273,6 +313,6 @@ export async function GET(
   }
 
   // Cache and return
-  cache.set(ca, { data: result, expiresAt: Date.now() + CACHE_TTL_MS });
+  cache.set(ca, result);
   return NextResponse.json({ ...result, cached: false });
 }

--- a/app/lib/bounded-ttl-cache.ts
+++ b/app/lib/bounded-ttl-cache.ts
@@ -1,0 +1,114 @@
+interface CacheEntry<Value> {
+  value: Value;
+  expiresAt: number;
+}
+
+interface BoundedTtlCacheOptions {
+  maxEntries: number;
+  ttlMs: number;
+  now?: () => number;
+}
+
+/**
+ * Small in-memory TTL cache with deterministic LRU eviction.
+ *
+ * Security properties:
+ * - Enforces a hard maximum cardinality.
+ * - Actively removes expired entries.
+ * - Refreshes recency on successful reads.
+ * - Evicts the least-recently-used entry before capacity overflow.
+ *
+ * This cache is process-local and is intended only for short-lived,
+ * non-authoritative API response caching.
+ */
+export class BoundedTtlCache<Key, Value> {
+  private readonly entries = new Map<Key, CacheEntry<Value>>();
+  private readonly maxEntries: number;
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+
+  constructor({
+    maxEntries,
+    ttlMs,
+    now = Date.now,
+  }: BoundedTtlCacheOptions) {
+    if (!Number.isSafeInteger(maxEntries) || maxEntries <= 0) {
+      throw new RangeError("maxEntries must be a positive safe integer");
+    }
+
+    if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+      throw new RangeError("ttlMs must be a positive finite number");
+    }
+
+    this.maxEntries = maxEntries;
+    this.ttlMs = ttlMs;
+    this.now = now;
+  }
+
+  get size(): number {
+    this.deleteExpired();
+    return this.entries.size;
+  }
+
+  get(key: Key): Value | undefined {
+    const entry = this.entries.get(key);
+
+    if (!entry) {
+      return undefined;
+    }
+
+    const now = this.now();
+
+    if (entry.expiresAt <= now) {
+      this.entries.delete(key);
+      return undefined;
+    }
+
+    // Map iteration order is insertion order. Reinsert a successful hit so
+    // the first entry always represents the least-recently-used item.
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+
+    return entry.value;
+  }
+
+  set(key: Key, value: Value): void {
+    const now = this.now();
+
+    this.deleteExpired(now);
+
+    // Replacing an existing key must also refresh its LRU position.
+    this.entries.delete(key);
+
+    while (this.entries.size >= this.maxEntries) {
+      const oldest = this.entries.keys().next();
+
+      if (oldest.done) {
+        break;
+      }
+
+      this.entries.delete(oldest.value);
+    }
+
+    this.entries.set(key, {
+      value,
+      expiresAt: now + this.ttlMs,
+    });
+  }
+
+  delete(key: Key): boolean {
+    return this.entries.delete(key);
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  private deleteExpired(now = this.now()): void {
+    for (const [key, entry] of this.entries) {
+      if (entry.expiresAt <= now) {
+        this.entries.delete(key);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR fixes the unbounded process-local cache growth and upstream request-amplification conditions reported in #2416.

The affected oracle routes previously used module-level JavaScript `Map` instances as five-minute TTL caches without:

- A hard maximum cardinality.
- Active expired-entry removal.
- LRU/FIFO eviction.
- Protection against attacker-controlled cache keys.
- In-flight request deduplication.
- A hard limit on concurrent unique resolver operations.

The TTL checks only determined whether cached data could be returned. Expired entries remained strongly referenced by the process, allowing cache cardinality and retained memory to continue growing across unique requests.

This patch replaces the raw caches with a reusable bounded TTL/LRU implementation, removes attacker-controlled admin authorities from the publisher cache path, validates admin authority inputs, deduplicates concurrent resolver lookups, and enforces a hard in-flight concurrency limit.

Fixes #2416.

---

## Security Impact

The vulnerable behavior could allow unauthenticated requests to gradually increase process-local memory consumption.

The primary allocation path was:

```text
GET /api/oracle/publishers?mode=admin&authority=<unique-value>
```

Each unique `authority` previously generated a unique cache key:

```ts
const cacheKey = `${mode}:${feedId || authority || ""}`;
```

The resulting response was then stored in a module-level `Map`:

```ts
cache.set(cacheKey, {
  data: result,
  timestamp: Date.now(),
});
```

Expired entries were no longer served after five minutes, but they were not deleted. Because the `Map` continued holding strong references to the keys and response objects, garbage collection could not reclaim them while the route module remained alive.

The resolver route had a related condition:

```text
GET /api/oracle/resolve/[ca]
```

Unique cache misses could both:

1. Increase process-local cache cardinality.
2. Trigger independent Jupiter and DexScreener requests without in-flight deduplication or a global unique-operation limit.

On warm serverless instances or long-running Node.js processes, sustained accumulation could increase heap usage, garbage-collection pressure, latency, process restarts, and HTTP 5xx responses.

---

## Root Cause

### Oracle publishers route

Affected file:

```text
app/app/api/oracle/publishers/route.ts
```

The route previously used an unbounded module-level cache:

```ts
const cache = new Map<string, CacheEntry>();
```

The cache key included request-controlled data:

```ts
const cacheKey = `${mode}:${feedId || authority || ""}`;
```

The TTL check did not remove stale entries:

```ts
const cached = cache.get(cacheKey);

if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
  return NextResponse.json(cached.data);
}
```

Admin-mode output was inexpensive to generate locally but was still written into the shared cache:

```ts
case "admin":
  result = getAdminPublishers(authority);
  break;
```

The `authority` parameter also lacked canonical Solana public-key validation and an explicit maximum input length before being retained in the cache key and cached response.

### Oracle resolver route

Affected file:

```text
app/app/api/oracle/resolve/[ca]/route.ts
```

The resolver also used an unbounded module-level cache:

```ts
const cache = new Map<string, CacheEntry>();
```

Expired entries were ignored but not deleted:

```ts
const cached = cache.get(ca);

if (cached && Date.now() < cached.expiresAt) {
  return NextResponse.json({
    ...cached.data,
    cached: true,
  });
}
```

Every unique cache miss independently initiated both upstream requests:

```ts
const [jupResult, dexResult] = await Promise.all([
  fetchJupiterPrice(ca),
  fetchDexScreenerInfo(ca),
]);
```

Concurrent requests for the same mint therefore duplicated upstream work, while many unique requests had no hard in-flight concurrency bound.

---

## Changes

### 1. Added a reusable bounded TTL/LRU cache

New file:

```text
app/lib/bounded-ttl-cache.ts
```

The new `BoundedTtlCache<Key, Value>` abstraction provides:

- A mandatory hard maximum entry count.
- A mandatory positive TTL.
- Active expired-entry removal during reads.
- Expired-entry sweeping before insertion.
- Deterministic least-recently-used eviction.
- Recency refresh after successful reads.
- TTL and recency refresh when replacing an existing key.
- Explicit `delete()` and `clear()` operations.
- Optional deterministic clock injection for testing.

Core configuration validation rejects invalid resource bounds:

```ts
if (!Number.isSafeInteger(maxEntries) || maxEntries <= 0) {
  throw new RangeError(
    "maxEntries must be a positive safe integer",
  );
}

if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
  throw new RangeError(
    "ttlMs must be a positive finite number",
  );
}
```

Expired entries are actively removed:

```ts
if (entry.expiresAt <= now) {
  this.entries.delete(key);
  return undefined;
}
```

Successful cache hits refresh their LRU position:

```ts
this.entries.delete(key);
this.entries.set(key, entry);
```

Insertions cannot exceed the configured cardinality:

```ts
while (this.entries.size >= this.maxEntries) {
  const oldest = this.entries.keys().next();

  if (oldest.done) {
    break;
  }

  this.entries.delete(oldest.value);
}
```

---

### 2. Bounded the publishers cache

The publishers route now uses:

```ts
const MAX_CACHE_ENTRIES = 128;

const cache = new BoundedTtlCache<
  string,
  PublishersResponse
>({
  maxEntries: MAX_CACHE_ENTRIES,
  ttlMs: CACHE_TTL_MS,
});
```

This ensures the process-local publishers cache cannot grow beyond 128 entries.

Fresh cache reads now rely on the bounded cache abstraction:

```ts
const cached = cache.get(cacheKey);

if (cached) {
  return NextResponse.json(cached, {
    headers: {
      "Cache-Control": "public, max-age=300",
    },
  });
}
```

Externally resolved publisher results are stored without the old timestamp wrapper:

```ts
cache.set(cacheKey, result);
```

Expired-entry handling and eviction are centralized in the shared cache implementation.

---

### 3. Removed admin mode from the shared cache path

Admin-mode publisher responses are now handled before the shared cache lookup and insertion flow:

```ts
if (mode === "admin") {
  const validation = validateAdminAuthority(authority);

  if (!validation.ok) {
    return NextResponse.json(
      { error: validation.error },
      { status: 400 },
    );
  }

  return NextResponse.json(
    getAdminPublishers(validation.authority),
    {
      headers: {
        "Cache-Control": "no-store",
      },
    },
  );
}
```

This provides two protections:

1. Attacker-controlled authorities can no longer increase shared-cache cardinality.
2. Admin responses are explicitly marked `no-store`.

The shared cache key now excludes `authority`:

```ts
const cacheKey = `${mode}:${feedId || ""}`;
```

Admin mode is no longer present in the shared result switch.

---

### 4. Added canonical admin-authority validation

Non-empty admin authorities must now:

- Be between 32 and 44 characters.
- Parse successfully as a Solana `PublicKey`.
- Serialize back to the exact canonical base58 representation.

Validation:

```ts
function validateAdminAuthority(
  authority: string | null,
): AdminAuthorityValidation {
  if (!authority || authority === SYSTEM_PROGRAM_ID) {
    return {
      ok: true,
      authority,
    };
  }

  if (authority.length < 32 || authority.length > 44) {
    return {
      ok: false,
      error: "Invalid admin authority",
    };
  }

  try {
    const canonicalAuthority =
      new PublicKey(authority).toBase58();

    if (canonicalAuthority !== authority) {
      return {
        ok: false,
        error: "Invalid admin authority",
      };
    }

    return {
      ok: true,
      authority: canonicalAuthority,
    };
  } catch {
    return {
      ok: false,
      error: "Invalid admin authority",
    };
  }
}
```

The existing empty state remains compatible for:

- A missing authority.
- The system-program placeholder:

```text
11111111111111111111111111111111
```

Malformed and oversized values now return HTTP `400` before cache or external-resource access.

---

### 5. Bounded the resolver response cache

The resolver now uses:

```ts
const MAX_CACHE_ENTRIES = 256;

const cache = new BoundedTtlCache<
  string,
  OracleResolveResult
>({
  maxEntries: MAX_CACHE_ENTRIES,
  ttlMs: CACHE_TTL_MS,
});
```

The response cache is therefore limited to 256 entries and actively removes expired values.

Cache hits preserve the existing response metadata contract:

```ts
const cached = cache.get(ca);

if (cached) {
  return NextResponse.json({
    ...cached,
    cached: true,
  });
}
```

Successful results are stored as domain values:

```ts
cache.set(ca, result);
```

The transport-only `cached` field is not persisted inside the cache.

---

### 6. Added resolver in-flight request deduplication

A shared source-fetch helper now represents one Jupiter plus DexScreener lookup:

```ts
function fetchOracleSources(ca: string) {
  return Promise.all([
    fetchJupiterPrice(ca),
    fetchDexScreenerInfo(ca),
  ] as const);
}
```

Concurrent requests for the same mint reuse one in-flight promise:

```ts
let sourceLookup = inFlight.get(ca);

if (!sourceLookup) {
  sourceLookup = fetchOracleSources(ca).finally(() => {
    inFlight.delete(ca);
  });

  inFlight.set(ca, sourceLookup);
}

const [jupResult, dexResult] = await sourceLookup;
```

This prevents duplicate upstream operations for identical concurrent requests.

For two concurrent requests targeting the same mint:

```text
Before:
2 Jupiter requests + 2 DexScreener requests

After:
1 Jupiter request + 1 DexScreener request
```

The in-flight entry is removed through `.finally()`, covering both fulfilled and rejected operations.

---

### 7. Added a hard resolver concurrency limit

The number of unique resolver operations that may remain in flight simultaneously is now limited:

```ts
const MAX_IN_FLIGHT_REQUESTS = 64;
```

A new unique lookup is rejected when all slots are occupied:

```ts
if (inFlight.size >= MAX_IN_FLIGHT_REQUESTS) {
  return NextResponse.json(
    {
      error: "Oracle resolver is busy. Retry shortly.",
    },
    {
      status: 503,
      headers: {
        "Retry-After": "1",
      },
    },
  );
}
```

This prevents unbounded unique upstream concurrency and communicates a retryable overload condition to clients.

Requests targeting an already in-flight mint continue sharing the existing promise and do not consume an additional slot.

---

## Behavioral Compatibility

The patch preserves the existing functional behavior for valid requests:

- Valid `pyth-pinned` requests remain cacheable.
- Valid `hyperp` requests remain cacheable.
- Valid resolver results preserve their existing response shape.
- Resolver cache hits continue returning `cached: true`.
- Newly resolved responses continue returning `cached: false`.
- Missing admin authorities retain the existing empty state.
- The system-program placeholder retains the existing empty state.
- Valid canonical admin authorities continue returning one active publisher.
- Existing resolver mint validation remains unchanged.

Intentional behavior changes:

- Invalid admin authorities now return HTTP `400`.
- Oversized admin authorities now return HTTP `400`.
- Admin publisher responses use `Cache-Control: no-store`.
- Admin publisher responses are no longer stored in the process-local cache.
- Resolver overload returns HTTP `503` with `Retry-After: 1`.

---

## Regression Coverage

### Bounded cache utility

Added:

```text
app/__tests__/lib/bounded-ttl-cache.test.ts
```

Coverage verifies:

- Fresh values remain available before TTL expiration.
- Expired entries are deleted and no longer returned.
- Expired entries are swept before new insertion.
- Cache cardinality never exceeds the configured maximum.
- Least-recently-used entries are evicted.
- Successful reads refresh LRU position.
- Replacement refreshes value, TTL, and LRU position.
- Explicit deletion works.
- Cache clearing works.
- Invalid resource-bound configuration is rejected.

### Publishers route

Added:

```text
app/__tests__/api/oracle-publishers-cache-bounds.test.ts
```

Coverage verifies:

- The publisher cache is configured with:
  - `maxEntries: 128`
  - `ttlMs: 300000`
- Valid admin responses bypass the cache.
- Admin responses use `Cache-Control: no-store`.
- Missing authority preserves the empty state.
- The system-program placeholder preserves the empty state.
- Oversized attacker-controlled authorities return HTTP `400`.
- Malformed authorities return HTTP `400`.
- Invalid admin requests do not access the cache.
- Invalid admin requests do not invoke external `fetch`.
- Externally resolved modes can still be served from the bounded cache.

### Resolver route

Added:

```text
app/__tests__/api/oracle-resolver-cache-bounds.test.ts
```

Coverage verifies:

- The resolver cache is configured with:
  - `maxEntries: 256`
  - `ttlMs: 300000`
- Fresh cache hits bypass upstream requests.
- Concurrent requests for the same mint reuse one upstream operation.
- Completed operations are removed from the in-flight registry.
- Malformed mint input is rejected before cache or upstream access.
- Sixty-four unique unresolved operations saturate the in-flight registry.
- The sixty-fifth unique operation receives HTTP `503`.
- The overload response contains `Retry-After: 1`.
- A rejected overflow request does not initiate additional upstream traffic.
- A rejected overflow request does not write to the response cache.

---

## Validation

### Targeted security regression tests

Command:

```bash
CI=1 pnpm --dir app exec vitest run \
  __tests__/lib/bounded-ttl-cache.test.ts \
  __tests__/api/oracle-publishers-cache-bounds.test.ts \
  __tests__/api/oracle-resolver-cache-bounds.test.ts \
  --reporter=verbose
```

Result:

```text
Test Files  3 passed (3)
Tests       21 passed (21)
Exit code   0
```

### TypeScript validation

Command:

```bash
pnpm --dir app exec tsc --noEmit --pretty false
```

Result:

```text
Exit code: 0
```

### Production build

Command:

```bash
pnpm --dir app build
```

Result:

```text
Compiled successfully
TypeScript validation completed
Exit code: 0
```

The production build includes both affected routes:

```text
/api/oracle/publishers
/api/oracle/resolve/[ca]
```

### Whitespace validation

Command:

```bash
git diff --check
```

Result:

```text
Exit code: 0
```

---

## Full-Suite Baseline Comparison

The full application suite contains existing failures unrelated to this patch.

To distinguish baseline failures from regressions, the suite was executed both:

1. On the clean `upstream/playground` revision.
2. With this patch restored.

### Clean baseline

```text
Test Files  30 failed | 220 passed | 1 skipped
Tests       100 failed | 2515 passed | 16 skipped
Errors      9
```

### Patched branch

```text
Test Files  30 failed | 223 passed | 1 skipped
Tests       100 failed | 2536 passed | 16 skipped
Errors      9
```

### Delta

```text
+3 passing test files
+21 passing tests
0 additional failed tests
0 additional failed test files
0 additional unhandled errors
```

The failure count and error count are identical to the clean baseline. The only delta is the 3 new passing test files and 21 new passing tests introduced by this PR.

---

## Files Changed

```text
app/app/api/oracle/publishers/route.ts
app/app/api/oracle/resolve/[ca]/route.ts
app/lib/bounded-ttl-cache.ts
app/__tests__/lib/bounded-ttl-cache.test.ts
app/__tests__/api/oracle-publishers-cache-bounds.test.ts
app/__tests__/api/oracle-resolver-cache-bounds.test.ts
```

---

## Security Invariants Enforced

After this patch:

- The publishers response cache cannot exceed 128 entries.
- The resolver response cache cannot exceed 256 entries.
- Expired entries are actively removed.
- Cache insertions cannot exceed configured capacity.
- LRU entries are evicted before capacity overflow.
- Admin authorities are no longer part of any shared cache key.
- Admin responses do not allocate shared cache entries.
- Admin responses use `Cache-Control: no-store`.
- Malformed and oversized admin authorities are rejected.
- Concurrent resolver requests for the same mint share upstream work.
- Unique resolver concurrency cannot exceed 64 operations.
- Saturated resolver requests receive a retryable HTTP `503`.
- In-flight operations are cleaned up after success or failure.

---

## Risk Assessment

The implementation is intentionally process-local and does not introduce:

- Persistent storage.
- Database migrations.
- New external dependencies.
- Changes to on-chain state.
- Changes to transaction construction.
- Changes to wallet authorization.
- Changes to oracle selection logic.
- Changes to supported DEX identifiers.
- Changes to valid resolver response fields.

The primary compatibility change is stricter validation of admin authority input and controlled HTTP `503` responses during resolver saturation.

---

## Checklist

- [x] Replaced unbounded publishers cache.
- [x] Replaced unbounded resolver cache.
- [x] Added hard cache cardinality limits.
- [x] Added TTL expiration cleanup.
- [x] Added LRU eviction.
- [x] Removed admin mode from shared caching.
- [x] Added canonical Solana authority validation.
- [x] Added resolver request deduplication.
- [x] Added resolver in-flight concurrency limit.
- [x] Added cleanup for completed and rejected operations.
- [x] Added HTTP `503` overload handling.
- [x] Added `Retry-After` response header.
- [x] Added 21 targeted regression tests.
- [x] Targeted tests pass.
- [x] Typecheck passes.
- [x] Production build passes.
- [x] Full-suite failures verified against clean baseline.
- [x] No additional failures or unhandled errors introduced.
- [x] Branch is based on the latest `upstream/playground`.
- [x] Working tree was clean before push.