### PR TITLE
Price the fresh-open liquidation preview against full cross-margin capital

### DIFF
--- a/app/__tests__/components/order-ticket-fresh-open-liq.test.ts
+++ b/app/__tests__/components/order-ticket-fresh-open-liq.test.ts
@@ -1,0 +1,55 @@
+/**
+ * PoC + regression — the order ticket's fresh-open liquidation PREVIEW must price
+ * against the full cross-margined account capital, not just the order's margin.
+ *
+ * Percolator v17 is cross-margined (withdraw is blocked while any leg is open), so
+ * the whole account backs a position. OrderTicket's scale-in branch already prices
+ * liq with `capital` (matching PositionsDock / useLiqPrice), but the fresh-open
+ * branch (existingPositionSize === 0n) used computePreTradeLiqPrice against only
+ * `marginNative`. Whenever capital > order margin, that understates liquidation
+ * distance — the confirm modal shows a scarier (closer) liq price than the real
+ * on-chain one, and it visibly jumps once the position opens and recomputes on
+ * full capital.
+ *
+ * This uses the real SDK/app math to show the margin-only preview differs from the
+ * capital-based value, and that the capital-based value is the sane one.
+ */
+import { describe, it, expect } from "vitest";
+import { computePreTradeLiqPrice, computeLiqPrice } from "@percolatorct/sdk";
+import { computeEstimatedEntryPrice } from "@/lib/trading";
+
+const oracleE6 = 100_000_000n;          // $100
+const capital = 1_000_000_000n;         // 1000 USDC total account capital
+const marginNative = 100_000_000n;      // 100 USDC reserved for THIS order
+const positionSize = 5_000_000n;        // 5 units (≈ $500 notional, 5x on 100 margin)
+const mmBps = 500n;                      // 5% maintenance margin
+const feeBps = 30n;
+
+describe("order ticket fresh-open liq preview", () => {
+  it("margin-only preview shows a scary liq for a position that's safer at full capital (the bug)", () => {
+    const estEntry = computeEstimatedEntryPrice(oracleE6, feeBps, "long");
+
+    // OLD fresh-open branch: prices against just the order's margin.
+    const marginOnlyLiq = computePreTradeLiqPrice(oracleE6, marginNative, positionSize, mmBps, feeBps, "long");
+    // FIXED: full account capital backs the position (cross-margin) — matches the
+    // scale-in branch and PositionsDock.
+    const capitalLiq = computeLiqPrice(estEntry, capital, positionSize, mmBps);
+
+    // The preview shows a real, scary liq price...
+    expect(marginOnlyLiq).toBeGreaterThan(0n);
+    // ...while the true cross-margin liq is either UNLIQUIDATABLE (0n = "∞", as in
+    // this 10x-capital case) or strictly farther from entry (lower, for a long).
+    expect(capitalLiq === 0n || capitalLiq < marginOnlyLiq).toBe(true);
+    // The preview materially disagrees with the reality the position will show once open.
+    expect(marginOnlyLiq).not.toBe(capitalLiq);
+  });
+
+  it("when order margin equals capital, the two agree (no false positive)", () => {
+    const estEntry = computeEstimatedEntryPrice(oracleE6, feeBps, "long");
+    const marginOnlyLiq = computePreTradeLiqPrice(oracleE6, capital, positionSize, mmBps, feeBps, "long");
+    const capitalLiq = computeLiqPrice(estEntry, capital, positionSize, mmBps);
+    // Same backing → liq prices are close (fee modeling aside).
+    const diff = marginOnlyLiq > capitalLiq ? marginOnlyLiq - capitalLiq : capitalLiq - marginOnlyLiq;
+    expect(diff).toBeLessThan(oracleE6 / 100n); // within ~$1
+  });
+});

--- a/app/components/trade/OrderTicket.tsx
+++ b/app/components/trade/OrderTicket.tsx
@@ -53,7 +53,7 @@ import { useTokenMeta } from "@/hooks/useTokenMeta";
 import { getLivePriceSnapshot } from "@/lib/priceStore/priceStore";
 import { useOracleFreshness } from "@/hooks/useOracleFreshness";
 import { useEngineFreshness } from "@/hooks/useEngineFreshness";
