### PR TITLE
fix(chart): prevent live mark ticks from mutating non-oracle series

### DIFF
--- a/app/__tests__/components/trade/TradingChart.live-source-wiring.test.tsx
+++ b/app/__tests__/components/trade/TradingChart.live-source-wiring.test.tsx
@@ -1,0 +1,309 @@
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const harness = vi.hoisted(() => {
+  const priceLine = {
+    applyOptions: vi.fn(),
+  };
+
+  const seriesPriceScale = {
+    applyOptions: vi.fn(),
+  };
+
+  const series = {
+    setData: vi.fn(),
+    update: vi.fn(),
+    applyOptions: vi.fn(),
+    createPriceLine: vi.fn(() => priceLine),
+    priceScale: vi.fn(() => seriesPriceScale),
+    dataByIndex: vi.fn(),
+    coordinateToPrice: vi.fn(),
+  };
+
+  const chartPriceScale = {
+    applyOptions: vi.fn(),
+  };
+
+  const timeScale = {
+    fitContent: vi.fn(),
+  };
+
+  const pane = {
+    setPreserveEmptyPane: vi.fn(),
+  };
+
+  const chart = {
+    panes: vi.fn(() => [pane]),
+    applyOptions: vi.fn(),
+    remove: vi.fn(),
+    removeSeries: vi.fn(),
+    addSeries: vi.fn(() => series),
+    priceScale: vi.fn(() => chartPriceScale),
+    timeScale: vi.fn(() => timeScale),
+    subscribeCrosshairMove: vi.fn(),
+    unsubscribeCrosshairMove: vi.fn(),
+    subscribeClick: vi.fn(),
+    unsubscribeClick: vi.fn(),
+  };
+
+  const percolatorCandles = Array.from({ length: 10 }, (_, index) => ({
+    time: 1_720_000_000 + index * 60,
+    open: 100 + index,
+    high: 101 + index,
+    low: 99 + index,
+    close: 100.5 + index,
+    volume: 0,
+  }));
+
+  // Stable identities are required. TradingChart's structural series effect
+  // depends on chartTheme and source arrays; returning fresh objects from mocks
+  // on every render would repeatedly call setSeriesEpoch() and loop forever.
+  const emptyCandles: never[] = [];
+
+  const chartTheme = {
+    bg: '#000000',
+    textColor: '#ffffff',
+    gridColor: '#222222',
+    borderColor: '#333333',
+    neutralLine: '#999999',
+    upColor: '#00ff00',
+    downColor: '#ff0000',
+    entryLine: '#00ffff',
+    volUpColor: '#00ff00',
+    volDownColor: '#ff0000',
+  };
+
+  return {
+    chart,
+    series,
+    priceLine,
+    percolatorCandles,
+    emptyCandles,
+    chartTheme,
+  };
+});
+
+vi.mock('lightweight-charts', () => ({
+  createChart: vi.fn(() => harness.chart),
+  LineStyle: {
+    Solid: 0,
+    Dashed: 2,
+  },
+  ColorType: {
+    Solid: 'solid',
+  },
+  CrosshairMode: {
+    Normal: 0,
+  },
+  CandlestickSeries: 'CandlestickSeries',
+  HistogramSeries: 'HistogramSeries',
+  BarSeries: 'BarSeries',
+  LineSeries: 'LineSeries',
+  AreaSeries: 'AreaSeries',
+}));
+
+vi.mock('@/lib/chart-live-tick', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/chart-live-tick')>();
+
+  return {
+    ...actual,
+    resolveChartDataSource: vi.fn(actual.resolveChartDataSource),
+  };
+});
+
+vi.mock('@/components/providers/SlabProvider', () => ({
+  useSlabState: () => ({
+    config: {},
+    params: {},
+  }),
+}));
+
+vi.mock('@/hooks/useLivePrice', () => ({
+  useLivePrice: () => ({
+    priceUsd: 100,
+  }),
+}));
+
+vi.mock('@/hooks/usePercolatorCandles', () => ({
+  usePercolatorCandles: () => ({
+    candles: harness.percolatorCandles,
+    status: 'success',
+  }),
+}));
+
+vi.mock('@/hooks/usePythChart', () => ({
+  usePythChart: () => ({
+    candles: harness.emptyCandles,
+    status: 'success',
+  }),
+}));
+
+vi.mock('@/hooks/useTokenChart', () => ({
+  useTokenChart: () => ({
+    candles: harness.emptyCandles,
+    status: 'idle',
+    poolAddress: null,
+  }),
+}));
+
+vi.mock('@/hooks/useUserAccount', () => ({
+  useUserAccount: () => null,
+}));
+
+vi.mock('@/hooks/useMarketConfig', () => ({
+  useMarketConfig: () => ({}),
+}));
+
+vi.mock('@/hooks/useMarketInfo', () => ({
+  useMarketInfo: () => ({
+    market: {
+      symbol: 'SOL',
+    },
+  }),
+}));
+
+vi.mock('@/hooks/useLiqPrice', () => ({
+  useLiqPrice: () => null,
+}));
+
+vi.mock('@/hooks/useChartTheme', () => ({
+  useChartTheme: () => harness.chartTheme,
+}));
+
+vi.mock('@/hooks/useChartStylePref', () => ({
+  useChartStylePref: () => ['candle-solid', vi.fn()],
+}));
+
+vi.mock('@/hooks/useChartOverlayPrefs', () => ({
+  useChartOverlayPrefs: () => [
+    {
+      liq: false,
+      entry: false,
+      position: false,
+      pnl: false,
+    },
+    vi.fn(),
+  ],
+}));
+
+vi.mock('@/hooks/useChartIndicatorPrefs', () => ({
+  useChartIndicatorPrefs: () => ({
+    indicators: [],
+    addIndicator: vi.fn(),
+    removeIndicator: vi.fn(),
+    updateIndicator: vi.fn(),
+    clearAll: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useChartDrawingTool', () => ({
+  useChartDrawingTool: () => ({
+    tool: 'pointer',
+    setTool: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useChartDrawings', () => ({
+  useChartDrawings: () => ({
+    drawings: [],
+    addDrawing: vi.fn(),
+    deleteDrawing: vi.fn(),
+    clearAll: vi.fn(),
+  }),
+}));
+
+vi.mock('@/components/trade/useIndicatorOverlays', () => ({
+  useIndicatorOverlays: vi.fn(),
+}));
+
+vi.mock('@/components/trade/useIndicatorOscillatorPane', () => ({
+  useIndicatorOscillatorPane: vi.fn(),
+}));
+
+vi.mock('@/lib/priceStore/priceStore', () => ({
+  subscribeSlab: vi.fn(() => vi.fn()),
+  getSnapshot: vi.fn(() => ({
+    priceUsd: 100,
+  })),
+}));
+
+vi.mock('@/lib/perf/perfTiming', () => ({
+  startPerfSpan: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('@/lib/pollWhenVisible', () => ({
+  pollWhenVisible: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('@/lib/mock-mode', () => ({
+  isMockMode: vi.fn(() => false),
+}));
+
+vi.mock('@/lib/mock-trade-data', () => ({
+  isMockSlab: vi.fn(() => false),
+  getMockUserAccount: vi.fn(() => null),
+}));
+
+vi.mock('@/lib/entry-price', () => ({
+  getEntryPrice: vi.fn(() => 0n),
+}));
+
+vi.mock('@/components/ui/ShimmerSkeleton', () => ({
+  ShimmerSkeleton: () => null,
+}));
+
+vi.mock('@/components/trade/ChartStyleMenu', () => ({
+  ChartStyleMenu: () => null,
+}));
+
+vi.mock('@/components/trade/ChartDisplayMenu', () => ({
+  ChartDisplayMenu: () => null,
+}));
+
+vi.mock('@/components/trade/ChartPnlBadge', () => ({
+  ChartPnlBadge: () => null,
+}));
+
+vi.mock('@/components/trade/ChartIndicatorMenu', () => ({
+  ChartIndicatorMenu: () => null,
+}));
+
+vi.mock('@/components/trade/ChartDrawingOverlay', () => ({
+  ChartDrawingOverlay: () => null,
+}));
+
+vi.mock('@/components/trade/ChartDrawingToolbar', () => ({
+  ChartDrawingToolbar: () => null,
+}));
+
+import { TradingChart } from '@/components/trade/TradingChart';
+import { resolveChartDataSource } from '@/lib/chart-live-tick';
+
+describe('TradingChart live-source wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          prices: [],
+        }),
+      })),
+    );
+  });
+
+  it("forwards the component's active Percolator source flags to the resolver", async () => {
+    render(
+      <TradingChart
+        slabAddress="TestSlab1111111111111111111111111111111111"
+        mintAddress="TestMint1111111111111111111111111111111111"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(vi.mocked(resolveChartDataSource)).toHaveBeenLastCalledWith(true, false, false);
+    });
+  });
+});

