### PR TITLE
fix(ci): port the deploy.yml hashFiles fix from playground to main (#2444)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,12 +21,33 @@ env:
   IMAGE_PREFIX: ${{ github.repository }}
 
 jobs:
+  # hashFiles() is NOT valid in a job-level `if:` (only step-level) — using it there
+  # made GitHub reject the whole workflow ("workflow file issue"). Detect package
+  # presence once here and gate the backend jobs on this output instead.
+  detect-packages:
+    name: Detect packages
+    runs-on: ubuntu-latest
+    outputs:
+      has_packages: ${{ steps.check.outputs.has_packages }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Check for packages/*
+        id: check
+        run: |
+          if [ -f packages/shared/package.json ]; then
+            echo "has_packages=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_packages=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build-and-push:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # Skip when packages/* workspaces are absent (e.g. waitlist-only forks).
-    # When packages/ is restored from upstream, the guard evaluates true and the job runs.
-    if: hashFiles('packages/shared/package.json') != ''
+    # Backend/monorepo job — runs only when packages/* is present (skips on the
+    # frontend-only playground; auto-runs if the monorepo packages are restored).
+    needs: detect-packages
+    if: needs.detect-packages.outputs.has_packages == 'true'
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Correction to this PR's original framing

I opened this as an independent fix. It is not — **#2444 fixed the same bug and merged at
2026-07-21T05:10Z.** I missed it because its base was `playground`, not `main`.

That said, this PR is still needed: **`main` is unfixed.** Right now, on `main`:

```
.github/workflows/deploy.yml:29:    if: hashFiles('packages/shared/package.json') != ''
```

I have replaced my version with **#2444's file verbatim**, so `main` and `playground` are now
byte-identical and cannot conflict when the branches meet. Two spellings of one fix is worse
than either spelling.

## The bug

`hashFiles()` is only available in `jobs.<job_id>.steps.*` — never in a job-level `if:`.
GitHub rejects the whole file at startup.

```
$ actionlint .github/workflows/deploy.yml          # on main
deploy.yml:29:9: calling function "hashFiles" is not allowed here. "hashFiles" is only
available in "jobs.<job_id>.steps.*"  [expression]
```

Introduced by #2164 (`ecef0545`, 2026-05-15).

## Impact on `main`

Every run since that date was a **startup failure creating zero jobs**:

| | |
|---|---|
| runs before 2026-05-15 | **all `success`**, all `workflow_dispatch` |
| runs since | **all `failure`** — 100/100 sampled, 0 successes |
| total | 361 |

1. A startup failure cannot resolve the workflow name, so GitHub attributed a bogus failed
   **Deploy** run to *every push on every branch* — despite `on:` declaring only
   `workflow_dispatch`. Permanent red X on every PR, which is what trains reviewers to stop
   reading red.
2. **`workflow_dispatch` itself was unusable** — the workflow's only intended trigger could
   not start.

## Verification

**Static** — the check discriminates:

| | hashFiles errors | exit |
|---|---|---|
| `main` | 2 | 1 |
| this branch | 0 | 0 |

**Controlled A/B on push** — same repo, same event, only this file differs:

| branch | Deploy runs for the push |
|---|---|
| this branch | **0** — parses, so `workflow_dispatch`-only is honored |
| `fix/launch-brace-expansion-audit-floor` (control) | 1 × `failure` |

**End-to-end** — dispatched this branch ([run 29809312441](https://github.com/dcccrypto/percolator-launch/actions/runs/29809312441)):

```
conclusion=success  event=workflow_dispatch  name=Deploy
  detect-packages: success
  build-and-push:  skipped
```

`name` resolves to `Deploy` rather than the raw path, confirming the file parses. The build
job skips because `packages/` is untracked here — that dispatch was a guaranteed no-op: no
image built, none pushed, nothing deployed.

## Notes

- This makes deploys **startable**, not proven working. Whether the matrix builds succeed once
  `packages/*` is present is untested and out of scope.
- Optional follow-up, deliberately **not** done here to preserve byte-identity with #2444: the
  `detect-packages` job could take `timeout-minutes` and an explicit
  `permissions: contents: read`. Worth applying to both branches together, not to one.
- Relevant to the current outage: `api.percolator.trade` is NXDOMAIN and the Railway CLI
  returns `Unauthorized`, so the CI deploy path being non-startable was one more closed door.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment workflow checks to ensure backend builds and publishes run only when the required package configuration is available.
  * Prevented unnecessary or invalid deployment jobs when backend packages are absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->