### PR TITLE
fix(middleware): dual-stack IP blocklist — IPv6 ranges and canonical matching (GH#2486)

### DIFF
--- a/app/__tests__/lib/ip-blocklist.test.ts
+++ b/app/__tests__/lib/ip-blocklist.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Regression — GH#2486: the IP blocklist must work for IPv6, not just IPv4.
+ *
+ * The old inline implementation in middleware.ts parsed with `_ipToInt`, which
+ * returned -1 for anything that wasn't four dotted octets. Two distinct effects,
+ * and it matters which is which:
+ *
+ *   - IPv6 CIDR entries were DROPPED at parse time (`net === -1 → null`), so no
+ *     IPv6 range could be banned at all.
+ *   - Bare IPv6 entries were NOT dropped — they fell through to
+ *     `{ type: "exact", ip: entry }` and matched by string equality. So a ban
+ *     worked only for the exact spelling supplied. IPv6 has many textual forms
+ *     for one address, so the same host in expanded, uppercase, or bracketed
+ *     form walked straight past its own ban.
+ *
+ * Both are asserted below, plus the wiring: middleware must use this module and
+ * carry no inline IPv4-only parser (a unit test of the matcher alone stays green
+ * if middleware keeps its own copy).
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { isIpBlocked, parseBlocklist, parseIp } from "@/lib/ip-blocklist";
+
+describe("parseIp", () => {
+  it("parses IPv4", () => {
+    expect(parseIp("192.168.1.100")?.family).toBe(4);
+    expect(Array.from(parseIp("192.168.1.100")!.bytes)).toEqual([192, 168, 1, 100]);
+  });
+
+  it("parses every textual form of one IPv6 address to the same bytes", () => {
+    const forms = [
+      "2001:db8::1",
+      "2001:0db8:0000:0000:0000:0000:0000:0001",
+      "2001:DB8::1",
+      "[2001:db8::1]",
+      "[2001:db8::1]:443",
+      "2001:db8::1%eth0",
+    ];
+    const expected = Array.from(parseIp("2001:db8::1")!.bytes);
+    for (const f of forms) {
+      expect(Array.from(parseIp(f)!.bytes), f).toEqual(expected);
+    }
+  });
+
+  it("folds IPv4-mapped IPv6 down to IPv4 (else the mapping is a bypass)", () => {
+    const mapped = parseIp("::ffff:192.168.1.100");
+    expect(mapped?.family).toBe(4);
+    expect(Array.from(mapped!.bytes)).toEqual([192, 168, 1, 100]);
+  });
+
+  it("rejects malformed input", () => {
+    for (const bad of ["", "unknown", "999.1.1.1", "1.2.3", "2001:db8::1::2", "not-an-ip", "0x7f.0.0.1"]) {
+      expect(parseIp(bad), bad).toBeNull();
+    }
+  });
+
+  it("rejects leading-zero IPv4 octets (010 must not slip past a ban on 10)", () => {
+    expect(parseIp("010.0.0.1")).toBeNull();
+  });
+});
+
+describe("blocklist matching — the GH#2486 bugs", () => {
+  it("keeps IPv6 CIDR entries instead of dropping them", () => {
+    const list = parseBlocklist(["2001:db8::/32"]);
+    expect(list).toHaveLength(1); // old parser produced 0
+    expect(isIpBlocked("2001:db8::99", list)).toBe(true);
+    expect(isIpBlocked("2001:db9::99", list)).toBe(false);
+  });
+
+  it("blocks an IPv6 host in EVERY textual form, not just the spelling supplied", () => {
+    const list = parseBlocklist(["2001:db8::1"]);
+    for (const form of [
+      "2001:db8::1",
+      "2001:0db8:0000:0000:0000:0000:0000:0001", // old code: false
+      "2001:DB8::1", // old code: false
+      "[2001:db8::1]:443", // old code: false
+    ]) {
+      expect(isIpBlocked(form, list), form).toBe(true);
+    }
+  });
+
+  it("still blocks IPv4 exactly and by CIDR (no regression)", () => {
+    const list = parseBlocklist(["192.168.1.100", "10.0.0.0/8"]);
+    expect(isIpBlocked("192.168.1.100", list)).toBe(true);
+    expect(isIpBlocked("10.255.3.4", list)).toBe(true);
+    expect(isIpBlocked("11.0.0.1", list)).toBe(false);
+    expect(isIpBlocked("192.168.1.101", list)).toBe(false);
+  });
+
+  it("catches an IPv4 rule presented in IPv4-mapped IPv6 notation", () => {
+    const list = parseBlocklist(["10.0.0.0/8"]);
+    expect(isIpBlocked("::ffff:10.1.2.3", list)).toBe(true);
+  });
+
+  it("does not cross families (an IPv4 /8 must not swallow IPv6)", () => {
+    const list = parseBlocklist(["10.0.0.0/8"]);
+    expect(isIpBlocked("2001:db8::1", list)).toBe(false);
+  });
+
+  it("honours non-byte-aligned IPv6 prefixes", () => {
+    const list = parseBlocklist(["2001:db8:8000::/33"]);
+    expect(isIpBlocked("2001:db8:8000::5", list)).toBe(true);
+    expect(isIpBlocked("2001:db8:7fff::5", list)).toBe(false);
+  });
+
+  it("never matches an unparseable client IP (incl. the 'unknown' sentinel)", () => {
+    const list = parseBlocklist(["0.0.0.0/0"]);
+    expect(isIpBlocked("unknown", list)).toBe(false);
+    expect(isIpBlocked("", list)).toBe(false);
+    expect(isIpBlocked("1.2.3.4", list)).toBe(true); // /0 does match a real v4
+  });
+
+  it("reports invalid entries instead of dropping them silently", () => {
+    const seen: string[] = [];
+    const list = parseBlocklist(["1.2.3.4", "nonsense", "2001:db8::/200"], (e) => seen.push(e));
+    expect(list).toHaveLength(1);
+    expect(seen).toEqual(["nonsense", "2001:db8::/200"]);
+  });
+
+  it("an empty blocklist blocks nothing", () => {
+    expect(isIpBlocked("1.2.3.4", [])).toBe(false);
+  });
+});
+
+describe("middleware uses the shared matcher", () => {
+  const src = readFileSync(resolve(__dirname, "../../middleware.ts"), "utf8");
+
+  it("calls isIpBlocked / parseBlocklist", () => {
+    expect(src).toContain("isIpBlocked(");
+    expect(src).toContain("parseBlocklist(");
+  });
+
+  it("has no inline IPv4-only parser left", () => {
+    // The exact shape that caused this: split on "." and bail on != 4 parts.
+    expect(src).not.toMatch(/split\("\."\)\.map\(Number\)/);
+    // Match a re-declared parser, not the comment that records why it went —
+    // that history is worth keeping in the file.
+    expect(src).not.toMatch(/function\s+_ipToInt/);
+  });
+});

--- a/app/lib/ip-blocklist.ts
+++ b/app/lib/ip-blocklist.ts
@@ -1,0 +1,216 @@
+/**
+ * Dual-stack (IPv4 + IPv6) IP blocklist matching.
+ *
+ * The previous implementation lived inline in middleware.ts and was IPv4-only:
+ * `_ipToInt` split on "." and returned -1 for anything else. That had two
+ * consequences (GH#2486):
+ *
+ *   1. An IPv6 CIDR entry (`2001:db8::/32`) was silently DROPPED at parse time,
+ *      so no IPv6 range could ever be banned.
+ *   2. A bare IPv6 entry was kept, but matched by literal string equality — so
+ *      banning `2001:db8::1` did not ban the same address written as
+ *      `2001:0db8:0000:0000:0000:0000:0000:0001`, `2001:DB8::1`, or
+ *      `[2001:db8::1]:443`. IPv6 has many textual forms for one address; a
+ *      string compare bans a spelling, not a host.
+ *
+ * Both are fixed by parsing every address to bytes and comparing bytes.
+ * Deliberately dependency-free: this runs in Next.js Edge middleware on every
+ * request, where pulling in a parsing library is a bundle cost paid by all
+ * traffic to ban a handful of addresses.
+ *
+ * IPv4-mapped IPv6 (`::ffff:192.168.1.100`) is folded to its IPv4 form, so an
+ * IPv4 rule still catches a client presented in mapped notation — otherwise
+ * that notation is itself a bypass.
+ */
+
+export type ParsedIp = { bytes: Uint8Array; family: 4 | 6 };
+
+export type BlockEntry =
+  | { type: "exact"; ip: ParsedIp }
+  | { type: "cidr"; ip: ParsedIp; prefix: number };
+
+/** Strip the decorations a proxy may add: brackets, zone id, and a port. */
+function stripDecorations(raw: string): string {
+  let s = raw.trim();
+  // "[2001:db8::1]:443" or "[2001:db8::1]"
+  if (s.startsWith("[")) {
+    const close = s.indexOf("]");
+    if (close > 0) return s.slice(1, close).split("%")[0]!.toLowerCase();
+  }
+  // "192.0.2.1:443" — only for IPv4, where a single colon is unambiguous.
+  // A bare IPv6 has 2+ colons, so this cannot truncate one.
+  const firstColon = s.indexOf(":");
+  if (firstColon !== -1 && s.indexOf(":", firstColon + 1) === -1 && s.includes(".")) {
+    s = s.slice(0, firstColon);
+  }
+  // "fe80::1%eth0"
+  s = s.split("%")[0]!;
+  return s.toLowerCase();
+}
+
+function parseIpv4(s: string): Uint8Array | null {
+  const parts = s.split(".");
+  if (parts.length !== 4) return null;
+  const out = new Uint8Array(4);
+  for (let i = 0; i < 4; i++) {
+    const p = parts[i]!;
+    // Reject empty, non-digit, and leading zeros ("010" is octal in some
+    // parsers — treating it as 10 here would let it dodge a ban on 10).
+    if (!/^\d{1,3}$/.test(p)) return null;
+    if (p.length > 1 && p[0] === "0") return null;
+    const n = Number(p);
+    if (n > 255) return null;
+    out[i] = n;
+  }
+  return out;
+}
+
+function parseIpv6(s: string): Uint8Array | null {
+  if (!s.includes(":")) return null;
+  const doubleColon = s.indexOf("::");
+  if (doubleColon !== s.lastIndexOf("::")) return null; // at most one "::"
+
+  let head: string[];
+  let tail: string[];
+  if (doubleColon === -1) {
+    head = s.split(":");
+    tail = [];
+  } else {
+    head = s.slice(0, doubleColon) === "" ? [] : s.slice(0, doubleColon).split(":");
+    tail = s.slice(doubleColon + 2) === "" ? [] : s.slice(doubleColon + 2).split(":");
+  }
+
+  // A trailing IPv4 literal ("::ffff:192.0.2.1") occupies the last two groups.
+  let trailingV4: Uint8Array | null = null;
+  const all = [...head, ...tail];
+  const last = all[all.length - 1];
+  if (last !== undefined && last.includes(".")) {
+    trailingV4 = parseIpv4(last);
+    if (trailingV4 === null) return null;
+    if (tail.length > 0) tail = tail.slice(0, -1);
+    else head = head.slice(0, -1);
+  }
+
+  const groupCount = head.length + tail.length + (trailingV4 ? 2 : 0);
+  if (doubleColon === -1 ? groupCount !== 8 : groupCount > 7) return null;
+
+  const bytes = new Uint8Array(16);
+  const writeGroup = (idx: number, hex: string): boolean => {
+    if (!/^[0-9a-f]{1,4}$/.test(hex)) return false;
+    const v = parseInt(hex, 16);
+    bytes[idx * 2] = (v >> 8) & 0xff;
+    bytes[idx * 2 + 1] = v & 0xff;
+    return true;
+  };
+
+  for (let i = 0; i < head.length; i++) {
+    if (!writeGroup(i, head[i]!)) return null;
+  }
+  const tailStart = 8 - tail.length - (trailingV4 ? 2 : 0);
+  for (let i = 0; i < tail.length; i++) {
+    if (!writeGroup(tailStart + i, tail[i]!)) return null;
+  }
+  if (trailingV4) {
+    bytes.set(trailingV4, 12);
+  }
+  return bytes;
+}
+
+/** True when the 16 bytes are an IPv4-mapped address (::ffff:a.b.c.d). */
+function isV4Mapped(b: Uint8Array): boolean {
+  for (let i = 0; i < 10; i++) if (b[i] !== 0) return false;
+  return b[10] === 0xff && b[11] === 0xff;
+}
+
+/**
+ * Parse an address (any common textual form) into comparable bytes.
+ * Returns null when the input is not a valid address.
+ */
+export function parseIp(raw: string): ParsedIp | null {
+  const s = stripDecorations(raw);
+  if (s === "" || s === "unknown") return null;
+
+  const v4 = parseIpv4(s);
+  if (v4) return { bytes: v4, family: 4 };
+
+  const v6 = parseIpv6(s);
+  if (v6) {
+    // Fold ::ffff:a.b.c.d down to a.b.c.d so IPv4 rules still apply.
+    if (isV4Mapped(v6)) return { bytes: v6.slice(12), family: 4 };
+    return { bytes: v6, family: 6 };
+  }
+  return null;
+}
+
+/** True when `ip` falls inside `network`/`prefix`. Families must match. */
+export function matchesPrefix(ip: ParsedIp, network: ParsedIp, prefix: number): boolean {
+  if (ip.family !== network.family) return false;
+  const fullBytes = prefix >> 3;
+  for (let i = 0; i < fullBytes; i++) {
+    if (ip.bytes[i] !== network.bytes[i]) return false;
+  }
+  const restBits = prefix & 7;
+  if (restBits === 0) return true;
+  const mask = (0xff << (8 - restBits)) & 0xff;
+  return (ip.bytes[fullBytes]! & mask) === (network.bytes[fullBytes]! & mask);
+}
+
+/**
+ * Parse `IP_BLOCKLIST`-style entries: comma-separated addresses and/or CIDRs,
+ * IPv4 or IPv6. Invalid entries are dropped; `onInvalid` reports them so a
+ * typo'd or unsupported rule is not silently ignored (the failure mode that
+ * made GH#2486 invisible).
+ */
+export function parseBlocklist(
+  entries: string[],
+  onInvalid?: (entry: string, reason: string) => void,
+): BlockEntry[] {
+  const out: BlockEntry[] = [];
+  for (const entry of entries) {
+    const slash = entry.lastIndexOf("/");
+    if (slash !== -1) {
+      const addr = entry.slice(0, slash);
+      const prefix = Number(entry.slice(slash + 1));
+      const ip = parseIp(addr);
+      if (!ip) {
+        onInvalid?.(entry, "unparseable address");
+        continue;
+      }
+      const max = ip.family === 4 ? 32 : 128;
+      if (!Number.isInteger(prefix) || prefix < 0 || prefix > max) {
+        onInvalid?.(entry, `prefix must be 0-${max} for IPv${ip.family}`);
+        continue;
+      }
+      out.push({ type: "cidr", ip, prefix });
+      continue;
+    }
+    const ip = parseIp(entry);
+    if (!ip) {
+      onInvalid?.(entry, "unparseable address");
+      continue;
+    }
+    out.push({ type: "exact", ip });
+  }
+  return out;
+}
+
+/** True when `clientIp` matches any entry. Unparseable client IPs never match. */
+export function isIpBlocked(clientIp: string, blocklist: BlockEntry[]): boolean {
+  if (blocklist.length === 0) return false;
+  const ip = parseIp(clientIp);
+  if (!ip) return false;
+  for (const e of blocklist) {
+    if (e.type === "exact") {
+      if (
+        e.ip.family === ip.family &&
+        e.ip.bytes.length === ip.bytes.length &&
+        e.ip.bytes.every((b, i) => b === ip.bytes[i])
+      ) {
+        return true;
+      }
+    } else if (matchesPrefix(ip, e.ip, e.prefix)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -24,6 +24,7 @@ import type { NextRequest } from "next/server";
 import { Redis } from "@upstash/redis";
 import { Ratelimit } from "@upstash/ratelimit";
 import { BLOCKED_SLAB_ADDRESSES } from "@/lib/blocklist-edge";
+import { parseBlocklist, isIpBlocked } from "@/lib/ip-blocklist";
 
 // ── Rate limiter configuration ───────────────────────────────────────────────
 // Two tiers: RPC proxy gets a higher limit since Solana web3.js generates many calls per page load.
@@ -153,54 +154,26 @@ async function getRateLimit(
 // ── IP Blocklist ────────────────────────────────────────────────────────────
 // Parsed once at module load (Edge Runtime: module is re-evaluated per region,
 // not per request, so this is effectively a startup cost).
-// Configure via IP_BLOCKLIST env var: comma-separated IPs or /8|/16|/24|/32 CIDRs.
-// Example (Railway): IP_BLOCKLIST=88.97.223.158,10.0.0.0/8
+// Configure via IP_BLOCKLIST env var: comma-separated addresses and/or CIDRs,
+// IPv4 or IPv6 (any prefix 0-32 for v4, 0-128 for v6).
+// Example (Railway): IP_BLOCKLIST=88.97.223.158,10.0.0.0/8,2001:db8::1,2001:db8::/32
 const _rawBlocklist = (process.env.IP_BLOCKLIST ?? "")
   .split(",")
   .map((s) => s.trim())
   .filter(Boolean);
 
-interface _BlockEntry {
-  type: "exact" | "cidr";
-  ip?: string;
-  network?: number;
-  mask?: number;
-}
-
-// IPv4 only — IPv6 addresses are not supported and will pass through unblocked.
-// See packages/api/src/middleware/ip-blocklist.ts for the Hono equivalent (also IPv4-only).
-function _ipToInt(ip: string): number {
-  const p = ip.split(".").map(Number);
-  if (p.length !== 4 || p.some((n) => isNaN(n) || n < 0 || n > 255)) return -1;
-  return ((p[0]! << 24) | (p[1]! << 16) | (p[2]! << 8) | p[3]!) >>> 0;
-}
-
-const _blocklist: _BlockEntry[] = _rawBlocklist
-  .map((entry): _BlockEntry | null => {
-    if (entry.includes("/")) {
-      const [addr, prefStr] = entry.split("/");
-      const prefix = Number(prefStr);
-      if (!addr || isNaN(prefix) || prefix < 0 || prefix > 32) return null;
-      const net = _ipToInt(addr);
-      if (net === -1) return null;
-      const mask = prefix === 0 ? 0 : (~0 << (32 - prefix)) >>> 0;
-      return { type: "cidr", network: (net & mask) >>> 0, mask };
-    }
-    return { type: "exact", ip: entry };
-  })
-  .filter((e): e is _BlockEntry => e !== null);
-
-function _isBlocked(clientIp: string): boolean {
-  if (_blocklist.length === 0) return false;
-  const clientInt = _ipToInt(clientIp);
-  for (const e of _blocklist) {
-    if (e.type === "exact" && clientIp === e.ip) return true;
-    if (e.type === "cidr" && clientInt !== -1) {
-      if ((clientInt & e.mask!) >>> 0 === e.network) return true;
-    }
-  }
-  return false;
-}
+// GH#2486: this was an inline IPv4-only parser. `_ipToInt` returned -1 for
+// anything without four dotted octets, which meant (a) an IPv6 CIDR entry was
+// silently DROPPED at parse time so no IPv6 range could be banned, and (b) a
+// bare IPv6 entry survived but was matched by literal string equality — so
+// banning "2001:db8::1" missed the same host written as
+// "2001:0db8:0000:...:0001", "2001:DB8::1", or "[2001:db8::1]:443".
+// lib/ip-blocklist parses both families to bytes and compares bytes.
+// Invalid entries are now logged rather than dropped in silence — a typo'd
+// rule reading as "protected" is what kept this invisible.
+const _blocklist = parseBlocklist(_rawBlocklist, (entry, reason) => {
+  console.warn(`[middleware] IP_BLOCKLIST: ignoring "${entry}" — ${reason}`);
+});
 
 // ── Slab blocklist (GH#1363, GH#1390) ────────────────────────────────────────
 // next.config.ts rewrites /api/funding/:slab, /api/open-interest/:slab, and
@@ -368,7 +341,7 @@ export async function middleware(request: NextRequest) {
     const _proxyDepth = Math.max(0, Number(process.env.TRUSTED_PROXY_DEPTH ?? 1));
     let _clientIp = "unknown";
     // NOTE: depth=0 means "no proxy" — _clientIp stays "unknown" and
-    // _isBlocked("unknown") returns false, effectively disabling the
+    // isIpBlocked("unknown", ...) returns false, effectively disabling the
     // Edge Runtime blocklist. The Hono ip-blocklist.ts middleware
     // handles depth=0 correctly for the API server path.
     if (_proxyDepth > 0) {
@@ -378,7 +351,7 @@ export async function middleware(request: NextRequest) {
         _clientIp = _ips[Math.max(0, _ips.length - _proxyDepth)] ?? "unknown";
       }
     }
-    if (_isBlocked(_clientIp)) {
+    if (isIpBlocked(_clientIp, _blocklist)) {
       return new NextResponse(JSON.stringify({ error: "Forbidden" }), {
         status: 403,
         headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
Fixes #2486.

## The core finding is real. One part of the report is not — worth correcting

I ran the reported parser and matcher verbatim against the described config
(`IP_BLOCKLIST=192.168.1.100,2001:db8::1,2001:db8::/32`) before writing any code:

```
parsed entries: [{"type":"exact","ip":"192.168.1.100"},{"type":"exact","ip":"2001:db8::1"}]

IPv4 exact  192.168.1.100                       -> true
IPv6 exact  2001:db8::1                         -> true    <-- report says this is dropped
IPv6 expanded form of the SAME address          -> false
IPv6 uppercase form of the SAME address         -> false
IPv6 bracketed+port (proxies emit this)         -> false
IPv6 inside the /32 CIDR  2001:db8::99          -> false
```

**Confirmed:** IPv6 CIDR entries are dropped at parse time (3 entries in, 2 out),
so no IPv6 range can be banned. `_ipToInt` is IPv4-only. The file comment admits
it.

**Not confirmed:** *"even if an administrator explicitly adds an IPv6 address to
`IP_BLOCKLIST`, it is silently discarded during parsing and never enforced"*
(PoC step 4), and PoC step 3's predicted `200 OK`. A bare entry takes
`return { type: "exact", ip: entry }` with **no** IPv4 validation, so it is kept,
and `_isBlocked` compares `clientIp === e.ip` — a string compare that works fine
for IPv6. The call site slices `x-forwarded-for` directly rather than going
through `getClientIp`, so the raw IPv6 string reaches the comparison intact.
Blocking a single IPv6 address does work today.

**The real weakness in that path is subtler and, I'd argue, worse than the one
reported:** the compare is literal, so a rule bans *a spelling, not a host*. The
three `false` rows above are all the same address as the banned one. An operator
who blocks `2001:db8::1` is bypassed by anyone whose proxy renders it expanded or
uppercased — no attacker effort required, and the admin has no signal.

So the conclusion stands (IPv6 bans are unreliable-to-impossible), the CVSS feels
about right, but the mechanism is "dropped ranges + spelling-sensitive exact
matching" rather than "all IPv6 discarded".

## The fix

`lib/ip-blocklist.ts` parses both families to bytes and compares bytes, so a rule
bans a host. Deliberately **dependency-free** rather than `ipaddr.js` as
suggested: this is Edge middleware on every request, and a parsing library is a
bundle cost paid by all traffic in order to ban a handful of addresses. The
parser is ~120 lines and fully covered.

Adjacent bypasses closed while writing it — each of these was reachable before:

| Vector | Before | After |
|---|---|---|
| `::ffff:10.1.2.3` vs an IPv4 rule | not matched | folds to IPv4, matched |
| `010.0.0.1` vs a ban on `10.0.0.1` | not matched | leading zeros rejected |
| IPv4 `/8` vs an IPv6 client | n/a | families cannot cross |
| IPv6 `/33` (non-byte-aligned) | impossible | matched correctly |

Invalid entries are now **logged** instead of dropped in silence. A rule that
parses to nothing while reading as "protected" is what kept this invisible.

## Tests

Two halves, and the second is the one that matters here: a unit test of the
matcher alone stays green if `middleware.ts` keeps its own inline parser — which
is exactly the shape of the original bug. So the wiring is asserted too.

Mutation-verified:

| Mutation | Result |
|---|---|
| restrict CIDR prefixes to ≤32 (re-drop IPv6 ranges) | **1 test fails** |
| revert exact matching to string equality | **2 tests fail** |
| re-inline an `_ipToInt` parser in middleware | **1 test fails** |

```
cd app && npx vitest run
Test Files  282 passed | 1 skipped (283)
     Tests  2935 passed | 16 skipped (2951)

npx tsc --noEmit    # clean
```

## Note on scope

The file comment points at `packages/api/src/middleware/ip-blocklist.ts` as a
Hono equivalent that is *also* IPv4-only. Only the built artifact
(`packages/api/dist/...`) is present in this repo, no source, so it is out of
scope here — but it is the same defect and worth tracking wherever that source
lives.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded IP blocklist support to IPv4, IPv6, IPv4-mapped IPv6, exact addresses, and CIDR ranges.
  * Added normalization for bracketed addresses, ports, and zone identifiers.
  * Invalid blocklist entries are reported without interrupting processing.

* **Bug Fixes**
  * Improved address matching accuracy and prevented malformed client addresses from being blocked incorrectly.
  * Ensured IPv4 and IPv6 rules remain properly isolated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->