### PR TITLE
fix(devnet): validate faucet and auto-fund transaction execution results

### DIFF
--- a/app/__tests__/api/auto-fund-usdc-confirmation-result.test.ts
+++ b/app/__tests__/api/auto-fund-usdc-confirmation-result.test.ts
@@ -1,0 +1,354 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { NextRequest } from "next/server";
+
+const mocks = vi.hoisted(() => ({
+  getBalance: vi.fn(),
+  getTokenAccountBalance: vi.fn(),
+  getLatestBlockhash: vi.fn(),
+  sendRawTransaction: vi.fn(),
+  confirmTransaction: vi.fn(),
+
+  getAssociatedTokenAddress: vi.fn(),
+  getDevnetMintSigner: vi.fn(),
+
+  tryFaucetGate: vi.fn(),
+  releaseFaucetClaim: vi.fn(),
+
+  analyticsInsert: vi.fn(),
+  analyticsFrom: vi.fn(),
+
+  captureException: vi.fn(),
+}));
+
+vi.mock("@solana/web3.js", () => {
+  class PublicKey {
+    constructor(
+      private readonly value: unknown,
+    ) {}
+
+    toBase58(): string {
+      return typeof this.value === "string"
+        ? this.value
+        : "11111111111111111111111111111111";
+    }
+  }
+
+  class Transaction {
+    recentBlockhash?: string;
+    feePayer?: PublicKey;
+
+    add(): this {
+      return this;
+    }
+
+    serialize(): Buffer {
+      return Buffer.from([]);
+    }
+  }
+
+  class Connection {
+    getBalance =
+      mocks.getBalance;
+
+    getTokenAccountBalance =
+      mocks.getTokenAccountBalance;
+
+    getLatestBlockhash =
+      mocks.getLatestBlockhash;
+
+    sendRawTransaction =
+      mocks.sendRawTransaction;
+
+    confirmTransaction =
+      mocks.confirmTransaction;
+  }
+
+  return {
+    Connection,
+    PublicKey,
+    Transaction,
+    LAMPORTS_PER_SOL: 1_000_000_000,
+  };
+});
+
+vi.mock("@solana/spl-token", () => ({
+  getAssociatedTokenAddress:
+    mocks.getAssociatedTokenAddress,
+
+  createAssociatedTokenAccountInstruction:
+    vi.fn(),
+
+  createMintToInstruction:
+    vi.fn(),
+}));
+
+vi.mock("@/lib/config", () => ({
+  getConfig: () => ({
+    rpcUrl:
+      "https://api.devnet.solana.com",
+
+    testUsdcMint:
+      "So11111111111111111111111111111111111111112",
+  }),
+}));
+
+vi.mock("@/lib/devnet-signer", () => ({
+  getDevnetMintSigner:
+    mocks.getDevnetMintSigner,
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceClient: () => ({
+    from: mocks.analyticsFrom,
+  }),
+}));
+
+vi.mock("@/lib/faucet-rate-gate", () => ({
+  tryFaucetGate:
+    mocks.tryFaucetGate,
+
+  releaseFaucetClaim:
+    mocks.releaseFaucetClaim,
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException:
+    mocks.captureException,
+}));
+
+let POST:
+  typeof import(
+    "@/app/api/auto-fund/route"
+  ).POST;
+
+function createRequest(): NextRequest {
+  return new NextRequest(
+    "http://localhost/api/auto-fund",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type":
+          "application/json",
+      },
+      body: JSON.stringify({
+        wallet:
+          "11111111111111111111111111111111",
+      }),
+    },
+  );
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.clearAllMocks();
+
+  process.env
+    .NEXT_PUBLIC_DEFAULT_NETWORK =
+    "devnet";
+
+  delete process.env
+    .NEXT_PUBLIC_SOLANA_NETWORK;
+
+  mocks.tryFaucetGate
+    .mockResolvedValue({
+      allowed: true,
+      nextClaimAt: null,
+      claimId: 99,
+    });
+
+  mocks.releaseFaucetClaim
+    .mockResolvedValue(undefined);
+
+  mocks.analyticsInsert
+    .mockResolvedValue({
+      error: null,
+    });
+
+  mocks.analyticsFrom
+    .mockReturnValue({
+      insert: mocks.analyticsInsert,
+    });
+
+  /*
+   * Skip the SOL airdrop path so this test remains
+   * focused on Auto-fund USDC confirmation handling.
+   */
+  mocks.getBalance
+    .mockResolvedValue(
+      1_000_000_000,
+    );
+
+  mocks.getAssociatedTokenAddress
+    .mockResolvedValue({
+      toBase58: () =>
+        "11111111111111111111111111111111",
+    });
+
+  /*
+   * First call: wallet has less than 1 USDC,
+   * therefore a mint is required.
+   *
+   * Second call: ATA exists, so no ATA-create
+   * instruction is needed.
+   */
+  mocks.getTokenAccountBalance
+    .mockResolvedValue({
+      value: {
+        uiAmount: 0,
+      },
+    });
+
+  mocks.getLatestBlockhash
+    .mockResolvedValue({
+      blockhash:
+        "auto-fund-test-blockhash",
+
+      lastValidBlockHeight:
+        54321,
+    });
+
+  mocks.sendRawTransaction
+    .mockResolvedValue(
+      "failed-on-chain-auto-fund-usdc-signature",
+    );
+
+  mocks.confirmTransaction
+    .mockResolvedValue({
+      context: {
+        slot: 300,
+      },
+
+      value: {
+        err: {
+          InstructionError: [
+            0,
+            {
+              Custom: 1,
+            },
+          ],
+        },
+      },
+    });
+
+  mocks.getDevnetMintSigner
+    .mockReturnValue({
+      publicKey: () =>
+        "11111111111111111111111111111111",
+
+      signTransaction:
+        (transaction: unknown) =>
+          transaction,
+    });
+
+  const route =
+    await import(
+      "@/app/api/auto-fund/route"
+    );
+
+  POST = route.POST;
+});
+
+afterEach(() => {
+  delete process.env
+    .NEXT_PUBLIC_DEFAULT_NETWORK;
+
+  delete process.env
+    .NEXT_PUBLIC_SOLANA_NETWORK;
+});
+
+describe(
+  "POST /api/auto-fund USDC confirmation validation",
+  () => {
+    it(
+      "must not report USDC funding when confirmation contains an on-chain execution error",
+      async () => {
+        const response =
+          await POST(createRequest());
+
+        const body =
+          await response.json();
+
+        expect(
+          mocks.sendRawTransaction,
+        ).toHaveBeenCalledTimes(1);
+
+        expect(
+          mocks.confirmTransaction,
+        ).toHaveBeenCalledTimes(1);
+
+        /*
+         * Auto-fund treats mint failures as non-fatal, so the
+         * corrected route may still return HTTP 200.
+         *
+         * The important invariant is that failed execution
+         * must not be recorded or returned as funded.
+         */
+        expect(body.funded)
+          .toBe(false);
+
+        expect(body.usdc_minted)
+          .toBe(false);
+
+        expect(
+          mocks.releaseFaucetClaim,
+        ).toHaveBeenCalledWith(
+          expect.anything(),
+          99,
+        );
+
+        expect(
+          mocks.analyticsInsert,
+        ).not.toHaveBeenCalled();
+      },
+    );
+
+    it(
+      "returns USDC funding success when confirmation contains no execution error",
+      async () => {
+        mocks.confirmTransaction
+          .mockResolvedValueOnce({
+            context: {
+              slot: 301,
+            },
+
+            value: {
+              err: null,
+            },
+          });
+
+        const response =
+          await POST(createRequest());
+
+        const body =
+          await response.json();
+
+        expect(response.status)
+          .toBe(200);
+
+        expect(
+          mocks.sendRawTransaction,
+        ).toHaveBeenCalledTimes(1);
+
+        expect(
+          mocks.confirmTransaction,
+        ).toHaveBeenCalledTimes(1);
+
+        expect(body.funded)
+          .toBe(true);
+
+        expect(body.usdc_minted)
+          .toBe(true);
+
+        expect(body.usdc_amount)
+          .toBe(1000);
+      },
+    );
+  },
+);

