### PR TITLE
fix(create-market): preserve Hyperp oracle mode on mainnet

### DIFF
--- a/app/__tests__/lib/resolveMarketOracleMode.test.ts
+++ b/app/__tests__/lib/resolveMarketOracleMode.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveMarketOracleMode,
+  type MarketOracleMode,
+} from "../../lib/resolveMarketOracleMode";
+
+describe("resolveMarketOracleMode", () => {
+  it("preserves Hyperp mode on mainnet when mainnetCA is present", () => {
+    expect(
+      resolveMarketOracleMode({
+        requestedMode: "hyperp",
+        network: "mainnet",
+        hasMainnetCA: true,
+      }),
+    ).toBe("hyperp");
+  });
+
+  it("falls back from Hyperp to Admin for a devnet mirror", () => {
+    expect(
+      resolveMarketOracleMode({
+        requestedMode: "hyperp",
+        network: "devnet",
+        hasMainnetCA: true,
+      }),
+    ).toBe("admin");
+  });
+
+  it("preserves Hyperp mode on devnet when mainnetCA is absent", () => {
+    expect(
+      resolveMarketOracleMode({
+        requestedMode: "hyperp",
+        network: "devnet",
+        hasMainnetCA: false,
+      }),
+    ).toBe("hyperp");
+  });
+
+  it.each<MarketOracleMode>([
+    "pyth",
+    "admin",
+    "keeper",
+  ])("does not alter %s mode", (requestedMode) => {
+    expect(
+      resolveMarketOracleMode({
+        requestedMode,
+        network: "mainnet",
+        hasMainnetCA: true,
+      }),
+    ).toBe(requestedMode);
+  });
+});

--- a/app/hooks/useCreateMarket.ts
+++ b/app/hooks/useCreateMarket.ts
@@ -83,6 +83,7 @@ import {
   checkSignatureLanded,
 } from "@/lib/tx";
 import { getConfig, getNetwork } from "@/lib/config";
