### PR TITLE
Harden admin-secret check: fixed-length compare + per-capability secrets

### DIFF
--- a/app/__tests__/api/admin-secret.test.ts
+++ b/app/__tests__/api/admin-secret.test.ts
@@ -1,0 +1,66 @@
+/**
+ * PoC + regression — shared admin-secret check: fixed-length compare (no length
+ * leak) + per-capability secret with fallback.
+ *
+ * The previous inline checks used `a.length === b.length && timingSafeEqual(a, b)`,
+ * which short-circuits on a length mismatch (a timing signal for the secret's
+ * length), and every admin route shared one ADMIN_API_SECRET.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { NextRequest } from "next/server";
+import { checkAdminSecret } from "@/lib/admin-secret";
+
+const reqWith = (value: string | null): NextRequest =>
+  ({ headers: { get: (k: string) => (k === "x-admin-secret" ? value : null) } } as unknown as NextRequest);
+
+const ENV_KEYS = ["ADMIN_API_SECRET", "ADMIN_ORACLE_SECRET", "ADMIN_REGISTER_SECRET"];
+let saved: Record<string, string | undefined>;
+beforeEach(() => {
+  saved = {};
+  for (const k of ENV_KEYS) { saved[k] = process.env[k]; delete process.env[k]; }
+});
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+describe("checkAdminSecret", () => {
+  it("PoC: the old compare leaks length by short-circuiting on a mismatch", () => {
+    // Model of the removed check: timingSafeEqual is not even reached when lengths
+    // differ, so a wrong-length guess returns faster than a right-length one.
+    let constantTimeReached = false;
+    const oldCheck = (secret: string, provided: string) => {
+      const a = Buffer.from(provided), b = Buffer.from(secret);
+      if (a.length !== b.length) return false;          // early return — timing signal
+      constantTimeReached = true;
+      return a.equals(b);
+    };
+    expect(oldCheck("supersecret", "x")).toBe(false);
+    expect(constantTimeReached).toBe(false);             // never did constant-time work
+  });
+
+  it("accepts the correct secret and rejects wrong/empty (fixed-length compare)", () => {
+    process.env.ADMIN_API_SECRET = "supersecret";
+    expect(checkAdminSecret(reqWith("supersecret"))).toBe(true);
+    expect(checkAdminSecret(reqWith("wrong"))).toBe(false);
+    expect(checkAdminSecret(reqWith("supersecre"))).toBe(false); // off-by-one length
+    expect(checkAdminSecret(reqWith(""))).toBe(false);
+    expect(checkAdminSecret(reqWith(null))).toBe(false);
+  });
+
+  it("denies when no secret is configured (fail closed)", () => {
+    expect(checkAdminSecret(reqWith("anything"), "oracle")).toBe(false);
+  });
+
+  it("per-capability secret overrides the shared fallback", () => {
+    process.env.ADMIN_API_SECRET = "shared";
+    process.env.ADMIN_ORACLE_SECRET = "oracle-only";
+    // oracle capability uses its own secret; the shared one no longer works for it
+    expect(checkAdminSecret(reqWith("oracle-only"), "oracle")).toBe(true);
+    expect(checkAdminSecret(reqWith("shared"), "oracle")).toBe(false);
+    // a capability without its own secret falls back to the shared one
+    expect(checkAdminSecret(reqWith("shared"), "register")).toBe(true);
+  });
+});

--- a/app/app/api/markets/[slab]/logo/route.ts
+++ b/app/app/api/markets/[slab]/logo/route.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer";
-import { timingSafeEqual } from "node:crypto";
+import { checkAdminSecret } from "@/lib/admin-secret";
 import { NextRequest, NextResponse } from "next/server";
 import { PublicKey } from "@solana/web3.js";
 import nacl from "tweetnacl";
@@ -77,12 +77,7 @@ const RATE_LIMIT_MS = 30_000; // 1 upload per 30s per slab
  *  /api/playground/keeper-register and /api/oracle/set-price-cap. Empty/unset
  *  ADMIN_API_SECRET always denies. */
 function isAdminBypass(req: NextRequest): boolean {
-  const secret = (process.env.ADMIN_API_SECRET ?? "").trim();
-  if (!secret) return false;
-  const provided = req.headers.get("x-admin-secret") ?? "";
-  const a = Buffer.from(provided, "utf8");
-  const b = Buffer.from(secret, "utf8");
-  return a.length === b.length && timingSafeEqual(a, b);
+  return checkAdminSecret(req, "logo");
 }
 
 /** Stateless deployer proof — see the file header for why this mirrors

--- a/app/app/api/oracle/set-price-cap/route.ts
+++ b/app/app/api/oracle/set-price-cap/route.ts
@@ -43,7 +43,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { timingSafeEqual } from "node:crypto";
+import { checkAdminSecret } from "@/lib/admin-secret";
 import {
   Connection,
   Keypair,
@@ -80,12 +80,7 @@ function loadCrankKeypair(): Keypair | null {
 
 /** Timing-safe auth check. Empty ADMIN_API_SECRET must deny (GH#1692 follow-up). */
 function isAuthorized(req: NextRequest): boolean {
-  const secret = (process.env.ADMIN_API_SECRET ?? "").trim();
-  if (!secret) return false;
-  const provided = req.headers.get("x-admin-secret") ?? "";
-  const a = Buffer.from(provided, "utf8");
-  const b = Buffer.from(secret, "utf8");
-  return a.length === b.length && timingSafeEqual(a, b);
+  return checkAdminSecret(req, "oracle");
 }
 
 export async function POST(req: NextRequest) {

--- a/app/app/api/playground/keeper-register/route.ts
+++ b/app/app/api/playground/keeper-register/route.ts
@@ -92,7 +92,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { timingSafeEqual } from "node:crypto";
+import { checkAdminSecret } from "@/lib/admin-secret";
 import { Connection, PublicKey } from "@solana/web3.js";
 import nacl from "tweetnacl";
 import * as Sentry from "@sentry/nextjs";
@@ -111,12 +111,7 @@ export const dynamic = "force-dynamic";
 /** Timing-safe admin-bypass check (H1b) — same secret/header convention as
  *  /api/oracle/set-price-cap. Empty/unset ADMIN_API_SECRET always denies. */
 function isAdminBypass(req: NextRequest): boolean {
-  const secret = (process.env.ADMIN_API_SECRET ?? "").trim();
-  if (!secret) return false;
-  const provided = req.headers.get("x-admin-secret") ?? "";
-  const a = Buffer.from(provided, "utf8");
-  const b = Buffer.from(secret, "utf8");
-  return a.length === b.length && timingSafeEqual(a, b);
+  return checkAdminSecret(req, "register");
 }
 
 /** H1v2 stateless deployer proof — see "Authentication (H1v2)" in the file header

--- a/app/lib/admin-secret.ts
+++ b/app/lib/admin-secret.ts
@@ -1,0 +1,32 @@
+import { timingSafeEqual, createHash } from "node:crypto";
+import type { NextRequest } from "next/server";
+
+/**
+ * Timing-safe `x-admin-secret` check for maintainer-only routes.
+ *
+ * Fixes two issues the previous inline checks shared:
+ *  1. Length leak — `a.length === b.length && timingSafeEqual(a, b)` short-circuits
+ *     on a length mismatch, so response timing revealed the secret's length. Both
+ *     sides are now hashed to a fixed 32 bytes before the compare (mirrors
+ *     lib/api-auth `checkInternalSecret`), so the compare is constant-shape.
+ *  2. Single shared secret — one `ADMIN_API_SECRET` gated every admin action, so one
+ *     leaked secret granted all of them. Callers pass a `capability`; the check uses
+ *     `ADMIN_<CAPABILITY>_SECRET` when set, falling back to `ADMIN_API_SECRET`.
+ *     Deployments can therefore set distinct per-capability secrets to separate the
+ *     blast radius, with no behavior change when only `ADMIN_API_SECRET` is set.
+ *
+ * Empty/unset resolved secret always denies (fail closed).
+ */
+export function checkAdminSecret(req: NextRequest, capability?: string): boolean {
+  const perCapability = capability
+    ? (process.env[`ADMIN_${capability.toUpperCase()}_SECRET`] ?? "").trim()
+    : "";
+  const secret = perCapability || (process.env.ADMIN_API_SECRET ?? "").trim();
+  if (!secret) return false;
+
+  const provided = req.headers.get("x-admin-secret") ?? "";
+  // Hash both to a fixed 32 bytes so timingSafeEqual never sees unequal lengths.
+  const expected = createHash("sha256").update(secret).digest();
+  const got = createHash("sha256").update(provided).digest();
+  return timingSafeEqual(expected, got);
+}


### PR DESCRIPTION
## What

Harden the `x-admin-secret` check used by the maintainer-only routes: a
fixed-length timing-safe compare plus optional per-capability secrets.

## Why

The check was copy-pasted across three routes (keeper-register admin bypass, oracle
`set-price-cap`, market logo upload) with two weaknesses:

- **Length leak** — `a.length === b.length && timingSafeEqual(a, b)` short-circuits
  on a length mismatch, so response timing reveals the secret's length.
- **One shared secret** — a single `ADMIN_API_SECRET` gated all three privileged
  actions, so one leaked secret grants every admin capability.

## Changes

- **`lib/admin-secret` (new)** — `checkAdminSecret(req, capability)`:
  - hashes both provided and expected to a fixed 32 bytes before `timingSafeEqual`
    (mirrors `lib/api-auth` `checkInternalSecret`) → no length leak.
  - resolves `ADMIN_<CAPABILITY>_SECRET` when set, else falls back to
    `ADMIN_API_SECRET` → deployments can set distinct per-capability secrets to
    separate the blast radius; **no behavior change** when only `ADMIN_API_SECRET`
    is set.
  - empty/unset resolved secret always denies (fail closed).
- **keeper-register / set-price-cap / logo** — replaced the three identical inline
  checks with `checkAdminSecret(req, "register" | "oracle" | "logo")`; removed the
  now-unused `timingSafeEqual` imports.
- **regression test** — fixed-length accept/reject (incl. off-by-one length),
  fail-closed, per-capability override + fallback; plus a PoC of the old
  short-circuit length leak.

## Testing

- `npx tsc --noEmit` — clean.
- admin-secret PoC + every route using the check (gh1692 timing-safe keeper auth,
  markets-deployer-auth, set-price-cap, market-logo-ownership, keeper-register
  concurrency) — **6 files, 37 tests, all pass**.

## Notes

- Frontend + devnet scope; no program/keeper/mainnet changes.
- Backward compatible: existing single-`ADMIN_API_SECRET` deployments behave
  identically; per-capability separation is opt-in by setting the new env vars.