--- a/app/__tests__/api/faucet-confirmation-result.test.ts
+++ b/app/__tests__/api/faucet-confirmation-result.test.ts
@@ -1,0 +1,227 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { NextRequest } from "next/server";
+
+const mocks = vi.hoisted(() => ({
+  requestAirdrop: vi.fn(),
+  confirmTransaction: vi.fn(),
+  tryFaucetGate: vi.fn(),
+  releaseFaucetClaim: vi.fn(),
+  analyticsInsert: vi.fn(),
+  analyticsFrom: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+vi.mock("@solana/web3.js", () => {
+  class PublicKey {
+    constructor(private readonly value: string) {}
+
+    toBase58(): string {
+      return this.value;
+    }
+
+    equals(other: { toBase58?: () => string }): boolean {
+      return other?.toBase58?.() === this.value;
+    }
+  }
+
+  class Transaction {
+    recentBlockhash?: string;
+    feePayer?: PublicKey;
+
+    add(): this {
+      return this;
+    }
+
+    serialize(): Buffer {
+      return Buffer.from([]);
+    }
+  }
+
+  class Connection {
+    requestAirdrop = mocks.requestAirdrop;
+    confirmTransaction = mocks.confirmTransaction;
+  }
+
+  return {
+    Connection,
+    PublicKey,
+    Transaction,
+    LAMPORTS_PER_SOL: 1_000_000_000,
+  };
+});
+
+vi.mock("@solana/spl-token", () => ({
+  getAssociatedTokenAddress: vi.fn(),
+  createAssociatedTokenAccountInstruction: vi.fn(),
+  createMintToInstruction: vi.fn(),
+  getAccount: vi.fn(),
+}));
+
+vi.mock("@/lib/config", () => ({
+  getConfig: () => ({
+    rpcUrl: "https://api.devnet.solana.com",
+    testUsdcMint:
+      "So11111111111111111111111111111111111111112",
+  }),
+}));
+
+vi.mock("@/lib/devnet-signer", () => ({
+  getDevnetMintSigner: vi.fn(() => null),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceClient: () => ({
+    from: mocks.analyticsFrom,
+  }),
+}));
+
+vi.mock("@/lib/faucet-rate-gate", () => ({
+  tryFaucetGate: mocks.tryFaucetGate,
+  releaseFaucetClaim: mocks.releaseFaucetClaim,
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: mocks.captureException,
+}));
+
+let POST: typeof import("@/app/api/faucet/route").POST;
+
+function createRequest(): NextRequest {
+  return new NextRequest("http://localhost/api/faucet", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      wallet:
+        "11111111111111111111111111111111",
+      type: "sol",
+    }),
+  });
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.clearAllMocks();
+
+  process.env.NEXT_PUBLIC_DEFAULT_NETWORK = "devnet";
+  delete process.env.NEXT_PUBLIC_SOLANA_NETWORK;
+
+  mocks.tryFaucetGate.mockResolvedValue({
+    allowed: true,
+    nextClaimAt: null,
+    claimId: 77,
+  });
+
+  mocks.releaseFaucetClaim.mockResolvedValue(undefined);
+
+  mocks.analyticsInsert.mockResolvedValue({
+    error: null,
+  });
+
+  mocks.analyticsFrom.mockReturnValue({
+    insert: mocks.analyticsInsert,
+  });
+
+  mocks.requestAirdrop.mockResolvedValue(
+    "failed-on-chain-airdrop-signature",
+  );
+
+  /**
+   * Solana RPC confirmation resolves normally but reports that
+   * transaction execution failed on-chain.
+   *
+   * confirmTransaction() does not need to throw for this condition.
+   */
+  mocks.confirmTransaction.mockResolvedValue({
+    context: {
+      slot: 123,
+    },
+    value: {
+      err: {
+        InstructionError: [
+          0,
+          {
+            Custom: 1,
+          },
+        ],
+      },
+    },
+  });
+
+  const route =
+    await import("@/app/api/faucet/route");
+
+  POST = route.POST;
+});
+
+afterEach(() => {
+  delete process.env.NEXT_PUBLIC_DEFAULT_NETWORK;
+  delete process.env.NEXT_PUBLIC_SOLANA_NETWORK;
+});
+
+describe("POST /api/faucet confirmation result validation", () => {
+  it("must reject a SOL airdrop whose confirmation contains an on-chain execution error", async () => {
+    const response = await POST(createRequest());
+    const body = await response.json();
+
+    // Confirm that the test reached the vulnerable confirmation sink.
+    expect(
+      mocks.requestAirdrop,
+    ).toHaveBeenCalledTimes(1);
+
+    expect(
+      mocks.confirmTransaction,
+    ).toHaveBeenCalledTimes(1);
+
+    /**
+     * Correct behavior:
+     *
+     * A confirmation response containing value.err represents a
+     * transaction that failed during on-chain execution. The route
+     * must reject that result rather than returning funded=true.
+     *
+     * The affected implementation ignores value.err and returns 200.
+     */
+    expect(response.status).toBe(500);
+    expect(body.funded).not.toBe(true);
+    expect(body.sol_airdropped).not.toBe(true);
+  });
+
+  it("returns success when SOL confirmation contains no execution error", async () => {
+    mocks.confirmTransaction.mockResolvedValueOnce({
+      context: {
+        slot: 124,
+      },
+      value: {
+        err: null,
+      },
+    });
+
+    const response = await POST(createRequest());
+    const body = await response.json();
+
+    expect(
+      mocks.requestAirdrop,
+    ).toHaveBeenCalledTimes(1);
+
+    expect(
+      mocks.confirmTransaction,
+    ).toHaveBeenCalledTimes(1);
+
+    expect(response.status).toBe(200);
+    expect(body.funded).toBe(true);
+    expect(body.sol_airdropped).toBe(true);
+    expect(body.signature).toBe(
+      "failed-on-chain-airdrop-signature",
+    );
+  });
+
+});