+import { resolveMarketOracleMode } from "@/lib/resolveMarketOracleMode";
 import { normalizeDexType } from "@/lib/dex-type";
 import { parseMarketCreationError } from "@/lib/parseMarketError";
 import {
@@ -1373,23 +1374,28 @@ export function useCreateMarket() {
       // - "pyth": index_feed_id = pyth hex, uses KeeperCrank with Pyth PDA
       // - "hyperp": index_feed_id = zeros, uses UpdateHyperpMark (reads DEX pool directly)
       // - "admin": index_feed_id = zeros, uses PushOraclePrice + KeeperCrank
-      // PERC-470 devnet guard: Hyperp mode reads live DEX pool accounts on-chain.
-      // On devnet, mirror tokens have no PumpSwap pool — mainnet pool addresses are invalid.
-      // Force admin oracle mode for all devnet mirror markets (params.mainnetCA is set).
-      const isDevnetMirror = !!params.mainnetCA;
-      const resolvedOracleMode = params.oracleMode ?? (params.oracleFeed === ALL_ZEROS_FEED ? "admin" : "pyth");
-      // "keeper" mode: AUTH_MARK oracle with oracle_authority delegated to our keeper service.
-      // On devnet mirrors, hyperp falls back to admin; keeper stays keeper (it's designed for devnet).
-      const oracleMode: "pyth" | "hyperp" | "admin" | "keeper" = (resolvedOracleMode === "hyperp" && isDevnetMirror) ? "admin" : resolvedOracleMode as "pyth" | "hyperp" | "admin" | "keeper";
+      // PERC-devnet: detect the runtime network instead of inferring it from
+      // params.mainnetCA. mainnetCA identifies mirrored-token metadata and is
+      // populated for mainnet market creation as well.
+      const network = getNetwork();
+      const isDevnetEnv = network === "devnet";
+
+      const resolvedOracleMode =
+        params.oracleMode ??
+        (params.oracleFeed === ALL_ZEROS_FEED ? "admin" : "pyth");
+
+      // Hyperp reads live DEX pool accounts on-chain. Mainnet pool accounts are
+      // unavailable for devnet mirrors, so only that exact combination falls
+      // back to Admin. Mainnet Hyperp must remain Hyperp.
+      const oracleMode = resolveMarketOracleMode({
+        requestedMode: resolvedOracleMode,
+        network,
+        hasMainnetCA: !!params.mainnetCA,
+      });
+
       const isAdminOracle = oracleMode === "admin";
       const isHyperpOracle = oracleMode === "hyperp";
       const isKeeperOracle = oracleMode === "keeper";
-      // PERC-devnet: isDevnetEnv must be runtime-detected, not build-time.
-      // Users toggle devnet via localStorage — NEXT_PUBLIC_DEFAULT_NETWORK is always "mainnet" on Vercel prod.
-      // Use getNetwork() which reads localStorage("percolator-network") first, then env var, then defaults
-      // to "mainnet" (fail-closed). DO NOT use params.mainnetCA as a devnet proxy — it signals
-      // "this is a devnet mirror market" not "the user is connected to devnet" (issue #835).
-      const isDevnetEnv = getNetwork() === "devnet";
 
       // PERC-470: Resolve DEX pool vault addresses for hyperp mode
       // If vaults weren't provided, fetch the pool account on-chain

--- a/app/lib/resolveMarketOracleMode.ts
+++ b/app/lib/resolveMarketOracleMode.ts
@@ -1,0 +1,39 @@
+export type MarketOracleMode =
+  | "pyth"
+  | "hyperp"
+  | "admin"
+  | "keeper";
+
+export type MarketNetwork = "mainnet" | "devnet";
+
+export interface ResolveMarketOracleModeInput {
+  requestedMode: MarketOracleMode;
+  network: MarketNetwork;
+  hasMainnetCA: boolean;
+}
+
+/**
+ * Resolve the effective oracle mode for market creation.
+ *
+ * Hyperp may fall back to Admin only for devnet mirror markets,
+ * because mainnet DEX pool accounts are unavailable on devnet.
+ *
+ * mainnetCA alone is token metadata and must not be treated as
+ * proof that the current runtime network is devnet.
+ */
+export function resolveMarketOracleMode(
+  input: ResolveMarketOracleModeInput,
+): MarketOracleMode {
+  const isDevnetMirror =
+    input.network === "devnet" &&
+    input.hasMainnetCA;
+
+  if (
+    input.requestedMode === "hyperp" &&
+    isDevnetMirror
+  ) {
+    return "admin";
+  }
+
+  return input.requestedMode;
+}


### PR DESCRIPTION
Fixes #2433

## Summary

This PR fixes a deterministic oracle-mode integrity issue in the market-creation flow where a user-selected `hyperp` oracle mode could be silently downgraded to `admin` on mainnet.

The affected logic treated the presence of `params.mainnetCA` as sufficient proof that the market was a devnet mirror:

```ts
const isDevnetMirror = !!params.mainnetCA;
```

However, the create-market wizard populates `mainnetCA` during normal mainnet market creation as token metadata:

```ts
mainnetCA: wizard.mintAddress,
```

As a result, the following valid mainnet configuration:

```text
network       = mainnet
requestedMode = hyperp
mainnetCA     = present
```

was incorrectly resolved as:

```text
effectiveMode = admin
```

instead of:

```text
effectiveMode = hyperp
```

This PR makes the fallback network-aware so that Hyperp is downgraded to Admin only for an actual devnet mirror.

---

## Root Cause

The issue was caused by using `mainnetCA` as a proxy for the active runtime network.

The previous implementation effectively used:

```ts
const isDevnetMirror = !!params.mainnetCA;

const oracleMode =
  resolvedOracleMode === "hyperp" && isDevnetMirror
    ? "admin"
    : resolvedOracleMode;
```

This assumption is unsafe because `mainnetCA` represents token metadata and may be populated on both mainnet and devnet.

The code therefore conflated two separate concepts:

```text
mainnetCA present
```

and:

```text
runtime network is devnet
```

The intended fallback is valid only when both of the following are true:

```text
runtime network is devnet
AND
mainnetCA is present for a mirrored token
```

---

## Security Invariant

The effective oracle mode used during market creation must match the mode selected by the creator, except for the intentional devnet-mirror compatibility fallback.

This PR enforces the following invariant matrix:

```text
mainnet + Hyperp + mainnetCA present
    => Hyperp

devnet + Hyperp + mainnetCA present
    => Admin fallback

devnet + Hyperp + mainnetCA absent
    => Hyperp

Pyth
    => unchanged

Admin
    => unchanged

Keeper
    => unchanged
```

In particular, `mainnetCA` must not independently determine the active runtime network.

---

## Changes

### 1. Added a pure oracle-mode resolver

A new helper was added:

```text
app/lib/resolveMarketOracleMode.ts
```

The resolver explicitly receives:

- requested oracle mode;
- runtime network;
- whether `mainnetCA` is present.

The corrected condition is:

```ts
const isDevnetMirror =
  input.network === "devnet" &&
  input.hasMainnetCA;
```

Hyperp falls back to Admin only when the request is running on devnet and represents a mirrored mainnet token.

---

### 2. Updated the production market-creation flow

`app/hooks/useCreateMarket.ts` now resolves the runtime network before selecting the effective oracle mode:

```ts
const network = getNetwork();
const isDevnetEnv = network === "devnet";

const resolvedOracleMode =
  params.oracleMode ??
  (
    params.oracleFeed === ALL_ZEROS_FEED
      ? "admin"
      : "pyth"
  );

const oracleMode = resolveMarketOracleMode({
  requestedMode: resolvedOracleMode,
  network,
  hasMainnetCA: !!params.mainnetCA,
});
```

This removes the incorrect assumption that the presence of `mainnetCA` alone indicates a devnet mirror.

The existing `isDevnetEnv` value continues to be used by the remaining devnet-specific market-creation logic.

---

### 3. Added regression coverage

A focused regression suite was added:

```text
app/__tests__/lib/resolveMarketOracleMode.test.ts
```

The tests cover:

```text
mainnet + Hyperp + mainnetCA
    => Hyperp

devnet + Hyperp + mainnetCA
    => Admin

devnet + Hyperp + no mainnetCA
    => Hyperp

Pyth
    => unchanged

Admin
    => unchanged

Keeper
    => unchanged
```

---

## Before This Fix

The affected implementation treated `mainnetCA` as proof of a devnet mirror:

```ts
const isDevnetMirror = input.hasMainnetCA;
```

The mainnet regression test failed with:

```text
Expected: "hyperp"
Received: "admin"

Test Files  1 failed
Tests       1 failed | 5 passed
Exit status: 1
```

The failure was isolated to this invariant:

```text
mainnet + Hyperp + mainnetCA
```

The other five control cases continued to pass.

---

## After This Fix

The resolver now requires an actual devnet runtime:

```ts
const isDevnetMirror =
  input.network === "devnet" &&
  input.hasMainnetCA;
```

The same regression suite now passes:

```text
Test Files  1 passed
Tests       6 passed
```

Verified behavior:

```text
PASS mainnet + Hyperp + mainnetCA    => Hyperp
PASS devnet + Hyperp + mainnetCA     => Admin
PASS devnet + Hyperp + no mainnetCA  => Hyperp
PASS Pyth                             => unchanged
PASS Admin                            => unchanged
PASS Keeper                           => unchanged
```

---

## Validation

### Targeted oracle regression tests

Command:

```bash
pnpm --filter @percolator/app exec vitest run \
  __tests__/lib/resolveMarketOracleMode.test.ts \
  __tests__/lib/oraclePrice.test.ts \
  --reporter=verbose
```

Result:

```text
Test Files  2 passed
Tests       35 passed
```

This includes the new resolver tests and the existing oracle-price regression suite.

---

### TypeScript validation

Command:

```bash
pnpm --filter @percolator/app exec tsc \
  --noEmit \
  -p tsconfig.json
```

Result:

```text
PASS
No TypeScript errors.
```

---

### Production build

Command:

```bash
pnpm --filter @percolator/app build
```

Result:

```text
PASS
Next.js production build completed successfully.
Static page generation completed successfully.
Page optimization completed successfully.
```

The build emitted existing non-fatal warnings related to Next.js configuration deprecations, middleware migration, `module.register()`, and the BigInt native-binding fallback. None were introduced by this PR and none caused the build to fail.

---

### Patch integrity

Commands:

```bash
git diff --check
git diff upstream/playground...HEAD --check
```

Result:

```text
PASS
No whitespace errors.
```

---

## Files Changed

```text
app/hooks/useCreateMarket.ts
app/lib/resolveMarketOracleMode.ts
app/__tests__/lib/resolveMarketOracleMode.test.ts
```

Patch statistics:

```text
3 files changed
110 insertions
14 deletions
```

---

## Scope

This PR is intentionally limited to the oracle-mode resolution defect reported in #2433.

It does not modify:

- transaction signing;
- wallet authorization;
- RPC behavior;
- API routes;
- account ownership validation;
- on-chain instruction encoding;
- market authorities;
- deployed Solana program logic;
- oracle price calculation or sanitization.

No unrelated refactoring is included.

---

## Impact of the Fix

After this change:

- valid mainnet Hyperp requests remain Hyperp;
- the intentional devnet mirror fallback remains intact;
- Hyperp-specific DEX pool processing is no longer skipped on mainnet because of `mainnetCA`;
- Pyth, Admin, and Keeper behavior remains unchanged;
- the effective oracle mode remains consistent with the creator's explicit selection.

---

## Review Notes

The most important review points are:

1. `getNetwork()` is evaluated before oracle-mode resolution.
2. `mainnetCA` is treated as metadata rather than a standalone network signal.
3. Hyperp falls back to Admin only for:

   ```text
   network === "devnet" && hasMainnetCA === true
   ```

4. Existing oracle modes are not altered.
5. Regression tests explicitly cover both the affected mainnet condition and the intended devnet fallback.

---

## Commit

```text
50c9d3ae fix(create-market): preserve Hyperp oracle mode on mainnet
```