### PR TITLE
fix(theme): brighten the dim dark-mode text tiers for legibility

### DIFF
--- a/app/app/globals.css
+++ b/app/app/globals.css
@@ -28,9 +28,14 @@
   --cyan-muted: rgba(20,241,149,0.08);
 
   --text: #E1E2E8;
-  --text-secondary: #7A7F96;
-  --text-muted: #454B5F;
-  --text-dim: #2A2E3D;
+  /* Brightened a step for legibility — the secondary/muted/dim tiers read too
+     faint on --bg (labels like VOL 24H / ENTRY / LEVERAGE, nav items, axis
+     text). Contrast vs --bg: secondary 4.99->7.00, muted 2.28->4.62 (now clears
+     WCAG AA), dim 1.46->2.55. Hierarchy (text > secondary > muted > dim) and the
+     cool-gray hue are preserved. */
+  --text-secondary: #9499B0;
+  --text-muted: #737997;
+  --text-dim: #4C5268;
 
   --long: #14F195;
   --short: #FF3B5C;

--- a/app/hooks/useChartTheme.ts
+++ b/app/hooks/useChartTheme.ts
@@ -19,7 +19,10 @@ export interface ChartTheme {
 
 const DARK_THEME: ChartTheme = {
   bg: "#0D0D0F",
-  textColor: "rgba(255,255,255,0.45)",
+  // Bumped 0.45 → 0.60 for legibility — the axis price/time labels read too
+  // faint (effective contrast on the chart bg ~4.3 → ~7.1, matching the
+  // brightened --text-secondary in globals.css).
+  textColor: "rgba(255,255,255,0.60)",
   // Grid bumped from 0.04 → 0.07 and border from 0.06 → 0.10 — the
   // earlier alphas sat at the very floor of what professional trading
   // UIs use (Bloomberg / TradingView / Binance run grids around 0.06–
@@ -27,7 +30,7 @@ const DARK_THEME: ChartTheme = {
   // give the panel a defined edge without competing with the data.
   // Indicator reference lines (RSI 30/70, MACD signal) derive from
   // textColor at ~25% / 75% alpha, which after multiplying through
-  // textColor's own 0.45 lands at ~0.11 / ~0.34 effective — still
+  // textColor's own 0.60 lands at ~0.15 / ~0.45 effective — still
   // clearly above this 0.07 grid, so the hierarchy holds.
   gridColor: "rgba(255,255,255,0.07)",
   borderColor: "rgba(255,255,255,0.10)",


### PR DESCRIPTION
## Problem

The dim dark-mode text tiers read too faint on the dark bg — labels like **VOL 24H / OPEN INTEREST / ENTRY / LEVERAGE / FEES**, nav items, filter chips, and the chart's axis numbers were hard to see. Two of the tiers were even **failing WCAG AA**.

## Fix

**`globals.css`** — dark `:root` tokens (affect every HTML label site-wide). Contrast vs `--bg`:

| token | old | new | contrast |
|---|---|---|---|
| `--text-secondary` | `#7A7F96` | `#9499B0` | 4.99 → **7.00** |
| `--text-muted` | `#454B5F` | `#737997` | 2.28 → **4.62** (now clears AA) |
| `--text-dim` | `#2A2E3D` | `#4C5268` | 1.46 → **2.55** |

Hierarchy (`text > secondary > muted > dim`) and the cool-gray hue are preserved; `--text` and the light-mode tokens are untouched.

**`useChartTheme.ts`** — the chart's axis labels are canvas-drawn, so the CSS token can't reach them. Bumped `DARK_THEME.textColor` white `0.45 → 0.60` (effective ~4.3 → ~7.1 on the chart bg). The RSI/MACD reference lines derived from it rise to ~0.15/0.45 effective — still above the 0.07 grid, so the chart hierarchy holds.

## Testing

- `tsc --noEmit` clean.
- Before/after on `/markets`: nav ("Earn", "Create a Market"), the subtitle, search placeholder, and every filter/stat label are clearly more legible — without looking washed out.
- Chart-axis bump verified by contrast math (the terminal needs live data to render, so it's best confirmed on the deployed playground).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