--- a/app/__tests__/api/faucet-usdc-confirmation-result.test.ts
+++ b/app/__tests__/api/faucet-usdc-confirmation-result.test.ts
@@ -1,0 +1,351 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { NextRequest } from "next/server";
+
+const mocks = vi.hoisted(() => ({
+  confirmTransaction: vi.fn(),
+  getAccountInfo: vi.fn(),
+  getLatestBlockhash: vi.fn(),
+  sendRawTransaction: vi.fn(),
+
+  getAssociatedTokenAddress: vi.fn(),
+  getAccount: vi.fn(),
+
+  getDevnetMintSigner: vi.fn(),
+
+  tryFaucetGate: vi.fn(),
+  releaseFaucetClaim: vi.fn(),
+
+  analyticsInsert: vi.fn(),
+  analyticsFrom: vi.fn(),
+
+  captureException: vi.fn(),
+}));
+
+vi.mock("@solana/web3.js", () => {
+  class PublicKey {
+    constructor(
+      private readonly value: unknown,
+    ) {}
+
+    toBase58(): string {
+      return typeof this.value === "string"
+        ? this.value
+        : "11111111111111111111111111111111";
+    }
+
+    equals(
+      other: { toBase58?: () => string },
+    ): boolean {
+      return (
+        other?.toBase58?.() === this.toBase58()
+      );
+    }
+  }
+
+  class Transaction {
+    recentBlockhash?: string;
+    feePayer?: PublicKey;
+
+    add(): this {
+      return this;
+    }
+
+    serialize(): Buffer {
+      return Buffer.from([]);
+    }
+  }
+
+  class Connection {
+    confirmTransaction =
+      mocks.confirmTransaction;
+
+    getAccountInfo =
+      mocks.getAccountInfo;
+
+    getLatestBlockhash =
+      mocks.getLatestBlockhash;
+
+    sendRawTransaction =
+      mocks.sendRawTransaction;
+  }
+
+  return {
+    Connection,
+    PublicKey,
+    Transaction,
+    LAMPORTS_PER_SOL: 1_000_000_000,
+  };
+});
+
+vi.mock("@solana/spl-token", () => ({
+  getAssociatedTokenAddress:
+    mocks.getAssociatedTokenAddress,
+
+  createAssociatedTokenAccountInstruction:
+    vi.fn(),
+
+  createMintToInstruction:
+    vi.fn(),
+
+  getAccount:
+    mocks.getAccount,
+}));
+
+vi.mock("@/lib/config", () => ({
+  getConfig: () => ({
+    rpcUrl:
+      "https://api.devnet.solana.com",
+
+    testUsdcMint:
+      "So11111111111111111111111111111111111111112",
+  }),
+}));
+
+vi.mock("@/lib/devnet-signer", () => ({
+  getDevnetMintSigner:
+    mocks.getDevnetMintSigner,
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceClient: () => ({
+    from: mocks.analyticsFrom,
+  }),
+}));
+
+vi.mock("@/lib/faucet-rate-gate", () => ({
+  tryFaucetGate:
+    mocks.tryFaucetGate,
+
+  releaseFaucetClaim:
+    mocks.releaseFaucetClaim,
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException:
+    mocks.captureException,
+}));
+
+let POST:
+  typeof import(
+    "@/app/api/faucet/route"
+  ).POST;
+
+function createRequest(): NextRequest {
+  return new NextRequest(
+    "http://localhost/api/faucet",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type":
+          "application/json",
+      },
+      body: JSON.stringify({
+        wallet:
+          "11111111111111111111111111111111",
+
+        type: "usdc",
+      }),
+    },
+  );
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.clearAllMocks();
+
+  process.env
+    .NEXT_PUBLIC_DEFAULT_NETWORK =
+    "devnet";
+
+  delete process.env
+    .NEXT_PUBLIC_SOLANA_NETWORK;
+
+  mocks.tryFaucetGate.mockResolvedValue({
+    allowed: true,
+    nextClaimAt: null,
+    claimId: 88,
+  });
+
+  mocks.releaseFaucetClaim
+    .mockResolvedValue(undefined);
+
+  mocks.analyticsInsert
+    .mockResolvedValue({
+      error: null,
+    });
+
+  mocks.analyticsFrom
+    .mockReturnValue({
+      insert: mocks.analyticsInsert,
+    });
+
+  /*
+   * Return an existing ATA so the test remains
+   * focused on confirmation-result handling.
+   */
+  mocks.getAssociatedTokenAddress
+    .mockResolvedValue({
+      toBase58: () =>
+        "11111111111111111111111111111111",
+    });
+
+  mocks.getAccount
+    .mockResolvedValue({});
+
+  /*
+   * A truthy mint account with short data skips
+   * the unrelated mint-authority byte comparison.
+   */
+  mocks.getAccountInfo
+    .mockResolvedValue({
+      data: Buffer.alloc(0),
+    });
+
+  mocks.getLatestBlockhash
+    .mockResolvedValue({
+      blockhash:
+        "test-blockhash",
+
+      lastValidBlockHeight:
+        12345,
+    });
+
+  mocks.sendRawTransaction
+    .mockResolvedValue(
+      "failed-on-chain-usdc-signature",
+    );
+
+  mocks.confirmTransaction
+    .mockResolvedValue({
+      context: {
+        slot: 200,
+      },
+
+      value: {
+        err: {
+          InstructionError: [
+            0,
+            {
+              Custom: 1,
+            },
+          ],
+        },
+      },
+    });
+
+  mocks.getDevnetMintSigner
+    .mockReturnValue({
+      publicKey: () =>
+        "11111111111111111111111111111111",
+
+      signTransaction:
+        (transaction: unknown) =>
+          transaction,
+    });
+
+  const route =
+    await import(
+      "@/app/api/faucet/route"
+    );
+
+  POST = route.POST;
+});
+
+afterEach(() => {
+  delete process.env
+    .NEXT_PUBLIC_DEFAULT_NETWORK;
+
+  delete process.env
+    .NEXT_PUBLIC_SOLANA_NETWORK;
+});
+
+describe(
+  "POST /api/faucet USDC confirmation validation",
+  () => {
+    it(
+      "must reject a USDC mint whose confirmation contains an on-chain execution error",
+      async () => {
+        const response =
+          await POST(createRequest());
+
+        const body =
+          await response.json();
+
+        expect(
+          mocks.sendRawTransaction,
+        ).toHaveBeenCalledTimes(1);
+
+        expect(
+          mocks.confirmTransaction,
+        ).toHaveBeenCalledTimes(1);
+
+        /*
+         * Correct behavior:
+         * value.err must prevent success recording.
+         *
+         * Current behavior is expected to return 200,
+         * producing the RED regression failure.
+         */
+        expect(response.status)
+          .toBe(500);
+
+        expect(body.funded)
+          .not.toBe(true);
+
+        expect(body.usdc_minted)
+          .not.toBe(true);
+      },
+    );
+
+    it(
+      "returns success when USDC confirmation contains no execution error",
+      async () => {
+        mocks.confirmTransaction
+          .mockResolvedValueOnce({
+            context: {
+              slot: 201,
+            },
+
+            value: {
+              err: null,
+            },
+          });
+
+        const response =
+          await POST(createRequest());
+
+        const body =
+          await response.json();
+
+        expect(
+          mocks.sendRawTransaction,
+        ).toHaveBeenCalledTimes(1);
+
+        expect(
+          mocks.confirmTransaction,
+        ).toHaveBeenCalledTimes(1);
+
+        expect(response.status)
+          .toBe(200);
+
+        expect(body.funded)
+          .toBe(true);
+
+        expect(body.usdc_minted)
+          .toBe(true);
+
+        expect(body.signature)
+          .toBe(
+            "failed-on-chain-usdc-signature",
+          );
+      },
+    );
+  },
+);

