### PR TITLE
Add per-IP rate limiting to the devnet fund endpoints

### DIFF
--- a/app/__tests__/api/fund-endpoints-ip-rate-limit-route-enforcement.test.ts
+++ b/app/__tests__/api/fund-endpoints-ip-rate-limit-route-enforcement.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Regression: the shared per-IP fund limiter must be ENFORCED BY EACH ROUTE.
+ *
+ * fund-endpoints-ip-rate-limit.test.ts exercises createUpstashRateLimiter in
+ * isolation (a different prefix) and imports none of the routes, so deleting the
+ * checkFundRateLimit guard from the four fund endpoints leaves it green — it does
+ * not bind the fix for GH#2471, which is the WIRING of the limiter into each route.
+ *
+ * This drives each real POST handler with the limiter mocked to DENY, and asserts
+ * a 429 with Retry-After before any spend. Deleting the guard from a route makes
+ * that route reach the (mocked-to-throw) Connection instead — i.e. it fails.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const checkFundRateLimit = vi.fn(async () => ({ allowed: false, retryAfter: 42 }));
+vi.mock("@/lib/fund-ip-rate-limit", () => ({ checkFundRateLimit }));
+
+// The guard must run before any of this is touched; if a route reaches these,
+// the guard is in the wrong place (or absent).
+vi.mock("@solana/web3.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@solana/web3.js")>();
+  return {
+    ...actual,
+    Connection: class {
+      requestAirdrop() { throw new Error("spend reached despite rate limit"); }
+      getAccountInfo() { throw new Error("spend reached despite rate limit"); }
+      getBalance() { throw new Error("spend reached despite rate limit"); }
+      getLatestBlockhash() { throw new Error("spend reached despite rate limit"); }
+    },
+  };
+});
+
+vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn(), captureMessage: vi.fn() }));
+
+process.env.NEXT_PUBLIC_DEFAULT_NETWORK = "devnet";
+
+const ROUTES: Array<[string, string]> = [
+  ["/api/faucet", "@/app/api/faucet/route"],
+  ["/api/playground/faucet", "@/app/api/playground/faucet/route"],
+  ["/api/auto-fund", "@/app/api/auto-fund/route"],
+  ["/api/devnet-airdrop", "@/app/api/devnet-airdrop/route"],
+];
+
+describe("fund endpoints enforce the shared per-IP limit", () => {
+  beforeEach(() => { checkFundRateLimit.mockClear(); });
+
+  it.each(ROUTES)("%s returns 429 when the shared limiter denies", async (_path, mod) => {
+    const { POST } = (await import(mod)) as { POST: (req: NextRequest) => Promise<Response> };
+    const res = await POST(
+      new NextRequest("http://localhost/x", {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-forwarded-for": "203.0.113.7" },
+        body: JSON.stringify({
+          wallet: "DJ54k4wH92NTtNP8RuHAwG8si1bevXEknzctDdqYN8eC",
+          walletAddress: "DJ54k4wH92NTtNP8RuHAwG8si1bevXEknzctDdqYN8eC",
+          mintAddress: "So11111111111111111111111111111111111111112",
+          type: "sol",
+        }),
+      }),
+    );
+
+    expect(checkFundRateLimit).toHaveBeenCalled();
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("42");
+  });
+});

--- a/app/__tests__/api/fund-endpoints-ip-rate-limit.test.ts
+++ b/app/__tests__/api/fund-endpoints-ip-rate-limit.test.ts
@@ -1,0 +1,53 @@
+/**
+ * PoC + regression — fund endpoints must be rate-limited per-IP, not only per-wallet.
+ *
+ * /api/faucet, /api/playground/faucet, /api/auto-fund and /api/devnet-airdrop each
+ * gate on the caller-supplied WALLET only (1 claim per wallet per window). Every
+ * mint/airdrop spends the shared DEVNET_MINT_AUTHORITY_KEYPAIR's SOL, so an
+ * attacker generating fresh keypairs bypasses the gate entirely and can drain the
+ * shared signer (playground-wide DoS) — unlike /api/devnet-mirror-mint, which
+ * already applies a per-IP limit.
+ *
+ * This shows a per-wallet gate lets one IP make unlimited claims via fresh
+ * wallets, while a per-IP limiter (the fix, reusing the app's own
+ * createUpstashRateLimiter) caps one IP regardless of wallet.
+ */
+import { describe, it, expect } from "vitest";
+import { createUpstashRateLimiter } from "@/lib/upstash-rate-limit";
+
+describe("fund endpoints: per-IP rate limiting", () => {
+  it("a per-wallet gate lets ONE IP drain via fresh keypairs (the bug)", () => {
+    const claimedWallets = new Set<string>();
+    const perWalletGate = (wallet: string): boolean => {
+      if (claimedWallets.has(wallet)) return false; // already claimed this window
+      claimedWallets.add(wallet);
+      return true;
+    };
+    let allowed = 0;
+    // One attacker, one IP, 100 freshly-generated wallets:
+    for (let i = 0; i < 100; i++) if (perWalletGate(`freshWallet_${i}`)) allowed++;
+    expect(allowed).toBe(100); // every claim goes through — no per-IP bound
+  });
+
+  it("a per-IP limiter caps one IP regardless of wallet (the fix)", async () => {
+    // No Upstash env in tests → deterministic in-memory sliding window.
+    const limiter = createUpstashRateLimiter({ limit: 10, windowMs: 60_000, prefix: "rl:test-fund-poc" });
+    const attackerIp = "203.0.113.7";
+    let allowed = 0;
+    for (let i = 0; i < 100; i++) {
+      const r = await limiter.check(attackerIp); // wallet is irrelevant to the IP key
+      if (r.allowed) allowed++;
+    }
+    expect(allowed).toBe(10);          // hard per-IP cap holds
+    const after = await limiter.check(attackerIp);
+    expect(after.allowed).toBe(false);
+    expect(after.retryAfterSecs).toBeGreaterThan(0);
+  });
+
+  it("a different IP has its own independent budget", async () => {
+    const limiter = createUpstashRateLimiter({ limit: 10, windowMs: 60_000, prefix: "rl:test-fund-poc2" });
+    for (let i = 0; i < 10; i++) await limiter.check("198.51.100.1"); // exhaust IP A
+    const b = await limiter.check("198.51.100.2");                    // IP B unaffected
+    expect(b.allowed).toBe(true);
+  });
+});

