### PR TITLE
fix(test): PORT-007 fails on hidden tooltip copy, not on a rendered banner

### DIFF
--- a/app/__tests__/components/Portfolio.test.tsx
+++ b/app/__tests__/components/Portfolio.test.tsx
@@ -629,8 +629,21 @@ describe("Portfolio Component Tests", () => {
 
       render(<PortfolioPage />);
 
-      expect(screen.queryByText(/Liquidation risk/i)).not.toBeInTheDocument();
-      expect(screen.queryByText(/Approaching liquidation/i)).not.toBeInTheDocument();
+      // `ignore` skips the always-mounted tooltip span. <Tooltip> keeps its
+      // copy in the DOM permanently and hides it with inline
+      // visibility/opacity (it animates on hover), so its text is invisible to
+      // users but still visible to queryByText. RISK_LEVERAGE_TITLE ends with
+      // "...lowers liquidation risk.", which matched this /i assertion the
+      // moment the Risk Lev. label swapped its `title=` attribute for an
+      // <InfoIcon>. Hidden tooltip copy is not a rendered banner, so it must
+      // not satisfy these assertions.
+      const ignoreTooltip = { ignore: '[role="tooltip"]' } as const;
+      expect(
+        screen.queryByText(/Liquidation risk/i, ignoreTooltip)
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/Approaching liquidation/i, ignoreTooltip)
+      ).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## What broke

`Portfolio.test.tsx` → **PORT-007 "renders nothing (zero height) when no position is at risk"** now fails on `playground`.

It is **deterministic, not flaky**: fails 3/3 on `fb53c2ff`, passes at `b828e025` (before the trade-UI batch).

## Root cause

`90be44c0` swapped the Risk Lev. label's `title=` attribute for an `<InfoIcon tooltip={RISK_LEVERAGE_TITLE}>`.

`<Tooltip>` keeps its copy **mounted permanently** and hides it with inline `visibility/opacity` (it animates in on hover):

```tsx
<span role="tooltip" style={{ visibility: "hidden", opacity: 0 }}>{text}</span>
```

So the text is invisible to users but **still visible to `queryByText`** (which filters only `script, style`). And:

> RISK_LEVERAGE_TITLE = "…Extra collateral lowers **liquidation risk**."

which the assertion `queryByText(/Liquidation risk/i)` matches. The test was failing on hidden tooltip prose, not on a rendered `AtRiskBanner`.

The component behaviour is intentional (that's how the animated tooltip works) — the **assertion** was too loose.

## Fix

Scope both negative assertions with `ignore: '[role="tooltip"]'`. Hidden tooltip copy is not a rendered banner, so it must not satisfy them. The sibling positive test already distinguished `AtRiskBanner` from `PositionCard`'s per-row banner by case; this extends the same care to the negative case.

## Verification — it still binds, it is not silenced

An `ignore` that hides a failure would be worse than the bug, so I mutation-tested it:

| state | PORT-007 |
|---|---|
| fix applied | **passes** |
| fix applied + `AtRiskBanner`'s `if (atRisk.length === 0) return null;` guard neutralised | **FAILS** |
| guard restored | **passes** |

The assertion still catches a genuinely mis-rendered banner.

Full suite (`app/`), with the open test-repair PRs stacked: **2805 passed, 0 failed.**

## Note

This was invisible to CI — see #2447: `Unit Tests` / `Integration Tests` / `Coverage Gate` report SKIPPED while the Merge Gate still reports SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)