--- a/app/__tests__/lib/chart-live-tick.test.ts
+++ b/app/__tests__/lib/chart-live-tick.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mergeMarkPriceIntoBar,
+  mergeMarkPriceIntoPoint,
+  resolveChartDataSource,
+  type ChartDataSource,
+} from '@/lib/chart-live-tick';
+
+describe('resolveChartDataSource', () => {
+  it('preserves the production source-priority order', () => {
+    expect(resolveChartDataSource(true, true, true)).toBe('percolator');
+    expect(resolveChartDataSource(false, true, true)).toBe('pyth');
+    expect(resolveChartDataSource(false, false, true)).toBe('dex');
+    expect(resolveChartDataSource(false, false, false)).toBe('oracle');
+  });
+});
+
+describe('live mark tick source integrity', () => {
+  const externalSources: ChartDataSource[] = ['percolator', 'pyth', 'dex'];
+
+  it.each(externalSources)('does not overwrite an OHLC bar backed by %s', (source) => {
+    const historicalBar = {
+      time: 1_721_234_500,
+      open: 0.0121,
+      high: 0.0125,
+      low: 0.0118,
+      close: 0.0122,
+    };
+
+    // Reproduces the observed fresh-market mismatch: chart history is near
+    // $0.012 while the market mark is near $0.0002.
+    const result = mergeMarkPriceIntoBar(source, historicalBar, 0.0002);
+
+    expect(result).toBe(historicalBar);
+    expect(result).toEqual({
+      time: 1_721_234_500,
+      open: 0.0121,
+      high: 0.0125,
+      low: 0.0118,
+      close: 0.0122,
+    });
+  });
+
+  it.each(externalSources)('does not overwrite a line/area point backed by %s', (source) => {
+    const historicalPoint = { time: 1_721_234_500, value: 0.0122 };
+    const result = mergeMarkPriceIntoPoint(source, historicalPoint, 0.0002);
+
+    expect(result).toBe(historicalPoint);
+    expect(result.value).toBe(0.0122);
+  });
+
+  it('continues updating the oracle fallback OHLC bar', () => {
+    const oracleBar = {
+      time: 1_721_234_500,
+      open: 0.00021,
+      high: 0.00022,
+      low: 0.0002,
+      close: 0.00021,
+    };
+
+    expect(mergeMarkPriceIntoBar('oracle', oracleBar, 0.00019)).toEqual({
+      time: 1_721_234_500,
+      open: 0.00021,
+      high: 0.00022,
+      low: 0.00019,
+      close: 0.00019,
+    });
+  });
+
+  it('continues updating the oracle fallback line/area point', () => {
+    const oraclePoint = { time: 1_721_234_500, value: 0.00021 };
+
+    expect(mergeMarkPriceIntoPoint('oracle', oraclePoint, 0.00019)).toEqual({
+      time: 1_721_234_500,
+      value: 0.00019,
+    });
+  });
+
+  it('rejects a non-finite mark without corrupting either series shape', () => {
+    const bar = {
+      time: 1_721_234_500,
+      open: 1,
+      high: 1,
+      low: 1,
+      close: 1,
+    };
+    const point = { time: 1_721_234_500, value: 1 };
+
+    expect(mergeMarkPriceIntoBar('oracle', bar, Number.NaN)).toBe(bar);
+    expect(mergeMarkPriceIntoPoint('oracle', point, Infinity)).toBe(point);
+  });
+
+  it('documents the old failure magnitude for the screenshot values', () => {
+    const dexClose = 0.0122;
+    const mark = 0.0002;
+    const syntheticDropPercent = ((dexClose - mark) / dexClose) * 100;
+
+    // The old unconditional merge created an artificial >98% red candle.
+    expect(syntheticDropPercent).toBeGreaterThan(98);
+    expect(
+      mergeMarkPriceIntoBar(
+        'dex',
+        {
+          time: 1,
+          open: dexClose,
+          high: dexClose,
+          low: dexClose,
+          close: dexClose,
+        },
+        mark,
+      ).close,
+    ).toBe(dexClose);
+  });
+});

