### PR TITLE
Apply phantom-OI suppression to /api/stats protocol open interest

### DIFF
--- a/app/__tests__/api/stats-phantom-oi.test.ts
+++ b/app/__tests__/api/stats-phantom-oi.test.ts
@@ -1,0 +1,46 @@
+/**
+ * PoC + regression — /api/stats must apply the same phantom-OI suppression as
+ * /api/markets when summing protocol-wide open interest.
+ *
+ * /api/markets zeroes a market's OI when it's phantom (no accounts / dust vault)
+ * via isPhantomOpenInterest + computeDisplayOiUsd. /api/stats' merged-rows path
+ * sums total_open_interest_usd directly, so a market shown as $0 OI in the list
+ * still inflates the protocol-wide OI stat. The helpers are the documented single
+ * source of truth (markets/route.ts) — stats just wasn't using them.
+ */
+import { describe, it, expect } from "vitest";
+import { isPhantomOpenInterest, MIN_VAULT_FOR_OI } from "@/lib/phantom-oi";
+import { computeDisplayOiUsd } from "@/lib/oi-display";
+
+type Row = {
+  total_open_interest_usd: number | null;
+  total_open_interest: number | null;
+  total_accounts: number | null;
+  vault_balance: number;
+};
+
+// A phantom market: carries stale OI USD but has no accounts and a dust vault.
+const phantom: Row = { total_open_interest_usd: 5_000, total_open_interest: 123, total_accounts: 0, vault_balance: 0 };
+// A real market: accounts + a funded vault.
+const real: Row = { total_open_interest_usd: 10_000, total_open_interest: 456, total_accounts: 5, vault_balance: MIN_VAULT_FOR_OI };
+
+describe("stats phantom-OI suppression", () => {
+  it("raw summation over-counts a phantom market (the bug)", () => {
+    const rawSum = [phantom, real].reduce((s, m) => s + (m.total_open_interest_usd ?? 0), 0);
+    expect(rawSum).toBe(15_000); // phantom's stale $5k is wrongly included
+  });
+
+  it("applying isPhantomOpenInterest + computeDisplayOiUsd excludes it (the fix)", () => {
+    const fixedSum = [phantom, real].reduce((s, m) => {
+      const isPhantom = isPhantomOpenInterest(m.total_accounts, m.vault_balance);
+      const oi = computeDisplayOiUsd(m.total_open_interest_usd, isPhantom, m.total_open_interest);
+      return s + (oi ?? 0);
+    }, 0);
+    expect(fixedSum).toBe(10_000); // phantom suppressed to 0, only the real market counts
+  });
+
+  it("the phantom market is individually suppressed to 0, the real one is unchanged", () => {
+    expect(computeDisplayOiUsd(phantom.total_open_interest_usd, isPhantomOpenInterest(phantom.total_accounts, phantom.vault_balance), phantom.total_open_interest)).toBe(0);
+    expect(computeDisplayOiUsd(real.total_open_interest_usd, isPhantomOpenInterest(real.total_accounts, real.vault_balance), real.total_open_interest)).toBe(10_000);
+  });
+});

--- a/app/app/api/stats/route.ts
+++ b/app/app/api/stats/route.ts
@@ -10,6 +10,7 @@ import { getServiceClient, getServerNetwork } from "@/lib/supabase";
 import { isActiveMarket, isSaneMarketValue, isZombieMarket } from "@/lib/activeMarketFilter";
 import { loadMergedMarketRows, type MarketRegistryRow } from "@/lib/market-registry";
 import { isPhantomOpenInterest } from "@/lib/phantom-oi";
+import { computeDisplayOiUsd } from "@/lib/oi-display";
 import { BLOCKED_SLAB_ADDRESSES } from "@/lib/blocklist";
 import { getClientIp } from "@/lib/get-client-ip";
 import { createMemoryRateLimiter } from "@/lib/memory-rate-limit";
@@ -135,8 +136,19 @@ async function computeStatsFromMarketsApi(_request: NextRequest): Promise<(Retur
 
     let totalOpenInterest = 0;
     for (const m of visible) {
-      const oiUsd = numericOrNull((m as Record<string, unknown>).total_open_interest_usd);
-      if (oiUsd != null && isSaneMarketValue(oiUsd)) totalOpenInterest += oiUsd;
+      const row = m as Record<string, unknown>;
+      // Mirror /api/markets exactly (markets/route.ts:827-833): suppress phantom-OI
+      // markets (no accounts / dust vault) via the shared predicate before summing,
+      // so a market shown as $0 OI in the list can't inflate the protocol-wide
+      // total. Previously this path summed total_open_interest_usd raw, re-introducing
+      // the drift the shared predicate exists to prevent.
+      const isPhantomOI = isPhantomOpenInterest(numericOrNull(row.total_accounts), numericOrNull(row.vault_balance) ?? 0);
+      const displayOiUsd = computeDisplayOiUsd(
+        numericOrNull(row.total_open_interest_usd),
+        isPhantomOI,
+        numericOrNull(row.total_open_interest),
+      );
+      if (displayOiUsd != null && isSaneMarketValue(displayOiUsd)) totalOpenInterest += displayOiUsd;
     }
 
     const activeTotal = visible.filter((m: MarketRegistryRow) =>


### PR DESCRIPTION
## What

Apply the phantom-OI suppression to `/api/stats`' protocol-wide open-interest sum so
it matches `/api/markets`.

Closes #2482.

## Why

`computeStatsFromMarketsApi` summed `total_open_interest_usd` directly, skipping the
`isPhantomOpenInterest` + `computeDisplayOiUsd` suppression `/api/markets` applies
(markets/route.ts:827-833). A market suppressed to $0 OI in the list (no accounts /
dust vault) therefore still inflated the protocol-wide `totalOpenInterest`. The
`/api/markets` comment names these helpers the single source of truth for both
routes; the stats shared-loader path just wasn't using them. (The existing
`stats-phantom-oi-guard` tests kept passing because they test a mirror of the
intended logic, not the route's actual summation.)

## Changes

- **stats/route** — compute per-market display OI with `isPhantomOpenInterest` +
  `computeDisplayOiUsd` (from `total_accounts`, `vault_balance`,
  `total_open_interest`, `total_open_interest_usd`) before summing, mirroring
  `/api/markets` exactly.
- **regression test** — a raw sum over-counts a phantom market; the helper-based
  sum excludes it (and the phantom market is individually suppressed to 0).

## Testing

- `npx tsc --noEmit` — clean.
- Stats cluster + new test — **8 files, 82 tests, all pass** (incl.
  `stats-phantom-oi-guard`, `stats-active-total-consistency`, `ProtocolStatsBar`).

## Notes

- Frontend + devnet scope only; no program, keeper, or mainnet changes.
- Reuses the existing shared helpers — no new predicate, so the two routes stay
  definitionally consistent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected statistics so phantom open interest is excluded from displayed totals.
  * Preserved open interest from valid markets when calculating aggregate USD values.

* **Tests**
  * Added regression coverage to verify phantom open interest is suppressed without affecting real-market data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->