### PR TITLE
Validate market symbol/name on the live registration path

### DIFF
--- a/app/__tests__/api/keeper-register-metadata-route-enforcement.test.ts
+++ b/app/__tests__/api/keeper-register-metadata-route-enforcement.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Regression: the metadata validator must be ENFORCED BY THE ROUTE, not merely
+ * exist as a library.
+ *
+ * keeper-register-metadata-validation.test.ts covers lib/market-metadata-validation
+ * in isolation. That unit alone cannot fail if the guard is deleted from
+ * app/api/playground/keeper-register/route.ts — i.e. it does not bind the actual
+ * fix for GH#2466, which is the WIRING of that validator into the live path.
+ *
+ * This test drives the real route handler: an impersonation payload must be
+ * rejected with 400 and the validator's own error text, before any registry
+ * write. Deleting the guard from the route makes this fail (the request instead
+ * falls through to the H1 auth check), which is exactly the binding the unit
+ * test is missing.
+ */
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// The route reads NETWORK at module scope — must be devnet before the import.
+const prevNetwork = process.env.NEXT_PUBLIC_DEFAULT_NETWORK;
+process.env.NEXT_PUBLIC_DEFAULT_NETWORK = "devnet";
+afterAll(() => {
+  process.env.NEXT_PUBLIC_DEFAULT_NETWORK = prevNetwork;
+});
+
+// Any registry write is a failure for this test: the guard runs before them.
+const blobPut = vi.fn(async () => ({ url: "https://blob.invalid/x" }));
+const supabaseUpsert = vi.fn(async () => ({ error: null }));
+
+vi.mock("@vercel/blob", () => ({
+  put: blobPut,
+  list: vi.fn(async () => ({ blobs: [] })),
+  head: vi.fn(async () => null),
+  del: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  getServerNetwork: () => "devnet",
+  getServiceClient: () => ({
+    from: () => ({
+      upsert: supabaseUpsert,
+      select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null, error: null }) }) }),
+    }),
+  }),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+const { POST } = await import("@/app/api/playground/keeper-register/route");
+
+// Real base58 pubkeys so the route's address validation passes and execution
+// reaches the metadata guard.
+const SLAB = "DJ54k4wH92NTtNP8RuHAwG8si1bevXEknzctDdqYN8eC";
+const POOL = "LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo";
+
+const post = (body: Record<string, unknown>) =>
+  POST(
+    new NextRequest("http://localhost/api/playground/keeper-register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ slabAddress: SLAB, dexPoolAddress: POOL, ...body }),
+    }),
+  );
+
+describe("keeper-register enforces market-metadata validation on the live path", () => {
+  beforeEach(() => {
+    blobPut.mockClear();
+    supabaseUpsert.mockClear();
+  });
+
+  const cp = (n: number) => String.fromCodePoint(n);
+
+  const cases: Array<[string, Record<string, unknown>, RegExp]> = [
+    ["body symbol — Cyrillic homoglyph", { symbol: "ЅОL" }, /Invalid symbol/],
+    ["body label — RTL override", { label: "SOL/USD Perpetual" + cp(0x202e) }, /Invalid name/],
+    ["payload.symbol — overlong", { payload: { symbol: "A".repeat(21) } }, /Invalid symbol/],
+    ["payload.name — zero-width", { payload: { name: "SOL" + cp(0x200b) + "/USD" } }, /Invalid name/],
+    ["payload.name — control char", { payload: { name: "SOL/USD\x00" } }, /Invalid name/],
+  ];
+
+  it.each(cases)("rejects %s with 400 and writes nothing", async (_label, body, expected) => {
+    const res = await post(body);
+    expect(res.status).toBe(400);
+    expect(String(((await res.json()) as { error?: string }).error)).toMatch(expected);
+    expect(blobPut).not.toHaveBeenCalled();
+    expect(supabaseUpsert).not.toHaveBeenCalled();
+  });
+
+  it("does not reject legitimate metadata at the metadata guard", async () => {
+    const res = await post({ symbol: "SOL", label: "Solana Perpetual" });
+    // It must get PAST the metadata guard. It is then stopped by H1 auth
+    // (no deployer/signature), which is a different, non-400-metadata outcome.
+    if (res.status === 400) {
+      const err = String(((await res.json()) as { error?: string }).error);
+      expect(err).not.toMatch(/Invalid symbol|Invalid name/);
+    }
+  });
+});

