### PR TITLE
fix(playground): enforce keeper/deployer signer separation in keeper-cosign

### DIFF
--- a/app/__tests__/api/keeper-cosign-signer-separation.test.ts
+++ b/app/__tests__/api/keeper-cosign-signer-separation.test.ts
@@ -1,0 +1,266 @@
+// @vitest-environment node
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import {
+  Connection,
+  Keypair,
+  Transaction,
+} from "@solana/web3.js";
+import { NextRequest } from "next/server";
+
+const state = vi.hoisted(() => ({
+  keeper: null as Keypair | null,
+  partialSign: vi.fn(),
+}));
+
+vi.mock("@/lib/config", () => ({
+  getRpcEndpoint: vi.fn(
+    () => "http://127.0.0.1:8899",
+  ),
+  getConfig: vi.fn(() => ({
+    programId:
+      "11111111111111111111111111111111",
+  })),
+}));
+
+vi.mock("@/lib/playground-keeper-signer", () => ({
+  requirePlaygroundKeeperSigner: () => {
+    if (!state.keeper) {
+      throw new Error(
+        "Test keeper was not initialized",
+      );
+    }
+
+    return {
+      publicKey: () =>
+        state.keeper!.publicKey.toBase58(),
+      partialSign: state.partialSign,
+    };
+  },
+}));
+
+const originalDefaultNetwork =
+  process.env.NEXT_PUBLIC_DEFAULT_NETWORK;
+
+const originalSolanaNetwork =
+  process.env.NEXT_PUBLIC_SOLANA_NETWORK;
+
+let POST: (
+  request: NextRequest,
+) => Promise<Response>;
+
+function buildCosignRequest(
+  deployer: string,
+): NextRequest {
+  return new NextRequest(
+    "http://localhost/api/playground/keeper-cosign",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        deployer,
+        slabAddress:
+          Keypair.generate().publicKey.toBase58(),
+        initialPriceE6: "1000000",
+        assetIndex: 0,
+      }),
+    },
+  );
+}
+
+describe("keeper-cosign signer-role separation", () => {
+  beforeAll(async () => {
+    process.env.NEXT_PUBLIC_DEFAULT_NETWORK =
+      "devnet";
+
+    delete process.env.NEXT_PUBLIC_SOLANA_NETWORK;
+
+    vi.spyOn(
+      Connection.prototype,
+      "getSlot",
+    );
+
+    vi.spyOn(
+      Connection.prototype,
+      "getLatestBlockhash",
+    );
+
+    ({ POST } = await import(
+      "@/app/api/playground/keeper-cosign/route"
+    ));
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    state.keeper = Keypair.generate();
+
+    state.partialSign.mockImplementation(
+      (tx: Transaction) => {
+        tx.partialSign(state.keeper!);
+      },
+    );
+
+    vi.mocked(
+      Connection.prototype.getSlot,
+    ).mockResolvedValue(123456);
+
+    vi.mocked(
+      Connection.prototype.getLatestBlockhash,
+    ).mockResolvedValue({
+      blockhash:
+        Keypair.generate().publicKey.toBase58(),
+      lastValidBlockHeight: 999999,
+    });
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+
+    if (originalDefaultNetwork === undefined) {
+      delete process.env.NEXT_PUBLIC_DEFAULT_NETWORK;
+    } else {
+      process.env.NEXT_PUBLIC_DEFAULT_NETWORK =
+        originalDefaultNetwork;
+    }
+
+    if (originalSolanaNetwork === undefined) {
+      delete process.env.NEXT_PUBLIC_SOLANA_NETWORK;
+    } else {
+      process.env.NEXT_PUBLIC_SOLANA_NETWORK =
+        originalSolanaNetwork;
+    }
+  });
+
+  it("rejects deployer equal to the server keeper before RPC or signing", async () => {
+    const keeper = state.keeper;
+    expect(keeper).not.toBeNull();
+
+    const response = await POST(
+      buildCosignRequest(
+        keeper!.publicKey.toBase58(),
+      ),
+    );
+
+    const payload = (await response.json()) as {
+      error?: string;
+    };
+
+    expect(response.status).toBe(400);
+
+    expect(payload).toEqual({
+      error:
+        "deployer must be distinct from keeper",
+    });
+
+    expect(
+      Connection.prototype.getSlot,
+    ).not.toHaveBeenCalled();
+
+    expect(
+      Connection.prototype.getLatestBlockhash,
+    ).not.toHaveBeenCalled();
+
+    expect(
+      state.partialSign,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("preserves the normal partial-signing flow for a distinct deployer", async () => {
+    const keeper = state.keeper;
+    expect(keeper).not.toBeNull();
+
+    const deployer =
+      Keypair.generate().publicKey;
+
+    expect(
+      deployer.equals(keeper!.publicKey),
+    ).toBe(false);
+
+    const response = await POST(
+      buildCosignRequest(
+        deployer.toBase58(),
+      ),
+    );
+
+    const payload = (await response.json()) as {
+      partialTxBase64?: string;
+      keeperPubkey?: string;
+      nowSlot?: string;
+      error?: string;
+      detail?: string;
+    };
+
+    expect(
+      response.status,
+      JSON.stringify(payload),
+    ).toBe(200);
+
+    expect(payload).toMatchObject({
+      keeperPubkey:
+        keeper!.publicKey.toBase58(),
+      nowSlot: "123456",
+    });
+
+    expect(payload.partialTxBase64).toEqual(
+      expect.any(String),
+    );
+
+    expect(
+      Connection.prototype.getSlot,
+    ).toHaveBeenCalledOnce();
+
+    expect(
+      Connection.prototype.getLatestBlockhash,
+    ).toHaveBeenCalledOnce();
+
+    expect(
+      state.partialSign,
+    ).toHaveBeenCalledOnce();
+
+    const tx = Transaction.from(
+      Buffer.from(
+        payload.partialTxBase64!,
+        "base64",
+      ),
+    );
+
+    const deployerSignature =
+      tx.signatures.find(({ publicKey }) =>
+        publicKey.equals(deployer),
+      );
+
+    const keeperSignature =
+      tx.signatures.find(({ publicKey }) =>
+        publicKey.equals(
+          keeper!.publicKey,
+        ),
+      );
+
+    expect(deployerSignature).toBeDefined();
+
+    expect(
+      deployerSignature?.signature,
+    ).toBeNull();
+
+    expect(keeperSignature).toBeDefined();
+
+    expect(
+      keeperSignature?.signature,
+    ).not.toBeNull();
+
+    expect(
+      tx.verifySignatures(),
+    ).toBe(false);
+  });
+});

--- a/app/app/api/playground/keeper-cosign/route.ts
+++ b/app/app/api/playground/keeper-cosign/route.ts
@@ -143,6 +143,23 @@ export async function POST(req: NextRequest) {
     const connection = new Connection(rpcUrl, "confirmed");
     const keeperPk = new PublicKey(keeper.publicKey());
 
+    /*
+     * Preserve the creator-signature authorization boundary.
+     *
+     * Solana deduplicates required signer slots by public key. If the
+     * requester aliases deployer to the server keeper, the keeper signature
+     * can satisfy both logical signer roles and turn this response into a
+     * fully signed transaction without an independent creator signature.
+     */
+    if (deployerPk.equals(keeperPk)) {
+      return NextResponse.json(
+        {
+          error: "deployer must be distinct from keeper",
+        },
+        { status: 400 },
+      );
+    }
+
     // Fetch slot (used as initial mark timestamp in ConfigureAuthMark)
     const nowSlot = BigInt(await connection.getSlot("confirmed"));
 


### PR DESCRIPTION
## Summary

Fixes #2427.

This PR enforces signer identity separation in the playground keeper co-signing flow.

The `POST /api/playground/keeper-cosign` route is designed to return a transaction that is partially signed by the server-managed keeper while still requiring an independent creator/deployer wallet signature before submission.

Previously, the route accepted a requester-controlled `deployer` public key without verifying that it was distinct from the server keeper public key.

When both logical signer roles used the same public key:

```text
deployerPk == keeperPk
```

Solana transaction compilation deduplicated the signer accounts into a single required signer identity. As a result, the server keeper signature could satisfy both the creator/deployer and keeper signer roles, causing the transaction returned by the route to become fully signed without an independent creator signature.

This PR restores the intended authorization boundary by rejecting keeper/deployer signer aliasing before any RPC access, transaction construction, or server-side signing occurs.

---

## Root Cause

The keeper co-sign route uses two logically independent authorization roles:

```text
Creator/deployer:
- ConfigureAuthMark oracle authority
- UpdateAssetAuthority current authority
- Transaction fee payer

Server keeper:
- UpdateAssetAuthority new authority
- Server-side partial signer
```

The route previously derived both public keys independently:

```ts
const deployerPk = new PublicKey(deployer);
const keeperPk = new PublicKey(keeper.publicKey());
```

However, it did not enforce the required identity invariant:

```text
deployerPk != keeperPk
```

The transaction was then signed by the server keeper:

```ts
keeper.partialSign(tx);
```

For distinct public keys, this correctly produced:

```text
deployer signature: missing
keeper signature:   present
fully signed:       false
```

For aliased public keys, the transaction signer set was deduplicated:

```text
logical signer roles: 2
unique signer keys:   1
keeper signature:     present
fully signed:         true
```

The issue was therefore caused by missing application-level signer-role separation rather than a failure in Solana signature verification.

---

## Changes

### 1. Reject keeper/deployer signer aliasing

The route now rejects requests where the requester-controlled deployer public key equals the server-managed keeper public key:

```ts
if (deployerPk.equals(keeperPk)) {
  return NextResponse.json(
    {
      error: "deployer must be distinct from keeper",
    },
    { status: 400 },
  );
}
```

The validation is intentionally placed immediately after deriving `keeperPk`.

This ensures the request is rejected before:

```text
- RPC slot retrieval
- recent blockhash retrieval
- instruction construction
- transaction construction
- keeper.partialSign()
- transaction serialization
```

This ordering prevents invalid aliased requests from consuming RPC resources or reaching the server signing boundary.

---

### 2. Add deterministic signer-separation regression coverage

A new route-level regression suite was added:

```text
app/__tests__/api/keeper-cosign-signer-separation.test.ts
```

The suite uses the real Solana transaction implementation while mocking only the external RPC metadata operations.

It includes both a negative security control and a positive compatibility control.

---

## Regression Coverage

### Case 1 — Reject aliased signer identities

Input condition:

```text
deployer == keeperPubkey
```

Expected behavior:

```text
HTTP 400
```

Expected response:

```json
{
  "error": "deployer must be distinct from keeper"
}
```

The test additionally verifies that rejection occurs before any downstream operation:

```text
Connection.prototype.getSlot:
  not called

Connection.prototype.getLatestBlockhash:
  not called

keeper.partialSign:
  not called
```

This confirms that an invalid aliased request cannot reach RPC metadata retrieval, transaction construction, or server-side signing.

---

### Case 2 — Preserve the normal distinct-deployer flow

Input condition:

```text
deployer != keeperPubkey
```

Expected behavior:

```text
HTTP 200
```

The test verifies that the legitimate keeper co-signing flow remains unchanged:

```text
getSlot:
  called exactly once

getLatestBlockhash:
  called exactly once

keeper.partialSign:
  called exactly once

partialTxBase64:
  returned

keeperPubkey:
  matches the configured keeper

nowSlot:
  matches the mocked slot
```

The returned transaction is deserialized and its signer state is inspected.

Expected signer state:

```text
deployer signer slot:
  present

deployer signature:
  null

keeper signer slot:
  present

keeper signature:
  present

Transaction.verifySignatures():
  false
```

This confirms that legitimate requests still receive a partially signed transaction and still require an independent creator/deployer wallet signature.

---

## Security Invariant

This PR explicitly enforces the following invariant:

```text
creator/deployer signer identity != server keeper signer identity
```

After this change, the server keeper cannot satisfy both logical authorization roles within the same transaction.

The intended signing model remains:

```text
server keeper signature
        +
independent creator signature
        =
fully authorized transaction
```

---

## Behavior Before This PR

For an aliased request:

```text
deployer == keeperPubkey
```

the route continued through:

```text
1. RPC slot retrieval
2. blockhash retrieval
3. ConfigureAuthMark construction
4. UpdateAssetAuthority construction
5. keeper.partialSign()
6. transaction serialization
```

Because the signer identities were identical, the returned transaction could verify as fully signed without an independent creator signature.

---

## Behavior After This PR

For an aliased request:

```text
deployer == keeperPubkey
```

the route now returns:

```text
HTTP 400
```

with:

```json
{
  "error": "deployer must be distinct from keeper"
}
```

No RPC request, transaction construction, or signing operation is performed.

For a legitimate request:

```text
deployer != keeperPubkey
```

the existing partial-signing behavior remains unchanged.

---

## Files Changed

```text
app/app/api/playground/keeper-cosign/route.ts
app/__tests__/api/keeper-cosign-signer-separation.test.ts
```

The production change is intentionally minimal and localized to the affected route.

This PR does not modify:

```text
- instruction encoding
- account-meta definitions
- keeper key loading
- transaction serialization format
- client-side transaction signing
- normal create-market behavior
- keeper registration authentication
```

---

## Validation

### Dedicated signer-separation regression suite

Command:

```bash
pnpm --dir app exec vitest run \
  __tests__/api/keeper-cosign-signer-separation.test.ts \
  --reporter=verbose
```

Result:

```text
Test Files  1 passed
Tests       2 passed
```

---

### Combined keeper security baseline

Command:

```bash
pnpm --dir app exec vitest run \
  __tests__/api/gh1692-timing-safe-keeper-auth.test.ts \
  __tests__/api/keeper-cosign-signer-separation.test.ts \
  --reporter=verbose
```

Result:

```text
Test Files  2 passed
Tests       9 passed
```

This confirms that the new signer-separation validation does not regress the existing keeper registration authentication controls.

---

### TypeScript validation

Command:

```bash
pnpm --dir app exec tsc --noEmit
```

Result:

```text
Exit code: 0
```

No TypeScript errors were produced.

---

### Production build

Command:

```bash
pnpm --dir app run build
```

Result:

```text
Final build exit code: 0
```

The production Next.js build completed successfully.

Observed Next.js deprecation and optional native binding warnings are pre-existing and do not affect the build result.

---

### Patch integrity

The following checks completed successfully:

```bash
git diff --check
git diff --cached --check
git diff --check upstream/playground...HEAD
```

Result:

```text
No whitespace errors
No malformed patch output
No unrelated source changes
```

---

## Compatibility and Regression Risk

Regression risk is low because the production behavior change is limited to one invalid identity relationship:

```text
deployerPk.equals(keeperPk)
```

All requests using distinct creator and keeper public keys continue through the existing transaction-building and partial-signing path.

The positive regression test confirms that the normal route response still contains:

```text
- a valid keeper signature;
- an absent creator signature;
- a partially signed transaction;
- the expected keeper public key;
- the expected slot metadata.
```

---

## Security Considerations

This PR directly fixes the confirmed signer-role aliasing condition.

Additional defense-in-depth improvements may be handled separately, including:

```text
- cryptographic deployer wallet proof;
- binding the request to the actual slab creator/admin;
- validating slab ownership by the expected program;
- signed request payloads containing a nonce and expiration;
- replay protection;
- request-level rate limiting and security logging.
```

Those measures are complementary hardening controls and are not required for the narrow signer-separation fix implemented here.

---

## Review Notes

Reviewers should verify that:

```text
- the equality guard executes before RPC access;
- the equality guard executes before keeper.partialSign();
- the aliased request returns HTTP 400;
- no signer or RPC operation occurs after rejection;
- the distinct-deployer path still returns a partially signed transaction;
- the creator signature remains absent in the normal flow;
- the keeper signature remains present in the normal flow.
```

---

## Checklist

- [x] Fixes #2427
- [x] Enforces keeper/deployer signer identity separation
- [x] Rejects the vulnerable condition before RPC access
- [x] Rejects the vulnerable condition before server-side signing
- [x] Adds negative security regression coverage
- [x] Adds positive compatibility coverage
- [x] Dedicated regression suite passes
- [x] Combined keeper security baseline passes
- [x] TypeScript validation passes
- [x] Production build passes
- [x] Patch contains only the affected route and regression test