### PR TITLE
fix(trade): prevent stale deposit balance reuse after wallet switches

### DIFF
--- a/app/__tests__/components/trade/DepositWithdrawCard.wallet-switch.test.tsx
+++ b/app/__tests__/components/trade/DepositWithdrawCard.wallet-switch.test.tsx
@@ -1,0 +1,251 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { PublicKey } from '@solana/web3.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DepositWithdrawCard } from '@/components/trade/DepositWithdrawCard';
+
+const mocks = vi.hoisted(() => ({
+  useWalletCompat: vi.fn(),
+  useConnectionCompat: vi.fn(),
+  getTokenAccountBalance: vi.fn(),
+  getAssociatedTokenAddressSync: vi.fn(),
+  useUserAccount: vi.fn(),
+  useSlabState: vi.fn(),
+  useTokenMeta: vi.fn(),
+  initUser: vi.fn(),
+}));
+
+vi.mock('@/hooks/useWalletCompat', () => ({
+  useWalletCompat: mocks.useWalletCompat,
+  useConnectionCompat: mocks.useConnectionCompat,
+}));
+
+vi.mock('@solana/spl-token', () => ({
+  getAssociatedTokenAddressSync: mocks.getAssociatedTokenAddressSync,
+}));
+
+vi.mock('@/hooks/useUserAccount', () => ({
+  useUserAccount: mocks.useUserAccount,
+}));
+
+vi.mock('@/hooks/useDeposit', () => ({
+  useDeposit: () => ({
+    deposit: vi.fn(),
+    loading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('@/hooks/useWithdraw', () => ({
+  useWithdraw: () => ({
+    withdraw: vi.fn(),
+    loading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('@/hooks/useInitUser', () => ({
+  useInitUser: () => ({
+    initUser: mocks.initUser,
+    loading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('@/components/providers/SlabProvider', () => ({
+  useSlabState: mocks.useSlabState,
+}));
+
+vi.mock('@/hooks/useTokenMeta', () => ({
+  useTokenMeta: mocks.useTokenMeta,
+}));
+
+vi.mock('@/hooks/useLivePrice', () => ({
+  useLivePrice: () => ({
+    priceE6: null,
+  }),
+}));
+
+vi.mock('@/lib/mock-mode', () => ({
+  isMockMode: () => false,
+}));
+
+vi.mock('@/lib/mock-trade-data', () => ({
+  isMockSlab: () => false,
+  getMockUserAccount: () => null,
+}));
+
+vi.mock('@/lib/tx', () => ({
+  prewarmTxLanding: vi.fn(),
+}));
+
+vi.mock('@/components/trade/DevnetTokenFaucetButton', () => ({
+  DevnetTokenFaucetButton: () => null,
+}));
+
+describe('DepositWithdrawCard wallet-scoped balance lifecycle', () => {
+  const walletA = new PublicKey('11111111111111111111111111111111');
+  const walletB = new PublicKey('So11111111111111111111111111111111111111112');
+  const collateralMint = new PublicKey('SysvarRent111111111111111111111111111111111');
+
+  const connection = {
+    getTokenAccountBalance: mocks.getTokenAccountBalance,
+  };
+
+  let activeWallet = walletA;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    activeWallet = walletA;
+
+    mocks.useWalletCompat.mockImplementation(() => ({
+      connected: true,
+      publicKey: activeWallet,
+    }));
+
+    mocks.useConnectionCompat.mockReturnValue({
+      connection,
+    });
+
+    mocks.getAssociatedTokenAddressSync.mockReturnValue(collateralMint);
+
+    mocks.useUserAccount.mockReturnValue(null);
+
+    mocks.useSlabState.mockReturnValue({
+      config: {
+        collateralMint,
+      },
+      params: null,
+    });
+
+    mocks.useTokenMeta.mockReturnValue({
+      symbol: 'USDC',
+      decimals: 6,
+    });
+
+    mocks.initUser.mockResolvedValue({
+      sig: 'test-signature',
+    });
+  });
+
+  it('withholds wallet A balance and prevents wallet A-derived account creation while wallet B balance is pending', async () => {
+    mocks.getTokenAccountBalance
+      .mockResolvedValueOnce({
+        value: {
+          amount: '900000000',
+          decimals: 6,
+        },
+      })
+      .mockImplementationOnce(
+        () =>
+          new Promise<{
+            value: {
+              amount: string;
+              decimals: number;
+            };
+          }>(() => {}),
+      );
+
+    const { rerender } = render(<DepositWithdrawCard slabAddress="test-slab" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/^Wallet:/)).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Create Trading Account',
+      }),
+    ).toBeInTheDocument();
+
+    expect(mocks.getTokenAccountBalance).toHaveBeenCalledTimes(1);
+
+    activeWallet = walletB;
+
+    await act(async () => {
+      rerender(<DepositWithdrawCard slabAddress="test-slab" />);
+
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(mocks.getTokenAccountBalance).toHaveBeenCalledTimes(2);
+    });
+
+    // Wallet A state must not remain visible or actionable after wallet B
+    // becomes active, even while wallet B's balance request is unresolved.
+    expect.soft(screen.queryByText(/^Wallet:/)).not.toBeInTheDocument();
+
+    expect
+      .soft(
+        screen.queryByRole('button', {
+          name: 'Create Trading Account',
+        }),
+      )
+      .not.toBeInTheDocument();
+
+    // Confirm that the second balance request belongs to wallet B.
+    expect(mocks.getAssociatedTokenAddressSync).toHaveBeenNthCalledWith(2, collateralMint, walletB);
+
+    const staleCreateAccountButton = screen.queryByRole('button', {
+      name: 'Create Trading Account',
+    });
+
+    // On a fixed implementation the stale button is absent and this block
+    // does not execute. On the vulnerable baseline it remains actionable.
+    if (staleCreateAccountButton) {
+      await act(async () => {
+        fireEvent.click(staleCreateAccountButton);
+        await Promise.resolve();
+      });
+    }
+
+    // 500 USDC is the starter-deposit cap. It must never be derived from
+    // wallet A after wallet B becomes active but remains unverified.
+    expect.soft(mocks.initUser).not.toHaveBeenCalledWith(500_000_000n);
+  });
+
+  it('updates to wallet B balance after the replacement request resolves', async () => {
+    mocks.getTokenAccountBalance
+      .mockResolvedValueOnce({
+        value: {
+          amount: '900000000',
+          decimals: 6,
+        },
+      })
+      .mockResolvedValueOnce({
+        value: {
+          amount: '25000000',
+          decimals: 6,
+        },
+      });
+
+    const { rerender } = render(<DepositWithdrawCard slabAddress="test-slab" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/^Wallet:/)).toHaveTextContent('900');
+    });
+
+    expect(mocks.getTokenAccountBalance).toHaveBeenCalledTimes(1);
+
+    activeWallet = walletB;
+
+    await act(async () => {
+      rerender(<DepositWithdrawCard slabAddress="test-slab" />);
+
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(mocks.getTokenAccountBalance).toHaveBeenCalledTimes(2);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/^Wallet:/)).toHaveTextContent('25');
+    });
+
+    expect(mocks.getAssociatedTokenAddressSync).toHaveBeenNthCalledWith(2, collateralMint, walletB);
+  });
+});

--- a/app/__tests__/components/trade/DepositWithdrawCard.wallet-switch.test.tsx
+++ b/app/__tests__/components/trade/DepositWithdrawCard.wallet-switch.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   useSlabState: vi.fn(),
   useTokenMeta: vi.fn(),
   initUser: vi.fn(),
+  deposit: vi.fn(),
 }));
 
 vi.mock('@/hooks/useWalletCompat', () => ({
@@ -30,7 +31,7 @@ vi.mock('@/hooks/useUserAccount', () => ({
 
 vi.mock('@/hooks/useDeposit', () => ({
   useDeposit: () => ({
-    deposit: vi.fn(),
+    deposit: mocks.deposit,
     loading: false,
     error: null,
   }),
@@ -123,6 +124,8 @@ describe('DepositWithdrawCard wallet-scoped balance lifecycle', () => {
       symbol: 'USDC',
       decimals: 6,
     });
+
+    mocks.deposit.mockResolvedValue('deposit-signature');
 
     mocks.initUser.mockResolvedValue({
       sig: 'test-signature',
@@ -247,5 +250,95 @@ describe('DepositWithdrawCard wallet-scoped balance lifecycle', () => {
     });
 
     expect(mocks.getAssociatedTokenAddressSync).toHaveBeenNthCalledWith(2, collateralMint, walletB);
+  });
+  it('clears a wallet A Max amount and blocks deposit while wallet B balance is unverified', async () => {
+    let resolveWalletBBalance:
+      | ((value: { value: { amount: string; decimals: number } }) => void)
+      | undefined;
+
+    mocks.useUserAccount.mockImplementation(() => ({
+      idx: 7,
+      pubkey: activeWallet,
+      account: {
+        capital: 100_000_000n,
+        positionSize: 0n,
+        entryPrice: 0n,
+        pnl: 0n,
+      },
+    }));
+
+    mocks.getTokenAccountBalance
+      .mockResolvedValueOnce({
+        value: {
+          amount: '900000000',
+          decimals: 6,
+        },
+      })
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ value: { amount: string; decimals: number } }>((resolve) => {
+            resolveWalletBBalance = resolve;
+          }),
+      );
+
+    const { rerender } = render(<DepositWithdrawCard slabAddress="test-slab" />);
+
+    const maxButton = await screen.findByRole('button', { name: 'Max' });
+    fireEvent.click(maxButton);
+
+    const amountInput = screen.getByPlaceholderText('Amount (USDC)');
+    expect(amountInput).toHaveValue('900');
+
+    activeWallet = walletB;
+
+    await act(async () => {
+      rerender(<DepositWithdrawCard slabAddress="test-slab" />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(mocks.getTokenAccountBalance).toHaveBeenCalledTimes(2);
+    });
+
+    expect(amountInput).toHaveValue('');
+
+    const pendingDepositButton = screen.getByRole('button', {
+      name: 'Deposit USDC',
+    });
+
+    expect(pendingDepositButton).toBeDisabled();
+    fireEvent.click(pendingDepositButton);
+    expect(mocks.deposit).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveWalletBBalance?.({
+        value: {
+          amount: '25000000',
+          decimals: 6,
+        },
+      });
+      await Promise.resolve();
+    });
+
+    const walletBMaxButton = await screen.findByRole('button', { name: 'Max' });
+    fireEvent.click(walletBMaxButton);
+
+    expect(amountInput).toHaveValue('25');
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Deposit USDC',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mocks.deposit).toHaveBeenCalledWith({
+        userIdx: 7,
+        amount: 25_000_000n,
+        accountExists: true,
+        portfolioPk: walletB,
+      });
+    });
   });
 });

--- a/app/components/trade/DepositWithdrawCard.tsx
+++ b/app/components/trade/DepositWithdrawCard.tsx
@@ -66,9 +66,35 @@ export const DepositWithdrawCard: FC<DepositWithdrawCardProps> = ({ slabAddress,
     if (!mockMode && walletConnected) prewarmTxLanding(connection);
   }, [connection, mockMode, walletConnected]);
   const [lastSig, setLastSig] = useState<string | null>(null);
-  const [walletBalance, setWalletBalance] = useState<bigint | null>(mockMode ? 500_000_000n : null);
+
+  type WalletBalanceSnapshot = {
+    scopeKey: string;
+    amount: bigint | null;
+    decimals: number | null;
+  };
+
+  const walletBalanceScopeKey =
+    publicKey && mktConfig?.collateralMint
+      ? `${publicKey.toBase58()}:${mktConfig.collateralMint.toBase58()}`
+      : null;
+
+  const [walletBalanceSnapshot, setWalletBalanceSnapshot] = useState<WalletBalanceSnapshot | null>(
+    null,
+  );
+
+  const walletBalance = mockMode
+    ? 500_000_000n
+    : walletBalanceSnapshot?.scopeKey === walletBalanceScopeKey
+      ? walletBalanceSnapshot.amount
+      : null;
+
   const maxRawRef = useRef<bigint | null>(null);
-  const [onChainDecimals, setOnChainDecimals] = useState<number | null>(null);
+
+  const onChainDecimals =
+    !mockMode && walletBalanceSnapshot?.scopeKey === walletBalanceScopeKey
+      ? walletBalanceSnapshot.decimals
+      : null;
+
   const decimals = onChainDecimals ?? tokenMeta?.decimals ?? 6;
 
   // Keep the mode-specific MAX raw value from leaking across Deposit/Withdraw.
@@ -76,33 +102,68 @@ export const DepositWithdrawCard: FC<DepositWithdrawCardProps> = ({ slabAddress,
   // both the display amount and the raw ref before the opposite action can submit.
   useEffect(() => {
     setMode(initialMode);
-    setAmount("");
+    setAmount('');
     maxRawRef.current = null;
   }, [initialMode]);
 
-  const switchMode = (nextMode: "deposit" | "withdraw") => {
+  const switchMode = (nextMode: 'deposit' | 'withdraw') => {
     if (nextMode === mode) return;
     maxRawRef.current = null;
-    setAmount("");
+    setAmount('');
     setMode(nextMode);
   };
   useEffect(() => {
-    if (!publicKey || !mktConfig?.collateralMint) { setWalletBalance(null); setOnChainDecimals(null); return; }
+    if (mockMode) return;
+
+    if (!publicKey || !mktConfig?.collateralMint || !walletBalanceScopeKey) {
+      setWalletBalanceSnapshot(null);
+      return;
+    }
+
+    const requestScopeKey = walletBalanceScopeKey;
     let cancelled = false;
+
+    // Immediately invalidate a snapshot owned by a different wallet or mint.
+    // Same-scope refreshes retain their verified value while a post-transaction
+    // balance refresh is pending.
+    setWalletBalanceSnapshot((current) =>
+      current?.scopeKey === requestScopeKey
+        ? current
+        : {
+            scopeKey: requestScopeKey,
+            amount: null,
+            decimals: null,
+          },
+    );
+
     (async () => {
       try {
         const ata = getAssociatedTokenAddressSync(mktConfig.collateralMint, publicKey);
+
         const info = await connection.getTokenAccountBalance(ata);
+
         if (!cancelled && info.value.amount) {
-          setWalletBalance(BigInt(info.value.amount));
-          if (info.value.decimals !== undefined) {
-            setOnChainDecimals(info.value.decimals);
-          }
+          setWalletBalanceSnapshot({
+            scopeKey: requestScopeKey,
+            amount: BigInt(info.value.amount),
+            decimals: info.value.decimals ?? null,
+          });
         }
-      } catch { if (!cancelled) { setWalletBalance(null); setOnChainDecimals(null); } }
+      } catch {
+        if (!cancelled) {
+          setWalletBalanceSnapshot({
+            scopeKey: requestScopeKey,
+            amount: null,
+            decimals: null,
+          });
+        }
+      }
     })();
-    return () => { cancelled = true; };
-  }, [publicKey, mktConfig?.collateralMint, connection, lastSig]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [mockMode, publicKey, mktConfig?.collateralMint, walletBalanceScopeKey, connection, lastSig]);
 
   // Pre-fill deposit: the FIRST time this card is open for a brand-new
   // (0-capital) account with a known wallet balance, default the amount

--- a/app/components/trade/DepositWithdrawCard.tsx
+++ b/app/components/trade/DepositWithdrawCard.tsx
@@ -90,6 +90,14 @@ export const DepositWithdrawCard: FC<DepositWithdrawCardProps> = ({ slabAddress,
 
   const maxRawRef = useRef<bigint | null>(null);
 
+  // A typed or Max-derived amount belongs to the wallet/mint scope that
+  // produced it. Clear both representations immediately after that scope
+  // changes so a replacement wallet cannot submit the previous value.
+  useEffect(() => {
+    maxRawRef.current = null;
+    setAmount("");
+  }, [walletBalanceScopeKey]);
+
   const onChainDecimals =
     !mockMode && walletBalanceSnapshot?.scopeKey === walletBalanceScopeKey
       ? walletBalanceSnapshot.decimals
@@ -309,6 +317,8 @@ export const DepositWithdrawCard: FC<DepositWithdrawCardProps> = ({ slabAddress,
   const freeMargin = capital > lockedMargin ? capital - lockedMargin : 0n;
   const loading = mode === "deposit" ? depositLoading : withdrawLoading;
   const error = mode === "deposit" ? depositError : withdrawError;
+  const isDepositBalanceUnverified =
+    !mockMode && mode === "deposit" && walletBalance === null;
 
   let parsedAmount: bigint = 0n;
   let parseError: string | null = null;
@@ -332,7 +342,7 @@ export const DepositWithdrawCard: FC<DepositWithdrawCardProps> = ({ slabAddress,
     : null;
 
   async function handleSubmit() {
-    if (!amount || !userAccount || validationError) return;
+    if (!amount || !userAccount || validationError || isDepositBalanceUnverified) return;
     if (mockMode) { setAmount(""); return; }
     try {
       const amtNative = maxRawRef.current ?? parseHumanAmount(amount, decimals);
@@ -469,7 +479,7 @@ export const DepositWithdrawCard: FC<DepositWithdrawCardProps> = ({ slabAddress,
 
       <button
         onClick={handleSubmit}
-        disabled={loading || !amount || !!validationError}
+        disabled={loading || !amount || !!validationError || isDepositBalanceUnverified}
         className={`w-full rounded-none py-2 text-[10px] font-medium uppercase tracking-[0.1em] hover:scale-[1.01] active:scale-[0.99] transition-transform disabled:cursor-not-allowed disabled:opacity-50 ${mode === "deposit" ? "bg-[var(--accent)] text-white hover:brightness-110" : "bg-[var(--warning)] text-[var(--bg)] hover:brightness-110"}`}
       >
         {loading ? "Sending..." : validationError ? validationError : mode === "deposit" ? `Deposit ${symbol}` : `Withdraw ${symbol}`}


### PR DESCRIPTION
## Summary

Fixes #2429.

This PR makes the wallet-balance lifecycle in `DepositWithdrawCard` explicitly scoped to the currently active wallet and collateral mint.

Previously, the component stored asynchronously fetched token-balance state without binding that state to the wallet and mint that produced it. During a wallet switch, the previous wallet's balance and balance-derived actions could remain visible or actionable while the replacement wallet's balance request was still pending.

The original patch introduced a wallet-scoped balance snapshot and prevented obsolete asynchronous responses from being consumed under a different wallet scope.

This PR now also closes the remaining existing-account deposit path identified during review:

- the visible deposit amount is cleared when the wallet/mint scope changes;
- the exact raw value stored by the `Max` button is cleared at the same time;
- deposit submission fails closed while the replacement wallet balance is unresolved;
- the Deposit button remains disabled until the active wallet's balance has been verified.

Together, these protections ensure that neither displayed balance state nor a previously selected deposit amount can cross wallet or collateral-mint boundaries.

---

## Problem

`DepositWithdrawCard` asynchronously fetches the connected wallet's collateral-token balance through:

```ts
connection.getTokenAccountBalance(associatedTokenAddress)
```

Before this change, the result was stored independently in local component state:

```ts
walletBalance
onChainDecimals
```

Those values did not carry any ownership identity proving which wallet and collateral mint produced them.

The component also keeps two representations of the selected transaction amount:

```ts
amount
maxRawRef.current
```

`amount` is the human-readable value displayed in the input, while `maxRawRef.current` preserves the exact native-unit `bigint` selected through the `Max` button.

Neither value was previously invalidated when the active wallet scope changed.

---

## Stale balance race

The original balance-state race was:

1. Wallet A is connected.
2. Wallet A's balance request resolves and populates the component.
3. The user switches to wallet B.
4. A new balance request for wallet B starts but remains pending.
5. Wallet A's previously resolved balance remains rendered.
6. Wallet A-derived account-creation state remains visible or actionable under wallet B.
7. A late response from an obsolete request may overwrite newer component state.

An effect cancellation flag prevented some writes after cleanup, but it did not provide a durable ownership relationship between the stored balance and the wallet for which that balance was fetched.

---

## Stale Max deposit race

An additional existing-account path remained after the initial fix:

1. Wallet A is active and has an existing trading account.
2. Wallet A has `900 USDC`.
3. The user selects `Max` on the Deposit tab.
4. The component stores:

   ```ts
   amount = "900"
   maxRawRef.current = 900_000_000n
   ```

5. The user switches to wallet B.
6. Wallet B's balance request remains pending.
7. The wallet-scoped balance becomes unavailable:

   ```ts
   walletBalance === null
   ```

8. The over-deposit check cannot compare the requested amount against wallet B because its balance has not resolved.
9. Without additional protection, `handleSubmit` can still prefer the stale exact value:

   ```ts
   maxRawRef.current
   ```

10. A deposit amount selected for wallet A may therefore remain actionable after wallet B becomes active.

The transaction would still require wallet B's signature and normal on-chain validation, but the client-side transaction intent and amount would incorrectly originate from wallet A's UI lifecycle.

---

## Security and correctness invariant

Any balance or balance-derived value rendered or consumed by `DepositWithdrawCard` must belong to the exact active identity tuple:

```text
connected wallet public key + collateral mint
```

After either part of that tuple changes:

- the previous balance must no longer be displayed;
- previous-wallet account-creation controls must not remain enabled;
- the previous input amount must be invalidated;
- the previous exact `Max` value must be invalidated;
- account creation must not derive a starter deposit from stale state;
- existing-account deposit submission must remain blocked while the new balance is unresolved;
- obsolete asynchronous responses must not become consumable under the new scope;
- the new balance must only become actionable after it has been verified for the active scope.

---

## Root cause

The previous implementation had three related lifecycle gaps.

### 1. Balance data had no provenance

Balance and decimals were stored separately from the wallet and collateral mint that produced them:

```ts
const [walletBalance, setWalletBalance] = useState<bigint | null>(...);
const [onChainDecimals, setOnChainDecimals] = useState<number | null>(null);
```

A render after a wallet switch could therefore consume values fetched for the former wallet.

### 2. User-entered and Max-derived amounts were not scope-bound

The deposit input and exact raw Max value persisted independently from the active wallet scope:

```ts
const [amount, setAmount] = useState("");
const maxRawRef = useRef<bigint | null>(null);
```

Invalidating only the balance snapshot did not invalidate an amount already derived from that balance.

### 3. Deposit validation was incomplete while balance was pending

The over-deposit check can only compare values when the active wallet balance is known:

```ts
walletBalance !== null
```

While the replacement balance remained unresolved, that comparison was intentionally unavailable. Without a separate fail-closed guard, a stale raw Max amount could remain eligible for submission.

---

## Implementation

### 1. Introduce a wallet-scoped balance snapshot

The component now stores balance data together with the ownership scope that produced it:

```ts
type WalletBalanceSnapshot = {
  scopeKey: string;
  amount: bigint | null;
  decimals: number | null;
};
```

The nullable `amount` allows the component to represent a known active scope whose balance is still pending or unavailable without reusing data from another scope.

---

### 2. Derive a scope from wallet and collateral mint

The scope key is derived from both active identity components:

```ts
const walletBalanceScopeKey =
  publicKey && mktConfig?.collateralMint
    ? `${publicKey.toBase58()}:${mktConfig.collateralMint.toBase58()}`
    : null;
```

This prevents balance data for:

- another wallet;
- another collateral mint; or
- an incomplete/disconnected scope

from being treated as current.

---

### 3. Expose balance state only for a matching scope

The rendered balance is derived only when the stored snapshot belongs to the currently active wallet/mint scope:

```ts
const walletBalance = mockMode
  ? 500_000_000n
  : walletBalanceSnapshot?.scopeKey === walletBalanceScopeKey
    ? walletBalanceSnapshot.amount
    : null;
```

Decimals are protected by the same scope comparison.

This provides a render-time ownership check in addition to the asynchronous request lifecycle guards.

Even before an effect finishes processing the wallet change, a snapshot belonging to wallet A cannot be consumed while wallet B is active because its `scopeKey` no longer matches.

---

### 4. Invalidate cross-scope balance state

When a request begins for a different wallet or collateral mint, the component replaces the previous snapshot with a pending snapshot owned by the new scope:

```ts
setWalletBalanceSnapshot((current) =>
  current?.scopeKey === requestScopeKey
    ? current
    : {
        scopeKey: requestScopeKey,
        amount: null,
        decimals: null,
      },
);
```

This prevents the previous wallet's:

- balance label;
- token availability state;
- account-creation prompt;
- starter-deposit derivation; and
- balance-dependent actions

from leaking into the replacement wallet lifecycle.

Same-scope post-transaction refreshes retain the already verified value while the refreshed request is pending.

---

### 5. Bind asynchronous requests to their originating scope

Each balance request captures the scope that initiated it:

```ts
const requestScopeKey = walletBalanceScopeKey;
```

A successful response is stored together with that exact scope:

```ts
setWalletBalanceSnapshot({
  scopeKey: requestScopeKey,
  amount: BigInt(info.value.amount),
  decimals: info.value.decimals ?? null,
});
```

A response from an obsolete request may still complete asynchronously, but it cannot become consumable under a different active scope.

---

### 6. Ignore cancelled request executions

Each effect execution retains a cancellation flag:

```ts
let cancelled = false;
```

Cleanup marks the request execution as cancelled:

```ts
return () => {
  cancelled = true;
};
```

Successful and failed requests update state only while their effect execution remains active.

A failed current-scope request leaves the scope in a fail-closed state with:

```ts
amount: null
decimals: null
```

It does not restore or reuse a previously verified balance from another wallet.

---

### 7. Clear visible and raw Max state on scope changes

The follow-up fix binds the selected deposit amount to the wallet/mint lifecycle:

```ts
useEffect(() => {
  maxRawRef.current = null;
  setAmount("");
}, [walletBalanceScopeKey]);
```

When either the wallet public key or collateral mint changes:

- the human-readable input is cleared;
- the exact native-unit value stored by `Max` is cleared;
- an amount selected for wallet A cannot remain available under wallet B;
- an amount selected for one collateral mint cannot cross into another market scope.

Both representations must be cleared because `handleSubmit` intentionally prioritizes `maxRawRef.current` to preserve exact token precision.

---

### 8. Fail closed while the active balance is unverified

The component derives an explicit pending/unverified condition for deposits:

```ts
const isDepositBalanceUnverified =
  !mockMode && mode === "deposit" && walletBalance === null;
```

The submit handler refuses to proceed while that condition is true:

```ts
async function handleSubmit() {
  if (
    !amount ||
    !userAccount ||
    validationError ||
    isDepositBalanceUnverified
  ) {
    return;
  }

  // Existing submission logic
}
```

The Deposit button uses the same guard:

```tsx
disabled={
  loading ||
  !amount ||
  !!validationError ||
  isDepositBalanceUnverified
}
```

This creates two layers of protection:

1. the UI disables the action while the replacement balance is unresolved;
2. the submission handler independently rejects the action.

The handler-level guard is required even though the input is cleared by an effect because it closes any timing window between the scope-changing render and effect execution.

---

### 9. Preserve exact Max precision after verification

Once the active wallet's balance resolves, the existing Max behavior remains unchanged:

```ts
maxRawRef.current = walletBalance;
setAmount(formatTokenAmount(walletBalance, decimals));
```

The displayed amount may be formatted for human readability, while submission continues to use the exact native-unit `bigint`.

The difference is that the raw value is now valid only for the active wallet/mint lifecycle and is cleared whenever that lifecycle changes.

---

### 10. Preserve valid same-scope refresh behavior

Post-transaction balance refreshes triggered through `lastSig` continue to operate normally.

When the wallet and collateral mint remain unchanged:

- `walletBalanceScopeKey` remains stable;
- the input is not cleared solely because of a same-scope balance refresh;
- the verified same-scope balance may remain visible while the refresh is pending;
- the refreshed result replaces only the snapshot for the same ownership scope.

---

## Regression tests

Added and extended:

```text
app/__tests__/components/trade/DepositWithdrawCard.wallet-switch.test.tsx
```

### Test 1: stale account-creation state is withheld while wallet B is pending

The test reproduces the new-account race:

1. Render with wallet A.
2. Resolve wallet A's collateral balance as `900 USDC`.
3. Confirm wallet A's balance is displayed.
4. Confirm `Create Trading Account` is available.
5. Switch the mocked active wallet to wallet B.
6. Keep wallet B's balance request unresolved.
7. Confirm a second balance request is made for wallet B's associated token account.
8. Confirm wallet A's balance is no longer visible.
9. Confirm `Create Trading Account` is no longer available.
10. Confirm the stale action cannot call `initUser`.
11. Confirm the `500 USDC` starter-deposit cap is not derived from wallet A while wallet B remains unverified.

This test fails against the vulnerable implementation because wallet A's balance and account-creation action remain available after wallet B becomes active.

---

### Test 2: the component updates after wallet B resolves

The second test verifies the successful replacement lifecycle:

1. Wallet A resolves with `900 USDC`.
2. The active wallet changes to wallet B.
3. Wallet B's request resolves with `25 USDC`.
4. The component updates to display wallet B's verified balance.
5. The associated token-address lookup is confirmed to use wallet B.

This confirms the fix does not permanently suppress balance state. It withholds data only until the active wallet's balance has been verified.

---

### Test 3: a Max-derived amount cannot cross wallet scopes

The third test covers the existing trading-account deposit path:

1. Render an existing trading account under wallet A.
2. Resolve wallet A's balance as `900 USDC`.
3. Click `Max`.
4. Confirm the input displays `900`.
5. Switch the active wallet to wallet B.
6. Keep wallet B's balance request pending.
7. Confirm the previous input value is cleared.
8. Confirm the Deposit button is disabled.
9. Attempt to click Deposit.
10. Confirm `deposit()` is not called.
11. Resolve wallet B's balance as `25 USDC`.
12. Click `Max` again.
13. Confirm the input displays `25`.
14. Submit the deposit.
15. Confirm the submitted amount is exactly:

    ```text
    25_000_000 native units
    ```

16. Confirm the submission uses wallet B's portfolio identity.

This verifies that both the visible amount and the exact raw Max value are invalidated when the wallet scope changes.

---

## Validation

### Focused regression suite

```bash
pnpm --filter @percolator/app exec vitest run \
  __tests__/components/trade/DepositWithdrawCard.wallet-switch.test.tsx \
  --reporter=verbose
```

Result:

```text
Test Files  1 passed
Tests       3 passed
```

The focused suite validates:

- stale wallet A account-creation state is withheld;
- wallet B's verified balance replaces wallet A's state;
- a wallet A Max-derived deposit amount cannot be submitted under wallet B.

---

### TypeScript validation

```bash
pnpm --filter @percolator/app exec tsc --noEmit
```

Result:

```text
Passed
```

---

### Production build

```bash
NEXT_PUBLIC_API_URL=http://127.0.0.1:3001 \
  pnpm --filter @percolator/app build
```

Result:

```text
Passed
```

---

### Repository whitespace validation

```bash
git diff --check
```

Result:

```text
Passed
```

---

### Formatting note

A full-file Prettier check reports existing formatting differences in:

```text
app/components/trade/DepositWithdrawCard.tsx
```

The same warning is reproducible against the previous PR HEAD before the review follow-up patch.

The follow-up therefore intentionally preserves a minimal behavioral diff instead of reformatting the entire component and introducing unrelated formatting churn.

The regression-test file itself does not produce the reported formatting warning.

---

### GitHub Actions

The latest PR head passes:

```text
PR Check (Build & Fast Tests)
Test Suite
```

---

## Files changed

```text
app/components/trade/DepositWithdrawCard.tsx
app/__tests__/components/trade/DepositWithdrawCard.wallet-switch.test.tsx
```

---

## User impact

After this change, switching wallets cannot temporarily expose or reuse the previous wallet's collateral balance inside the trade deposit/account-creation card.

For a replacement wallet:

- the previous wallet's balance is immediately treated as invalid;
- the previous wallet's input amount is cleared;
- the previous wallet's exact Max value is cleared;
- account creation remains unavailable while the replacement balance is unresolved;
- existing-account deposits remain disabled while the replacement balance is unresolved;
- deposit actions become available only after the replacement wallet's balance has been verified;
- subsequent Max and deposit actions use only the replacement wallet's verified balance.

This prevents stale client-side transaction intent from crossing wallet or collateral-mint ownership boundaries.

---

## Scope

This change is intentionally limited to the wallet-balance and deposit-input lifecycle inside `DepositWithdrawCard`.

It does not alter:

- on-chain deposit or withdrawal instructions;
- program-level authorization;
- account ownership rules;
- transaction signing;
- token-account ownership validation;
- collateral calculations;
- position margin calculations;
- withdrawal free-margin calculations; or
- unrelated trade-page state.

The patch ensures that client-side balance data and balance-derived deposit values remain bound to the wallet and collateral mint that produced them.