### PR TITLE
Alert loudly when rate limiters degrade to the per-instance fallback

### DIFF
--- a/app/__tests__/api/rate-limit-fail-open.test.ts
+++ b/app/__tests__/api/rate-limit-fail-open.test.ts
@@ -1,0 +1,45 @@
+/**
+ * PoC — rate limiters fail OPEN when Upstash is unconfigured.
+ *
+ * createUpstashRateLimiter falls back to a per-instance in-memory sliding window
+ * when UPSTASH_REDIS_REST_URL/TOKEN are absent. On a horizontally-scaled deploy
+ * each serverless instance has its own window, so one IP's effective limit is
+ * (configured limit) × (number of warm instances). The unconfigured case is also
+ * silent — nothing logs that global rate limiting is degraded.
+ *
+ * This models two instances as two limiter instances (each has its own closure /
+ * localMap) and shows one IP exceeding the configured limit.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { createUpstashRateLimiter } from "@/lib/upstash-rate-limit";
+
+describe("PoC: limiters fail open (per-instance) without Upstash", () => {
+  beforeEach(() => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  });
+
+  it("one IP exceeds the configured limit across separate instances", async () => {
+    const LIMIT = 5;
+    // Two independent limiter instances model two serverless workers.
+    const instanceA = createUpstashRateLimiter({ limit: LIMIT, windowMs: 60_000, prefix: "rl:failopen-poc" });
+    const instanceB = createUpstashRateLimiter({ limit: LIMIT, windowMs: 60_000, prefix: "rl:failopen-poc" });
+
+    const ip = "203.0.113.9";
+    let allowed = 0;
+    for (let i = 0; i < LIMIT; i++) if ((await instanceA.check(ip)).allowed) allowed++;
+    for (let i = 0; i < LIMIT; i++) if ((await instanceB.check(ip)).allowed) allowed++;
+
+    // Same IP, limit=5, but 10 requests were allowed — the per-instance window
+    // does not bound a client spread across instances.
+    expect(allowed).toBe(LIMIT * 2);
+  });
+
+  it("a single instance DOES bound (the fallback works locally — it just isn't global)", async () => {
+    const LIMIT = 5;
+    const one = createUpstashRateLimiter({ limit: LIMIT, windowMs: 60_000, prefix: "rl:failopen-poc2" });
+    let allowed = 0;
+    for (let i = 0; i < 20; i++) if ((await one.check("198.51.100.5")).allowed) allowed++;
+    expect(allowed).toBe(LIMIT); // correct within one instance
+  });
+});

--- a/app/lib/upstash-rate-limit.ts
+++ b/app/lib/upstash-rate-limit.ts
@@ -18,6 +18,7 @@
 
 import { Redis } from "@upstash/redis";
 import { Ratelimit } from "@upstash/ratelimit";
+import * as Sentry from "@sentry/nextjs";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -113,6 +114,23 @@ export function createUpstashRateLimiter(
     };
   }
 
+  // Alert once per process (production only) when this limiter degrades to the
+  // per-instance in-memory fallback. Previously this happened SILENTLY when
+  // Upstash was unconfigured, so a misconfigured deploy lost GLOBAL rate limiting
+  // with no signal (limits still apply per-instance, but not across the fleet).
+  // Making it loud means a degraded deploy can no longer ship unnoticed.
+  let _degradedAlerted = false;
+  function alertDegradedOnce(reason: string): void {
+    if (_degradedAlerted || process.env.NODE_ENV !== "production") return;
+    _degradedAlerted = true;
+    const msg =
+      `[rate-limit] ${prefix}: DEGRADED to per-instance in-memory limiting (${reason}). ` +
+      `Rate limits are NOT enforced globally across serverless instances until Upstash ` +
+      `(UPSTASH_REDIS_REST_URL / UPSTASH_REDIS_REST_TOKEN) is configured.`;
+    console.error(msg);
+    try { Sentry.captureMessage(msg, "error"); } catch { /* best-effort */ }
+  }
+
   return {
     async check(key: string): Promise<RateLimitResult> {
       const limiter = getUpstashLimiter();
@@ -130,14 +148,17 @@ export function createUpstashRateLimiter(
           };
         } catch (err) {
           // Redis/network error — fall through to per-instance in-memory fallback.
-          // Log so operators know rate limiting is degraded (per-instance, not global).
           console.warn(
             `[rate-limit] ${prefix}: Redis error, falling back to in-memory limiter (per-instance only).`,
             err instanceof Error ? err.message : err,
           );
+          alertDegradedOnce("Redis unreachable");
+          return checkLocal(key);
         }
       }
 
+      // limiter === null → Upstash is not configured.
+      alertDegradedOnce("Upstash not configured");
       return checkLocal(key);
     },
   };


### PR DESCRIPTION
## What

Make rate-limiter degradation **loud** instead of silent: when a limiter falls back
to the per-instance in-memory window (Upstash unconfigured or Redis unreachable),
emit a production-only, once-per-process `console.error` + Sentry alert.

Closes #2477.

## Why

`createUpstashRateLimiter` silently returned `null` and fell back to a per-instance
in-memory sliding window when `UPSTASH_REDIS_REST_URL/TOKEN` were unset. On a
horizontally-scaled deploy that means limits are enforced per-instance, not
globally (a client spread across instances gets `limit × instances`), and a
misconfigured production deploy lost global rate limiting with **no signal** — only
the Redis-*error* path logged; the unconfigured path was silent. This limiter
backs every rate-limited route, including the fund/mint/create-market endpoints.

## Changes

- **`upstash-rate-limit`** — `alertDegradedOnce(reason)` fires on both fallback
  paths (unconfigured and Redis-unreachable), gated on `NODE_ENV === "production"`
  and de-duped per process. Rate-limiting behavior is unchanged; dev/test are
  unaffected.
- **regression test** — one IP exceeds the configured limit across two separate
  instances (documents the fail-open), while a single instance bounds correctly.

## Testing

- `npx tsc --noEmit` — clean.
- Limiter suite + PoC + middleware + create-market limiter — **4 files, 48 tests,
  all pass** (the existing in-memory-fallback behavior is preserved).

## Notes

- Frontend + devnet scope only; no program, keeper, or mainnet changes.
- **Deliberately not fail-closed.** Fully closing the gap (fail-closed on the
  fund/mint/create-market limiters when Upstash is unset in prod) would take the
  site down if the production deploy isn't running Upstash, so it's left as a
  maintainer follow-up — recommended behind an explicit env flag
  (`RATE_LIMIT_FAIL_CLOSED=true`) enabled once Upstash is confirmed in production,
  with the global middleware limiter staying fail-open-with-alert. See the issue.
