### PR TITLE
ci: enable CodeRabbit auto-review on PRs based on `playground`

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,16 @@
+# CodeRabbit configuration.
+#
+# Why this file exists: CodeRabbit only auto-reviews PRs whose BASE branch is
+# the repository default branch (`main`) unless told otherwise — the default
+# for `base_branches` is an empty list. This repo does almost all of its work
+# against `playground` (13 of the last 15 merged PRs), so in practice the
+# large majority of PRs were being opened with "Review skipped: auto reviews
+# are disabled on base/target branches other than the default branch" and
+# received no automated review at all.
+#
+# Entries are regex patterns matched against the PR's base branch name.
+reviews:
+  auto_review:
+    base_branches:
+      - "main"
+      - "playground"


### PR DESCRIPTION
## The gap

CodeRabbit auto-reviews only PRs whose **base branch is the repository default** (`main`). `reviews.auto_review.base_branches` defaults to an empty list, and this repo has no `.coderabbit.yaml` at all.

But the repo does almost all of its work against `playground`:

```
$ gh pr list --state merged --limit 15 --json baseRefName
playground: 13    main: 2
```

So in practice **the large majority of PRs in this repo receive no automated review.** Every one gets:

> **Review skipped** — Auto reviews are disabled on base/target branches other than the default branch.

I found this while chasing review on #2451 / #2452 / #2453 — all three were skipped for exactly this reason, which is why they'd sat with zero review signal.

## The change

One new file, four lines of config:

```yaml
reviews:
  auto_review:
    base_branches:
      - "main"
      - "playground"
```

Key verified against [the configuration reference](https://docs.coderabbit.ai/reference/configuration): `reviews.auto_review.base_branches`, a list of **regex patterns** matched against the PR's base branch name. `main` is listed explicitly rather than relying on the implicit default, so the effective set is obvious from the file.

## One thing I could not verify — please confirm on merge

**The docs do not state which branch CodeRabbit reads `.coderabbit.yaml` from** (PR base, head, or repo default). I checked the configuration reference and searched the docs; it's simply not specified.

That matters here because the file is landing on `playground`, not the default branch:

- If CodeRabbit reads config from the **PR's base branch**, this works as-is for the `playground` → PR flow.
- If it reads from the **repository default branch**, this also needs to land on `main` before it takes effect.

**Recommend porting to `main` as well** — it's harmless in either case, and it removes the ambiguity. Easy to confirm after merge: open any throwaway PR against `playground` and check whether CodeRabbit reviews it instead of skipping.

I did not want to quietly assume one behaviour and have this look like it worked when it hadn't.

## Immediate unblock (already done)

`@coderabbitai review` posted manually on #2451, #2452 and #2453 — that path works regardless of this config, so those three have review running now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)