### PR TITLE
Bound the caller-supplied initial mark on keeper-cosign

### DIFF
--- a/app/__tests__/api/keeper-cosign-price-bound.test.ts
+++ b/app/__tests__/api/keeper-cosign-price-bound.test.ts
@@ -1,0 +1,38 @@
+/**
+ * PoC + regression — keeper-cosign must bound the caller-supplied initial mark.
+ *
+ * /api/playground/keeper-cosign builds a ConfigureAuthMark instruction with
+ * initialMarkE6 = BigInt(initialPriceE6) from the request body, validated only
+ * as `> 0n`. There is no upper bound, so a creator can seed their own market's
+ * initial mark with an absurd value (contrast MAX_PRICE_E6 = 1e12 in
+ * lib/oraclePrice, which every other price path is clamped to).
+ *
+ * This reproduces the current gate vs the bounded gate using the real
+ * MAX_PRICE_E6 constant.
+ */
+import { describe, it, expect } from "vitest";
+import { MAX_PRICE_E6 } from "@/lib/oraclePrice";
+
+// Current keeper-cosign gate (route.ts:130-131): only rejects non-positive.
+const currentGateAccepts = (v: bigint): boolean => v > 0n;
+// Fixed gate: also reject anything above the protocol max.
+const boundedGateAccepts = (v: bigint): boolean => v > 0n && v <= MAX_PRICE_E6;
+
+describe("PoC: keeper-cosign initial mark must be upper-bounded", () => {
+  it("the current gate accepts an absurd mark; the bounded gate rejects it", () => {
+    const absurd = 1_000_000_000_000_000_000_000n; // 1e21, far above $1M (1e12)
+    expect(currentGateAccepts(absurd)).toBe(true);   // bug: accepted today
+    expect(boundedGateAccepts(absurd)).toBe(false);  // fix: rejected
+  });
+
+  it("legitimate prices are accepted by the bounded gate", () => {
+    expect(boundedGateAccepts(150_000_000n)).toBe(true); // $150 in E6
+    expect(boundedGateAccepts(1n)).toBe(true);           // smallest positive
+    expect(boundedGateAccepts(MAX_PRICE_E6)).toBe(true); // boundary ($1M)
+  });
+
+  it("non-positive is still rejected", () => {
+    expect(boundedGateAccepts(0n)).toBe(false);
+    expect(boundedGateAccepts(-5n)).toBe(false);
+  });
+});

--- a/app/app/api/playground/keeper-cosign/route.ts
+++ b/app/app/api/playground/keeper-cosign/route.ts
@@ -55,6 +55,7 @@ import {
   buildAccountMetas,
 } from "@percolatorct/sdk";
 import { getRpcEndpoint, getConfig } from "@/lib/config";
+import { MAX_PRICE_E6 } from "@/lib/oraclePrice";
 import { requirePlaygroundKeeperSigner } from "@/lib/playground-keeper-signer";
 
 export const dynamic = "force-dynamic";
@@ -129,8 +130,16 @@ export async function POST(req: NextRequest) {
   try {
     priceE6 = BigInt(initialPriceE6);
     if (priceE6 <= 0n) throw new Error("must be positive");
+    // SEC: bound the caller-supplied initial mark to the protocol max — the same
+    // ceiling every other price path is clamped to (lib/oraclePrice MAX_PRICE_E6).
+    // Without it a creator could seed their own market's ConfigureAuthMark with an
+    // absurd initial mark.
+    if (priceE6 > MAX_PRICE_E6) throw new Error("exceeds max");
   } catch {
-    return NextResponse.json({ error: "Invalid initialPriceE6 — must be positive bigint string" }, { status: 400 });
+    return NextResponse.json(
+      { error: `Invalid initialPriceE6 — must be a positive bigint string ≤ ${MAX_PRICE_E6} (E6)` },
+      { status: 400 },
+    );
   }
 
   const assetIdx = typeof assetIndex === "number" ? assetIndex : 0;


### PR DESCRIPTION
## What

Bound the caller-supplied initial mark on `/api/playground/keeper-cosign`.

Closes #2479.

## Why

The route builds a `ConfigureAuthMark` instruction with
`initialMarkE6 = BigInt(initialPriceE6)` from the request body, validated only as
`> 0n`. With no upper bound, a market creator could seed their own market's initial
mark with an absurd value. It's self-scoped (`ConfigureAuthMark` requires the
deployer's own signature, so it can't affect other markets), but the value should
be clamped to the protocol max like every other price path before v2.

## Changes

- **keeper-cosign** — reject `initialPriceE6 > MAX_PRICE_E6` (1e12 / $1M in E6,
  reusing the existing `lib/oraclePrice` constant) with a 400.
- **regression test** — an absurd value is rejected; legitimate values (incl. the
  `MAX_PRICE_E6` boundary) are accepted; non-positive is still rejected.

## Testing

- `npx tsc --noEmit` — clean.
- keeper-cosign tests + new test — **2 files, 5 tests, all pass** (incl. the
  existing signer-separation test).

## Notes

- Frontend + devnet scope only; no program, keeper, or mainnet changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject keeper-cosign requests with prices exceeding the protocol maximum.
  * Invalid or non-positive prices now return a clear 400 error, while valid prices continue to be accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->