### PR TITLE
fix(nav): "Trade" opens the markets browser instead of one default market

### DIFF
--- a/app/components/layout/Header.tsx
+++ b/app/components/layout/Header.tsx
@@ -63,7 +63,7 @@ const mobileGroupsAll = [
   {
     label: "Menu",
     items: [
-      { href: "/trade", label: "Trade" },
+      { href: "/markets", label: "Trade" },
       ...primaryLinks,
       { href: "/portfolio", label: "Portfolio" },
     ],
@@ -189,13 +189,17 @@ export const Header: FC = () => {
           <nav className="hidden items-center gap-0.5 md:flex" aria-label="Main navigation">
             {!isWaitlistHost && (
               <>
-                {/* Trade — filled primary CTA into the terminal. */}
+                {/* Trade — filled primary CTA into the markets browser (was
+                    /trade, which auto-redirected into one default market;
+                    users expect it to land on the full markets list). Stays
+                    highlighted across the whole trade flow: the browser
+                    (/markets) and the terminal (/trade/:slab). */}
                 <Link
-                  href="/trade"
-                  aria-label="Trade terminal"
-                  aria-current={pathname === "/trade" || pathname.startsWith("/trade/") ? "page" : undefined}
+                  href="/markets"
+                  aria-label="Trade — browse all markets"
+                  aria-current={pathname.startsWith("/markets") || pathname.startsWith("/trade") ? "page" : undefined}
                   className={`flex min-h-8 items-center rounded-sm px-3 text-[13px] font-semibold text-[var(--text)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg)] ${
-                    pathname === "/trade" || pathname.startsWith("/trade/")
+                    pathname.startsWith("/markets") || pathname.startsWith("/trade")
                       ? "bg-[var(--accent)]/25"
                       : "bg-[var(--accent)]/15 hover:bg-[var(--accent)]/25"
                   }`}


### PR DESCRIPTION
## Problem

The header's **Trade** button linked to `/trade` — a redirect page that auto-jumps into SOL-PERP or the highest-volume market. So clicking "Trade" dropped users straight into one arbitrary market (often a brand-new, low-volume one) instead of letting them choose which to trade.

## Fix

Point the "Trade" nav link at **`/markets`** (the full markets browser) so it opens the list and the user picks the market to open in the terminal.

- The button is otherwise **unchanged** — same label, same filled-accent styling, same position — only its destination changes.
- Applied to both the **desktop** CTA and the **mobile** menu link.
- The tab stays highlighted across the whole trade flow — active on `/markets` (browser) **and** `/trade/:slab` (terminal).
- `aria-label` updated ("Trade terminal" → "Trade — browse all markets") to match the destination.
- The `/trade` redirect route is left intact for direct hits and old links.

## Testing

- `tsc --noEmit` clean.
- Verified in the browser: the "Trade" link's `href` is `/markets`; clicking it from an app page lands on `/markets`; `/markets` stays put (no redirect) and lists the markets. Screenshot below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