--- a/app/app/api/auto-fund/route.ts
+++ b/app/app/api/auto-fund/route.ts
@@ -11,6 +11,8 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { getClientIp } from "@/lib/get-client-ip";
+import { checkFundRateLimit } from "@/lib/fund-ip-rate-limit";
 import { Connection, PublicKey, LAMPORTS_PER_SOL, Transaction } from "@solana/web3.js";
 import {
   getAssociatedTokenAddress,
@@ -64,6 +66,18 @@ export async function POST(req: NextRequest) {
       return NextResponse.json(
         { error: "Auto-fund only available on devnet" },
         { status: 403 },
+      );
+    }
+
+    // SEC: per-IP rate limit. The per-wallet gate below is trivially bypassed
+    // with fresh keypairs, and every mint/airdrop spends the shared
+    // DEVNET_MINT_AUTHORITY_KEYPAIR — bound the drain per IP (shared across the
+    // fund endpoints), mirroring /api/devnet-mirror-mint.
+    const fundRl = await checkFundRateLimit(getClientIp(req));
+    if (!fundRl.allowed) {
+      return NextResponse.json(
+        { error: "Too many requests. Please slow down and try again shortly." },
+        { status: 429, headers: { "Retry-After": String(fundRl.retryAfter) } },
       );
     }
 

--- a/app/app/api/devnet-airdrop/route.ts
+++ b/app/app/api/devnet-airdrop/route.ts
@@ -30,6 +30,8 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { getClientIp } from "@/lib/get-client-ip";
+import { checkFundRateLimit } from "@/lib/fund-ip-rate-limit";
 import {
   Connection,
   Keypair,
@@ -410,6 +412,18 @@ export async function POST(req: NextRequest) {
   try {
     if (NETWORK !== "devnet") {
       return NextResponse.json({ error: "Only available on devnet" }, { status: 403 });
+    }
+
+    // SEC: per-IP rate limit. The per-wallet:mint gate below is trivially bypassed
+    // with fresh keypairs, and every airdrop spends the shared
+    // DEVNET_MINT_AUTHORITY_KEYPAIR — bound the drain per IP (shared across the
+    // fund endpoints), mirroring /api/devnet-mirror-mint.
+    const fundRl = await checkFundRateLimit(getClientIp(req));
+    if (!fundRl.allowed) {
+      return NextResponse.json(
+        { error: "Too many requests. Please slow down and try again shortly." },
+        { status: 429, headers: { "Retry-After": String(fundRl.retryAfter) } },
+      );
     }
 
     const body = await req.json();

--- a/app/app/api/faucet/route.ts
+++ b/app/app/api/faucet/route.ts
@@ -21,6 +21,8 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { getClientIp } from "@/lib/get-client-ip";
+import { checkFundRateLimit } from "@/lib/fund-ip-rate-limit";
 import {
   Connection,
   PublicKey,
@@ -80,6 +82,18 @@ export async function POST(req: NextRequest) {
       return NextResponse.json(
         { error: "Faucet only available on devnet" },
         { status: 403 },
+      );
+    }
+
+    // SEC: per-IP rate limit. The per-wallet gate below is trivially bypassed
+    // with fresh keypairs, and every mint/airdrop spends the shared
+    // DEVNET_MINT_AUTHORITY_KEYPAIR — bound the drain per IP (shared across the
+    // fund endpoints), mirroring /api/devnet-mirror-mint.
+    const fundRl = await checkFundRateLimit(getClientIp(req));
+    if (!fundRl.allowed) {
+      return NextResponse.json(
+        { error: "Too many requests. Please slow down and try again shortly." },
+        { status: 429, headers: { "Retry-After": String(fundRl.retryAfter) } },
       );
     }
 

--- a/app/app/api/playground/faucet/route.ts
+++ b/app/app/api/playground/faucet/route.ts
@@ -28,6 +28,8 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { getClientIp } from "@/lib/get-client-ip";
+import { checkFundRateLimit } from "@/lib/fund-ip-rate-limit";
 import {
   Connection,
   PublicKey,
@@ -99,6 +101,18 @@ export async function POST(req: NextRequest) {
       return NextResponse.json(
         { error: "Playground faucet only available on devnet" },
         { status: 403 },
+      );
+    }
+
+    // SEC: per-IP rate limit. The per-wallet gate below is trivially bypassed
+    // with fresh keypairs, and every mint/airdrop spends the shared
+    // DEVNET_MINT_AUTHORITY_KEYPAIR — bound the drain per IP (shared across the
+    // fund endpoints), mirroring /api/devnet-mirror-mint.
+    const fundRl = await checkFundRateLimit(getClientIp(req));
+    if (!fundRl.allowed) {
+      return NextResponse.json(
+        { error: "Too many requests. Please slow down and try again shortly." },
+        { status: 429, headers: { "Retry-After": String(fundRl.retryAfter) } },
       );
     }
 

--- a/app/lib/fund-ip-rate-limit.ts
+++ b/app/lib/fund-ip-rate-limit.ts
@@ -1,0 +1,21 @@
+import { createUpstashRateLimiter } from "./upstash-rate-limit";
+
+/**
+ * Shared per-IP limit across ALL free-asset ("fund") endpoints — /api/faucet,
+ * /api/playground/faucet, /api/auto-fund and /api/devnet-airdrop. Each spends
+ * the shared DEVNET_MINT_AUTHORITY_KEYPAIR and gates only on the caller-supplied
+ * wallet, so without a per-IP bound one client can drain the shared signer by
+ * cycling fresh keypairs (playground-wide DoS). Mirrors the per-IP limit
+ * /api/devnet-mirror-mint already applies. Falls back to a per-instance in-memory
+ * window when Upstash is unconfigured (see upstash-rate-limit.ts).
+ */
+const rateLimiter = createUpstashRateLimiter({
+  limit: 10,
+  windowMs: 60_000,
+  prefix: "rl:devnet-fund",
+});
+
+export async function checkFundRateLimit(ip: string): Promise<{ allowed: boolean; retryAfter: number }> {
+  const res = await rateLimiter.check(ip);
+  return { allowed: res.allowed, retryAfter: res.retryAfterSecs };
+}


### PR DESCRIPTION
## What

Add per-IP rate limiting to the devnet fund endpoints so a client cannot drain the
shared mint authority by cycling fresh keypairs.

Closes #2471.

## Why

`/api/faucet`, `/api/playground/faucet`, `/api/auto-fund` and `/api/devnet-airdrop`
each gate only on the caller-supplied wallet. Every mint/airdrop spends the shared
`DEVNET_MINT_AUTHORITY_KEYPAIR`, so fresh keypairs bypass the gate and can exhaust
the shared signer's SOL — a playground-wide DoS (faucet, market-creation pre-fund,
and keeper co-sign then all fail). `/api/devnet-mirror-mint` already applies a
per-IP limit; these routes were missing one.

## Changes

- **`lib/fund-ip-rate-limit` (new)** — `checkFundRateLimit(ip)` backed by the app's
  existing `createUpstashRateLimiter` (10/min/IP, shared prefix across the fund
  endpoints), identical in shape to `lib/devnet-mirror-mint-rate-limit`.
- **faucet / playground-faucet / auto-fund / devnet-airdrop** — after the devnet
  guard and before any spend, return `429` with `Retry-After` when the per-IP limit
  is exceeded. The existing per-wallet gates are unchanged (defence in depth).
- **regression test** — a per-wallet gate lets one IP drain via fresh wallets,
  while the per-IP limiter caps one IP regardless of wallet (and different IPs keep
  independent budgets).

## Testing

- `npx tsc --noEmit` — clean.
- Full fund-route suite + new test — **11 files, 100 tests, all pass** (faucet,
  playground-faucet, auto-fund, devnet-airdrop, incl. network-guard and
  confirmation-result behaviours).

## Notes

- Frontend + devnet scope only; no program, keeper, or mainnet changes.
- When Upstash is unconfigured the limiter falls back to a per-instance in-memory
  window (fail-open across horizontally-scaled instances). Requiring Upstash in
  production for these limits to hold globally is a related hardening item worth
  tracking separately.