--- a/app/__tests__/api/keeper-register-metadata-validation.test.ts
+++ b/app/__tests__/api/keeper-register-metadata-validation.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Regression: market metadata validation on the LIVE registration path.
+ *
+ * The market-creation wizard registers a market by POSTing user-supplied
+ * `symbol`/`name` to /api/playground/keeper-register (useCreateMarket.ts). That
+ * route previously wrote the market row (and the Blob registry) after only a
+ * non-empty-string check:
+ *
+ *     const str = (v) => (typeof v === "string" && v.length > 0 ? v : null);
+ *
+ * i.e. any non-empty string was accepted, so a market creator could impersonate
+ * a real market's name/ticker with homoglyph / bidi / zero-width / control /
+ * overlong values. The full validation only existed on the now-dead
+ * POST /api/markets path.
+ *
+ * The fix extracts that validation into lib/market-metadata-validation (the
+ * single source of truth) and applies it on keeper-register before any write.
+ * This test asserts the shared validator REJECTS the impersonation corpus that
+ * the old non-empty gate ACCEPTED, and accepts legitimate metadata.
+ */
+import { describe, it, expect } from "vitest";
+import { checkSymbol, checkName } from "@/lib/market-metadata-validation";
+
+// The old live gate (keeper-register): any non-empty string passed.
+const oldGateAccepts = (v: unknown): boolean => typeof v === "string" && v.length > 0;
+
+const cp = (n: number) => String.fromCodePoint(n);
+
+describe("shared market-metadata validator rejects impersonation the old gate accepted", () => {
+  const symbolAttacks: Array<[string, string]> = [
+    ["Cyrillic homoglyph ticker", "ЅОL"],          // non-ASCII lookalike of "SOL"
+    ["ticker with spaces", "SOL PERP"],
+    ["markup-injection ticker", "<script>"],
+    ["overlong ticker (>20)", "A".repeat(21)],
+  ];
+
+  it.each(symbolAttacks)("symbol: %s", (_label, attack) => {
+    expect(oldGateAccepts(attack)).toBe(true);        // old path accepted it
+    expect(checkSymbol(attack).ok).toBe(false);        // shared validator rejects it
+  });
+
+  const nameAttacks: Array<[string, string]> = [
+    ["RTL-override name", "SOL/USD Perpetual" + cp(0x202e)],
+    ["zero-width-joined name", "SOL" + cp(0x200b) + "/USD"],
+    ["null-byte name", "SOL/USD\x00"],
+    ["ANSI-escape name", "\x1b[31mSOL/USD\x1b[0m"],
+    ["overlong name (>64)", "A".repeat(65)],
+    ["whitespace-only name", "   "],
+  ];
+
+  it.each(nameAttacks)("name: %s", (_label, attack) => {
+    expect(oldGateAccepts(attack)).toBe(true);        // old path accepted it
+    expect(checkName(attack).ok).toBe(false);          // shared validator rejects it
+  });
+
+  it("accepts legitimate metadata (no false positives)", () => {
+    for (const sym of ["SOL", "BTC", "mSOL", "USD-C", "BTC.b"]) {
+      expect(checkSymbol(sym).ok).toBe(true);
+    }
+    for (const nm of ["Solana Perpetual", "Wrapped BTC / USD", "Café Coin", "柴犬", "Doge 🐕"]) {
+      expect(checkName(nm).ok).toBe(true);
+    }
+  });
+});

