### PR TITLE
fix(portfolio): exclude closed (size-0) positions from the dashboard Overview

### DIFF
--- a/app/__tests__/hooks/isOpenPosition.test.ts
+++ b/app/__tests__/hooks/isOpenPosition.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { isOpenPosition, type PortfolioPosition } from "@/hooks/usePortfolio";
+
+// isOpenPosition only reads `pos.account?.positionSize`, so a minimal shape is
+// enough to lock the open/closed boundary that the dashboard counts depend on.
+const pos = (positionSize: bigint | undefined, capital = 0n): PortfolioPosition =>
+  ({ account: positionSize === undefined ? undefined : { positionSize, capital } } as unknown as PortfolioPosition);
+
+describe("isOpenPosition", () => {
+  it("is true for an open long (positive size)", () => {
+    expect(isOpenPosition(pos(5_000n))).toBe(true);
+  });
+
+  it("is true for an open short (negative size)", () => {
+    expect(isOpenPosition(pos(-5_000n))).toBe(true);
+  });
+
+  it("is FALSE for a closed/flat position (size 0) — the reported bug", () => {
+    // A position the user closed still has a portfolio account with size 0;
+    // it must NOT count as open.
+    expect(isOpenPosition(pos(0n))).toBe(false);
+  });
+
+  it("is FALSE for a funded-but-flat account (idle deposit: size 0, capital > 0)", () => {
+    // Idle capital in a closed market is not an open position — it belongs in
+    // the idle-deposits surface, not the open-positions count.
+    expect(isOpenPosition(pos(0n, 1_000_000n))).toBe(false);
+  });
+
+  it("is FALSE when the account is missing entirely", () => {
+    expect(isOpenPosition(pos(undefined))).toBe(false);
+  });
+
+  it("filters a mixed book down to only the open positions", () => {
+    const book = [pos(5_000n), pos(0n, 1_000_000n), pos(-3_000n), pos(0n)];
+    expect(book.filter(isOpenPosition)).toHaveLength(2);
+  });
+});

--- a/app/components/dashboard/DashboardHeader.tsx
+++ b/app/components/dashboard/DashboardHeader.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { usePortfolio } from "@/hooks/usePortfolio";
+import { usePortfolio, isOpenPosition } from "@/hooks/usePortfolio";
 import { useWalletCompat } from "@/hooks/useWalletCompat";
 import { formatTokenAmount } from "@/lib/format";
 import { useState } from "react";
