### PR TITLE
feat: trade RPC optimization and numeric input robustness (supersedes #2407)

### DIFF
--- a/app/__tests__/hooks/useDeposit.test.ts
+++ b/app/__tests__/hooks/useDeposit.test.ts
@@ -28,6 +28,10 @@ vi.mock("@/lib/tx", () => ({
   sendTx: vi.fn(),
 }));
 
+vi.mock("@/lib/errorMessages", () => ({
+  humanizeError: vi.fn((msg) => msg),
+}));
+
 // Bypass the program-allowlist gate for tests that focus on the deposit flow.
 // The gate is exercised in app/__tests__/lib/programAllowlist.test.ts and
 // app/__tests__/providers/SlabProvider-allowlist.test.tsx.

--- a/app/__tests__/hooks/useWithdraw-portfolio-fastpath.test.ts
+++ b/app/__tests__/hooks/useWithdraw-portfolio-fastpath.test.ts
@@ -1,0 +1,213 @@
+/**
+ * useWithdraw v17 portfolio fast-path tests
+ *
+ * When the caller supplies params.portfolioPk (SlabProvider's userAccount),
+ * useWithdraw takes a targeted getAccountInfo fast path instead of the GPA
+ * scan. Review finding on PR #2407: a fetch failure/null result must RESET
+ * portfolioPk so the GPA scan fallback runs — otherwise portfolioData stays
+ * null, the M7 over-withdraw pre-check is skipped, and the crank-prepend
+ * decision (hasActiveLegs) is silently wrong. The fast path must also
+ * owner-verify the fetched account, mirroring the scan-store path.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { act } from "react";
+import { PublicKey } from "@solana/web3.js";
+import { useWithdraw } from "../../hooks/useWithdraw";
+
+vi.mock("@/hooks/useWalletCompat", () => ({
+  useConnectionCompat: vi.fn(),
+  useWalletCompat: vi.fn(),
+}));
+
+vi.mock("@/components/providers/SlabProvider", () => ({
+  useSlabState: vi.fn(),
+}));
+
+vi.mock("@/lib/tx", () => ({
+  sendTx: vi.fn(),
+}));
+
+vi.mock("@/lib/errorMessages", () => ({
+  humanizeError: vi.fn((msg) => msg),
+}));
+
+vi.mock("@/lib/config", () => ({
+  getBackendUrl: vi.fn(() => "http://localhost:3001"),
+}));
+
+vi.mock("@/lib/programAllowlist", () => ({
+  isKnownProgram: () => true,
+  assertKnownProgram: () => {},
+}));
+
+// The scan-store snapshot must miss so the only paths in play are the
+// caller-supplied fast path and the GPA scan fallback.
+vi.mock("@/lib/userAccountScan", () => ({
+  getPortfolioRawSnapshot: vi.fn(() => undefined),
+  makePortfolioScanKey: vi.fn(() => "test-key"),
+  isLpPortfolio: vi.fn(() => false),
+}));
+
+const mockVaultAuth = new PublicKey("DjVE6JNiYqPL2QXyCUUh8rNjHrbz9hXHNYt99MQ59qw1");
+const mockOraclePda = new PublicKey("8DjWTsU1o8RHTKpRsqGFyYqFMknb8g7z2mjLfVYUyYyF");
+
+vi.mock("@percolatorct/sdk", async () => {
+  const actual = await vi.importActual("@percolatorct/sdk");
+  return {
+    ...actual,
+    getAta: vi.fn(),
+    deriveVaultAuthority: vi.fn(() => [mockVaultAuth, 255]),
+    derivePythPushOraclePDA: vi.fn(() => [mockOraclePda, 255]),
+    parsePortfolioV17: vi.fn(),
+  };
+});
+
+import { useConnectionCompat, useWalletCompat } from "@/hooks/useWalletCompat";
+import { useSlabState } from "@/components/providers/SlabProvider";
+import { sendTx } from "@/lib/tx";
+import { getAta, parsePortfolioV17 } from "@percolatorct/sdk";
+
+describe("useWithdraw v17 portfolio fast path", () => {
+  const mockSlabAddress = "11111111111111111111111111111111";
+  const mockWalletPubkey = new PublicKey("7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU");
+  const mockProgramId = new PublicKey("5BZWY6XWPxuWFxs2nPCLLsVaKRWZVnzZh3FkJDLJBkJf");
+  const mockCollateralMint = new PublicKey("So11111111111111111111111111111111111111112");
+  const mockVault = new PublicKey("9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin");
+  const mockUserAta = new PublicKey("DjVE6JNiYqPL2QXyCUUh8rNjHrbz9hXHNYt99MQ59qw1");
+  const fastPathPortfolioPk = new PublicKey("4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T");
+  const scannedPortfolioPk = new PublicKey("BPFLoaderUpgradeab1e11111111111111111111111");
+
+  let mockConnection: any;
+  let mockWallet: any;
+  let mockSlabState: any;
+
+  const walletOwnedPortfolio = () => ({
+    owner: mockWalletPubkey,
+    legs: [],
+    pnl: 0n,
+    capital: 10_000_000n,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockConnection = {
+      getAccountInfo: vi.fn().mockResolvedValue({ data: Buffer.alloc(1288) }),
+      getProgramAccounts: vi.fn().mockResolvedValue([
+        { pubkey: scannedPortfolioPk, account: { data: Buffer.alloc(1288) } },
+      ]),
+    };
+
+    mockWallet = {
+      publicKey: mockWalletPubkey,
+      signTransaction: vi.fn(),
+      connected: true,
+    };
+
+    mockSlabState = {
+      config: {
+        collateralMint: mockCollateralMint,
+        vaultPubkey: mockVault,
+        oracleAuthority: PublicKey.default,
+        indexFeedId: new PublicKey(new Uint8Array(32).fill(1)),
+        authorityPriceE6: 1000000n,
+        lastEffectivePriceE6: 1000000n,
+        invert: false,
+      },
+      // Non-null → v17 path, network re-check skipped.
+      wrapperConfigV17: { oracleMode: 0 },
+      params: { initialMarginBps: 1000n },
+      programId: mockProgramId,
+      refresh: vi.fn(),
+    };
+
+    vi.mocked(useConnectionCompat).mockReturnValue({ connection: mockConnection });
+    vi.mocked(useWalletCompat).mockReturnValue(mockWallet);
+    vi.mocked(useSlabState).mockReturnValue(mockSlabState);
+    vi.mocked(sendTx).mockResolvedValue({ signature: "mock-signature" } as any);
+    vi.mocked(getAta).mockResolvedValue(mockUserAta);
+    vi.mocked(parsePortfolioV17).mockReturnValue(walletOwnedPortfolio() as any);
+  });
+
+  it("uses the caller-supplied portfolioPk without a GPA scan when fetch + owner check succeed", async () => {
+    const { result } = renderHook(() => useWithdraw(mockSlabAddress));
+
+    await act(async () => {
+      await result.current.withdraw({ userIdx: 1, amount: 1n, portfolioPk: fastPathPortfolioPk });
+    });
+
+    expect(mockConnection.getAccountInfo).toHaveBeenCalledWith(fastPathPortfolioPk, "confirmed");
+    expect(mockConnection.getProgramAccounts).not.toHaveBeenCalled();
+    expect(sendTx).toHaveBeenCalledTimes(1);
+    // Withdraw ix must target the fast-path portfolio.
+    const { instructions } = vi.mocked(sendTx).mock.calls[0][0];
+    const withdrawIx = instructions[instructions.length - 1];
+    expect(withdrawIx.keys[2].pubkey.equals(fastPathPortfolioPk)).toBe(true);
+  });
+
+  it("falls back to the GPA scan when the fast-path fetch throws", async () => {
+    mockConnection.getAccountInfo.mockRejectedValueOnce(new Error("429 Too Many Requests"));
+
+    const { result } = renderHook(() => useWithdraw(mockSlabAddress));
+
+    await act(async () => {
+      await result.current.withdraw({ userIdx: 1, amount: 1n, portfolioPk: fastPathPortfolioPk });
+    });
+
+    expect(mockConnection.getProgramAccounts).toHaveBeenCalledTimes(1);
+    const { instructions } = vi.mocked(sendTx).mock.calls[0][0];
+    const withdrawIx = instructions[instructions.length - 1];
+    expect(withdrawIx.keys[2].pubkey.equals(scannedPortfolioPk)).toBe(true);
+  });
+
+  it("falls back to the GPA scan when the fast-path account is missing (null)", async () => {
+    mockConnection.getAccountInfo.mockResolvedValueOnce(null);
+
+    const { result } = renderHook(() => useWithdraw(mockSlabAddress));
+
+    await act(async () => {
+      await result.current.withdraw({ userIdx: 1, amount: 1n, portfolioPk: fastPathPortfolioPk });
+    });
+
+    expect(mockConnection.getProgramAccounts).toHaveBeenCalledTimes(1);
+    const { instructions } = vi.mocked(sendTx).mock.calls[0][0];
+    const withdrawIx = instructions[instructions.length - 1];
+    expect(withdrawIx.keys[2].pubkey.equals(scannedPortfolioPk)).toBe(true);
+  });
+
+  it("falls back to the GPA scan when the fast-path account is owned by a different wallet", async () => {
+    const otherOwner = new PublicKey(new Uint8Array(32).fill(7));
+    vi.mocked(parsePortfolioV17)
+      .mockReturnValueOnce({ ...walletOwnedPortfolio(), owner: otherOwner } as any) // fast path: mismatch
+      .mockReturnValue(walletOwnedPortfolio() as any); // scan path + M7 check
+
+    const { result } = renderHook(() => useWithdraw(mockSlabAddress));
+
+    await act(async () => {
+      await result.current.withdraw({ userIdx: 1, amount: 1n, portfolioPk: fastPathPortfolioPk });
+    });
+
+    expect(mockConnection.getProgramAccounts).toHaveBeenCalledTimes(1);
+    const { instructions } = vi.mocked(sendTx).mock.calls[0][0];
+    const withdrawIx = instructions[instructions.length - 1];
+    expect(withdrawIx.keys[2].pubkey.equals(scannedPortfolioPk)).toBe(true);
+  });
+
+  it("runs the M7 over-withdraw pre-check on fast-path data (amount > capital rejects client-side)", async () => {
+    const { result } = renderHook(() => useWithdraw(mockSlabAddress));
+
+    await act(async () => {
+      await expect(
+        result.current.withdraw({
+          userIdx: 1,
+          amount: 999_999_999_999n, // way past capital (10_000_000n), no open legs
+          portfolioPk: fastPathPortfolioPk,
+        }),
+      ).rejects.toThrow(/exceeds your account balance/);
+    });
+
+    expect(sendTx).not.toHaveBeenCalled();
+  });
+});

--- a/app/__tests__/hooks/useWithdraw.test.ts
+++ b/app/__tests__/hooks/useWithdraw.test.ts
@@ -29,6 +29,10 @@ vi.mock("@/lib/tx", () => ({
   sendTx: vi.fn(),
 }));
 
+vi.mock("@/lib/errorMessages", () => ({
+  humanizeError: vi.fn((msg) => msg),
+}));
+
 vi.mock("@/lib/config", () => ({
   getBackendUrl: vi.fn(() => "http://localhost:3001"),
 }));

--- a/app/__tests__/lib/errorMessages.test.ts
+++ b/app/__tests__/lib/errorMessages.test.ts
@@ -113,6 +113,37 @@ describe("isTransientError", () => {
   it("returns false for unknown text", () => {
     expect(isTransientError("something went wrong")).toBe(false);
   });
+
+  it("returns true for genuine HTTP 429 rate limit", () => {
+    expect(isTransientError("429 Too Many Requests")).toBe(true);
+    expect(isTransientError("Server responded with 429: rate limit exceeded")).toBe(true);
+    expect(isTransientError("Too many requests for a specific RPC call")).toBe(true);
+  });
+
+  it("does NOT classify a bare '429' inside a base58 signature as transient", () => {
+    // '429' at a word boundary inside a signature-bearing message must not
+    // trigger a retry — withTransientRetry callers rebuild and RESEND the tx.
+    expect(isTransientError("failed: see tx 5Kd429Xw8pQzR7vGm2NhLt3fUj6yBcAeSD9krWq4TnYoZxEHVuJgP1M8iC7sbFa2")).toBe(false);
+    expect(isTransientError("error at slot 429")).toBe(false);
+    expect(isTransientError("balance is 429 lamports")).toBe(false);
+  });
+
+  it("NEVER classifies a confirmation-timeout message as transient (tx may have landed — resend double-fills)", () => {
+    const sigWith429 =
+      "429aBcDeFgHiJkMnPqRsTuVwXyZ123456789ABCDEFGHJKLMNPQRSTUVWXYZabc";
+    expect(
+      isTransientError(
+        `Confirmation timeout (90s) — tx may still land. Check explorer: ${sigWith429}`,
+      ),
+    ).toBe(false);
+    // Even if the message ALSO contains rate-limit phrasing, timeout wins.
+    expect(
+      isTransientError(
+        "Confirmation timeout (90s) — tx may still land. Check explorer: abc (429 Too Many Requests)",
+      ),
+    ).toBe(false);
+    expect(isTransientError("tx may still land, check explorer")).toBe(false);
+  });
 });
 
 describe("isOracleStaleError", () => {

--- a/app/components/trade/DepositWithdrawCard.tsx
+++ b/app/components/trade/DepositWithdrawCard.tsx
@@ -281,9 +281,9 @@ export const DepositWithdrawCard: FC<DepositWithdrawCardProps> = ({ slabAddress,
         // accountExists=true: DepositWithdrawCard only renders when userAccount !== null,
         // so the account is confirmed by SlabProvider. Skips the stale-slab re-check in
         // useDeposit that would incorrectly prepend a duplicate InitUser. (P0 race fix)
-        sig = await deposit({ userIdx: userAccount.idx, amount: amtNative, accountExists: true });
+        sig = await deposit({ userIdx: userAccount.idx, amount: amtNative, accountExists: true, portfolioPk: userAccount.pubkey });
       } else {
-        sig = await withdraw({ userIdx: userAccount.idx, amount: amtNative });
+        sig = await withdraw({ userIdx: userAccount.idx, amount: amtNative, portfolioPk: userAccount.pubkey });
       }
       setLastSig(sig ?? null);
       maxRawRef.current = null;

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -430,7 +430,16 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
       }
       const notionalUsd = unit === "token" ? n * priceUsd : n;
       const marginAmt = notionalUsd / lev;
-      setMarginInput(marginAmt.toFixed(decimals));
+      
+      // Truncate rather than round to prevent fractional float-overshoot
+      // from generating a marginNative slightly larger than the user's actual balance.
+      const str = marginAmt.toString();
+      if (str.includes("e")) {
+        setMarginInput(marginAmt.toFixed(decimals));
+      } else {
+        const dot = str.indexOf(".");
+        setMarginInput(dot === -1 ? str : str.slice(0, dot + 1 + decimals));
+      }
     },
     [priceUsd, decimals],
   );
@@ -450,7 +459,15 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
       const n = parseFloat(sizeInput);
       if (!isNaN(n) && priceUsd && priceUsd > 0) {
         const converted = prev === "token" ? n * priceUsd : n / priceUsd;
-        const nextStr = next === "token" ? converted.toFixed(6) : converted.toFixed(2);
+        const targetDecimals = next === "token" ? 6 : 2;
+        const str = converted.toString();
+        let nextStr: string;
+        if (str.includes("e")) {
+          nextStr = converted.toFixed(targetDecimals);
+        } else {
+          const dot = str.indexOf(".");
+          nextStr = dot === -1 ? str : str.slice(0, dot + 1 + targetDecimals);
+        }
         setSizeInput(nextStr);
         recomputeFromSize(nextStr, next, leverage);
       }
@@ -478,7 +495,14 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
       const notionalUsd = marginNum * leverage;
       if (priceUsd && priceUsd > 0) {
         const nextSize = sizeUnit === "token" ? notionalUsd / priceUsd : notionalUsd;
-        setSizeInput(sizeUnit === "token" ? nextSize.toFixed(6) : nextSize.toFixed(2));
+        const targetDecimals = sizeUnit === "token" ? 6 : 2;
+        const str = nextSize.toString();
+        if (str.includes("e")) {
+          setSizeInput(nextSize.toFixed(targetDecimals));
+        } else {
+          const dot = str.indexOf(".");
+          setSizeInput(dot === -1 ? str : str.slice(0, dot + 1 + targetDecimals));
+        }
       }
     },
     [effectiveBalance, decimals, leverage, priceUsd, sizeUnit],
@@ -600,7 +624,7 @@ setEngineLockError(null);
         async () =>
           trade(
             bindConfirmedLimitPrice(
-              { lpIdx, userIdx: userAccount!.idx, size },
+              { lpIdx, userIdx: userAccount!.idx, size, userPortfolioPk: userAccount!.pubkey },
               snapshotLimitPriceE6,
             ),
           ),

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -80,6 +80,21 @@ function sanitizeDecimalInput(value: string): string {
   return cleaned.slice(0, dotIndex + 1) + cleaned.slice(dotIndex + 1).replace(/\./g, "");
 }
 
+// Truncate (never round) a number's decimal representation to `decimals`
+// places. Rounding up can produce a native amount slightly larger than the
+// user's actual balance (fractional float-overshoot), so derived input fields
+// must truncate. Exponent-notation values fall back to toFixed (which never
+// overshoots for the tiny magnitudes that render as e-notation). decimals=0
+// returns the bare integer part — no trailing ".".
+function truncateToDecimals(value: number, decimals: number): string {
+  const str = value.toString();
+  if (str.includes("e")) return value.toFixed(decimals);
+  const dot = str.indexOf(".");
+  if (dot === -1) return str;
+  if (decimals === 0) return str.slice(0, dot);
+  return str.slice(0, dot + 1 + decimals);
+}
+
 
 
 function parsePercToNative(input: string, decimalsRaw = 6): bigint {
@@ -430,16 +445,9 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
       }
       const notionalUsd = unit === "token" ? n * priceUsd : n;
       const marginAmt = notionalUsd / lev;
-      
       // Truncate rather than round to prevent fractional float-overshoot
       // from generating a marginNative slightly larger than the user's actual balance.
-      const str = marginAmt.toString();
-      if (str.includes("e")) {
-        setMarginInput(marginAmt.toFixed(decimals));
-      } else {
-        const dot = str.indexOf(".");
-        setMarginInput(dot === -1 ? str : str.slice(0, dot + 1 + decimals));
-      }
+      setMarginInput(truncateToDecimals(marginAmt, decimals));
     },
     [priceUsd, decimals],
   );
@@ -459,15 +467,7 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
       const n = parseFloat(sizeInput);
       if (!isNaN(n) && priceUsd && priceUsd > 0) {
         const converted = prev === "token" ? n * priceUsd : n / priceUsd;
-        const targetDecimals = next === "token" ? 6 : 2;
-        const str = converted.toString();
-        let nextStr: string;
-        if (str.includes("e")) {
-          nextStr = converted.toFixed(targetDecimals);
-        } else {
-          const dot = str.indexOf(".");
-          nextStr = dot === -1 ? str : str.slice(0, dot + 1 + targetDecimals);
-        }
+        const nextStr = truncateToDecimals(converted, next === "token" ? 6 : 2);
         setSizeInput(nextStr);
         recomputeFromSize(nextStr, next, leverage);
       }
@@ -495,14 +495,7 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
       const notionalUsd = marginNum * leverage;
       if (priceUsd && priceUsd > 0) {
         const nextSize = sizeUnit === "token" ? notionalUsd / priceUsd : notionalUsd;
-        const targetDecimals = sizeUnit === "token" ? 6 : 2;
-        const str = nextSize.toString();
-        if (str.includes("e")) {
-          setSizeInput(nextSize.toFixed(targetDecimals));
-        } else {
-          const dot = str.indexOf(".");
-          setSizeInput(dot === -1 ? str : str.slice(0, dot + 1 + targetDecimals));
-        }
+        setSizeInput(truncateToDecimals(nextSize, sizeUnit === "token" ? 6 : 2));
       }
     },
     [effectiveBalance, decimals, leverage, priceUsd, sizeUnit],
@@ -624,7 +617,7 @@ setEngineLockError(null);
         async () =>
           trade(
             bindConfirmedLimitPrice(
-              { lpIdx, userIdx: userAccount!.idx, size, userPortfolioPk: userAccount!.pubkey },
+              { lpIdx, userIdx: userAccount!.idx, size },
               snapshotLimitPriceE6,
             ),
           ),

--- a/app/components/trade/PositionPanel.tsx
+++ b/app/components/trade/PositionPanel.tsx
@@ -96,11 +96,12 @@ interface AddMarginModalProps {
   userIdx: number;
   symbol: string;
   decimals: number;
+  portfolioPk?: import("@solana/web3.js").PublicKey;
   onClose: () => void;
   onSuccess?: () => void;
 }
 
-export const AddMarginModal: FC<AddMarginModalProps> = ({ slabAddress, userIdx, symbol, decimals, onClose, onSuccess}) => {
+export const AddMarginModal: FC<AddMarginModalProps> = ({ slabAddress, userIdx, symbol, decimals, portfolioPk, onClose, onSuccess}) => {
   const [amount, setAmount] = useState("");
   const [lastSig, setLastSig] = useState<string | null>(null);
   const { deposit, loading, error } = useDeposit(slabAddress);
@@ -120,7 +121,7 @@ export const AddMarginModal: FC<AddMarginModalProps> = ({ slabAddress, userIdx, 
   async function handleDeposit() {
     if (!canSubmit) return;
     try {
-      const sig = await deposit({ userIdx, amount: parsedAmount, accountExists: true });
+      const sig = await deposit({ userIdx, amount: parsedAmount, accountExists: true, portfolioPk });
       setLastSig(sig ?? null);
       setAmount("");
 
@@ -703,6 +704,7 @@ export const PositionPanel: FC<{ slabAddress: string }> = ({ slabAddress }) => {
           userIdx={userAccount.idx}
           symbol={symbol}
           decimals={decimals}
+          portfolioPk={userAccount.pubkey}
           onClose={() => setShowAddMarginModal(false)}
         onSuccess={refreshSlab}
         />

--- a/app/hooks/useClosePosition.ts
+++ b/app/hooks/useClosePosition.ts
@@ -324,7 +324,7 @@ export function useClosePosition(slabAddress: string): UseClosePositionReturn {
         // resolves accountA via findV17Portfolio + accountB via GPA scan.
         // v12: pass the real lpIdx and userAccount.idx as before.
         const sig = await withTransientRetry(
-          async () => trade({ lpIdx, userIdx: userAccount.idx, size: closeSize, userPortfolioPk: userAccount.pubkey }),
+          async () => trade({ lpIdx, userIdx: userAccount.idx, size: closeSize }),
           { maxRetries: 2, delayMs: 3000 },
         );
 

--- a/app/hooks/useClosePosition.ts
+++ b/app/hooks/useClosePosition.ts
@@ -324,7 +324,7 @@ export function useClosePosition(slabAddress: string): UseClosePositionReturn {
         // resolves accountA via findV17Portfolio + accountB via GPA scan.
         // v12: pass the real lpIdx and userAccount.idx as before.
         const sig = await withTransientRetry(
-          async () => trade({ lpIdx, userIdx: userAccount.idx, size: closeSize }),
+          async () => trade({ lpIdx, userIdx: userAccount.idx, size: closeSize, userPortfolioPk: userAccount.pubkey }),
           { maxRetries: 2, delayMs: 3000 },
         );
 

--- a/app/hooks/useDeposit.ts
+++ b/app/hooks/useDeposit.ts
@@ -98,7 +98,7 @@ export function useDeposit(slabAddress: string) {
   const inflightRef = useRef(false);
 
   const deposit = useCallback(
-    async (params: { userIdx: number; amount: bigint; accountExists?: boolean }) => {
+    async (params: { userIdx: number; amount: bigint; accountExists?: boolean; portfolioPk?: PublicKey }) => {
       if (inflightRef.current) throw new Error("Deposit already in progress");
       inflightRef.current = true;
       setLoading(true);
@@ -177,7 +177,7 @@ export function useDeposit(slabAddress: string) {
 
         if (isV17) {
           // v17: derive vault authority PDA to build the vault token ATA.
-          // vaultPda is a program PDA (off the ed25519 curve) → allowOwnerOffCurve=true,
+          // vaultPda is program PDA (off the ed25519 curve) → allowOwnerOffCurve=true,
           // else spl-token throws TokenOwnerOffCurveError.
           const [vaultPda] = deriveVaultAuthority(programId, slabPk);
           const vaultTokenAta = await getAta(vaultPda, mktConfig.collateralMint, true);
@@ -194,6 +194,7 @@ export function useDeposit(slabAddress: string) {
           const [ataExists, resolvedPortfolioPk] = await Promise.all([
             getAccount(connection, userAta).then(() => true, () => false),
             (async () => {
+              if (params.portfolioPk) return params.portfolioPk;
               const snap = getPortfolioRawSnapshot(
                 makePortfolioScanKey(programId, slabAddress, wallet.publicKey!),
               );
@@ -348,8 +349,8 @@ export function useDeposit(slabAddress: string) {
 
         // Force immediate slab re-read so balance updates without waiting for
         // the next poll cycle (which can be up to 30 s when WS is active).
-        refreshSlab();
-        setTimeout(() => refreshSlab(), 2000);
+        refreshSlab?.();
+        setTimeout(() => refreshSlab?.(), 2000);
         return sig;
       } catch (e) {
         setError(humanizeError(e instanceof Error ? e.message : String(e)));

--- a/app/hooks/useTrade.ts
+++ b/app/hooks/useTrade.ts
@@ -489,7 +489,7 @@ export function useTrade(slabAddress: string) {
           // normally an instant cache hit instead of two program scans
           // between the confirm click and the wallet popup.
           const resolved = await getOrResolveV17TradeAccounts(connection, programId, slabPk, wallet.publicKey);
-          accountA = params.userPortfolioPk ?? resolved.accountA;
+          accountA = resolved.accountA;
           accountB = resolved.accountB;
           matcherProg = resolved.matcherProg;
           matcherCtx = resolved.matcherCtx;

--- a/app/hooks/useTrade.ts
+++ b/app/hooks/useTrade.ts
@@ -413,12 +413,6 @@ export function useTrade(slabAddress: string) {
 
         // Determine oracle mode using centralised detectOracleMode (oraclePrice.ts).
         // "pyth-pinned" = Pyth feed; "admin" or "hyperp" = use slab as oracle account.
-        // Pass wrapperConfigV17?.oracleMode (the on-chain oracle_mode byte) so v17
-        // AUTH_MARK/keeper markets (byte=3) classify as "keeper" instead of falling
-        // through to "hyperp" — SlabProvider forces indexFeedId to ZERO for both
-        // modes, so key-based detection alone can't tell them apart. Every other
-        // call site (MarketStatsCard, useOracleFreshness, markets/page,
-        // MarketBrowser) already passes this; useTrade was the one straggler.
         const oracleMode = detectOracleMode({ ...mktConfig, oracleModeByte: wrapperConfigV17?.oracleMode });
         const useAdminOracle = oracleMode !== "pyth-pinned";
         const feedHex = Array.from(mktConfig.indexFeedId.toBytes()).map(b => b.toString(16).padStart(2, "0")).join("");
@@ -426,7 +420,10 @@ export function useTrade(slabAddress: string) {
 
         const instructions = [];
 
-        // For admin oracle markets where user IS the oracle authority,
+        // If user is oracle authority, push price first.
+        // B-2: Check that oracleAuthority actually matches wallet before attempting
+        // inline push.
+        // B-3: In beta.29 on-chain wrapper removed inline advance-phase support, so
         // push a fresh price before cranking (crank needs fresh oracle data).
         // PERC-8328 / GH#1966: NEVER fall back to a hardcoded price — if we can't get
         // a valid, fresh price from the backend, abort the trade entirely. Pushing a
@@ -435,10 +432,6 @@ export function useTrade(slabAddress: string) {
         if (userIsOracleAuth) {
           throw new Error(INLINE_ORACLE_PUSH_REMOVED_ERROR);
         }
-
-        // Pre-trade crank ix will be built after portfolio (accountA) is resolved below,
-        // since v17 PermissionlessCrank needs a valid portfolio at accounts[2].
-        // The crank is inserted into instructions[] before the trade ix at the end.
 
         // ── v17 TradeCpi account resolution ──────────────────────────────────
         // v17 TradeCpi (tag 10) requires 7 accounts:
@@ -496,7 +489,7 @@ export function useTrade(slabAddress: string) {
           // normally an instant cache hit instead of two program scans
           // between the confirm click and the wallet popup.
           const resolved = await getOrResolveV17TradeAccounts(connection, programId, slabPk, wallet.publicKey);
-          accountA = resolved.accountA;
+          accountA = params.userPortfolioPk ?? resolved.accountA;
           accountB = resolved.accountB;
           matcherProg = resolved.matcherProg;
           matcherCtx = resolved.matcherCtx;
@@ -584,8 +577,8 @@ export function useTrade(slabAddress: string) {
         // the balance/position reflect the trade within ~1-2s instead of waiting
         // on the (30s when WS-active) background poll. Fixes "balance doesn't
         // update after I trade". Mirrors useDeposit/useWithdraw.
-        refreshSlab();
-        [1200, 2200, 3500].forEach((ms) => setTimeout(() => refreshSlab(), ms));
+        refreshSlab?.();
+        [1200, 2200, 3500].forEach((ms) => setTimeout(() => refreshSlab?.(), ms));
         return sig;
       } catch (e) {
         // Invalidate the cached v17 account resolution — the failure may be a
@@ -604,7 +597,7 @@ export function useTrade(slabAddress: string) {
         if (mountedRef.current) setLoading(false);
       }
     },
-    [connection, wallet, mktConfig, accounts, raw, slabAddress, slabProgramId, refreshSlab]
+    [connection, wallet, mktConfig, accounts, raw, slabAddress, slabProgramId, refreshSlab, wrapperConfigV17]
   );
 
   return { trade, loading, error };

--- a/app/hooks/useWithdraw.ts
+++ b/app/hooks/useWithdraw.ts
@@ -145,17 +145,39 @@ export function useWithdraw(slabAddress: string) {
           let portfolioPk: PublicKey | null = params.portfolioPk ?? null;
           let portfolioData: Buffer | null = null;
           if (portfolioPk) {
+            // Fast path: caller supplied the portfolio pubkey (SlabProvider's
+            // userAccount). Fetch, parse, and owner-verify it exactly like the
+            // scan-store path below. On ANY failure — fetch throw, missing
+            // account, parse error, or owner mismatch — reset portfolioPk to
+            // null so the GPA scan fallback runs. Leaving portfolioPk set with
+            // portfolioData null would silently skip the M7 over-withdraw
+            // pre-check AND the hasActiveLegs crank-prepend decision, turning
+            // a transient RPC blip into an on-chain EngineStale(19) revert
+            // with a misleading "needs maintainer crank" message.
             try {
               const info = await connection.getAccountInfo(portfolioPk, "confirmed");
-              if (info) portfolioData = Buffer.from(info.data);
-            } catch { /* best-effort */ }
-          } else {
+              if (info) {
+                const candidateData = Buffer.from(info.data);
+                const candidatePf = parsePortfolioV17(candidateData);
+                if (candidatePf.owner.equals(wallet.publicKey)) {
+                  portfolioData = candidateData;
+                } else {
+                  portfolioPk = null; // owner mismatch — fall back to the scan
+                }
+              } else {
+                portfolioPk = null; // account not found — fall back to the scan
+              }
+            } catch {
+              portfolioPk = null; // fetch/parse failed — fall back to the scan
+            }
+          }
+          if (!portfolioPk) {
             // Latency: when the shared scan store knows the portfolio's pubkey
             // (its address never changes for a wallet+market), one targeted
             // getAccountInfo replaces the filtered program scan below — the
             // DATA read is equally live either way (withdraw needs fresh data
-            // for the free-margin gate and the crank-prepend decision). The
-            // owner re-verification below applies to both paths.
+            // for the free-margin gate and the crank-prepend decision). Owner
+            // re-verification happens inline in each path before trusting it.
             const storePk = getPortfolioRawSnapshot(
               makePortfolioScanKey(programId, slabAddress, wallet.publicKey),
             )?.pubkey;

--- a/app/hooks/useWithdraw.ts
+++ b/app/hooks/useWithdraw.ts
@@ -64,7 +64,7 @@ export function useWithdraw(slabAddress: string) {
   const inflightRef = useRef(false);
 
   const withdraw = useCallback(
-    async (params: { userIdx: number; amount: bigint }) => {
+    async (params: { userIdx: number; amount: bigint; portfolioPk?: PublicKey }) => {
       if (inflightRef.current) throw new Error("Withdrawal already in progress");
       inflightRef.current = true;
       setLoading(true);
@@ -142,29 +142,36 @@ export function useWithdraw(slabAddress: string) {
 
           // Find the user's portfolio account.
           const V17_MAGIC_BYTES = Buffer.from([0x00, 0x36, 0x31, 0x56, 0x43, 0x52, 0x45, 0x50]);
-          let portfolioPk: PublicKey | null = null;
+          let portfolioPk: PublicKey | null = params.portfolioPk ?? null;
           let portfolioData: Buffer | null = null;
-          // Latency: when the shared scan store knows the portfolio's pubkey
-          // (its address never changes for a wallet+market), one targeted
-          // getAccountInfo replaces the filtered program scan below — the
-          // DATA read is equally live either way (withdraw needs fresh data
-          // for the free-margin gate and the crank-prepend decision). The
-          // owner re-verification below applies to both paths.
-          const storePk = getPortfolioRawSnapshot(
-            makePortfolioScanKey(programId, slabAddress, wallet.publicKey),
-          )?.pubkey;
-          if (storePk) {
+          if (portfolioPk) {
             try {
-              const info = await connection.getAccountInfo(storePk, "confirmed");
-              if (info) {
-                const candidateData = Buffer.from(info.data);
-                const candidatePf = parsePortfolioV17(candidateData);
-                if (candidatePf.owner.equals(wallet.publicKey)) {
-                  portfolioPk = storePk;
-                  portfolioData = candidateData;
+              const info = await connection.getAccountInfo(portfolioPk, "confirmed");
+              if (info) portfolioData = Buffer.from(info.data);
+            } catch { /* best-effort */ }
+          } else {
+            // Latency: when the shared scan store knows the portfolio's pubkey
+            // (its address never changes for a wallet+market), one targeted
+            // getAccountInfo replaces the filtered program scan below — the
+            // DATA read is equally live either way (withdraw needs fresh data
+            // for the free-margin gate and the crank-prepend decision). The
+            // owner re-verification below applies to both paths.
+            const storePk = getPortfolioRawSnapshot(
+              makePortfolioScanKey(programId, slabAddress, wallet.publicKey),
+            )?.pubkey;
+            if (storePk) {
+              try {
+                const info = await connection.getAccountInfo(storePk, "confirmed");
+                if (info) {
+                  const candidateData = Buffer.from(info.data);
+                  const candidatePf = parsePortfolioV17(candidateData);
+                  if (candidatePf.owner.equals(wallet.publicKey)) {
+                    portfolioPk = storePk;
+                    portfolioData = candidateData;
+                  }
                 }
-              }
-            } catch { /* fall through to the scan */ }
+              } catch { /* fall through to the scan */ }
+            }
           }
           if (!portfolioPk) try {
             // Mutable owner (SDK PF_OWNER_OFF) is at offset 116, NOT offset 80
@@ -340,8 +347,8 @@ export function useWithdraw(slabAddress: string) {
         // crank+trade budget); all pre-existing paths keep the original 300k.
         const sig = await sendTx({ connection, wallet, instructions, computeUnits: v17CrankIncluded ? 600_000 : 300_000 });
         // Force immediate slab re-read so balance updates without waiting for the next poll.
-        refreshSlab();
-        setTimeout(() => refreshSlab(), 2000);
+        refreshSlab?.();
+        setTimeout(() => refreshSlab?.(), 2000);
         return sig;
       } catch (e) {
         const rawMsg = e instanceof Error ? e.message : String(e);

--- a/app/lib/errorMessages.ts
+++ b/app/lib/errorMessages.ts
@@ -225,12 +225,24 @@ function extractCustomIndex(msg: string): number | null {
 const TRANSIENT_CODES = new Set([20, 26, 27]);
 
 export function isTransientError(msg: string): boolean {
+  // A confirmation timeout must NEVER classify as transient: the tx may have
+  // already landed, and withTransientRetry callers (OrderTicket handleTrade,
+  // useClosePosition) REBUILD AND RESEND the transaction — retrying a landed
+  // trade double-fills. pollConfirmation's message also embeds a base58
+  // signature whose digit runs ("429") used to false-positive the old
+  // substring rate-limit check. Guard first, before any other match.
+  if (/confirmation timeout|may still land/i.test(msg)) return false;
   const code = extractErrorCode(msg);
   if (code !== null && TRANSIENT_CODES.has(code)) return true;
   if (msg.includes("Blockhash not found")) return true;
   if (msg.includes("block height exceeded")) return true;
   if (msg.includes("has expired")) return true;
-  if (msg.includes("429") || msg.toLowerCase().includes("too many requests")) return true;
+  // HTTP 429 rate limit → safe to retry (the tx was never accepted). A bare
+  // "429" substring is NOT enough — base58 signatures and arbitrary numbers
+  // can contain it — so require explicit rate-limit phrasing, optionally
+  // alongside a word-bounded 429 status code.
+  if (/too many requests/i.test(msg)) return true;
+  if (/\b429\b/.test(msg) && /rate.?limit/i.test(msg)) return true;
   return false;
 }
 

--- a/app/lib/errorMessages.ts
+++ b/app/lib/errorMessages.ts
@@ -230,6 +230,7 @@ export function isTransientError(msg: string): boolean {
   if (msg.includes("Blockhash not found")) return true;
   if (msg.includes("block height exceeded")) return true;
   if (msg.includes("has expired")) return true;
+  if (msg.includes("429") || msg.toLowerCase().includes("too many requests")) return true;
   return false;
 }
 

--- a/app/lib/mock-trade-data.ts
+++ b/app/lib/mock-trade-data.ts
@@ -7,6 +7,7 @@ import { PublicKey } from "@solana/web3.js";
 import type { MarketConfig, EngineState, RiskParams, SlabHeader, Account } from "@percolatorct/sdk";
 import { AccountKind } from "@percolatorct/sdk";
 import type { PortfolioPosition } from "@/hooks/usePortfolio";
+import type { UserAccountInfo } from "@/hooks/useUserAccount";
 
 interface MockMarketData {
   symbol: string;
@@ -303,7 +304,7 @@ export function getMockUserAccount(address: string) {
   return getMockUserAccountIdle(address);
 }
 
-export function getMockUserAccountWithPosition(address: string) {
+export function getMockUserAccountWithPosition(address: string): UserAccountInfo | null {
   const m = MOCK_MAP[address];
   if (!m) return null;
   const priceE6 = BigInt(Math.round(m.priceUsd * 1_000_000));
@@ -356,7 +357,7 @@ export function getMockUserAccountWithPosition(address: string) {
 }
 
 /** Mock user account with NO open position (for showing the trade form) */
-export function getMockUserAccountIdle(address: string) {
+export function getMockUserAccountIdle(address: string): UserAccountInfo | null {
   const m = MOCK_MAP[address];
   if (!m) return null;
   const capital = 50_000_000n;

--- a/app/lib/tx.ts
+++ b/app/lib/tx.ts
@@ -83,11 +83,10 @@ async function fetchPriorityFee(connection: Connection): Promise<number> {
     const dynamicFee = sorted[p75Index] || 0;
     
     // Use dynamic fee if it's reasonable, otherwise fall back
-    // Cap at 10x the fallback to avoid excessive fees
-    if (dynamicFee > 0 && dynamicFee < PRIORITY_FEE_FALLBACK * 10) {
-      return dynamicFee;
+    // Cap at 10x fallback to prevent massive spikes
+    if (dynamicFee > 0) {
+      return Math.min(dynamicFee, PRIORITY_FEE_FALLBACK * 10);
     }
-    
     return PRIORITY_FEE_FALLBACK;
   } catch (error) {
     console.warn("[getPriorityFee] Failed to fetch dynamic fees, using fallback:", error);

--- a/app/lib/userAccountScan.ts
+++ b/app/lib/userAccountScan.ts
@@ -89,6 +89,7 @@ import { isLpPortfolio } from "@/lib/lpPortfolio";
 export interface UserAccountInfo {
   idx: number;
   account: Account;
+  pubkey?: PublicKey;
   /** `true` only on the snapshot published immediately by
    *  `applyConfirmedFill` (a locally-patched confirmed-fill result), and
    *  only until the next real scan reconciles it (see that function's doc
@@ -287,7 +288,7 @@ function publishPortfolioResult(entry: PortfolioEntry, result: OwnPortfolioScanR
   const bypassEqualityForProvisional = entry.provisionalUntil > 0 && Date.now() < entry.provisionalUntil;
   if (!bypassEqualityForProvisional && ownPortfolioResultsEqual(entry.raw, result)) return;
   entry.raw = result;
-  entry.userAccount = result ? { idx: 0, account: portfolioV17ToAccount(result.portfolio) } : null;
+  entry.userAccount = result ? { idx: 0, account: portfolioV17ToAccount(result.portfolio), pubkey: result.pubkey } : null;
   entry.provisionalUntil = 0;
   notifyPortfolio(entry);
 }
@@ -476,7 +477,7 @@ export function applyConfirmedFill(key: string, signedSizeDeltaQ: bigint): boole
   };
 
   entry.raw = patched;
-  entry.userAccount = { idx: 0, account: portfolioV17ToAccount(patched.portfolio), provisional: true };
+  entry.userAccount = { idx: 0, account: portfolioV17ToAccount(patched.portfolio), pubkey: patched.pubkey, provisional: true };
   entry.provisionalUntil = Date.now() + CONFIRMED_FILL_PROVISIONAL_MS;
   notifyPortfolio(entry);
   return true;


### PR DESCRIPTION
Supersedes #2407 — full credit to @v1ktorrr0x for the original work: trade-page RPC optimization (portfolio pubkey fast paths for deposit/withdraw, scan-store plumbing), numeric-input truncation to prevent balance overshoot, priority-fee cap, wrapperConfigV17 dep-array fix, and MAX-click bigint truncation. This PR carries all of that, rebased onto current `playground` (clean merge), with the following review fixes applied on top.

## Review fixes applied

1. **HIGH — useWithdraw fast path no longer silently degrades.** With `params.portfolioPk` supplied, a single `getAccountInfo` failure/null left `portfolioPk` set with `portfolioData` null, so the GPA scan fallback never ran — skipping the M7 over-withdraw pre-check and the `hasActiveLegs` crank-prepend decision, ending in an on-chain EngineStale(19) revert with a misleading "needs maintainer crank" message. The fast path now parses via `parsePortfolioV17`, requires `owner.equals(wallet.publicKey)` (mirroring the scan-store path), and resets `portfolioPk = null` on fetch throw, missing account, parse error, or owner mismatch so the scan fallback runs. Added `useWithdraw-portfolio-fastpath.test.ts` (5 tests) covering success, fetch-throw, null-account, owner-mismatch fallback, and the M7 pre-check on fast-path data.

2. **MEDIUM — safe 429 transient-retry classifier.** `isTransientError`'s `msg.includes("429")` could match a digit run inside a base58 signature — e.g. `pollConfirmation`'s "Confirmation timeout (90s) — tx may still land. Check explorer: <sig>" — and `withTransientRetry` callers (OrderTicket `handleTrade`, `useClosePosition`) rebuild **and resend** the tx, risking a double fill. Now: confirmation-timeout / "may still land" messages are never transient (guarded first), and 429 classification requires rate-limit phrasing (`too many requests` or word-bounded `429` + `rate limit`). Unit tests added for both directions.

3. **LOW — removed `userPortfolioPk` from useTrade's v17 path.** The resolver is awaited unconditionally, so the override saved zero RPC and could diverge from the resolved matcher context. The deposit/withdraw `portfolioPk` fast paths are kept — those skip a real GPA scan.

4. **NIT — OrderTicket truncation dedup.** Extracted a shared `truncateToDecimals(value, decimals)` helper for the three duplicated truncation sites; also fixes the trailing "." when `decimals === 0`.

## Verification

- `npx tsc --noEmit` — 0 errors
- 248 tests green across 17 related files (useWithdraw, useDeposit, useTrade, useClosePosition, errorMessages, trade components)
- Pre-existing local failures in unrelated suites (chart drawings / stake hooks / useWallet, localStorage env issue) fail identically on `playground` without these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)