### PR TITLE
Back the playground faucet rate limit with the durable gate

### DIFF
--- a/app/__tests__/api/playground-faucet-durable-gate.test.ts
+++ b/app/__tests__/api/playground-faucet-durable-gate.test.ts
@@ -1,0 +1,65 @@
+/**
+ * PoC + regression — the playground faucet's per-wallet limit must be durable.
+ *
+ * /api/playground/faucet gates on an in-memory `Map` (wallet → last-claim ts).
+ * That Map is process-local, so a serverless cold start (or landing on a
+ * different warm instance) resets it — the same wallet can re-claim inside its
+ * 1h window by hitting a fresh instance. /api/faucet and /api/auto-fund avoid
+ * this by backing the gate with the shared `faucet_claims` table (tryFaucetGate)
+ * and only falling back to in-memory when Supabase is unavailable.
+ *
+ * This models the two stores: a per-instance in-memory gate loses its state when
+ * the instance recycles, while a durable (shared) gate keyed on (wallet, window)
+ * still denies the second claim. tryFaucetGate's window is 24h by default; the
+ * fix threads a per-call windowMs so the playground faucet keeps its 1h window
+ * while gaining durability.
+ */
+import { describe, it, expect } from "vitest";
+
+// A per-instance in-memory gate (what the route uses today).
+function makeInMemoryGate(windowMs: number) {
+  const store = new Map<string, number>();
+  return {
+    allow(wallet: string, now: number): boolean {
+      const last = store.get(wallet);
+      if (last !== undefined && now - last < windowMs) return false;
+      store.set(wallet, now);
+      return true;
+    },
+  };
+}
+
+// A durable gate — shared state that survives an instance recycle (models the DB row).
+function makeDurableGate(windowMs: number, shared: Map<string, number>) {
+  return {
+    allow(wallet: string, now: number): boolean {
+      const last = shared.get(wallet);
+      if (last !== undefined && now - last < windowMs) return false;
+      shared.set(wallet, now);
+      return true;
+    },
+  };
+}
+
+const ONE_HOUR = 60 * 60 * 1000;
+
+describe("playground faucet: durable per-wallet gate", () => {
+  it("in-memory gate lets one wallet re-claim after an instance recycle (the bug)", () => {
+    const now = 1_000_000;
+    let gate = makeInMemoryGate(ONE_HOUR);
+    expect(gate.allow("W", now)).toBe(true);        // first claim
+    expect(gate.allow("W", now + 60_000)).toBe(false); // blocked, same instance
+    gate = makeInMemoryGate(ONE_HOUR);               // <-- cold start / new instance
+    expect(gate.allow("W", now + 60_000)).toBe(true);  // re-claims within the hour
+  });
+
+  it("durable gate denies re-claim within the window even across recycles (the fix)", () => {
+    const now = 1_000_000;
+    const shared = new Map<string, number>();        // survives instance recycle
+    let gate = makeDurableGate(ONE_HOUR, shared);
+    expect(gate.allow("W", now)).toBe(true);
+    gate = makeDurableGate(ONE_HOUR, shared);         // new instance, same shared store
+    expect(gate.allow("W", now + 60_000)).toBe(false); // still blocked — 1h window holds
+    expect(gate.allow("W", now + ONE_HOUR + 1)).toBe(true); // window elapsed → allowed
+  });
+});

--- a/app/app/api/playground/faucet/route.ts
+++ b/app/app/api/playground/faucet/route.ts
@@ -125,11 +125,27 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Invalid wallet address" }, { status: 400 });
     }
 