-import { AccountKind, computePreTradeLiqPrice, computeLiqPrice } from "@percolatorct/sdk";
+import { AccountKind, computeLiqPrice } from "@percolatorct/sdk";
 import { computeEstimatedEntryPrice, computeTradingFee, computePositionInitialMargin, estimateEntryFromPnl } from "@/lib/trading";
 import { TradeConfirmationModal } from "@/components/trade/TradeConfirmationModal";
 import { InfoIcon } from "@/components/ui/Tooltip";
@@ -635,12 +635,16 @@ const OrderTicketInner: FC<{ slabAddress: string }> = ({ slabAddress }) => {
     // Opposite direction: a partial reduce keeps the original cost basis; a
     // flip's residual position takes on this trade's fill price as its entry.
     : (positionSize < existingAbsSize ? existingEntryPriceE6 : estEntry);
-  const afterLiqPrice = hasOrder
-    ? (existingPositionSize === 0n
-        ? computePreTradeLiqPrice(oracleE6, marginNative, positionSize, maintenanceMarginBps, tradingFeeBps, direction)
-        : (combinedSignedSize !== 0n && combinedEntryPriceE6 > 0n
-            ? computeLiqPrice(combinedEntryPriceE6, capital, combinedSignedSize, maintenanceMarginBps)
-            : 0n))
+  // Cross-margin: the full account capital backs the position — including a fresh
+  // open (withdraw is blocked while any leg is open). Price both the fresh-open and
+  // scale-in cases with the same capital-based computeLiqPrice as PositionsDock /
+  // useLiqPrice: when there is no existing position, combinedSignedSize and
+  // combinedEntryPriceE6 already reduce to this order's own signed size and
+  // estimated entry, so one branch is correct for both. (Previously the fresh-open
+  // case priced against only the order's margin, understating liq distance and
+  // making the preview jump once the position opened on full capital.)
+  const afterLiqPrice = hasOrder && combinedSignedSize !== 0n && combinedEntryPriceE6 > 0n
+    ? computeLiqPrice(combinedEntryPriceE6, capital, combinedSignedSize, maintenanceMarginBps)
     : 0n;
   const beforeLiqPrice = userAccount && userAccount.account.positionSize !== 0n && existingEntryPriceE6 > 0n
     ? computeLiqPrice(existingEntryPriceE6, capital, userAccount.account.positionSize, maintenanceMarginBps)


### PR DESCRIPTION
## What

Price the order ticket's fresh-open liquidation **preview** against the full
cross-margined account capital, matching the scale-in branch and PositionsDock.

## Why

OrderTicket priced a FRESH open (`existingPositionSize === 0`) with
`computePreTradeLiqPrice` against only the order's `marginNative`, while every other
liq surface (the scale-in branch, `PositionsDock`, `useLiqPrice`) uses full
`capital`. Percolator v17 is cross-margined (withdraw is blocked while any leg is
open), so the whole account backs the position. The margin-only preview therefore
understated liquidation distance — the confirm modal showed a scarier (closer) liq
price than reality, which then jumped once the position opened and recomputed on
full capital (e.g. a preview liq of ~$81 for a position that is actually
unliquidatable at full capital).

## Changes

- **OrderTicket** — drop the fresh-open special case. When there's no existing
  position, `combinedSignedSize` / `combinedEntryPriceE6` already equal this order's
  own signed size and estimated entry, so the existing capital-based
  `computeLiqPrice` branch is correct for both fresh-open and scale-in. Removed the
  now-unused `computePreTradeLiqPrice` import.
- **regression test** — real SDK math showing the margin-only preview disagrees with
  the capital-based value (margin-only shows a real liq for a position that is
  unliquidatable / safer at full capital), and that when order margin == capital the
  two agree (no false positive).

## Testing

- `npx tsc --noEmit` — clean.
- New PoC + `liquidation-distance` suite — **13 tests, all pass**.

## Notes

- Frontend + devnet scope; no program/keeper/mainnet changes.
- Scale-in and before-open behavior is unchanged; only the fresh-open preview is
  corrected so it matches what the opened position displays (no more jump). The old
  preview erred conservative (scarier); this shows the true (farther / unliquidatable)
  liq.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved liquidation price previews for fresh orders and existing-position adjustments.
  * Previews now consistently account for full account capital and combined positions, providing more accurate results.

* **Tests**
  * Added regression coverage to verify liquidation pricing across margin-only and full-capital scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->