### PR TITLE
Sanitize on-chain OI/insurance before Number() in live-market-state

### DIFF
--- a/app/__tests__/lib/live-market-state-oi-sentinel.test.ts
+++ b/app/__tests__/lib/live-market-state-oi-sentinel.test.ts
@@ -1,0 +1,32 @@
+/**
+ * PoC + regression — live-market-state must sanitize on-chain OI/insurance before
+ * converting to Number.
+ *
+ * markPrice is guarded (< MAX_SANE_PRICE_E6), but oiLongQ/oiShortQ/insurance were
+ * `Number(rawBigint)` with no guard, so a sentinel/uninitialized slab (u64::MAX)
+ * yields an astronomically large value that propagates into total_open_interest_usd.
+ * sanitizeOnChainValue zeros sentinels and negatives — the same treatment other
+ * on-chain reads already get.
+ */
+import { describe, it, expect } from "vitest";
+import { sanitizeOnChainValue, isSentinelValue } from "@/lib/health";
+
+const U64_MAX = 2n ** 64n - 1n;
+
+describe("live-market-state OI/insurance sentinel guard", () => {
+  it("raw conversion of a sentinel yields an astronomical number (the bug)", () => {
+    expect(isSentinelValue(U64_MAX)).toBe(true);
+    expect(Number(U64_MAX)).toBeGreaterThan(1e19); // absurd OI/insurance
+  });
+
+  it("sanitizeOnChainValue zeros sentinels and negatives (the fix)", () => {
+    expect(Number(sanitizeOnChainValue(U64_MAX))).toBe(0);
+    expect(sanitizeOnChainValue(-5n)).toBe(0n);
+    expect(sanitizeOnChainValue(0n)).toBe(0n);
+  });
+
+  it("legitimate values pass through unchanged", () => {
+    expect(sanitizeOnChainValue(1_000_000n)).toBe(1_000_000n);
+    expect(sanitizeOnChainValue(42n)).toBe(42n);
+  });
+});

--- a/app/lib/live-market-state.ts
+++ b/app/lib/live-market-state.ts
@@ -7,6 +7,7 @@ import {
   V17_MARKET_GROUP_OFF,
 } from "@percolatorct/sdk";
 import { getRpcEndpoint } from "@/lib/config";
+import { sanitizeOnChainValue } from "@/lib/health";
 
 /**
  * Live per-market state, read straight from the slab account.
@@ -111,9 +112,12 @@ function parseLiveState(data: Uint8Array): LiveMarketState | null {
   let insurance = 0;
   try {
     const oi = parseMarketGroupV17OI(data);
-    oiLongQ = Number(oi.totalLongOiQ);
-    oiShortQ = Number(oi.totalShortOiQ);
-    insurance = Number(oi.insuranceBalance);
+    // Sanitize sentinel/negative on-chain values (u64::MAX from an uninitialized
+    // slab) to 0 before Number() — otherwise they become astronomical OI/insurance
+    // that poisons total_open_interest_usd downstream. Same treatment markPrice gets.
+    oiLongQ = Number(sanitizeOnChainValue(oi.totalLongOiQ));
+    oiShortQ = Number(sanitizeOnChainValue(oi.totalShortOiQ));
+    insurance = Number(sanitizeOnChainValue(oi.insuranceBalance));
   } catch {
     // OI unreadable — zeros, same as the pre-existing degradation behaviour.
   }


### PR DESCRIPTION
## What
Wrap `live-market-state`'s OI/insurance bigint→Number conversions with
`sanitizeOnChainValue`.

## Why
`markPriceUsd` is guarded (`< MAX_SANE_PRICE_E6`), but `oiLongQ`/`oiShortQ`/
`insurance` were `Number(rawBigint)` with no guard. A sentinel/uninitialized slab
(u64::MAX) therefore produces an astronomically large OI/insurance that flows into
`total_open_interest_usd`. `sanitizeOnChainValue` zeros sentinels and negatives —
the same treatment `markPrice` and other on-chain reads already receive.

## Changes
- live-market-state: `sanitizeOnChainValue` on OI long/short + insurance before `Number()`.
- regression test: u64::MAX → 0, negatives → 0, legit values preserved.

## Testing
- `npx tsc --noEmit` — clean.
- New test — 3/3 pass.

## Notes
- Frontend + devnet scope; no program/keeper/mainnet changes.