### PR TITLE
fix(ci): stop deploy.yml failing on every push (job-level hashFiles)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,12 +21,33 @@ env:
   IMAGE_PREFIX: ${{ github.repository }}
 
 jobs:
+  # hashFiles() is NOT valid in a job-level `if:` (only step-level) — using it there
+  # made GitHub reject the whole workflow ("workflow file issue"). Detect package
+  # presence once here and gate the backend jobs on this output instead.
+  detect-packages:
+    name: Detect packages
+    runs-on: ubuntu-latest
+    outputs:
+      has_packages: ${{ steps.check.outputs.has_packages }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Check for packages/*
+        id: check
+        run: |
+          if [ -f packages/shared/package.json ]; then
+            echo "has_packages=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_packages=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build-and-push:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # Skip when packages/* workspaces are absent (e.g. waitlist-only forks).
-    # When packages/ is restored from upstream, the guard evaluates true and the job runs.
-    if: hashFiles('packages/shared/package.json') != ''
+    # Backend/monorepo job — runs only when packages/* is present (skips on the
+    # frontend-only playground; auto-runs if the monorepo packages are restored).
+    needs: detect-packages
+    if: needs.detect-packages.outputs.has_packages == 'true'
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## What

`deploy.yml` uses `hashFiles()` in a **job-level** `if:`. That function is only valid in step-level contexts, so GitHub rejects the entire workflow and emits a failed run with **zero jobs executed** — the "This run likely failed because of a workflow file issue" error.

Net effect: `deploy.yml` has been failing on **every push** to both `main` and `playground`.

## Why it was missed

`test.yml` had the identical bug and was already fixed on `playground` with a `detect-packages` job — the fix even carries a comment naming this exact root cause. `deploy.yml` was simply missed in that pass. This PR applies the same, already-reviewed pattern.

## How to test

```bash
actionlint .github/workflows/*.yml
```

- Before: 1 error at `deploy.yml:29`
- After: clean, no errors

Behaviour is unchanged — `build-and-push` still skips when `packages/*` is absent (the current frontend-only layout) and auto-runs if the monorepo packages are restored.

## Note (separate issue, not fixed here)

`main` is 1078 commits behind `playground` and still carries the **broken** `test.yml` as well. Since `main` is the repo default branch, its Test Suite + Deploy runs fail on every push. Worth a follow-up decision on branch strategy — flagging rather than force-syncing 1078 commits unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)