### PR TITLE
fix(trade): block stale oracles for every mode, not an allowlist (GH#2484)

### DIFF
--- a/app/__tests__/lib/oracle-stale-gate.test.ts
+++ b/app/__tests__/lib/oracle-stale-gate.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Regression — GH#2484: a stale oracle must block trading for EVERY oracle mode.
+ *
+ * The gate used to be an inline allowlist (`mode === "admin" || "hyperp" ||
+ * "keeper"`) duplicated across four trade components. It leaked twice: "keeper"
+ * was missing (H7), then "pyth-pinned" (GH#2484) — so a stale Pyth market stayed
+ * tradeable while admin/hyperp/keeper markets in the identical state were blocked.
+ *
+ * Two things are asserted here, deliberately:
+ *
+ *  1. The predicate blocks every member of the OracleMode union — driven off the
+ *     union itself, not a hand-written list, so a new mode fails this test rather
+ *     than silently passing. (The Record<OracleMode, boolean> exemption map also
+ *     makes an unclassified new mode a COMPILE error; this is the runtime half.)
+ *
+ *  2. No trade component has re-inlined the allowlist. That is what binds the
+ *     four call sites: a unit test of the predicate alone would still pass if a
+ *     component reverted to its own copy, which is exactly how this bug spread.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { OracleMode } from "@/lib/oraclePrice";
+import type { FreshnessLevel } from "@/hooks/useOracleFreshness";
+import { isOracleStaleBlocking, STALE_EXEMPT_MODES } from "@/lib/oracle-stale-gate";
+
+// Derived from the exemption map, which is a Record over the union — adding a
+// mode to OracleMode without classifying it fails to compile, and once
+// classified it automatically appears here.
+const ALL_MODES = Object.keys(STALE_EXEMPT_MODES) as OracleMode[];
+
+describe("isOracleStaleBlocking", () => {
+  it("covers every OracleMode member (the union has not outgrown the map)", () => {
+    expect(ALL_MODES).toEqual(
+      expect.arrayContaining(["admin", "hyperp", "keeper", "pyth-pinned"]),
+    );
+    expect(ALL_MODES).toHaveLength(4);
+  });
+
+  it.each(ALL_MODES)("blocks a stale oracle for mode %s", (mode) => {
+    expect(isOracleStaleBlocking("stale", mode, true)).toBe(true);
+  });
+
+  it.each(ALL_MODES)("does not block fresh or aging for mode %s", (mode) => {
+    expect(isOracleStaleBlocking("fresh", mode, true)).toBe(false);
+    expect(isOracleStaleBlocking("aging", mode, true)).toBe(false);
+  });
+
+  it("leaves the 'unavailable' level to the caller's own handling", () => {
+    // Callers compose this themselves — OrderTicket excludes it, the position
+    // panels fold it in — so the predicate must not claim it.
+    for (const mode of ALL_MODES) {
+      expect(isOracleStaleBlocking("unavailable" as FreshnessLevel, mode, true)).toBe(false);
+    }
+  });
+
+  it("does not block before a price has been seen, or before the mode resolves", () => {
+    expect(isOracleStaleBlocking("stale", "pyth-pinned", false)).toBe(false);
+    expect(isOracleStaleBlocking("stale", null, true)).toBe(false);
+  });
+
+  it("exempts nothing today — every mode is blocked when stale", () => {
+    expect(Object.values(STALE_EXEMPT_MODES).some(Boolean)).toBe(false);
+  });
+});
+
+describe("the trade surfaces use the shared gate, not their own allowlist", () => {
+  const FILES = [
+    "components/trade/OrderTicket.tsx",
+    "components/trade/PositionPanel.tsx",
+    "components/trade/PositionsDock.tsx",
+    "components/trade/OtherMarketPositions.tsx",
+  ];
+
+  it.each(FILES)("%s calls isOracleStaleBlocking", (rel) => {
+    const src = readFileSync(resolve(__dirname, "../..", rel), "utf8");
+    expect(src).toContain("isOracleStaleBlocking(");
+  });
+
+  it.each(FILES)("%s has no inline oracle-mode allowlist", (rel) => {
+    const src = readFileSync(resolve(__dirname, "../..", rel), "utf8");
+    // The exact shape that leaked twice: a disjunction of mode equality checks
+    // guarding the stale branch.
+    expect(src).not.toMatch(/oracleMode === "[a-z-]+"\s*\|\|\s*oracleMode === "[a-z-]+"/);
+  });
+});

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -72,6 +72,7 @@ import { DepositWithdrawCard } from "@/components/trade/DepositWithdrawCard";
 import { useInitUser } from "@/hooks/useInitUser";
 import { AUTO_DEPOSIT_AMOUNT } from "@/hooks/useAutoDeposit";
 import { useWalletNetworkGuard } from "@/hooks/useWalletNetworkGuard";
+import { isOracleStaleBlocking } from "@/lib/oracle-stale-gate";
 
 const LEVERAGE_SNAP_POINTS = [1, 3, 5, 10, 20];
 const SIZE_PRESETS = [25, 50, 75, 100];
@@ -301,10 +302,12 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
   const { priceUsd, priceE6: livePriceE6 } = getLivePriceSnapshot(slabAddress);
   const { level: oracleLevel, mode: oracleMode, ready: oracleReady } = useOracleFreshness();
   const oracleUnavailable = oracleLevel === "unavailable";
-  // H7: this gate was dead for keeper-mode markets (byte=3/AUTH_MARK) — the
-  // mode set only listed "admin"/"hyperp", so a stale keeper-priced market
-  // never blocked trading (fired for 0/5 live markets). "keeper" added.
-  const oracleStale = !oracleUnavailable && oracleReady && oracleLevel === "stale" && (oracleMode === "admin" || oracleMode === "hyperp" || oracleMode === "keeper");
+  // GH#2484: this was an inline ALLOWLIST of oracle modes, and it leaked twice —
+  // first "keeper" (H7: a stale keeper-priced market never blocked trading,
+  // firing for 0/5 live markets), then "pyth-pinned". The predicate now lives in
+  // lib/oracle-stale-gate and blocks every recognised mode by default, so the
+  // next mode added to the union cannot silently trade on a stale price.
+  const oracleStale = !oracleUnavailable && isOracleStaleBlocking(oracleLevel, oracleMode, oracleReady);
   // H6: engine accrue-staleness — see useEngineFreshness's file header.
   const { engineStale } = useEngineFreshness();
   const openWalletModal = usePrivyLogin();

--- a/app/components/trade/OtherMarketPositions.tsx
+++ b/app/components/trade/OtherMarketPositions.tsx
@@ -55,6 +55,7 @@ import {
 } from "@/lib/format";
 import { isMockMode } from "@/lib/mock-mode";
 import { isMockSlab, getMockPortfolioPositions } from "@/lib/mock-trade-data";
+import { isOracleStaleBlocking } from "@/lib/oracle-stale-gate";
 
 function abs(n: bigint): bigint {
   return n < 0n ? -n : n;
@@ -88,8 +89,7 @@ const CloseFlow: FC<{
   const mockExempt = isMockMode() && isMockSlab(pos.slabAddress);
   const oracleStale =
     !mockExempt &&
-    (oracleLevel === "unavailable" ||
-      (oracleReady && oracleLevel === "stale" && (oracleMode === "admin" || oracleMode === "hyperp" || oracleMode === "keeper")));
+    (oracleLevel === "unavailable" || isOracleStaleBlocking(oracleLevel, oracleMode, oracleReady));
   const posSize = pos.account?.positionSize ?? 0n;
   return (
     <ClosePositionModal

--- a/app/components/trade/PositionPanel.tsx
+++ b/app/components/trade/PositionPanel.tsx
@@ -44,6 +44,7 @@ import { applyInvert, sanitizePriceE6 } from "@/lib/oraclePrice";
 import { getBackendUrl } from "@/lib/config";
 import { pollWhenVisible } from "@/lib/pollWhenVisible";
 import { parseHumanAmount } from "@/lib/parseAmount";
+import { isOracleStaleBlocking } from "@/lib/oracle-stale-gate";
 import {
   formatLeverage,
   ORDER_LEVERAGE_TITLE,
@@ -240,7 +241,7 @@ export const PositionPanel: FC<{ slabAddress: string }> = ({ slabAddress }) => {
   // playground markets) never blocked closing.
   const { level: oracleLevel, mode: oracleMode, ready: oracleReady } = useOracleFreshness();
   const oracleUnavailable = oracleLevel === "unavailable";
-  const oracleStale = !mockMode && (oracleUnavailable || (oracleReady && oracleLevel === "stale" && (oracleMode === "admin" || oracleMode === "hyperp" || oracleMode === "keeper")));
+  const oracleStale = !mockMode && (oracleUnavailable || isOracleStaleBlocking(oracleLevel, oracleMode, oracleReady));
   // H6: engine accrue-staleness — distinct from the oracle-push freshness
   // above. A market can look perfectly fresh here (keeper still pushing
   // prices) while the ENGINE hasn't accrued in ~500 slots, cliff-dead and

--- a/app/components/trade/PositionsDock.tsx
+++ b/app/components/trade/PositionsDock.tsx
@@ -78,6 +78,7 @@ import { getEntryPrice, clearEntryPrice } from "@/lib/entry-price";
 import { applyInvert, sanitizePriceE6 } from "@/lib/oraclePrice";
 import { isSentinelValue } from "@/lib/health";
 import { RenderProfiler } from "@/components/dev/RenderProfiler";
+import { isOracleStaleBlocking } from "@/lib/oracle-stale-gate";
 
 function abs(n: bigint): bigint {
   return n < 0n ? -n : n;
@@ -138,7 +139,7 @@ const PositionRow: FC<{ slabAddress: string }> = memo(function PositionRow({ sla
   // H7: "keeper" added to the mode set — this gate previously only fired for
   // admin/hyperp markets, so a stale keeper-priced market (all 5 live
   // playground markets) never blocked closing.
-  const oracleStale = !mockMode && (oracleUnavailable || (oracleReady && oracleLevel === "stale" && (oracleMode === "admin" || oracleMode === "hyperp" || oracleMode === "keeper")));
+  const oracleStale = !mockMode && (oracleUnavailable || isOracleStaleBlocking(oracleLevel, oracleMode, oracleReady));
   // H6: engine accrue-staleness — distinct from the oracle-push freshness
   // above. A market can look perfectly fresh here (keeper still pushing
   // prices) while the ENGINE hasn't accrued in ~500 slots, cliff-dead and

--- a/app/lib/oracle-stale-gate.ts
+++ b/app/lib/oracle-stale-gate.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared oracle-staleness trading gate.
+ *
+ * The trade surfaces disable trading when a market's oracle price has gone
+ * stale. That gate used to be written inline at each call site as an ALLOWLIST
+ * of oracle modes:
+ *
+ *     oracleLevel === "stale" && (mode === "admin" || mode === "hyperp" || mode === "keeper")
+ *
+ * An allowlist is the wrong default here: a mode that nobody remembers to add
+ * silently trades on a stale price. That has already happened twice —
+ * "keeper" was missing (fixed inline as H7, the comment is still in
+ * OrderTicket), and "pyth-pinned" was missing after that (GH#2484), while the
+ * copy of the same expression had spread to four components.
+ *
+ * So this inverts it: stale blocks EVERY recognised mode, and any exemption has
+ * to be declared. `STALE_EXEMPT_MODES` is a `Record<OracleMode, boolean>` rather
+ * than an array, so adding a member to the `OracleMode` union is a COMPILE
+ * ERROR until it is classified here — a new mode cannot reach production
+ * unclassified, which is the failure this keeps having.
+ *
+ * Callers keep their own handling of the "unavailable" level, because the two
+ * surfaces differ deliberately: the order ticket treats unavailable separately
+ * (it has its own message), while the position panels fold it in.
+ */
+import type { OracleMode } from "@/lib/oraclePrice";
+import type { FreshnessLevel } from "@/hooks/useOracleFreshness";
+
+/**
+ * Modes exempt from the stale-oracle trading block.
+ *
+ * Every entry is `false` today: no mode has a justification for trading on a
+ * stale price. Flipping one to `true` is a deliberate, reviewable act and needs
+ * a comment saying why.
+ */
+export const STALE_EXEMPT_MODES: Record<OracleMode, boolean> = {
+  "pyth-pinned": false,
+  hyperp: false,
+  admin: false,
+  keeper: false,
+};
+
+/**
+ * True when a stale oracle should block trading for this market.
+ *
+ * Deliberately does NOT consider the "unavailable" level — that is a different
+ * condition with its own copy on each surface. Compose:
+ *
+ *     // order ticket: unavailable handled separately
+ *     const oracleStale = !oracleUnavailable && isOracleStaleBlocking(level, mode, ready);
+ *     // position panels: unavailable folded in
+ *     const oracleStale = oracleUnavailable || isOracleStaleBlocking(level, mode, ready);
+ *
+ * @param level  Freshness level from useOracleFreshness.
+ * @param mode   Detected oracle mode; null when not yet resolved.
+ * @param ready  Whether a price has ever been seen (a never-priced market is
+ *               "unavailable", not "stale").
+ */
+export function isOracleStaleBlocking(
+  level: FreshnessLevel,
+  mode: OracleMode | null,
+  ready: boolean,
+): boolean {
+  if (!ready || level !== "stale" || mode === null) return false;
+  return !STALE_EXEMPT_MODES[mode];
+}


### PR DESCRIPTION
Fixes #2484.

## The reported bug is real, and wider than reported

Verified the premise on `playground@f2a3bbe5` before touching anything:
`OracleMode` is a four-member union (`oraclePrice.ts:40`) and the gate at
`OrderTicket.tsx:307` listed three of them. Confirmed.

The part the issue doesn't cover: **the same expression is duplicated in four
components, not one.**

| File | Gate |
|---|---|
| `components/trade/OrderTicket.tsx:307` | opening a trade — the reported one |
| `components/trade/PositionPanel.tsx:243` | managing an open position |
| `components/trade/PositionsDock.tsx:141` | the positions dock |
| `components/trade/OtherMarketPositions.tsx:92` | cross-market positions |

All four carried the identical `admin || hyperp || keeper` allowlist, so a stale
Pyth market also bypassed the gates on the **close/manage** surfaces. Fixing only
the order ticket would have left three copies to drift again.

## The fix

Took the issue's *preferred* option (fail-safe default) rather than the minimal
one, since the allowlist has now leaked twice — `keeper` was missing before (the
H7 comment is still in the file), then `pyth-pinned`.

`lib/oracle-stale-gate.ts` holds one predicate. Stale blocks every recognised
mode; exemptions must be declared:

```ts
export const STALE_EXEMPT_MODES: Record<OracleMode, boolean> = {
  "pyth-pinned": false, hyperp: false, admin: false, keeper: false,
};
```

`Record<OracleMode, boolean>` rather than the issue's suggested array is the one
deliberate deviation, and it's the point of the change: **adding a member to
`OracleMode` is a compile error until it's classified here.** An array-based
`!STALE_EXEMPT_MODES.includes(mode)` is fail-safe at runtime but still lets a new
mode ship unconsidered. This makes that impossible rather than merely unlikely.

Callers keep their own `unavailable` handling, which differs on purpose — the
order ticket excludes it (it has its own message), the position panels fold it
in. Behaviour for `admin`/`hyperp`/`keeper` is unchanged.

## Tests, and what actually binds them

Two halves, because the first alone would not have caught this bug:

1. **Exhaustiveness driven off the union.** The mode list comes from
   `Object.keys(STALE_EXEMPT_MODES)`, not a hand-written array, so a new mode
   fails the test rather than quietly passing it.
2. **Each of the four components is asserted to call the shared gate and to
   contain no inline allowlist.** This is what binds the call sites. A unit test
   of the predicate on its own stays green if a component reverts to its own
   copy — which is precisely how this defect spread to four files.

Mutation-verified both ways:

| Mutation | Result |
|---|---|
| flip `"pyth-pinned"` back to exempt (restores #2484) | **2 tests fail** |
| re-inline the allowlist in `PositionsDock` only | **2 tests fail** |

```
cd app && npx vitest run
Test Files  282 passed | 1 skipped (283)
     Tests  2939 passed | 16 skipped (2955)

npx tsc --noEmit    # clean
```

## Severity

Agree with the issue's **Medium**, and for its stated reason: the on-chain Pyth
staleness filter is still the fund-safety backstop, so this is a UI safety-gate
gap rather than a direct loss-of-funds path. What it costs users is signing
transactions that are expected to fail, and a worst-fill bound anchored to a
stale mark in the window before the on-chain filter rejects it. The close/manage
surfaces being affected too is why I'd not leave it sitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection against trading with stale market pricing.
  * Buying, opening, and closing positions are now consistently blocked when pricing data is stale and ready for use.
  * Markets with unavailable or unresolved pricing data continue to follow their existing handling.
  * Mock markets remain available for testing and development.
* **Tests**
  * Added coverage across all supported pricing modes and freshness states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->