--- a/app/app/api/markets/route.ts
+++ b/app/app/api/markets/route.ts
@@ -21,7 +21,7 @@ import { getKnownMarketLpCapitals, scanEnabledMarketLpCapitals } from "@/lib/lp-
 import { loadMergedMarketRows } from "@/lib/market-registry";
 import { isPhantomOpenInterest, MIN_VAULT_FOR_OI } from "@/lib/phantom-oi";
 import { computeDisplayOiUsd } from "@/lib/oi-display";
-import { hasInvisibleOrBidi } from "@/lib/text-safety";
+import { validateSymbol, validateName } from "@/lib/market-metadata-validation";
 import { sanitizeLogoUrl } from "@/lib/token-metadata-validators";
 import { computeMarketHealthFromStats } from "@/lib/health";
 import { BLOCKED_SLAB_ADDRESSES } from "@/lib/blocklist";
@@ -1474,41 +1474,18 @@ export async function POST(req: NextRequest) {
 
   // GH#1963: Validate symbol — alphanumeric + dash/dot/underscore, 1–20 chars.
   // Prevents deceptive or garbage metadata from entering the registry.
-  const SYMBOL_RE = /^[A-Za-z0-9._\-]{1,20}$/;
-  const resolvedSymbol: string = symbol || mint_address.slice(0, 4).toUpperCase();
-  if (!SYMBOL_RE.test(resolvedSymbol)) {
-    return NextResponse.json(
-      { error: "Invalid symbol: must be 1–20 chars, alphanumeric/dash/dot/underscore only" },
-      { status: 400 }
-    );
+  const symbolCheck = validateSymbol(symbol, mint_address.slice(0, 4).toUpperCase());
+  if (!symbolCheck.ok) {
+    return NextResponse.json({ error: symbolCheck.error }, { status: 400 });
   }
+  const resolvedSymbol: string = symbolCheck.value!;
 
   // GH#1963: Validate name — printable ASCII, 1–64 chars.
-  const resolvedName: string = name || `Token ${mint_address.slice(0, 8)}`;
-  if (typeof resolvedName !== "string" || resolvedName.trim().length === 0 || resolvedName.length > 64) {
-    return NextResponse.json(
-      { error: "Invalid name: must be 1–64 characters" },
-      { status: 400 }
-    );
+  const nameCheck = validateName(name, `Token ${mint_address.slice(0, 8)}`);
+  if (!nameCheck.ok) {
+    return NextResponse.json({ error: nameCheck.error }, { status: 400 });
   }
-  // Reject control characters and non-printable chars.
-  // eslint-disable-next-line no-control-regex
-  if (/[\x00-\x1f\x7f]/.test(resolvedName)) {
-    return NextResponse.json(
-      { error: "Invalid name: must not contain control characters" },
-      { status: 400 }
-    );
-  }
-  // SEC: reject invisible / bidirectional / format characters (RTL overrides,
-  // zero-width chars, etc.) \u2014 the name-impersonation vectors the sweep
-  // flagged. These are NOT control chars (they passed the check above).
-  // Visible Unicode (accents, CJK, emoji) stays allowed. See hasInvisibleOrBidi.
-  if (hasInvisibleOrBidi(resolvedName)) {
-    return NextResponse.json(
-      { error: "Invalid name: must not contain invisible or bidirectional formatting characters" },
-      { status: 400 }
-    );
-  }
+  const resolvedName: string = nameCheck.value!;
 
   // SEC: sanitize the attacker-suppliable logo_url with the SAME allowlist
   // (https/ipfs only, ≤500 chars) that external-API metadata already gets —

--- a/app/app/api/playground/keeper-register/route.ts
+++ b/app/app/api/playground/keeper-register/route.ts
@@ -105,6 +105,7 @@ import { getServiceClient, getServerNetwork } from "@/lib/supabase";
 import { resolveTokenLogo } from "@/lib/token-logo";
 import { sanitizeLogoUrl } from "@/lib/token-metadata-validators";
 import { upsertRegisteredMarketRow, type RegistrationRow } from "@/lib/market-registration";
+import { checkSymbol, checkName } from "@/lib/market-metadata-validation";
 
 export const dynamic = "force-dynamic";
 
@@ -247,6 +248,32 @@ export async function POST(req: NextRequest) {
   if (mainnetCA) {
     try { new PublicKey(mainnetCA); } catch {
       return NextResponse.json({ error: "Invalid mainnetCA" }, { status: 400 });
+    }
+  }
+
+  // SEC: validate all caller-supplied metadata BEFORE it can reach the markets
+  // DB row (upsertRegisteredMarketRow) or the Blob registry
+  // (upsertRegisteredMarket). `symbol`/`label` (body) and `payload.symbol`/
+  // `payload.name` are attacker-controllable and are rendered as the market's
+  // identity across the UI; without this, deceptive names (homoglyph / RTL /
+  // zero-width), control characters, or overlong values could impersonate a
+  // real market. This mirrors the guards the removed POST /api/markets path
+  // enforced (see lib/market-metadata-validation). Server-derived fallbacks
+  // ("UNKNOWN", the derived label, `Market <slab>`) are safe and unvalidated;
+  // the retry path sends nulls here and is unaffected.
+  {
+    const payloadMeta = (payload ?? {}) as Record<string, unknown>;
+    const metaFields: Array<[unknown, "symbol" | "name"]> = [
+      [symbol, "symbol"],
+      [payloadMeta.symbol, "symbol"],
+      [label, "name"],
+      [payloadMeta.name, "name"],
+    ];
+    for (const [raw, kind] of metaFields) {
+      if (typeof raw === "string" && raw.length > 0) {
+        const res = kind === "symbol" ? checkSymbol(raw) : checkName(raw);
+        if (!res.ok) return NextResponse.json({ error: res.error }, { status: 400 });
+      }
     }
   }
 

--- a/app/lib/market-metadata-validation.ts
+++ b/app/lib/market-metadata-validation.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared validation for market `symbol` / `name` metadata.
+ *
+ * On the permissionless launch surface these fields are caller-supplied and are
+ * rendered as the market's identity across the UI, so they must reject deceptive
+ * or malformed values before being stored:
+ *   - symbol: 1–20 chars, alphanumeric / dash / dot / underscore only
+ *   - name:   1–64 chars, no control chars, no invisible / bidirectional
+ *             formatting chars (RTL overrides, zero-width, etc.)
+ *
+ * This is the single source of truth. It previously lived inline on the
+ * POST /api/markets path only; the launch flow now registers via
+ * /api/playground/keeper-register, which must apply the same guards so the two
+ * paths cannot drift.
+ */
+import { hasInvisibleOrBidi } from "@/lib/text-safety";
+
+export const SYMBOL_RE = /^[A-Za-z0-9._\-]{1,20}$/;
+export const NAME_MAX_LEN = 64;
+
+export type MetadataCheck = { ok: true } | { ok: false; error: string };
+
+/** Validate an already-resolved symbol string. */
+export function checkSymbol(value: string): MetadataCheck {
+  if (!SYMBOL_RE.test(value)) {
+    return {
+      ok: false,
+      error: "Invalid symbol: must be 1–20 chars, alphanumeric/dash/dot/underscore only",
+    };
+  }
+  return { ok: true };
+}
+
+/** Validate an already-resolved name/label string. */
+export function checkName(value: string): MetadataCheck {
+  if (typeof value !== "string" || value.trim().length === 0 || value.length > NAME_MAX_LEN) {
+    return { ok: false, error: "Invalid name: must be 1–64 characters" };
+  }
+  // Reject control / non-printable characters.
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1f\x7f]/.test(value)) {
+    return { ok: false, error: "Invalid name: must not contain control characters" };
+  }
+  // Reject invisible / bidirectional formatting characters (RTL overrides,
+  // zero-width, etc.) — the name-impersonation vectors. Visible Unicode
+  // (accents, CJK, emoji) stays allowed.
+  if (hasInvisibleOrBidi(value)) {
+    return {
+      ok: false,
+      error: "Invalid name: must not contain invisible or bidirectional formatting characters",
+    };
+  }
+  return { ok: true };
+}
+
+/** Resolve `raw` (or `fallback` when raw is empty/absent), then validate as a symbol. */
+export function validateSymbol(
+  raw: unknown,
+  fallback: string,
+): { ok: boolean; error?: string; value?: string } {
+  const resolved = typeof raw === "string" && raw.length > 0 ? raw : fallback;
+  const r = checkSymbol(resolved);
+  return r.ok ? { ok: true, value: resolved } : { ok: false, error: r.error };
+}
+
+/** Resolve `raw` (or `fallback` when raw is empty/absent), then validate as a name. */
+export function validateName(
+  raw: unknown,
+  fallback: string,
+): { ok: boolean; error?: string; value?: string } {
+  const resolved = typeof raw === "string" && raw.length > 0 ? raw : fallback;
+  const r = checkName(resolved);
+  return r.ok ? { ok: true, value: resolved } : { ok: false, error: r.error };
+}


### PR DESCRIPTION
## What

Validate market `symbol`/`name` on the live registration path
(`/api/playground/keeper-register`), closing a metadata-impersonation gap where a
market creator could store deceptive names/tickers (homoglyph / RTL-override /
zero-width names, control characters, or overlong values).

Closes #2466.

## Why

The launch flow registers markets via `keeper-register`, which wrote the `markets`
row **and** the Blob registry after only a non-empty-string check. The symbol/name
validation lived solely on the now-unused `POST /api/markets` path, so it was dead
code on the live path. Both the top-level `symbol`/`label` body fields and
`payload.symbol`/`payload.name` are caller-controlled and reach both stores.

## Changes

- **`lib/market-metadata-validation` (new)** — single source of truth:
  `checkSymbol`/`checkName` plus `validateSymbol`/`validateName`
  resolve-then-validate wrappers. Rules are unchanged from the original create
  path: symbol 1–20 `[A-Za-z0-9._-]`; name 1–64, no control chars, no
  invisible/bidirectional formatting chars (visible Unicode — accents, CJK, emoji
  — still allowed).
- **`keeper-register`** — validate `symbol`/`label` (body) and
  `payload.symbol`/`payload.name` before any write; return HTTP 400 on invalid
  input. Server-derived fallbacks (`"UNKNOWN"`, the derived label,
  `Market <slab>`) are safe and unvalidated; the retry path (which sends nulls) is
  unaffected.
- **`POST /api/markets`** — refactored to consume the shared validator
  (behavior- and message-preserving) so the two paths cannot drift again.
- **Regression test** — asserts the shared validator rejects the impersonation
  corpus the previous non-empty gate accepted, and accepts legitimate metadata.

## Testing

- `npx tsc --noEmit` — clean.
- New test + existing `gh1963-markets-input-validation` + `text-safety` — 45/45 pass.
- Market/registration cluster (markets-deployer-auth, markets-post-leverage-guard,
  useCreateMarket-keeper-register, keeper-register-concurrency-race,
  market-registration, mobile-create-market-blockhash-recovery) — 48/48 pass.
- Full suite otherwise green; the single unrelated failure
  (`blocklist-indexer-sync`, a pre-existing cross-repo blocklist drift) is
  untouched by this change.

## Notes

- Frontend + devnet scope only; no program, keeper, or mainnet changes.
- App output is already React-escaped, so this addresses **impersonation**, not
  script injection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added consistent validation for market symbols and names across registration flows.
  * Market metadata now rejects unsafe characters, invisible formatting, impersonation patterns, blank values, and excessive lengths.
  * Invalid metadata is clearly rejected before registration data is saved.

* **Tests**
  * Added regression coverage confirming malformed metadata is rejected and valid metadata remains accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->