@@ -40,7 +40,9 @@ export function DashboardHeader() {
   const address = publicKey?.toBase58() ?? "";
   const totalValue = portfolio.totalValue ?? 0n;
   const totalPnl = portfolio.totalUnrealizedPnl ?? 0n;
-  const positionCount = portfolio.positions?.length ?? 0;
+  // Count OPEN positions only — a closed (size-0 "Flat") position still has a
+  // portfolio account and would otherwise inflate the "Active Positions" stat.
+  const positionCount = (portfolio.positions ?? []).filter(isOpenPosition).length;
 
   const displayValue = totalValue > 0n
     ? formatTokenAmount(totalValue)

--- a/app/components/dashboard/PnlChart.tsx
+++ b/app/components/dashboard/PnlChart.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { usePortfolio } from "@/hooks/usePortfolio";
+import { usePortfolio, isOpenPosition } from "@/hooks/usePortfolio";
 
 /**
  * PnL Chart — shows real portfolio PnL.
@@ -15,12 +15,16 @@ export function PnlChart() {
   const [range, setRange] = useState<typeof ranges[number]>("7D");
   const { totalUnrealizedPnl, positions, loading } = usePortfolio();
 
+  // Only OPEN positions contribute PnL — exclude closed (size-0 "Flat") ones so
+  // the "Across N positions" caption matches the real open-position count.
+  const openPositions = positions.filter(isOpenPosition);
+
   // Use totalUnrealizedPnl (mark-to-market, already guarded against u64::MAX sentinels)
   // rather than totalPnl (raw account.pnl sum) which can contain uninitialized sentinel
   // values producing septillion-dollar overflow display (GH#1352).
   const pnlFloat = Number(totalUnrealizedPnl) / 1e6;
   const isPositive = pnlFloat >= 0;
-  const hasData = positions.length > 0;
+  const hasData = openPositions.length > 0;
 
   return (
     <div className="border border-[var(--border)] bg-[var(--panel-bg)]">
@@ -62,7 +66,7 @@ export function PnlChart() {
               {isPositive ? "+" : ""}${Math.abs(pnlFloat).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
             </p>
             <p className="mt-1 text-[9px] text-[var(--text-secondary)]">
-              Across {positions.length} position{positions.length !== 1 ? "s" : ""} • Historical chart coming soon
+              Across {openPositions.length} position{openPositions.length !== 1 ? "s" : ""} • Historical chart coming soon
             </p>
           </div>
         )}

--- a/app/components/dashboard/PositionSummary.tsx
+++ b/app/components/dashboard/PositionSummary.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { usePortfolio, getLiquidationSeverity, type PortfolioPosition } from "@/hooks/usePortfolio";
+import { usePortfolio, getLiquidationSeverity, isOpenPosition, type PortfolioPosition } from "@/hooks/usePortfolio";
 import { formatTokenAmount, formatUsdPriceE6 } from "@/lib/format";
 import { useMultiTokenMeta } from "@/hooks/useMultiTokenMeta";
 
@@ -179,7 +179,9 @@ export function PositionSummary() {
   const { connected } = useWalletCompat();
   const portfolio = usePortfolio();
 
-  const positions = (portfolio.positions ?? []) as PortfolioPosition[];
+  // Only OPEN positions — exclude closed (size-0 "Flat") ones that still have a
+  // portfolio account, so a market you've closed doesn't linger in the list/count.
+  const positions = ((portfolio.positions ?? []) as PortfolioPosition[]).filter(isOpenPosition);
   const loading = portfolio.loading;
 
   // v17 markets return an empty `market.config` from the SDK (real value in

--- a/app/components/dashboard/StatsBar.tsx
+++ b/app/components/dashboard/StatsBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { usePortfolio } from "@/hooks/usePortfolio";
+import { usePortfolio, isOpenPosition } from "@/hooks/usePortfolio";
 
 function formatUsd(val: number): string {
   if (val === 0) return "--";
@@ -15,7 +15,14 @@ function formatTradeFeeBps(bps: bigint): string {
 }
 
 export function StatsBar() {
-  const { positions, loading } = usePortfolio();
+  const { positions: allPositions, loading } = usePortfolio();
+
+  // Stats reflect OPEN positions only — closed (size-0 "Flat") positions still
+  // carry a portfolio account and would otherwise skew the "empty state" checks
+  // and per-market fee readout. Memoized so downstream memos stay referentially
+  // stable across renders. (Win/loss already ignore flat rows via the >0/<0 PnL
+  // test; this also fixes the length-based cases below.)
+  const positions = useMemo(() => allPositions.filter(isOpenPosition), [allPositions]);
 
   // Calculate real stats from portfolio positions (memoized — pure over `positions`)
   const { totalPnl, wins, losses, total, winRate } = useMemo(() => {

--- a/app/hooks/usePortfolio.ts
+++ b/app/hooks/usePortfolio.ts
@@ -258,6 +258,20 @@ export function getLiquidationSeverity(distancePct: number): LiquidationSeverity
 }
 
 /**
+ * True when a position is actually OPEN (non-zero size).
+ * `usePortfolio().positions` also includes closed positions that still have a
+ * portfolio account in that market (size 0, "Flat" — often holding idle
+ * capital): those must be excluded from any "open positions" count/list, or a
+ * market you've closed keeps showing as an active position. Keyed on
+ * `account.positionSize` to match the canonical open/idle split already used by
+ * PortfolioPositionsView and the site-wide PositionsBar, so every
+ * open-position surface agrees.
+ */
+export function isOpenPosition(pos: PortfolioPosition): boolean {
+  return (pos.account?.positionSize ?? 0n) !== 0n;
+}
+
+/**
  * Map a parsed v17 portfolio into an enriched PortfolioPosition (liq price, PnL,
  * leverage). Shared by the owner-scan path and the NFT-wrapped recovery scan so
  * both surface identical rows. `nftWrapped` flags escrowed positions for the UI.


### PR DESCRIPTION
## Problem

A closed position still has a portfolio account in its market — `positionSize == 0`, rendered **Flat**, and often still holding idle capital — so `usePortfolio().positions` returns it. The dashboard **Overview** consumed that raw array **unfiltered**, so a market the user had closed kept appearing as an active position:

- **Open Positions** listed a `Flat` row for the closed market and its count was inflated (`(2)` with one real position).
- **Active Positions** stat showed `2`.
- **Portfolio PnL** read "Across 2 positions".

Repro: open a position, close it, open `/portfolio` → the closed market still shows under Open Positions with `Size 0`.

## Root cause

The canonical open/flat split already exists in the codebase — `PortfolioPositionsView` separates open positions from idle deposits with `account.positionSize !== 0n`, and the site-wide `PositionsBar` filters the same way. The **dashboard** components just never applied it; they mapped/counted `portfolio.positions` directly.

## Fix

Add a single shared helper in `usePortfolio` and apply it everywhere the Overview counts or lists positions:

```ts
export function isOpenPosition(pos: PortfolioPosition): boolean {
  return (pos.account?.positionSize ?? 0n) !== 0n;
}
```

Keyed on `account.positionSize` to match the existing canonical definition (`PortfolioPositionsView`, `PositionsBar`) so **every** open-position surface agrees — no third variant.

Applied in the four Overview components:

| component | before | after |
|---|---|---|
| `PositionSummary` | list + count over all accounts | filtered to open |
| `DashboardHeader` | `positions.length` | open-only count |
| `PnlChart` | "Across N positions" / empty gate over all | open-only |
| `StatsBar` | stats + fee readout + empty checks over all | open-only (memoized) |

**Design notes**
- Filtering is **consumer-side**, not at the hook — surfaces that legitimately need every account (idle deposits, my-markets) are untouched, so there's no blast radius.
- A **funded-but-flat** account (idle deposit) is correctly *not* counted as open; it belongs to the idle-deposits surface.
- An **all-flat** book now renders the correct empty state instead of phantom positions.
- `StatsBar`'s win/loss already ignored flat rows via the `>0/<0` PnL test; this additionally corrects the length-based empty checks and per-market fee readout, and the filtered list is memoized to stay referentially stable.

## Testing

- `tsc --noEmit` clean.
- New `isOpenPosition` unit suite — **6/6**: open long, open short, closed (size 0), funded-but-flat idle deposit, missing account, and a mixed-book filter.
- No regressions: the only failing test in the portfolio suite (`PORT-007: AtRiskBanner`) reproduces **identically on the untouched baseline**, so it's pre-existing and unrelated to this change.
- Note: the dashboard needs live wallet/market data to fully render, so the end-to-end visual is best confirmed on the deployed playground; the logic is covered by the unit test above and matches the already-shipped `PortfolioPositionsView` / `PositionsBar` behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