--- a/app/__tests__/lib/transaction-confirmation.test.ts
+++ b/app/__tests__/lib/transaction-confirmation.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertSuccessfulConfirmation,
+} from "../../lib/transaction-confirmation";
+
+describe("assertSuccessfulConfirmation", () => {
+  it("accepts a confirmation with value.err set to null", () => {
+    expect(() =>
+      assertSuccessfulConfirmation(
+        {
+          value: {
+            err: null,
+          },
+        },
+        "Test operation",
+      ),
+    ).not.toThrow();
+  });
+
+  it("rejects a confirmation containing an on-chain execution error", () => {
+    expect(() =>
+      assertSuccessfulConfirmation(
+        {
+          value: {
+            err: {
+              InstructionError: [
+                0,
+                {
+                  Custom: 1,
+                },
+              ],
+            },
+          },
+        },
+        "Test operation",
+      ),
+    ).toThrow(
+      /Test operation confirmed but failed on-chain/,
+    );
+  });
+
+  it("fails closed when value is missing", () => {
+    expect(() =>
+      assertSuccessfulConfirmation(
+        {},
+        "Malformed confirmation",
+      ),
+    ).toThrow(
+      /Malformed confirmation confirmed but failed on-chain/,
+    );
+  });
+
+  it("fails closed when err is missing", () => {
+    expect(() =>
+      assertSuccessfulConfirmation(
+        {
+          value: {},
+        },
+        "Incomplete confirmation",
+      ),
+    ).toThrow(
+      /Incomplete confirmation confirmed but failed on-chain/,
+    );
+  });
+});

