### PR TITLE
Return 503 on open-interest all-paths-failure instead of fabricated zeros

### DIFF
--- a/app/__tests__/api/open-interest-degraded-status.test.ts
+++ b/app/__tests__/api/open-interest-degraded-status.test.ts
@@ -1,0 +1,46 @@
+/**
+ * PoC + regression — /api/open-interest/[slab] must signal a degraded state on an
+ * all-paths-failure, not return HTTP 200 with fabricated zeros.
+ *
+ * The route's fallback returned { totalOi:"0", ... } with status 200 when every
+ * data path failed, so a transient RPC failure rendered as a real "$0 OI /
+ * Balanced" market. The consumer (OpenInterestCard) is already built correctly:
+ *   if (!res.ok) throw  →  catch → fall back to on-chain engine OI
+ * so a 5xx makes it show the REAL on-chain OI instead of trusting the zeros.
+ *
+ * This models the consumer's exact handling and shows a 200-with-zeros yields a
+ * false $0, while a 503 yields the real on-chain value.
+ */
+import { describe, it, expect } from "vitest";
+
+// Faithful model of OpenInterestCard's fetch handling (route.tsx:110-142).
+function consumerTotalOi(
+  res: { ok: boolean; body: { totalOi?: string } },
+  engineOi: { long: bigint; short: bigint } | null,
+): string | null {
+  if (!res.ok) {
+    // catch → on-chain fallback
+    if (engineOi) return (engineOi.long + engineOi.short).toString();
+    return null; // neutral/error state (no fabricated number)
+  }
+  return res.body.totalOi ?? null; // trusts the API body
+}
+
+const engine = { long: 100n, short: 50n }; // real on-chain OI = 150
+
+describe("open-interest degraded response", () => {
+  it("200 + zeros makes the consumer show a false $0 (the bug)", () => {
+    const res = { ok: true, body: { totalOi: "0" } };
+    expect(consumerTotalOi(res, engine)).toBe("0"); // wrong — market actually has OI
+  });
+
+  it("503 makes the consumer fall back to real on-chain OI (the fix)", () => {
+    const res = { ok: false, body: {} };
+    expect(consumerTotalOi(res, engine)).toBe("150"); // real OI shown instead
+  });
+
+  it("503 with no engine yields a neutral/error state, not a fabricated $0", () => {
+    const res = { ok: false, body: {} };
+    expect(consumerTotalOi(res, null)).toBeNull();
+  });
+});

--- a/app/app/api/open-interest/[slab]/route.ts
+++ b/app/app/api/open-interest/[slab]/route.ts
@@ -208,11 +208,18 @@ export async function GET(
     });
   }
 
-  // ── FALLBACK: all paths failed — return empty zeros ───────────────────────
-  // Valid shape so the component doesn't throw; renders "Balanced / 0 / 0" state.
-  console.warn(`[/api/open-interest/${validSlab}] all paths failed — returning zero OI`);
+  // ── FALLBACK: all paths failed — signal a DEGRADED state, do not fabricate $0 ──
+  // Returning 200 with zeros made a transient RPC failure render as a genuine
+  // "$0 OI / Balanced" market. A 5xx lets the client distinguish "temporarily
+  // unavailable" from "no open interest": OpenInterestCard already throws on
+  // !res.ok and falls back to the real on-chain engine OI, so this restores the
+  // correct value instead of a fabricated zero. The zero fields + `unavailable`
+  // flag keep the body shape valid for any other consumer.
+  console.warn(`[/api/open-interest/${validSlab}] all paths failed — returning 503 (degraded)`);
   return NextResponse.json(
     {
+      error: "Open interest temporarily unavailable",
+      unavailable: true,
       totalOi: "0",
       longOi: "0",
       shortOi: "0",
@@ -220,6 +227,7 @@ export async function GET(
       historicalOi: [],
     },
     {
+      status: 503,
       headers: { "Cache-Control": "no-store" },
     },
   );


### PR DESCRIPTION
## What

Return `503` (not `200` with zeros) when `/api/open-interest/[slab]` exhausts every
data path, so a transient failure isn't rendered as a real "$0 OI" market.

Closes #2489.

## Why

The all-paths-failed fallback returned `{ totalOi:"0", ... }` with HTTP 200, so a
transient RPC/backend failure looked like a genuine zero-OI market. `OpenInterestCard`
is already built to recover — `if (!res.ok) throw` → catch → fall back to the real
on-chain engine OI — but the 200 response prevented that fallback from firing, so
the fabricated zeros were trusted and displayed.

## Changes

- **open-interest/[slab]** — the all-paths-failed fallback now returns `503` with an
  `unavailable: true` marker (zero fields kept so the body shape stays valid). The
  account-missing `404` path and the success path are unchanged.
- **regression test** — models `OpenInterestCard`'s handling: `200`+zeros yields a
  false `$0`, while `503` triggers the real on-chain OI fallback (and a neutral
  error state when no engine data is available).

## Testing

- `npx tsc --noEmit` — clean.
- PoC + `phantom-oi-unknown-accounts` + the `OpenInterestCard` component test —
  **3 files, 22 tests, all pass**.

## Notes

- Frontend + devnet scope only; no program, keeper, or mainnet changes.
- Behavioral change is limited to the exception path — the client already handles
  a `5xx` correctly, so this makes its existing on-chain fallback actually engage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Open-interest data now clearly indicates when it is unavailable instead of displaying misleading zero values.
  * Preserved valid zero open-interest results when the service responds successfully.
  * Added fallback handling to show on-chain data when primary data is unavailable.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->