### PR TITLE
fix(api): distributed rate limiting for the public read endpoints (GH#2487)

### DIFF
--- a/app/__tests__/api/trader-stats-distributed-rate-limit.test.ts
+++ b/app/__tests__/api/trader-stats-distributed-rate-limit.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression — GH#2487: the public read endpoints must rate-limit through the
+ * DISTRIBUTED limiter, not a per-process Map.
+ *
+ * `/api/trader/[wallet]/trades`, `/api/trader/[wallet]/stats` and `/api/stats`
+ * used `createMemoryRateLimiter`, whose state is a Map in one process. On
+ * serverless that makes the effective limit `configured × instance count`: a
+ * client spread across warm instances is not bounded by the number on the tin.
+ *
+ * `createUpstashRateLimiter` shares the window through Redis when configured and
+ * degrades to the same in-memory behaviour when it is not, so dev and CI are
+ * unchanged.
+ *
+ * The per-instance property is what the bug was about, so that is what is
+ * asserted: two independently-constructed limiters sharing a prefix must NOT
+ * each hand out a full budget once a shared store is in play. That cannot be
+ * observed without Redis, so the binding assertion here is the wiring — each
+ * route constructs the distributed limiter and no longer imports the
+ * per-process one. A test of the limiter alone would stay green with the routes
+ * reverted, which is exactly how this shipped.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { createUpstashRateLimiter } from "@/lib/upstash-rate-limit";
+
+const ROUTES = [
+  ["trader trades", "app/api/trader/[wallet]/trades/route.ts", "rl:trader-trades"],
+  ["trader stats", "app/api/trader/[wallet]/stats/route.ts", "rl:trader-stats"],
+  ["protocol stats", "app/api/stats/route.ts", "rl:stats"],
+] as const;
+
+const read = (rel: string) => readFileSync(resolve(__dirname, "../..", rel), "utf8");
+
+describe("public read endpoints use the distributed rate limiter", () => {
+  it.each(ROUTES)("%s constructs createUpstashRateLimiter", (_label, rel) => {
+    const src = read(rel);
+    expect(src).toContain("createUpstashRateLimiter(");
+    expect(src).toContain('from "@/lib/upstash-rate-limit"');
+  });
+
+  it.each(ROUTES)("%s no longer uses the per-process limiter", (_label, rel) => {
+    const src = read(rel);
+    expect(src).not.toMatch(/createMemoryRateLimiter\s*\(/);
+    expect(src).not.toContain('from "@/lib/memory-rate-limit"');
+  });
+
+  it.each(ROUTES)("%s uses a distinct Redis prefix", (_label, rel, prefix) => {
+    expect(read(rel)).toContain(`prefix: "${prefix}"`);
+  });
+
+  it("the three prefixes are distinct (one endpoint cannot spend another's budget)", () => {
+    const prefixes = ROUTES.map(([, , p]) => p);
+    expect(new Set(prefixes).size).toBe(prefixes.length);
+  });
+
+  it.each(ROUTES)("%s still derives the key via getClientIp", (_label, rel) => {
+    // Proxy-depth handling is the reason this helper exists; swapping limiters
+    // must not quietly reintroduce a raw x-forwarded-for read.
+    const src = read(rel);
+    expect(src).toContain('from "@/lib/get-client-ip"');
+    expect(src).not.toMatch(/x-forwarded-for"\)\?\.split\(","\)\[0\]/);
+  });
+
+  it.each(ROUTES)("%s awaits the check (the API is async — a bare call is truthy)", (_label, rel) => {
+    // `if (rateLimiter.check(ip))` would be a Promise: always truthy, limit
+    // silently dead. Assert the awaited form is what's there.
+    expect(read(rel)).toMatch(/await\s+rateLimiter\.check\(/);
+  });
+});
+
+describe("the distributed limiter still bounds a single instance", () => {
+  it("caps at the configured limit and reports a retry hint", async () => {
+    const limiter = createUpstashRateLimiter({
+      limit: 5,
+      windowMs: 60_000,
+      prefix: "rl:test-trader-2487",
+    });
+    let allowed = 0;
+    for (let i = 0; i < 20; i++) {
+      if ((await limiter.check("203.0.113.42")).allowed) allowed++;
+    }
+    expect(allowed).toBe(5);
+    const after = await limiter.check("203.0.113.42");
+    expect(after.allowed).toBe(false);
+    expect(after.retryAfterSecs).toBeGreaterThan(0);
+  });
+
+  it("keeps separate budgets per client IP", async () => {
+    const limiter = createUpstashRateLimiter({
+      limit: 3,
+      windowMs: 60_000,
+      prefix: "rl:test-trader-2487b",
+    });
+    for (let i = 0; i < 3; i++) await limiter.check("198.51.100.1");
+    expect((await limiter.check("198.51.100.2")).allowed).toBe(true);
+  });
+});

--- a/app/app/api/stats/route.ts
+++ b/app/app/api/stats/route.ts
@@ -12,7 +12,7 @@ import { loadMergedMarketRows, type MarketRegistryRow } from "@/lib/market-regis
 import { isPhantomOpenInterest } from "@/lib/phantom-oi";
 import { BLOCKED_SLAB_ADDRESSES } from "@/lib/blocklist";
 import { getClientIp } from "@/lib/get-client-ip";
-import { createMemoryRateLimiter } from "@/lib/memory-rate-limit";
+import { createUpstashRateLimiter } from "@/lib/upstash-rate-limit";
 import { getConfig, getRpcEndpoint } from "@/lib/config";
 import {
   hasIndexerDb,
@@ -29,12 +29,16 @@ export const dynamic = "force-dynamic";
 type MarketWithStats = Database['public']['Views']['markets_with_stats']['Row'];
 
 // ---------------------------------------------------------------------------
-// PERC-660: In-memory rate limiter — 60 req/min per IP (matches /api/trader pattern)
-// Uses shared createMemoryRateLimiter from lib/memory-rate-limit.ts.
-// Per-process only (multi-instance: effective limit = 60 × N). At mainnet
-// scale, replace with Redis-backed rate limiting.
+// PERC-660: Rate limiter — 60 req/min per IP (matches /api/trader pattern).
+// The "at mainnet scale, replace with Redis-backed rate limiting" note that used
+// to sit here is now done — see below.
 // ---------------------------------------------------------------------------
-const rateLimiter = createMemoryRateLimiter({ limit: 60, windowMs: 60_000 });
+// GH#2487: was createMemoryRateLimiter — a per-process Map, so on serverless the
+// limit is per instance and a client spread across warm instances multiplies it
+// by the instance count. createUpstashRateLimiter shares the window through
+// Redis when configured and falls back to the same in-memory behaviour when it
+// is not, so dev/CI are unchanged while production becomes global.
+const rateLimiter = createUpstashRateLimiter({ limit: 60, windowMs: 60_000, prefix: "rl:stats" });
 
 // ---------------------------------------------------------------------------
 // Playground self-contained stats path (no Supabase required)
@@ -334,7 +338,8 @@ async function computeStatsFromIndexer(): Promise<ReturnType<typeof zeroStats>> 
  */
 export async function GET(request: NextRequest) {
   const ip = getClientIp(request);
-  if (rateLimiter.isLimited(ip)) {
+  const rl = await rateLimiter.check(ip);
+  if (!rl.allowed) {
     return NextResponse.json(
       { error: "Rate limited. Max 60 requests per minute." },
       { status: 429, headers: { "Retry-After": "60" } },

--- a/app/app/api/trader/[wallet]/stats/route.ts
+++ b/app/app/api/trader/[wallet]/stats/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { PublicKey } from "@solana/web3.js";
 import { getClientIp } from "@/lib/get-client-ip";
-import { createMemoryRateLimiter } from "@/lib/memory-rate-limit";
+import { createUpstashRateLimiter } from "@/lib/upstash-rate-limit";
 import { hasIndexerDb, queryTraderStatsRows } from "@/lib/indexer-db";
 
 /**
@@ -14,7 +14,12 @@ import { hasIndexerDb, queryTraderStatsRows } from "@/lib/indexer-db";
 export const dynamic = "force-dynamic";
 
 const RATE_LIMIT = 30;
-const rateLimiter = createMemoryRateLimiter({ limit: RATE_LIMIT, windowMs: 60_000 });
+// GH#2487: was createMemoryRateLimiter — a per-process Map, so on serverless the
+// limit is per instance and a client spread across warm instances multiplies it
+// by the instance count. createUpstashRateLimiter shares the window through
+// Redis when configured and falls back to the same in-memory behaviour when it
+// is not, so dev/CI are unchanged while production becomes global.
+const rateLimiter = createUpstashRateLimiter({ limit: RATE_LIMIT, windowMs: 60_000, prefix: "rl:trader-stats" });
 
 export interface TraderStatsResponse {
   totalTrades: number;
@@ -76,7 +81,8 @@ export async function GET(
   { params }: { params: Promise<{ wallet: string }> },
 ) {
   const ip = getClientIp(request);
-  if (rateLimiter.isLimited(ip)) {
+  const rl = await rateLimiter.check(ip);
+  if (!rl.allowed) {
     return NextResponse.json(
       { error: "Too many requests — max 30 per minute" },
       { status: 429, headers: { "Retry-After": "60", "X-RateLimit-Limit": String(RATE_LIMIT), "X-RateLimit-Window": "60s" } },

--- a/app/app/api/trader/[wallet]/trades/route.ts
+++ b/app/app/api/trader/[wallet]/trades/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { PublicKey } from "@solana/web3.js";
 import { validateNumericParam } from "@/lib/route-validators";
 import { getClientIp } from "@/lib/get-client-ip";
-import { createMemoryRateLimiter } from "@/lib/memory-rate-limit";
+import { createUpstashRateLimiter } from "@/lib/upstash-rate-limit";
 import { hasIndexerDb, queryTraderTradesPage } from "@/lib/indexer-db";
 
 /**
@@ -14,7 +14,12 @@ import { hasIndexerDb, queryTraderTradesPage } from "@/lib/indexer-db";
 export const dynamic = "force-dynamic";
 
 const RATE_LIMIT = 60;
-const rateLimiter = createMemoryRateLimiter({ limit: RATE_LIMIT, windowMs: 60_000 });
+// GH#2487: was createMemoryRateLimiter — a per-process Map, so on serverless the
+// limit is per instance and a client spread across warm instances multiplies it
+// by the instance count. createUpstashRateLimiter shares the window through
+// Redis when configured and falls back to the same in-memory behaviour when it
+// is not, so dev/CI are unchanged while production becomes global.
+const rateLimiter = createUpstashRateLimiter({ limit: RATE_LIMIT, windowMs: 60_000, prefix: "rl:trader-trades" });
 
 export interface TraderTradeEntry {
   id: string;
@@ -33,7 +38,8 @@ export async function GET(
   { params }: { params: Promise<{ wallet: string }> },
 ) {
   const ip = getClientIp(_request);
-  if (rateLimiter.isLimited(ip)) {
+  const rl = await rateLimiter.check(ip);
+  if (!rl.allowed) {
     return NextResponse.json(
       { error: "Too many requests — max 60 per minute" },
       {
@@ -94,7 +100,7 @@ export async function GET(
           headers: {
             "Cache-Control": "public, s-maxage=10, stale-while-revalidate=30",
             "X-RateLimit-Limit": String(RATE_LIMIT),
-            "X-RateLimit-Remaining": String(rateLimiter.remaining(ip)),
+            "X-RateLimit-Remaining": String(rl.remaining),
             "X-RateLimit-Window": "60s",
           },
         },
@@ -156,7 +162,7 @@ export async function GET(
         headers: {
           "Cache-Control": "public, s-maxage=10, stale-while-revalidate=30",
           "X-RateLimit-Limit": String(RATE_LIMIT),
-          "X-RateLimit-Remaining": String(rateLimiter.remaining(ip)),
+          "X-RateLimit-Remaining": String(rl.remaining),
           "X-RateLimit-Window": "60s",
         },
       },
@@ -170,7 +176,7 @@ export async function GET(
         headers: {
           "Cache-Control": "public, s-maxage=10, stale-while-revalidate=30",
           "X-RateLimit-Limit": String(RATE_LIMIT),
-          "X-RateLimit-Remaining": String(rateLimiter.remaining(ip)),
+          "X-RateLimit-Remaining": String(rl.remaining),
           "X-RateLimit-Window": "60s",
         },
       },


### PR DESCRIPTION
Fixes #2487.

Premise verified on `playground@f2a3bbe5`: both trader routes construct
`createMemoryRateLimiter`, whose state is a `Map` in one process. Confirmed.

## A third route has the same defect

`/api/stats` uses the identical pattern, and its own comment already predicted
this outcome:

```ts
// Per-process only (multi-instance: effective limit = 60 × N). At mainnet
// scale, replace with Redis-backed rate limiting.
```

Included here rather than left to be rediscovered separately. `/api/stats` was
the only other `createMemoryRateLimiter` caller in the app — after this, none
remain outside the lib and its own unit test.

## The change

All three move to `createUpstashRateLimiter`. As you noted, it already falls back
to in-memory when Upstash is unconfigured, so **dev and CI behave exactly as
before** and only production gains the shared window.

Each route gets a distinct Redis prefix — `rl:trader-trades`, `rl:trader-stats`,
`rl:stats` — so one endpoint cannot spend another's budget. Limits, response
bodies, 429 headers and `getClientIp`-based keying are unchanged;
`X-RateLimit-Remaining` now comes from the single `check()` result rather than a
second call into the limiter.

**One trap worth flagging for anyone doing this elsewhere:** the new API is
`async`. `if (rateLimiter.check(ip))` without `await` is a Promise — always
truthy — so the check inverts into "always limited", and the mirror slip
(`if (!rateLimiter.check(ip))`) silently disables the limit entirely while
looking correct. The tests assert the awaited form at each call site for exactly
that reason.

## On the suggested regression test

The proposed test fires 120 real `fetch`es at a live endpoint and expects ≥60 to
be 429. That needs a running server and a shared Redis, so in CI it would either
be skipped or assert the in-memory fallback — i.e. pass without testing the
distributed property. The property you actually care about (shared across
instances) can't be observed without Redis at all.

So the binding assertion here is the wiring: each route constructs the
distributed limiter, no longer imports the per-process one, uses a distinct
prefix, and awaits the check. That's what fails if this regresses. A test of the
limiter alone stays green with the routes reverted — which is how the
per-process version shipped in the first place.

Mutation-verified:

| Mutation | Result |
|---|---|
| revert one route to `createMemoryRateLimiter` | **3 tests fail** |
| drop the `await` on `check()` | **1 test fails** |

```
cd app && npx vitest run
Test Files  282 passed | 1 skipped (283)
     Tests  2937 passed | 16 skipped (2953)

npx tsc --noEmit    # clean
```

## Deployment note

If `UPSTASH_REDIS_REST_URL` / `_TOKEN` are not set in production, these three
endpoints keep exactly today's per-instance behaviour — the fix is inert until
Upstash is configured. #2478 (pending) makes that state alert loudly instead of
passing silently, which is the other half of making this real.