-    // Rate limit check
-    const { limited, nextClaimAt: limitNext } = isRateLimited(walletAddress);
-    if (limited) {
+    // Rate limit: durable Supabase gate (insert-as-gate) when available, the
+    // process-local in-memory Map as fallback — mirrors /api/faucet and
+    // /api/auto-fund so the 1h per-wallet limit survives a serverless cold start
+    // (the in-memory Map resets on cold start / a different warm instance). A
+    // distinct fund_type keeps it off the sol/usdc/auto-fund slots; RATE_LIMIT_MS
+    // (1h) preserves this faucet's shorter window.
+    let supabase: ReturnType<typeof import("@/lib/supabase").getServiceClient> | null = null;
+    let gate: { allowed: boolean; nextClaimAt: string | null; claimId?: number } = { allowed: true, nextClaimAt: null };
+    try {
+      const sbMod = await import("@/lib/supabase");
+      const gateMod = await import("@/lib/faucet-rate-gate");
+      supabase = sbMod.getServiceClient();
+      gate = await gateMod.tryFaucetGate(supabase, walletAddress, "playground-faucet", RATE_LIMIT_MS);
+    } catch {
+      // Supabase unavailable — fall back to the in-memory limiter.
+      const { limited, nextClaimAt } = isRateLimited(walletAddress);
+      gate = { allowed: !limited, nextClaimAt: nextClaimAt || null };
+    }
+    if (!gate.allowed) {
       return NextResponse.json(
-        { error: "Already claimed in the last hour. Come back later.", nextClaimAt: limitNext },
+        { error: "Already claimed in the last hour. Come back later.", nextClaimAt: gate.nextClaimAt },
         { status: 429 },
       );
     }
@@ -137,6 +153,10 @@ export async function POST(req: NextRequest) {
     // Load mint signer — required for USDC mint
     const mintSigner = getDevnetMintSigner();
     if (!mintSigner) {
+      // Release the durable claim slot so a config error doesn't lock the wallet.
+      if (supabase && gate.claimId) {
+        try { const { releaseFaucetClaim } = await import("@/lib/faucet-rate-gate"); await releaseFaucetClaim(supabase, gate.claimId); } catch { /* best-effort */ }
+      }
       return NextResponse.json(
         {
           error:
@@ -203,6 +223,10 @@ export async function POST(req: NextRequest) {
         "confirmed",
       );
     } catch (mintErr) {
+      // Release the durable claim slot so a mint failure doesn't lock the wallet.
+      if (supabase && gate.claimId) {
+        try { const { releaseFaucetClaim } = await import("@/lib/faucet-rate-gate"); await releaseFaucetClaim(supabase, gate.claimId); } catch { /* best-effort */ }
+      }
       Sentry.captureException(mintErr, {
         tags: { endpoint: "/api/playground/faucet", step: "mint_usdc" },
         extra: { walletAddress },

--- a/app/lib/faucet-rate-gate.ts
+++ b/app/lib/faucet-rate-gate.ts
@@ -27,7 +27,9 @@ export interface GateResult {
  *
  * @param supabase  Service-role Supabase client
  * @param wallet    Wallet address
- * @param fundType  "sol" | "usdc" | "auto-fund"
+ * @param fundType  "sol" | "usdc" | "auto-fund" | "playground-faucet"
+ * @param windowMs  Rate-limit window (defaults to 24h; the playground faucet
+ *                  passes a shorter 1h window while keeping the durable gate).
  */
 /**
  * Thrown when the gate cannot function at all (its table is missing), as opposed
@@ -42,8 +44,8 @@ export class FaucetGateUnavailableError extends Error {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function tryFaucetGate(supabase: any, wallet: string, fundType: string): Promise<GateResult> {
-  const windowStart = new Date(Date.now() - RATE_LIMIT_MS).toISOString();
+export async function tryFaucetGate(supabase: any, wallet: string, fundType: string, windowMs: number = RATE_LIMIT_MS): Promise<GateResult> {
+  const windowStart = new Date(Date.now() - windowMs).toISOString();
 
   try {
     // GH#1803: Step 0 — Pre-check SELECT FIRST.
@@ -91,7 +93,7 @@ export async function tryFaucetGate(supabase: any, wallet: string, fundType: str
 
     if (activeClaim) {
       const nextClaimAt = new Date(
-        new Date(activeClaim.claimed_at as string).getTime() + RATE_LIMIT_MS,
+        new Date(activeClaim.claimed_at as string).getTime() + windowMs,
       ).toISOString();
       return { allowed: false, nextClaimAt };
     }
@@ -122,7 +124,7 @@ export async function tryFaucetGate(supabase: any, wallet: string, fundType: str
           .maybeSingle();
 
         const nextClaimAt = existing
-          ? new Date(new Date(existing.claimed_at as string).getTime() + RATE_LIMIT_MS).toISOString()
+          ? new Date(new Date(existing.claimed_at as string).getTime() + windowMs).toISOString()
           : null;
         return { allowed: false, nextClaimAt };
       }


### PR DESCRIPTION
## What

Back the playground faucet's per-wallet rate limit with the durable
`faucet_claims` gate so it survives serverless cold starts, matching `/api/faucet`
and `/api/auto-fund`.

Closes #2474.

## Why

`/api/playground/faucet` gated on a process-local in-memory `Map`, which resets on
a cold start / a different warm instance — the same wallet could re-claim inside
its 1h window by hitting a fresh instance, each claim minting from the shared mint
authority. The sibling faucets already use the shared `faucet_claims` table
(`tryFaucetGate`) and only fall back to in-memory when Supabase is unavailable.

## Changes

- **`faucet-rate-gate`** — add a backward-compatible `windowMs` parameter to
  `tryFaucetGate` (defaults to the existing 24h; existing callers unchanged).
- **`playground/faucet`** — use the durable insert-as-gate
  (`fund_type: "playground-faucet"`, 1h window) with the in-memory `Map` retained
  as the fallback, and `releaseFaucetClaim` on both post-gate failure paths
  (missing signer, mint failure) so an error never locks the wallet — matching
  `/api/faucet`.
- **regression test** — an in-memory gate re-allows a wallet after an instance
  recycle, while a durable gate keyed on (wallet, window) does not.

## Testing

- `npx tsc --noEmit` — clean.
- Gate + all `tryFaucetGate` callers + new test — **10 files, 86 tests, all pass**
  (incl. `faucet-gate-missing-table` exercising `tryFaucetGate` directly, and
  `faucet-route`'s 53 tests), confirming the new default param is
  backward-compatible.

## Notes

- Frontend + devnet scope only; no program, keeper, or mainnet changes.
- The 1h window is preserved (not silently widened to 24h) via the new `windowMs`
  argument.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playground faucet rate limiting so claim restrictions persist across service restarts.
  * Added a one-hour claim window for the playground faucet.
  * Failed mint attempts or missing configuration no longer incorrectly prevent future claims.
  * Added fallback protection when the durable rate-limit service is unavailable.

* **Tests**
  * Added regression coverage for rate-limit persistence, expiration, and instance recycling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->