### PR TITLE
chore: post-merge review nits (#2409 #2413 #2403 #2417 #2418)

### DIFF
--- a/app/__tests__/lib/chart-style.test.ts
+++ b/app/__tests__/lib/chart-style.test.ts
@@ -236,9 +236,10 @@ describe("finiteCandles", () => {
   });
 
   it("an all-NaN batch collapses to empty, so hasRenderableData reports not-ready (no crash path)", () => {
-    // This is the exact regression: a length>=1 batch of whitespace candles
-    // used to pass `ready` and then throw "Value is null" once a price line
-    // was drawn. After filtering, `ready` is false and the empty overlay shows.
+    // This is the exact regression: a length>=1 batch of all-NaN candles
+    // (fulfilled rows the autoscale pass skips → null autoscale range) used to
+    // pass `ready` and then throw "Value is null" (ensureNotNull) once a price
+    // line was drawn. After filtering, `ready` is false and the empty overlay shows.
     const allNaN = [c(NaN, NaN, NaN, NaN), c(NaN, NaN, NaN, NaN)];
     const filtered = finiteCandles(allNaN);
     expect(filtered).toHaveLength(0);

--- a/app/app/api/oracle/publishers/route.ts
+++ b/app/app/api/oracle/publishers/route.ts
@@ -98,7 +98,10 @@ export async function GET(req: NextRequest) {
   }
 
   // Check the bounded cache for externally resolved publisher modes.
-  const cacheKey = `${mode}:${feedId || ""}`;
+  // Normalize the feedId so case/0x-prefix variants of the SAME feed share
+  // one cache entry instead of each burning a slot in the bounded cache
+  // (hex is case-insensitive and the 0x prefix is optional throughout).
+  const cacheKey = `${mode}:${(feedId || "").toLowerCase().replace(/^0x/, "")}`;
   const cached = cache.get(cacheKey);
 
   if (cached) {
@@ -137,7 +140,17 @@ export async function GET(req: NextRequest) {
         return NextResponse.json({ error: `Unknown mode: ${mode}` }, { status: 400 });
     }
 
-    // Store only externally resolved modes in the bounded cache.
+    // Error-sentinel results (publisherCount === null: Pythnet unreachable /
+    // non-200 / bad magic, or the oracle bridge being down) are NOT cached —
+    // caching one would pin a transient upstream blip as "no publishers" for
+    // the full 5-minute TTL. Return it uncached so the next request retries.
+    if (result.publisherCount === null) {
+      return NextResponse.json(result, {
+        headers: { "Cache-Control": "no-store" },
+      });
+    }
+
+    // Store only successfully resolved external modes in the bounded cache.
     cache.set(cacheKey, result);
 
     return NextResponse.json(result, {

--- a/app/app/earn/[slab]/page.tsx
+++ b/app/app/earn/[slab]/page.tsx
@@ -228,7 +228,7 @@ function VaultDetailInner({ slabAddress }: { slabAddress: string }) {
   }
 
   return (
-    <div className="min-h-[calc(100dvh-48px)] animate-fade-in">
+    <div className="relative min-h-[calc(100dvh-48px)] animate-fade-in">
       {/* Background */}
       <div className="absolute inset-x-0 top-0 h-48 bg-grid pointer-events-none" />
 

--- a/app/components/create/CreateMarketWizard.tsx
+++ b/app/components/create/CreateMarketWizard.tsx
@@ -1073,6 +1073,12 @@ export const CreateMarketWizard: FC<{ initialMint?: string }> = ({ initialMint }
             {/* Oracle detection status */}
             {quickLaunch.loading ? (
               <p className="text-[10px] text-[var(--text-dim)]">⏳ Detecting oracle...</p>
+            ) : quickLaunch.oracleResolveFailed ? (
+              <p className="text-[10px] text-[var(--warning)]">
+                ⚠ Price feed lookup failed — this market will launch with an
+                admin oracle at $1.00. Re-enter the mint to retry, or proceed
+                only if that price is intentional.
+              </p>
             ) : quickLaunch.oracleType === "pyth" && quickLaunch.pythFeedId ? (
               <p className="text-[10px] text-[var(--long)]">
                 ✓ Pyth oracle detected — price feed will be used automatically

--- a/app/components/trade/OtherMarketPositions.tsx
+++ b/app/components/trade/OtherMarketPositions.tsx
@@ -18,14 +18,13 @@
  * modal is open (useClosePosition needs slab context) — so this list never
  * pays N providers' RPC cost for rows the user isn't closing.
  *
- * Perf note (review fix): this component reuses the SAME usePortfolio scan
- * the header's PositionsBar strip would otherwise also run on /trade — see
- * PositionsBar's HIDDEN_ROUTES, which now includes "/trade" so the strip
- * hides here and this dock is the only usePortfolio caller on the page.
- * Without that, /trade would run TWO concurrent wallet-wide portfolio scans
- * (market discovery + batched getMultipleAccountsInfo + up to two
- * getProgramAccounts/market, each on its own 30s poll) for no extra
- * information — usePortfolio has no cross-instance dedup.
+ * Perf note: the header's PositionsBar strip renders on /trade too, so this
+ * dock is NOT the page's only usePortfolio caller — but that doesn't double
+ * the cost. usePortfolio is fronted by a wallet-keyed dedup layer
+ * (loadPortfolioShared: 12s TTL cache + in-flight join) that collapses every
+ * mounted instance into ONE scan cycle (market discovery + batched
+ * getMultipleAccountsInfo + up to two getProgramAccounts/market), so this
+ * dock's scan coalesces with the strip's rather than duplicating it.
  */
 
 import { FC, memo, useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react";

--- a/app/components/trade/PositionPanel.tsx
+++ b/app/components/trade/PositionPanel.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/lib/trading";
 import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab, getMockUserAccount } from "@/lib/mock-trade-data";
+import { computeLiquidationDistancePct } from "@/lib/liquidation-distance";
 import { WarmupProgress } from "./WarmupProgress";
 import { ClosePositionModal } from "./ClosePositionModal";
 import { sanitizeSymbol } from "@/lib/symbol-utils";
@@ -326,10 +327,14 @@ export const PositionPanel: FC<{ slabAddress: string }> = ({ slabAddress }) => {
     maintenanceBps,
   );
 
-  // Liq price danger color: amber when mark is within 15% of liq
+  // Liq price danger color: amber when mark is within 15% of liq.
+  // Direction-aware (shared helper): a short whose mark has crossed ABOVE its
+  // liq price is distance 0 (critical), not "safe" — the old
+  // Math.abs(cur-liq)/cur showed a crossed position as far from liquidation.
+  // Helper returns percent 0-100; thresholds below consume a 0-1 fraction.
   const liqDistPct = (() => {
     if (liqPriceE6 <= 0n || !hasValidMark || currentPriceE6 <= 0n) return Infinity;
-    return Math.abs(Number(currentPriceE6) - Number(liqPriceE6)) / Number(currentPriceE6);
+    return computeLiquidationDistancePct(account.positionSize, currentPriceE6, liqPriceE6) / 100;
   })();
 
   // Long-side clamp: liq at/below $0 with a resolved entry = cannot be

--- a/app/components/trade/PositionsDock.tsx
+++ b/app/components/trade/PositionsDock.tsx
@@ -55,6 +55,7 @@ import {
 } from "@/lib/trading";
 import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab, getMockUserAccount } from "@/lib/mock-trade-data";
+import { computeLiquidationDistancePct } from "@/lib/liquidation-distance";
 import { ClosePositionModal } from "./ClosePositionModal";
 import { OtherMarketPositions } from "./OtherMarketPositions";
 import { WarmupProgress } from "./WarmupProgress";
@@ -256,7 +257,10 @@ const PositionRow: FC<{ slabAddress: string }> = memo(function PositionRow({ sla
     if (liqUnliquidatable) return "text-[var(--text-secondary)]";
     if (liqPriceE6 <= 0n) return "text-[var(--text-secondary)]";
     if (!hasValidMark || currentPriceE6 <= 0n) return "text-[var(--warning)]";
-    const distPct = Math.abs(Number(currentPriceE6) - Number(liqPriceE6)) / Number(currentPriceE6);
+    // Direction-aware (shared helper): a short whose mark has crossed ABOVE
+    // its liq price is distance 0 (critical), not "safe". Helper returns
+    // percent 0-100; thresholds here consume a 0-1 fraction.
+    const distPct = computeLiquidationDistancePct(account.positionSize, currentPriceE6, liqPriceE6) / 100;
     if (distPct < 0.05) return "text-[var(--short)]";
     if (distPct < 0.10) return "text-[var(--warning)]";
     return "text-[var(--text-secondary)]";

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -394,6 +394,24 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
     [percolatorCandlesRaw],
   );
 
+  // Finite-filtered views of each candle source, memoized ONCE so both the
+  // source-selection gates below and the candleData memo share the same
+  // filtering pass (identical semantics: full-OHLC + timestamp finiteness,
+  // volume exempt — see finiteCandles). The gates MUST count these, not the
+  // raw arrays: a feed whose rows are mostly/all non-finite (e.g. a corrupt
+  // Percolator batch) would otherwise pass the raw length checks, win source
+  // selection, then collapse to nothing after filtering — defeating the
+  // Pyth/Gecko fallback and mislabeling the source badge.
+  const percolatorFinite = useMemo(() => finiteCandles(percolatorCandles), [percolatorCandles]);
+  const pythFinite = useMemo(
+    () => finiteCandles(pythCandles as { timestamp: number; open: number; high: number; low: number; close: number; volume: number }[]),
+    [pythCandles],
+  );
+  const externalFinite = useMemo(
+    () => finiteCandles(externalCandles as { timestamp: number; open: number; high: number; low: number; close: number; volume: number }[]),
+    [externalCandles],
+  );
+
   // Prefer Percolator as the chart source only when it has enough coverage to
   // form a readable chart. With 1–2 candles against a 24 h window, the tier-0
   // source produces a mostly-empty chart that looks broken — Pyth's deep spot
@@ -408,15 +426,15 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
   // In either case "any Percolator data" is strictly better than nothing.
   const MIN_PERC_BARS = 10;
   const percHasEnough =
-    percolatorStatus === "success" && percolatorCandles.length >= MIN_PERC_BARS;
+    percolatorStatus === "success" && percolatorFinite.length >= MIN_PERC_BARS;
   const pythHasNothing =
-    (pythStatus === "success" && pythCandles.length === 0) || pythStatus === "error";
+    (pythStatus === "success" && pythFinite.length === 0) || pythStatus === "error";
   const hasPercolatorData =
     percolatorStatus === "success" &&
-    percolatorCandles.length > 0 &&
+    percolatorFinite.length > 0 &&
     (percHasEnough || pythHasNothing);
-  const hasPythData = !hasPercolatorData && pythStatus === "success" && pythCandles.length > 0;
-  const hasExternalData = !hasPercolatorData && !hasPythData && externalStatus === "success" && externalCandles.length > 0;
+  const hasPythData = !hasPercolatorData && pythStatus === "success" && pythFinite.length > 0;
+  const hasExternalData = !hasPercolatorData && !hasPythData && externalStatus === "success" && externalFinite.length > 0;
 
   // Fetch oracle price history
   useEffect(() => {
@@ -530,10 +548,11 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
     () => {
       const cutoff = Date.now() - TIMEFRAME_MS[timeframe];
       // finitePricePoints drops any point whose price parsed to NaN (e.g. a
-      // malformed price_e6 from the indexer) — a non-finite value is a
-      // whitespace point that plots nothing and establishes no price range,
-      // which is what makes an overlay price line throw "Value is null". This
-      // is the single chokepoint feeding both the oracle line fallback and the
+      // malformed price_e6 from the indexer) — a NaN row is a fulfilled plot
+      // row that the autoscale pass (_plotMinMax) skips, so an all-NaN series
+      // has a null autoscale range and an overlay price line throws
+      // "Value is null" (ensureNotNull) on paint. This is the single
+      // chokepoint feeding both the oracle line fallback and the
       // aggregated-candle fallback, so sanitising here covers both.
       return finitePricePoints(oraclePrices.filter((p) => p.timestamp >= cutoff));
     },
@@ -550,20 +569,22 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
   // re-fires the indicator hooks' effects and tears down + reallocates the
   // oscillator pane on every WebSocket tick.
   // finiteCandles / finitePricePoints strip any non-finite point BEFORE it can
-  // reach lightweight-charts' setData. A NaN OHLC/price is silently demoted to
-  // a whitespace point (plots nothing, no price range); a series that ends up
-  // all-whitespace has a null firstValue and any overlay price line drawn on it
-  // throws "Value is null" on paint. Sanitising at the source means every
-  // downstream consumer (the render switch, indicator overlays, the volume
-  // pane, referencePriceUsd) sees only plottable data, and an all-NaN batch
-  // degrades to the empty/building overlay via hasRenderableData instead of
-  // crashing the chart. oracleFiltered is already sanitised above.
+  // reach lightweight-charts' setData. A NaN OHLC/price row is NOT treated as
+  // whitespace by lightweight-charts — it's a fulfilled plot row; but the
+  // autoscale pass (_plotMinMax) skips non-finite values, so a series whose
+  // rows are all NaN computes a null autoscale range / firstValue, and the
+  // paint paths (incl. any Mark/Liq/Entry price line) then hit
+  // ensureNotNull → throw "Value is null". Sanitising at the source means
+  // every downstream consumer (the render switch, indicator overlays, the
+  // volume pane, referencePriceUsd) sees only plottable data, and an all-NaN
+  // batch degrades to the empty/building overlay via hasRenderableData
+  // instead of crashing the chart. oracleFiltered is already sanitised above.
   const candleData = useMemo(() => {
-    if (hasPercolatorData) return finiteCandles(percolatorCandles);
-    if (hasPythData) return finiteCandles(pythCandles as { timestamp: number; open: number; high: number; low: number; close: number; volume: number }[]);
-    if (hasExternalData) return finiteCandles(externalCandles as { timestamp: number; open: number; high: number; low: number; close: number; volume: number }[]);
+    if (hasPercolatorData) return percolatorFinite;
+    if (hasPythData) return pythFinite;
+    if (hasExternalData) return externalFinite;
     return finiteCandles(aggregateCandles(oracleFiltered, CANDLE_INTERVAL_MS));
-  }, [hasPercolatorData, hasPythData, hasExternalData, percolatorCandles, pythCandles, externalCandles, oracleFiltered]);
+  }, [hasPercolatorData, hasPythData, hasExternalData, percolatorFinite, pythFinite, externalFinite, oracleFiltered]);
 
   const lineData = useMemo(() => {
     if (hasPercolatorData) return finitePricePoints(percolatorCandles.map((c) => ({ timestamp: c.timestamp, price: c.close })));
@@ -1041,8 +1062,8 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
     return subscribeSlab(slabAddress, () => {
       const snap = getSnapshot(slabAddress);
       // Reject a non-finite tick too, not just null: a NaN would corrupt the
-      // last bar/point via series.update() below, re-introducing a whitespace
-      // point on an already-rendered series and reviving the "Value is null"
+      // last bar/point via series.update() below, re-introducing a non-finite
+      // row on an already-rendered series and reviving the "Value is null"
       // crash after the initial safe paint.
       if (snap.priceUsd == null || !Number.isFinite(snap.priceUsd)) return;
       const finishSpan = startPerfSpan("chart-tick-to-paint");

--- a/app/hooks/usePortfolio.ts
+++ b/app/hooks/usePortfolio.ts
@@ -904,11 +904,13 @@ function loadPortfolioShared(
  *   market) and the 30s auto-refresh interval are short-circuited — nothing
  *   fires and no RPC calls are made. Defaults to `true` so every existing
  *   call site (portfolio page, dashboard widgets) is unaffected. Callers
- *   that only conditionally need portfolio data — e.g. a site-wide strip
- *   that must not double-scan on a page that already mounts its own
- *   `usePortfolio()`, or must not scan at all while hidden — must pass
+ *   that only conditionally need portfolio data — e.g. the site-wide
+ *   PositionsBar strip and trade's OtherMarketPositions dock, which pass
+ *   `walletConnected` so a disconnected wallet never scans — must pass
  *   `enabled` here rather than gate their render only, otherwise this hook
  *   still pays the full RPC cost even though nothing reads its output.
+ *   (Concurrent ENABLED instances are cheap: `loadPortfolioShared` dedups
+ *   them into one scan cycle.)
  */
 export function usePortfolio(enabled: boolean = true): PortfolioData {
   const { connection } = useConnectionCompat();
@@ -1078,7 +1080,7 @@ export function usePortfolio(enabled: boolean = true): PortfolioData {
 
   // Auto-refresh when tab becomes visible (e.g., after closing position on trade page)
   // and every 30s while visible. Gated on `enabled` too — otherwise a
-  // disabled hook instance (e.g. PositionsBar on a hidden route) would still
+  // disabled hook instance (e.g. PositionsBar with the wallet disconnected) would still
   // bump `refreshCounter` every 30s, which the fetch effect above depends on
   // and would just re-run (uselessly, since it early-returns) forever.
   useEffect(() => {

--- a/app/hooks/useQuickLaunch.ts
+++ b/app/hooks/useQuickLaunch.ts
@@ -33,6 +33,15 @@ export interface QuickLaunchResult {
   adminPrice: string;
   /** PERC-470: DEX pool address for hyperp oracle mode */
   dexPoolAddress: string | null;
+  /**
+   * True when the /api/oracle/resolve lookup itself FAILED (non-ok response,
+   * network error, timeout) — as opposed to succeeding and genuinely finding
+   * no feed. In the failure case the hook still falls back to the admin
+   * oracle with adminPrice "1.000000" (a transient 503 must not block
+   * launches), but consumers should surface this so the user doesn't
+   * unknowingly create a market hardcoded at $1.00.
+   */
+  oracleResolveFailed: boolean;
 }
 
 /**
@@ -53,6 +62,7 @@ export function useQuickLaunch(mint: string | null): QuickLaunchResult {
   const [pythFeedId, setPythFeedId] = useState<string | null>(null);
   const [adminPrice, setAdminPrice] = useState<string>("1.000000");
   const [dexPoolAddress, setDexPoolAddress] = useState<string | null>(null);
+  const [oracleResolveFailed, setOracleResolveFailed] = useState(false);
 
   // Oracle resolution: call /api/oracle/resolve/[mint] after token meta loads.
   // If Pyth feed found → pyth oracle; else → admin oracle with best available price.
@@ -61,6 +71,7 @@ export function useQuickLaunch(mint: string | null): QuickLaunchResult {
     setPythFeedId(null);
     setAdminPrice("1.000000");
     setDexPoolAddress(null);
+    setOracleResolveFailed(false);
     if (!mint || mint.length < 32 || !tokenMeta) return;
 
     let cancelled = false;
@@ -77,6 +88,7 @@ export function useQuickLaunch(mint: string | null): QuickLaunchResult {
           // stale parsed body would stomp B's fresh oracle-type state and the
           // market gets created with the WRONG oracle config.
           if (cancelled) return;
+          setOracleResolveFailed(false);
           if (data.feedId) {
             setOracleType("pyth");
             setPythFeedId(data.feedId);
@@ -95,14 +107,18 @@ export function useQuickLaunch(mint: string | null): QuickLaunchResult {
             if (data.price > 0) setAdminPrice(data.price.toFixed(6));
           }
         } else {
-          // 404 or error — fall back to admin oracle
+          // Non-ok response — fall back to admin oracle, but flag the failure
+          // so the wizard can warn: a transient 503 would otherwise silently
+          // create a market with a hardcoded $1.00 admin price.
           setOracleType("admin");
           setPythFeedId(null);
+          setOracleResolveFailed(true);
         }
       } catch {
         if (!cancelled) {
           setOracleType("admin");
           setPythFeedId(null);
+          setOracleResolveFailed(true);
         }
       }
     })();
@@ -217,5 +233,6 @@ export function useQuickLaunch(mint: string | null): QuickLaunchResult {
     pythFeedId,
     adminPrice,
     dexPoolAddress,
+    oracleResolveFailed,
   };
 }

--- a/app/lib/chart-style.ts
+++ b/app/lib/chart-style.ts
@@ -168,14 +168,15 @@ interface PriceValue {
   readonly price: number;
 }
 
-/** Drop any candle lightweight-charts would treat as a WHITESPACE point.
+/** Drop any candle whose OHLC/timestamp isn't a finite number.
  *
- *  A point whose value isn't a finite number (NaN / ±Infinity) is silently
- *  demoted by lightweight-charts to a "whitespace" item: it still reserves the
- *  time slot but plots nothing and contributes NO price range. A series whose
- *  points are ALL whitespace has a null `firstValue`/`priceRange`, and drawing
- *  any price line (Mark / Liq / Entry) onto it makes the library throw
- *  "Value is null" on the next paint (the TradingChart error boundary then
+ *  A row with a NaN / ±Infinity value is NOT demoted to a whitespace item by
+ *  lightweight-charts — it stays a fulfilled plot row. The problem is the
+ *  autoscale pass (`_plotMinMax`), which skips non-finite values: a series
+ *  whose rows are ALL non-finite computes a null autoscale range /
+ *  `firstValue`, and the paint paths — including drawing any price line
+ *  (Mark / Liq / Entry) — then hit `ensureNotNull` and throw
+ *  "Value is null" (the TradingChart error boundary then
  *  shows "something broke"). That state is reachable when the oracle-aggregated
  *  fallback runs over price points that parsed to NaN (e.g. a malformed
  *  `price_e6` from the indexer on a brand-new market) — the candle sources are
@@ -196,8 +197,8 @@ export function finiteCandles<T extends OhlcValues>(candles: readonly T[]): T[] 
 }
 
 /** Single-value counterpart to `finiteCandles` for line/area + oracle points.
- *  Same rationale — a non-finite `price` is a whitespace point that plots
- *  nothing and establishes no price range. */
+ *  Same rationale — a non-finite `price` is skipped by the autoscale pass and
+ *  establishes no price range, so an all-NaN series crashes on paint. */
 export function finitePricePoints<T extends PriceValue>(points: readonly T[]): T[] {
   return points.filter((p) => Number.isFinite(p.timestamp) && Number.isFinite(p.price));
 }

--- a/app/lib/mock-trade-data.ts
+++ b/app/lib/mock-trade-data.ts
@@ -7,6 +7,7 @@ import { PublicKey } from "@solana/web3.js";
 import type { MarketConfig, EngineState, RiskParams, SlabHeader, Account } from "@percolatorct/sdk";
 import { AccountKind } from "@percolatorct/sdk";
 import type { PortfolioPosition } from "@/hooks/usePortfolio";
+import { computeLiquidationDistancePct } from "@/lib/liquidation-distance";
 
 interface MockMarketData {
   symbol: string;
@@ -464,10 +465,8 @@ export function getMockPortfolioPositions(): PortfolioPosition[] {
     // Mock liquidation: assume liq at 80% loss for longs, 120% gain for shorts
     const liqFactor = isLong ? 0.2 : 1.8;
     const liquidationPriceE6 = BigInt(Math.round(m.priceUsd * liqFactor * 1_000_000));
-    const liqDist = isLong
-      ? (Number(priceE6 - liquidationPriceE6) / Number(priceE6)) * 100
-      : (Number(liquidationPriceE6 - priceE6) / Number(priceE6)) * 100;
-    const liquidationDistancePct = Math.max(0, Math.min(100, liqDist));
+    // Same direction-aware helper the real portfolio scan uses (percent 0-100).
+    const liquidationDistancePct = computeLiquidationDistancePct(posSize, priceE6, liquidationPriceE6);
 
     positions.push({
       slabAddress: slabAddr,


### PR DESCRIPTION
Collects the verified review nits from the six PRs just squash-merged to `playground` (#2409, #2413, #2403, #2417, #2418, #2401 — no nit survived from #2401).

## Fixes

- **#2409 — earn/[slab] grid overlay jump**: the page wrapper (`min-h-[calc(100dvh-48px)] animate-fade-in`) lacked `relative`, so the `.bg-grid` overlay anchored to the root layout and jumped under the sticky header after the route-transition animation. Added `relative`.

- **#2417 — stale comments**: `OtherMarketPositions.tsx`'s header referenced the deleted `HIDDEN_ROUTES` and claimed "usePortfolio has no cross-instance dedup" (false — `loadPortfolioShared` has a 12s TTL cache + in-flight join). `usePortfolio.ts`'s `enabled` JSDoc and the 30s-interval comment described the deleted hidden-route behavior. All rewritten to describe current reality (PositionsBar renders on every route; `enabled` gates on wallet connection).

- **#2403 — chart source gates count raw arrays**: `hasPercolatorData`/`hasPythData`/`hasExternalData` and the `MIN_PERC_BARS` comparison counted RAW candle arrays, so an all-non-finite / mostly-corrupt Percolator feed would win source selection, collapse to nothing after `finiteCandles`, defeat the Pyth/Gecko fallback, and mislabel the source badge. Gates now count finite-filtered arrays, memoized once and reused by the `candleData` memo (identical filtering semantics, no double pass). Also corrected the wrong "demoted to a whitespace item" mechanism wording in the 4 comment sites (chart-style.ts JSDoc, two TradingChart comments, chart-style.test.ts): NaN rows are fulfilled plot rows; `_plotMinMax` skips NaN → null autoscale range → `ensureNotNull('Value is null')` on paint paths.

- **#2413 — direction-unaware liq distance**: `PositionPanel.tsx` and `PositionsDock.tsx` used `Math.abs(cur-liq)/cur` for the liq-price color/warn thresholds, so a short whose mark had crossed ABOVE its liq price showed as "safe". Both now use the shared direction-aware `computeLiquidationDistancePct` (converted to the 0–1 fraction each site's thresholds consume; crossed boundary → 0 → critical red + warning banner). `mock-trade-data.ts`'s hand-rolled equivalent also routes through the helper.

- **#2418 — silent $1.00 admin-oracle fallback**: a non-ok/failed `/api/oracle/resolve` response silently fell back to admin oracle with adminPrice `1.000000` — a transient 503 could create a market at a wrong hardcoded price with no warning. `useQuickLaunch` now exposes `oracleResolveFailed` (set on `!resp.ok`/catch, reset on success/new mint), and the Quick Launch slab step shows a visible warning in the oracle-detection status area: price feed lookup failed, market will launch with admin oracle at $1.00, retry or proceed deliberately. The fallback itself is unchanged (launches are not blocked).

- **#2418 — publishers route cache**: `/api/oracle/publishers` now normalizes the cache key (lowercase, strip `0x` prefix) so case/prefix variants of the same feed share one bounded-cache entry, and no longer caches error-sentinel results (`publisherCount: null` from a Pythnet blip / bridge outage) — those return with `Cache-Control: no-store` so a transient failure isn't pinned as "no publishers" for 5 minutes.

## Verification

- `npx tsc --noEmit`: 0 errors
- Targeted tests (chart-style, liquidation-distance, oracle-publishers ×2): 69/69 pass
- Full `vitest run`: identical results on this branch and pristine `origin/playground` (aabc98b9) — 2554 passed, 101 pre-existing env-dependent failures in both runs (waitlist/privy/wallet/rate-limit suites), failing-file sets byte-identical, zero new failures introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)