--- a/app/app/api/auto-fund/route.ts
+++ b/app/app/api/auto-fund/route.ts
@@ -19,6 +19,7 @@ import {
 } from "@solana/spl-token";
 import { getConfig } from "@/lib/config";
 import { getDevnetMintSigner } from "@/lib/devnet-signer";
+import { assertSuccessfulConfirmation } from "@/lib/transaction-confirmation";
 import * as Sentry from "@sentry/nextjs";
 
 // ── In-memory rate limiter (fallback when Supabase unavailable) ───────────────
@@ -190,8 +191,20 @@ export async function POST(req: NextRequest) {
 
             // Sign and send transaction using sealed signer
             const signed = mintSigner.signTransaction(tx);
-            const sig = await connection.sendRawTransaction((signed as Transaction).serialize());
-            await connection.confirmTransaction({ signature: sig, blockhash, lastValidBlockHeight }, "confirmed");
+            const sig = await connection.sendRawTransaction(
+              (signed as Transaction).serialize(),
+            );
+
+            const confirmation =
+              await connection.confirmTransaction(
+                { signature: sig, blockhash, lastValidBlockHeight },
+                "confirmed",
+              );
+
+            assertSuccessfulConfirmation(
+              confirmation,
+              "Auto-fund USDC mint",
+            );
 
             results.usdc_minted = true;
             results.usdc_amount = USDC_MINT_AMOUNT / 1_000_000;

--- a/app/app/api/faucet/route.ts
+++ b/app/app/api/faucet/route.ts
@@ -35,6 +35,7 @@ import {
 } from "@solana/spl-token";
 import { getConfig } from "@/lib/config";
 import { getDevnetMintSigner } from "@/lib/devnet-signer";
+import { assertSuccessfulConfirmation } from "@/lib/transaction-confirmation";
 import * as Sentry from "@sentry/nextjs";
 
 // ── In-memory rate-limit fallback (when Supabase unavailable) ─────────────────
@@ -175,7 +176,14 @@ export async function POST(req: NextRequest) {
         const pubConn = new Connection(rpcUrl, "confirmed");
         try {
           sig = await pubConn.requestAirdrop(walletPk, SOL_AIRDROP_AMOUNT);
-          await pubConn.confirmTransaction(sig, "confirmed");
+          const confirmation =
+            await pubConn.confirmTransaction(sig, "confirmed");
+
+          assertSuccessfulConfirmation(
+            confirmation,
+            "SOL airdrop",
+          );
+
           break; // success — exit loop
         } catch (airdropErr) {
           // GH#1474: fall back to toString() when .message is empty
@@ -399,9 +407,15 @@ export async function POST(req: NextRequest) {
       sig = await connection.sendRawTransaction(
         (signedTx as Transaction).serialize(),
       );
-      await connection.confirmTransaction(
-        { signature: sig, blockhash, lastValidBlockHeight },
-        "confirmed",
+      const confirmation =
+        await connection.confirmTransaction(
+          { signature: sig, blockhash, lastValidBlockHeight },
+          "confirmed",
+        );
+
+      assertSuccessfulConfirmation(
+        confirmation,
+        "USDC faucet mint",
       );
     } catch (chainErr) {
       if (supabase && gate.claimId) { try { const { releaseFaucetClaim } = await import("@/lib/faucet-rate-gate"); await releaseFaucetClaim(supabase, gate.claimId); } catch { /* best-effort */ } }

--- a/app/lib/transaction-confirmation.ts
+++ b/app/lib/transaction-confirmation.ts
@@ -1,0 +1,45 @@
+/**
+ * Minimal structural type accepted from Solana RPC confirmation results.
+ *
+ * The optional fields intentionally make this helper fail closed when
+ * an RPC provider returns a malformed or incomplete confirmation result.
+ */
+export interface TransactionConfirmationLike {
+  value?: {
+    err?: unknown | null;
+  };
+}
+
+/**
+ * Assert that a confirmed Solana transaction completed successfully
+ * during on-chain execution.
+ *
+ * confirmTransaction() may resolve normally even when the transaction
+ * itself failed. A successful RPC call or returned signature therefore
+ * must not be treated as proof of successful execution.
+ */
+export function assertSuccessfulConfirmation(
+  confirmation: TransactionConfirmationLike,
+  operation: string,
+): void {
+  const executionError =
+    confirmation?.value?.err;
+
+  if (executionError === null) {
+    return;
+  }
+
+  let serializedError: string;
+
+  try {
+    serializedError =
+      JSON.stringify(executionError);
+  } catch {
+    serializedError =
+      String(executionError);
+  }
+
+  throw new Error(
+    `${operation} confirmed but failed on-chain: ${serializedError}`,
+  );
+}


### PR DESCRIPTION
Fixes #2435

## Summary

This PR fixes a devnet funding-integrity issue where the Faucet SOL, Faucet USDC, and Auto-fund USDC flows could report funding success even when Solana RPC confirmation explicitly reported an on-chain execution failure.

The affected call sites awaited `confirmTransaction()`, but discarded its returned `SignatureResult`:

```ts
await connection.confirmTransaction(...);
```

A resolved RPC confirmation request does not necessarily mean that the transaction executed successfully. Solana may return:

```ts
{
  value: {
    err: {
      InstructionError: [
        0,
        {
          Custom: 1,
        },
      ],
    },
  },
}
```

In that condition, the transaction has failed on-chain even though `confirmTransaction()` resolved normally.

Before this patch, the affected routes could continue into their success paths and return or record:

```text
funded = true
sol_airdropped = true
usdc_minted = true
```

despite the wallet receiving no assets.

This PR validates the confirmation execution result before any success state is recorded.

---

## Root Cause

Three production call sites treated a successfully resolved RPC call as proof of successful transaction execution.

### Faucet SOL

The previous flow effectively performed:

```ts
sig = await pubConn.requestAirdrop(
  walletPk,
  SOL_AIRDROP_AMOUNT,
);

await pubConn.confirmTransaction(
  sig,
  "confirmed",
);

break;
```

The confirmation result was discarded, and the RPC fallback loop exited as though the airdrop had succeeded.

The route subsequently recorded the faucet claim and returned:

```text
funded = true
sol_airdropped = true
```

### Faucet USDC

The previous USDC path performed:

```ts
const sig =
  await connection.sendRawTransaction(
    signedTransaction.serialize(),
  );

await connection.confirmTransaction(
  {
    signature: sig,
    blockhash,
    lastValidBlockHeight,
  },
  "confirmed",
);
```

The route then recorded the claim and successful mint analytics without checking `confirmation.value.err`.

### Auto-fund USDC

The previous Auto-fund USDC path performed:

```ts
const sig =
  await connection.sendRawTransaction(
    signedTransaction.serialize(),
  );

await connection.confirmTransaction(
  {
    signature: sig,
    blockhash,
    lastValidBlockHeight,
  },
  "confirmed",
);

results.usdc_minted = true;
```

This allowed a failed MintTo execution to set the success flag, retain the claim, write successful analytics, and return `funded: true`.

---

## Required Invariant

A funding operation may only be recorded as successful when:

```text
confirmation.value.err === null
```

The following conditions must be treated as failure:

```text
confirmation.value.err contains an execution error
confirmation.value is missing
confirmation.value.err is missing
```

The code must distinguish between:

```text
RPC request completed
```

and:

```text
transaction completed successfully on-chain
```

These conditions are not equivalent.

---

## Changes

### 1. Added a shared fail-closed confirmation validator

New file:

```text
app/lib/transaction-confirmation.ts
```

The helper accepts only an explicit `value.err === null` as success:

```ts
export interface TransactionConfirmationLike {
  value?: {
    err?: unknown | null;
  };
}

export function assertSuccessfulConfirmation(
  confirmation: TransactionConfirmationLike,
  operation: string,
): void {
  const executionError =
    confirmation?.value?.err;

  if (executionError === null) {
    return;
  }

  let serializedError: string;

  try {
    serializedError =
      JSON.stringify(executionError);
  } catch {
    serializedError =
      String(executionError);
  }

  throw new Error(
    `${operation} confirmed but failed on-chain: ${serializedError}`,
  );
}
```

The validator fails closed when the RPC result is malformed or incomplete.

---

### 2. Fixed Faucet SOL confirmation handling

The SOL faucet now stores and validates the returned confirmation:

```ts
const confirmation =
  await pubConn.confirmTransaction(
    sig,
    "confirmed",
  );

assertSuccessfulConfirmation(
  confirmation,
  "SOL airdrop",
);
```

The RPC fallback loop exits through its success branch only after execution validation passes.

When `value.err` is populated:

- the operation is treated as failed;
- success state is not recorded;
- the route does not return `funded: true`;
- the existing failure and retry handling remains active.

---

### 3. Fixed Faucet USDC confirmation handling

The USDC faucet now validates the MintTo transaction before recording its claim or analytics:

```ts
const confirmation =
  await connection.confirmTransaction(
    {
      signature: sig,
      blockhash,
      lastValidBlockHeight,
    },
    "confirmed",
  );

assertSuccessfulConfirmation(
  confirmation,
  "USDC faucet mint",
);
```

When execution fails:

- `funded: true` is not returned;
- `usdc_minted: true` is not returned;
- successful funding analytics are not recorded;
- the reserved claim is released through the existing failure path.

---

### 4. Fixed Auto-fund USDC confirmation handling

Auto-fund now validates execution before setting its success flags:

```ts
const confirmation =
  await connection.confirmTransaction(
    {
      signature: sig,
      blockhash,
      lastValidBlockHeight,
    },
    "confirmed",
  );

assertSuccessfulConfirmation(
  confirmation,
  "Auto-fund USDC mint",
);

results.usdc_minted = true;
```

If execution fails:

```text
results.usdc_minted remains false
results.usdc_amount is not assigned
successful analytics are not inserted
the claim is released when nothing else was funded
the user remains eligible to retry
```

The route preserves its existing non-fatal Auto-fund behavior and may still return HTTP `200`, but it no longer reports funding success.

---

## Existing Safe Control

The Auto-fund SOL path already stores the confirmation result and checks:

```ts
if (airdropResult.value.err) {
  throw new Error(...);
}
```

This PR applies the same execution-result invariant consistently to the three remaining affected call sites.

The existing Auto-fund SOL behavior is not otherwise changed.

---

## Behavior Before and After

### Faucet SOL

Before:

```text
confirmation.value.err != null
→ HTTP 200
→ funded=true
→ sol_airdropped=true
```

After:

```text
confirmation.value.err != null
→ operation rejected
→ HTTP 500
→ no funding success recorded
```

### Faucet USDC

Before:

```text
confirmation.value.err != null
→ HTTP 200
→ funded=true
→ usdc_minted=true
→ successful analytics recorded
```

After:

```text
confirmation.value.err != null
→ operation rejected
→ HTTP 500
→ claim released
→ no successful analytics
```

### Auto-fund USDC

Before:

```text
confirmation.value.err != null
→ funded=true
→ usdc_minted=true
→ claim retained
→ successful analytics recorded
```

After:

```text
confirmation.value.err != null
→ HTTP 200 remains non-fatal
→ funded=false
→ usdc_minted=false
→ claim released
→ no successful analytics
```

---

## Regression Coverage

This PR adds focused tests for the shared invariant and every affected route.

### Shared validator

```text
app/__tests__/lib/transaction-confirmation.test.ts
```

Coverage:

```text
value.err === null
    => accepted

value.err contains an execution error
    => rejected

value is missing
    => rejected

err is missing
    => rejected
```

### Faucet SOL

```text
app/__tests__/api/faucet-confirmation-result.test.ts
```

Coverage:

```text
execution error
    => HTTP 500
    => no false funding flags

err === null
    => existing success behavior preserved
```

### Faucet USDC

```text
app/__tests__/api/faucet-usdc-confirmation-result.test.ts
```

Coverage:

```text
execution error
    => HTTP 500
    => no false funding flags

err === null
    => existing success behavior preserved
```

### Auto-fund USDC

```text
app/__tests__/api/auto-fund-usdc-confirmation-result.test.ts
```

Coverage:

```text
execution error
    => funded=false
    => usdc_minted=false
    => claim released
    => no successful analytics

err === null
    => existing success behavior preserved
```

---

## RED Evidence Before Fix

Each affected route was tested with a confirmation response that resolved normally but contained:

```ts
value: {
  err: {
    InstructionError: [
      0,
      {
        Custom: 1,
      },
    ],
  },
}
```

### Faucet SOL

Observed:

```text
status: 200
funded: true
sol_airdropped: true
```

Regression failure:

```text
Expected: 500
Received: 200
```

Result:

```text
1 failed
1 passed
```

### Faucet USDC

Observed:

```text
status: 200
funded: true
usdc_minted: true
```

Regression failure:

```text
Expected: 500
Received: 200
```

Result:

```text
1 failed
1 passed
```

### Auto-fund USDC

Observed:

```text
funded: true
usdc_minted: true
releaseFaucetClaim calls: 0
analyticsInsert calls: 1
```

Regression failure:

```text
Expected: false
Received: true
```

Result:

```text
1 failed
1 passed
```

Each RED suite included a successful-confirmation positive control.

---

## GREEN Validation

Command:

```bash
pnpm --filter @percolator/app exec vitest run \
  __tests__/lib/transaction-confirmation.test.ts \
  __tests__/api/faucet-confirmation-result.test.ts \
  __tests__/api/faucet-usdc-confirmation-result.test.ts \
  __tests__/api/auto-fund-usdc-confirmation-result.test.ts \
  --reporter=verbose
```

Result:

```text
Test Files  4 passed
Tests       10 passed
Exit status: 0
```

Verified cases:

```text
PASS successful confirmation is accepted
PASS execution error is rejected
PASS missing value fails closed
PASS missing err fails closed
PASS Faucet SOL rejects failed execution
PASS Faucet SOL success control remains valid
PASS Faucet USDC rejects failed execution
PASS Faucet USDC success control remains valid
PASS Auto-fund USDC does not report failed execution as funded
PASS Auto-fund USDC success control remains valid
```

---

## Existing Related Test Validation

All existing Faucet and Auto-fund related tests were run after applying the patch.

Result:

```text
Test Files  8 passed
Tests       69 passed
Exit status: 0
```

This includes existing coverage for:

```text
request parsing
wallet validation
SOL and USDC dispatch
rate limiting
RPC fallback
retryable error classification
mint authority validation
network guards
Auto-fund amount behavior
Faucet UI hook behavior
```

---

## TypeScript Validation

Command:

```bash
pnpm --filter @percolator/app exec tsc \
  --noEmit \
  -p tsconfig.json
```

Result:

```text
PASS
No TypeScript errors.
```

---

## Production Build

Command:

```bash
pnpm --filter @percolator/app build
```

Result:

```text
PASS

Production build completed successfully.
Static pages generated successfully.
Page optimization completed successfully.
Exit status: 0.
```

Existing non-fatal warnings related to Next.js configuration, middleware migration, `module.register()`, and BigInt native bindings were not introduced by this PR.

---

## Patch Integrity

Commands:

```bash
git diff upstream/playground...HEAD --check
git diff upstream/playground...HEAD --name-status
```

Result:

```text
PASS
No whitespace or malformed-patch errors.
```

Final scope:

```text
A  app/__tests__/api/auto-fund-usdc-confirmation-result.test.ts
A  app/__tests__/api/faucet-confirmation-result.test.ts
A  app/__tests__/api/faucet-usdc-confirmation-result.test.ts
A  app/__tests__/lib/transaction-confirmation.test.ts
M  app/app/api/auto-fund/route.ts
M  app/app/api/faucet/route.ts
A  app/lib/transaction-confirmation.ts
```

---

## Scope

This PR is intentionally limited to the transaction-confirmation result issue reported in #2435.

It does not modify:

- core trading behavior;
- matcher or risk-engine logic;
- margin or liquidation behavior;
- settlement logic;
- wallet authorization;
- signer ownership;
- on-chain program instructions;
- mainnet funding;
- production assets;
- RPC provider selection;
- faucet amount constants;
- rate-limit duration.

The five newly added files are intentional remediation and regression-coverage files, not missing upstream dependencies.

---

## Files Changed

```text
app/app/api/faucet/route.ts
app/app/api/auto-fund/route.ts
app/lib/transaction-confirmation.ts
app/__tests__/lib/transaction-confirmation.test.ts
app/__tests__/api/faucet-confirmation-result.test.ts
app/__tests__/api/faucet-usdc-confirmation-result.test.ts
app/__tests__/api/auto-fund-usdc-confirmation-result.test.ts
```

---

## Revisions

```text
Target branch:
playground

Tested base commit:
2ae3f35827affb719a90b645cbb13dda3ffcf782

Fix commit:
d37471befc0746d411ec4ac0b8500140beffd1ec

Ahead / behind:
0 / 1
```

---

## Review Notes

The most important review points are:

1. Only an explicit `confirmation.value.err === null` is accepted as success.
2. Faucet SOL validates execution before exiting its RPC fallback loop.
3. Faucet USDC validates execution before recording the claim or analytics.
4. Auto-fund USDC validates execution before setting `results.usdc_minted`.
5. Auto-fund failure remains non-fatal but no longer reports false success.
6. Reserved claims are released when no funding operation succeeds.
7. Existing successful-confirmation behavior remains unchanged.
8. Auto-fund SOL's existing validation remains intact.
9. The patch contains no unrelated production changes.
10. Route-level and helper-level regression coverage prevents recurrence.

---

## Commit

```text
d37471be fix(devnet): validate faucet transaction execution results
```