### PR TITLE
Bound set-price-cap maxChangeE2bps to u64 on the number path

### DIFF
--- a/app/__tests__/api/set-price-cap-u64-bound.test.ts
+++ b/app/__tests__/api/set-price-cap-u64-bound.test.ts
@@ -1,0 +1,40 @@
+/**
+ * PoC + regression — set-price-cap must bound maxChangeE2bps to u64 on BOTH the
+ * number and string input paths.
+ *
+ * The route rejects `> u64max` only when maxChangeE2bps arrives as a string. On the
+ * `number` path it checks only integer + non-negative, so a value like 1e21 passes
+ * and is handed to encodeSetOraclePriceCap where it exceeds u64. (Admin-only, so
+ * the impact is a malformed request rather than an attack — but it should 400, not
+ * emit a broken instruction.)
+ */
+import { describe, it, expect } from "vitest";
+
+const U64_MAX = 0xffff_ffff_ffff_ffffn;
+
+// Current number-path gate (route.ts): integer + non-negative only.
+const currentNumberAccepts = (raw: number) => Number.isInteger(raw) && raw >= 0;
+// Fixed gate: also reject anything above u64 max.
+const fixedNumberAccepts = (raw: number) =>
+  Number.isInteger(raw) && raw >= 0 && BigInt(raw) <= U64_MAX;
+
+describe("set-price-cap number-path u64 bound", () => {
+  it("current number path accepts a value that overflows u64 (the bug)", () => {
+    expect(currentNumberAccepts(1e21)).toBe(true);     // accepted today
+    expect(BigInt(1e21) > U64_MAX).toBe(true);          // ...but exceeds u64
+    expect(fixedNumberAccepts(1e21)).toBe(false);       // fix rejects it
+  });
+
+  it("legitimate values still pass", () => {
+    expect(fixedNumberAccepts(1_000)).toBe(true);       // default-ish
+    expect(fixedNumberAccepts(0)).toBe(true);           // 0 = disabled
+    // boundary: the largest safe integer is well within u64
+    expect(fixedNumberAccepts(Number.MAX_SAFE_INTEGER)).toBe(true);
+  });
+
+  it("string path already bounded (parity target)", () => {
+    const stringAccepts = (raw: string) => /^\d+$/.test(raw) && BigInt(raw) <= U64_MAX;
+    expect(stringAccepts("1000000000000000000000")).toBe(false); // 1e21 as string — rejected
+    expect(stringAccepts("1000")).toBe(true);
+  });
+});

--- a/app/app/api/oracle/set-price-cap/route.ts
+++ b/app/app/api/oracle/set-price-cap/route.ts
@@ -120,6 +120,14 @@ export async function POST(req: NextRequest) {
         );
       }
       maxChangeE2bps = BigInt(raw);
+      // Bound the number path to u64 too — the string path already does this, but a
+      // JS number like 1e21 is a non-negative integer that overflows u64.
+      if (maxChangeE2bps > 0xffff_ffff_ffff_ffffn) {
+        return NextResponse.json(
+          { error: "maxChangeE2bps exceeds u64 max" },
+          { status: 400 },
+        );
+      }
     } else if (typeof raw === "string" && /^\d+$/.test(raw)) {
       const parsed = BigInt(raw);
       if (parsed > 0xffff_ffff_ffff_ffffn) {


### PR DESCRIPTION
## What
Reject `maxChangeE2bps` above u64 max on the **number** input path of
`/api/oracle/set-price-cap` (the string path already does this).

## Why
The number path validated integer + non-negative but had no upper bound, so a JS
number like `1e21` (a non-negative integer that overflows u64) passed and was handed
to `encodeSetOraclePriceCap`. Admin-only, so the impact is a malformed request
rather than an attack — but it should return 400, consistent with the string path.

## Changes
- set-price-cap: add the same `> 0xffff_ffff_ffff_ffff` check on the number path.
- regression test: `1e21` rejected; legit values (incl. `MAX_SAFE_INTEGER`, `0`) pass;
  string-path parity documented.

## Testing
- `npx tsc --noEmit` — clean.
- New test + `oracle-set-price-cap` — 2 files, 8 tests, all pass.

## Notes
- Frontend + devnet scope; no program/keeper/mainnet changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject numeric price-cap values exceeding the supported 64-bit unsigned integer range.
  * Invalid oversized values now return a clear HTTP 400 response instead of being processed.
  * Valid values, including zero and the maximum safe integer, continue to be accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->