--- a/app/components/trade/TradingChart.tsx
+++ b/app/components/trade/TradingChart.tsx
@@ -55,6 +55,12 @@ import {
   finitePricePoints,
   type ChartSeriesKind,
 } from "@/lib/chart-style";
+import {
+  mergeMarkPriceIntoBar,
+  mergeMarkPriceIntoPoint,
+  resolveChartDataSource,
+  type ChartDataSource,
+} from "@/lib/chart-live-tick";
 import { assertNever } from "@/lib/exhaustive";
 import { formatUsdFromNumber, chartPricePrecision } from "@/lib/format";
 
@@ -339,6 +345,10 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
   // effect below (that effect should not resubscribe just because the user
   // changed candle vs. line style — only the merge SHAPE changes).
   const chartDataKindRef = useRef<"ohlc" | "single">("ohlc");
+  // The tick subscription deliberately depends only on slabAddress. Mirror the
+  // active series source so every live tick can enforce source integrity
+  // without rebuilding the subscription.
+  const activeDataSourceRef = useRef<ChartDataSource>("oracle");
   // Track whether we've done the initial viewport fit for the current
   // timeframe/chart-type/data-source. Without this, calling fitContent() on
   // every poll (new bar arrives every ~30s for Pyth / 60s for GeckoTerminal)
@@ -441,6 +451,12 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
     (percHasEnough || pythHasNothing);
   const hasPythData = !hasPercolatorData && pythStatus === "success" && pythFinite.length > 0;
   const hasExternalData = !hasPercolatorData && !hasPythData && externalStatus === "success" && externalFinite.length > 0;
+
+  const activeDataSource = resolveChartDataSource(
+    hasPercolatorData,
+    hasPythData,
+    hasExternalData,
+  );
 
   // Fetch oracle price history
   useEffect(() => {
@@ -1033,14 +1049,13 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
     // OHLC; line + area both read the single-value lineData stream. Flipping
     // between styles that share a data source preserves pan/zoom; only
     // switching kinds (candle ↔ line) refits the viewport.
-    const source = hasPercolatorData
-      ? "percolator"
-      : hasPythData
-        ? "pyth"
-        : hasExternalData
-          ? "dex"
-          : "oracle";
-    const fitKey = `${chartDataKind(chartStyle)}:${timeframe}:${source}`;
+    //
+    // Commit the source ref only after this structural effect has finished
+    // rebuilding the visible series. Updating the ref during render creates a
+    // brief mismatch window where a tick can treat the previous DEX/Pyth/PERC
+    // series as the new oracle series and mutate it before the effect runs.
+    activeDataSourceRef.current = activeDataSource;
+    const fitKey = `${chartDataKind(chartStyle)}:${timeframe}:${activeDataSource}`;
     if (fitKeyRef.current !== fitKey) {
       chart.timeScale().fitContent();
       fitKeyRef.current = fitKey;
@@ -1060,7 +1075,7 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
     // measured perf bug (see BUILD-LOG.md Phase 2). Live price now reaches
     // the chart exclusively through the "Live tick -> chart" effect below,
     // via series.update()/applyOptions() — cheap, no series recreation.
-  }, [chartStyle, timeframe, candleData, lineData, liqPriceE6, entryPriceNum, chartTheme, hasPercolatorData, hasPythData, hasExternalData, overlayPrefs.entry, overlayPrefs.liq]);
+  }, [chartStyle, timeframe, candleData, lineData, liqPriceE6, entryPriceNum, chartTheme, activeDataSource, overlayPrefs.entry, overlayPrefs.liq]);
 
   // Phase 2: Live tick -> chart. Subscribes directly to the price store
   // (bypassing React state/useLivePrice() entirely, per the reference doc's
@@ -1099,19 +1114,32 @@ const TradingChartInner: FC<{ slabAddress: string; mintAddress?: string }> = ({
 
       const series = seriesRef.current;
       if (series) {
+        // Mark ticks may mutate the visible series only when that series is
+        // the oracle fallback built from the same mark-price stream. Pyth and
+        // DEX history have independent upstreams, while Percolator candles are
+        // updated by actual trades:<slab> events.
         if (chartDataKindRef.current === "ohlc" && lastBarRef.current) {
-          const merged = {
-            ...lastBarRef.current,
-            high: Math.max(lastBarRef.current.high, usd),
-            low: Math.min(lastBarRef.current.low, usd),
-            close: usd,
-          };
-          lastBarRef.current = merged;
-          (series as ISeriesApi<"Candlestick">).update(merged);
+          const current = lastBarRef.current;
+          const merged = mergeMarkPriceIntoBar(
+            activeDataSourceRef.current,
+            current,
+            usd,
+          );
+          if (merged !== current) {
+            lastBarRef.current = merged;
+            (series as ISeriesApi<"Candlestick">).update(merged);
+          }
         } else if (chartDataKindRef.current === "single" && lastPointRef.current) {
-          const merged = { time: lastPointRef.current.time, value: usd };
-          lastPointRef.current = merged;
-          (series as ISeriesApi<"Line">).update(merged);
+          const current = lastPointRef.current;
+          const merged = mergeMarkPriceIntoPoint(
+            activeDataSourceRef.current,
+            current,
+            usd,
+          );
+          if (merged !== current) {
+            lastPointRef.current = merged;
+            (series as ISeriesApi<"Line">).update(merged);
+          }
         }
       }
 

--- a/app/lib/chart-live-tick.ts
+++ b/app/lib/chart-live-tick.ts
@@ -1,0 +1,67 @@
+/**
+ * Identifies the source currently backing the visible chart series.
+ *
+ * Mark-price ticks and historical candle sources are deliberately separate:
+ * - oracle: built from the same mark-price stream, so the open bar may be
+ *   updated directly between the slower React/state aggregation passes;
+ * - percolator: updated by actual `trades:<slab>` events;
+ * - pyth/dex: refreshed by their own upstream candle feeds.
+ */
+export type ChartDataSource = 'percolator' | 'pyth' | 'dex' | 'oracle';
+
+export interface LiveOhlcBar<TTime> {
+  time: TTime;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+}
+
+export interface LivePricePoint<TTime> {
+  time: TTime;
+  value: number;
+}
+
+export function resolveChartDataSource(
+  hasPercolatorData: boolean,
+  hasPythData: boolean,
+  hasExternalData: boolean,
+): ChartDataSource {
+  if (hasPercolatorData) return 'percolator';
+  if (hasPythData) return 'pyth';
+  if (hasExternalData) return 'dex';
+  return 'oracle';
+}
+
+/**
+ * Merge a live mark into the visible OHLC bar only when that bar was itself
+ * built from mark/oracle observations.
+ *
+ * Returning the original object for external sources is intentional. The
+ * caller can use identity to skip `series.update()` completely, preventing a
+ * mark tick from overwriting a Pyth, DEX, or trade-derived close.
+ */
+export function mergeMarkPriceIntoBar<TTime>(
+  source: ChartDataSource,
+  bar: LiveOhlcBar<TTime>,
+  markPriceUsd: number,
+): LiveOhlcBar<TTime> {
+  if (source !== 'oracle' || !Number.isFinite(markPriceUsd)) return bar;
+
+  return {
+    ...bar,
+    high: Math.max(bar.high, markPriceUsd),
+    low: Math.min(bar.low, markPriceUsd),
+    close: markPriceUsd,
+  };
+}
+
+/** Same source-integrity rule as `mergeMarkPriceIntoBar`, for line/area mode. */
+export function mergeMarkPriceIntoPoint<TTime>(
+  source: ChartDataSource,
+  point: LivePricePoint<TTime>,
+  markPriceUsd: number,
+): LivePricePoint<TTime> {
+  if (source !== 'oracle' || !Number.isFinite(markPriceUsd)) return point;
+  return { time: point.time, value: markPriceUsd };
+}


### PR DESCRIPTION
## Summary

Fixes #2441.

This PR restores chart source integrity by preventing live protocol mark-price
ticks from mutating a visible chart series backed by a different data source.

Before this change, `TradingChart` correctly selected one of four possible
series sources:

```text
Percolator internal trades
  -> Pyth benchmark candles
  -> GeckoTerminal / DEX candles
  -> Oracle fallback
```

However, the live slab-price subscriber did not preserve that source boundary.

Every finite mark-price tick correctly updated the separate `Mark` overlay, but
the same tick was also unconditionally merged into the current visible OHLC bar
or line/area point through `series.update()`.

As a result, a mark observation could overwrite:

- a GeckoTerminal/DEX candle;
- a Pyth benchmark candle;
- a Percolator internal-trade candle;
- a DEX/Pyth/Percolator line or area point.

This produced synthetic chart movement that never occurred in the source
feeding the chart.

On the affected Playground market, DEX candles were approximately
`$0.010–$0.022`, while the protocol mark was approximately
`$0.000189–$0.0002`. Applying the mark to the last DEX candle created an
artificial downward candle greater than 98%.

---

## Root Cause

`TradingChart` stores the latest rendered value in generic refs:

```ts
lastBarRef.current
lastPointRef.current
```

These refs retain the current data shape, but the live tick handler previously
did not know which source produced the data stored in them.

The old OHLC update path was effectively:

```ts
const merged = {
  ...lastBarRef.current,
  high: Math.max(lastBarRef.current.high, markPriceUsd),
  low: Math.min(lastBarRef.current.low, markPriceUsd),
  close: markPriceUsd,
};

lastBarRef.current = merged;
series.update(merged);
```

The line/area path similarly replaced the last visible value:

```ts
const merged = {
  time: lastPointRef.current.time,
  value: markPriceUsd,
};

lastPointRef.current = merged;
series.update(merged);
```

Those operations were executed for every active series, even when the series
was populated from DEX, Pyth, or actual Percolator trades.

This violated the following invariant:

> A rendered price series must only be mutated by observations belonging to
> the same source domain.

The correct ownership model is:

```text
DEX series
  <- GeckoTerminal / DEX observations only

Pyth series
  <- Pyth benchmark observations only

Percolator series
  <- actual trades:<slab> events only

Oracle fallback series
  <- mark/oracle observations

Mark overlay
  <- live protocol mark price
```

---

## What Changed

### 1. Added an explicit chart-source model

A new `ChartDataSource` type identifies the source currently backing the
visible price series:

```ts
type ChartDataSource =
  | "percolator"
  | "pyth"
  | "dex"
  | "oracle";
```

The source is resolved using the same production-priority rules already used by
`TradingChart`:

```ts
resolveChartDataSource(
  hasPercolatorData,
  hasPythData,
  hasExternalData,
);
```

The priority remains unchanged:

```text
Percolator -> Pyth -> DEX -> Oracle
```

This PR does not alter source selection. It only makes the selected source
explicit and available to the live-tick path.

---

### 2. Added source-aware live-mark merge helpers

The new pure helpers:

```ts
mergeMarkPriceIntoBar(...)
mergeMarkPriceIntoPoint(...)
```

apply a mark tick only when the active source is:

```text
oracle
```

For non-oracle sources:

```text
percolator
pyth
dex
```

the helpers return the original bar or point unchanged.

This preserves object identity intentionally, allowing `TradingChart` to skip
`series.update()` completely when the live mark does not own the active series.

---

### 3. Preserved live updates for the Oracle fallback

This fix does not disable live chart updates globally.

When the visible series is the Oracle fallback, the live mark continues to
update the current bar:

```text
high  = max(previous high, mark)
low   = min(previous low, mark)
close = mark
```

The same behavior is retained for Oracle-backed line and area series.

Therefore:

```text
Oracle fallback:
  remains live

DEX / Pyth / Percolator:
  remain owned by their original sources
```

---

### 4. Kept the Mark overlay live for every source

The separate `Mark` price line still updates on every valid live mark tick,
regardless of the source backing the chart.

This preserves the intended trading interface:

```text
Historical or trade-derived series:
  source-specific market context

Mark overlay:
  current protocol mark and risk context
```

The fix separates those responsibilities instead of suppressing the mark
display.

---

### 5. Prevented a source-transition mismatch window

The active-source ref is committed only after the structural chart effect has
rebuilt the visible series.

It is not updated prematurely during render.

This matters during transitions such as:

```text
DEX -> Oracle
Pyth -> DEX
Percolator -> Pyth
```

Updating the ref during render would briefly create this inconsistent state:

```text
new source identity
+ previous visible series
+ incoming live tick
```

A live tick arriving in that window could still mutate the previous source
under the new source identity.

The ref is now synchronized with the series after the structural rebuild, so
the live subscriber observes the source corresponding to the series actually
mounted in `seriesRef.current`.

---

### 6. Reused the resolved source for viewport identity

The structural chart effect now uses the resolved `activeDataSource` when
building the fit key:

```ts
`${chartDataKind(chartStyle)}:${timeframe}:${activeDataSource}`
```

This removes duplicate source-resolution logic and ensures that viewport
identity and live-series ownership use the same source-of-truth.

The existing pan/zoom behavior remains unchanged:

- the viewport refits when the timeframe, data shape, or source changes;
- ordinary source polling does not continuously reset user pan/zoom.

---

## Files Changed

### `app/components/trade/TradingChart.tsx`

- resolves the active chart source explicitly;
- tracks the source committed to the currently mounted series;
- synchronizes source identity after structural series reconstruction;
- keeps the Mark overlay live;
- prevents mark ticks from mutating DEX, Pyth, or Percolator series;
- preserves mark-driven updates for the Oracle fallback;
- skips unnecessary `series.update()` calls for unchanged values;
- uses the same resolved source in the viewport fit key.

### `app/lib/chart-live-tick.ts`

Adds pure source-integrity primitives:

- `ChartDataSource`;
- `resolveChartDataSource`;
- `mergeMarkPriceIntoBar`;
- `mergeMarkPriceIntoPoint`;
- shared OHLC and single-value interfaces.

### `app/__tests__/lib/chart-live-tick.test.ts`

Adds deterministic regression coverage for:

- source-priority resolution;
- DEX OHLC protection;
- Pyth OHLC protection;
- Percolator OHLC protection;
- DEX line/area protection;
- Pyth line/area protection;
- Percolator line/area protection;
- Oracle OHLC live updates;
- Oracle line/area live updates;
- non-finite mark rejection;
- the observed greater-than-98% synthetic-drop scenario.

---

## Behavioral Matrix

| Active chart source | Mark overlay updates | Visible OHLC/point updated by mark |
|---|---:|---:|
| Oracle fallback | Yes | Yes |
| GeckoTerminal / DEX | Yes | No |
| Pyth | Yes | No |
| Percolator internal trades | Yes | No |

Percolator candles continue to receive their live OHLC updates through actual
`trades:<slab>` events rather than generic protocol mark notifications.

---

## Regression Scenario

Representative values from the affected deployment:

```text
DEX close: 0.0122
Mark:      0.0002
```

The previous implementation produced:

```text
open:  0.012x
high:  0.012x
low:   0.0002
close: 0.0002
```

Synthetic drop:

```text
((0.0122 - 0.0002) / 0.0122) * 100
≈ 98.36%
```

After this change:

```text
DEX close remains: 0.0122
DEX low remains:   source-provided value
Mark overlay:      moves independently to 0.0002
```

No synthetic candle is generated.

---

## Validation

### Targeted and related regression tests

```bash
cd app

pnpm exec vitest run \
  __tests__/lib/chart-live-tick.test.ts \
  __tests__/lib/chart-style.test.ts \
  --reporter=verbose
```

Result:

```text
Test Files  2 passed
Tests       52 passed
```

The new source-integrity suite contains:

```text
11 passed
```

---

### TypeScript

```bash
pnpm exec tsc --noEmit
```

Result:

```text
Passed with no TypeScript errors.
```

---

### Formatting

```bash
pnpm exec prettier --check \
  lib/chart-live-tick.ts \
  __tests__/lib/chart-live-tick.test.ts
```

Result:

```text
All matched files use Prettier code style.
```

---

### Production build

```bash
pnpm build
```

Result:

```text
Compiled successfully.
TypeScript configuration validation completed.
Static pages generated successfully.
Page optimization completed.
```

Existing non-blocking warnings related to Next.js configuration,
middleware naming, Node deprecations, and optional BigInt native bindings remain
unchanged and are unrelated to this PR.

---

### Git validation

```bash
git diff --cached --check
```

Result:

```text
No whitespace errors.
```

The branch contains one focused commit and only the three files required for
this fix.

---

## Runtime Validation Note

The original issue was reproduced on the deployed Playground market:

```text
https://percolator-playground.vercel.app/trade/98Em84STzK8sL81TRt3ePnFQ9hG5HsVrQKydZDMYibso
```

The local environment could load the on-chain slab and position state, but it
could not load the equivalent DEX chart because the local
`/api/markets/[slab]` request did not resolve the deployment-specific metadata
required by GeckoTerminal.

Local result:

```text
error: Failed to load market. Please try again later.
symbol: null
mainnet_ca: null
dex_pool_address: null
mark_price: null
```

Playground result:

```text
error: null
symbol: Jimoothy
name: Jimoothy/USDC - meteora-dlmm
mainnet_ca: present
dex_pool_address: present
mark_price: 0.000189
```

Because the DEX chart mint is supplied through `mainnet_ca`, the affected DEX
series could not be recreated in the local UI.

The cross-source mutation itself is covered deterministically by the regression
tests.

Deployment-level post-fix validation should be completed against the Vercel PR
preview using the affected slab.

This PR does not claim that the fix has already been deployed to or verified on
the live Playground environment.

---

## Scope

This PR fixes frontend chart source integrity only.

It does not change:

- on-chain protocol state;
- mark-price calculation;
- liquidation-price calculation;
- trade execution;
- PnL accounting;
- order validation;
- collateral handling;
- wallet or signer behavior;
- RPC configuration;
- DEX/Pyth/Percolator source-selection priority.

The liquidation line observed in #2441 remains outside this fix because its
direction was consistent with a short position. Its compressed position on the
chart resulted from the large difference between the DEX price domain and the
position's Mark/Entry/Liquidation domain.

---

## Acceptance Criteria

- [x] Mark overlay continues updating for all chart sources.
- [x] DEX OHLC candles are not mutated by mark ticks.
- [x] Pyth OHLC candles are not mutated by mark ticks.
- [x] Percolator OHLC candles are not mutated by generic mark ticks.
- [x] DEX line/area points are not overwritten by mark ticks.
- [x] Pyth line/area points are not overwritten by mark ticks.
- [x] Percolator line/area points are not overwritten by mark ticks.
- [x] Oracle-fallback OHLC bars continue receiving live mark updates.
- [x] Oracle-fallback line/area points continue receiving live mark updates.
- [x] Non-finite mark values remain rejected.
- [x] Source transitions do not expose a render-to-effect identity mismatch.
- [x] Related regression tests pass.
- [x] TypeScript validation passes.
- [x] Production build passes.
- [ ] Verify the affected slab against the Vercel PR preview.

---

## Related Work

This is distinct from previous chart fixes:

- PR #2125 introduced the Percolator/Pyth/DEX/Oracle source cascade and the
  actual `trades:<slab>` live-update path for Percolator candles.
- PR #2403 rejected non-finite values such as `NaN` and `Infinity`.

The values involved in this issue are valid finite numbers:

```ts
Number.isFinite(0.0122);   // true
Number.isFinite(0.000189); // true
```

The defect was not malformed data. It was a valid observation being applied to
a series owned by a different source.

---

## Final Result

After this change:

```text
Mark ticks update the Mark overlay.

Oracle-backed series continue updating from mark observations.

DEX-backed series remain owned by GeckoTerminal.

Pyth-backed series remain owned by Pyth.

Percolator-backed series remain owned by actual protocol trades.
```

This removes the synthetic giant-candle path while preserving the existing
source priority, live mark display, Oracle fallback behavior, and chart
interaction model.