### PR TITLE
Clamp on-chain numUsedAccounts before the warmup account-index bound

### DIFF
--- a/app/__tests__/api/warmup-account-index-clamp.test.ts
+++ b/app/__tests__/api/warmup-account-index-clamp.test.ts
@@ -1,0 +1,37 @@
+/**
+ * PoC + regression — warmup must clamp the on-chain numUsedAccounts before using
+ * it as the account-index bound.
+ *
+ * The route guards `accountIdx >= engine.numUsedAccounts` with the raw on-chain
+ * value, and accountIdx has no upper bound (only >= 0). A sentinel/garbage
+ * numUsedAccounts (u64::MAX / uninitialized slab) is huge, so the guard passes and
+ * parseAccount reads an out-of-range slot. sanitizeAccountCount clamps garbage to 0.
+ */
+import { describe, it, expect } from "vitest";
+import { sanitizeAccountCount } from "@/lib/health";
+
+// Models the guard: rejects (404) when accountIdx >= the (sanitized) count.
+const guardRejects = (accountIdx: number, rawNumUsed: number) =>
+  accountIdx >= sanitizeAccountCount(rawNumUsed);
+
+describe("warmup account-index clamp", () => {
+  it("sanitizeAccountCount clamps sentinel/garbage counts to 0", () => {
+    expect(sanitizeAccountCount(Number(2n ** 64n - 1n))).toBe(0); // u64::MAX sentinel
+    expect(sanitizeAccountCount(999_999)).toBe(0);                 // above the 4096 slab cap
+    expect(sanitizeAccountCount(-1)).toBe(0);
+  });
+
+  it("legitimate counts pass through", () => {
+    expect(sanitizeAccountCount(10)).toBe(10);
+    expect(sanitizeAccountCount(4096)).toBe(4096); // large-slab capacity
+  });
+
+  it("guard: garbage count no longer lets an index through (the fix)", () => {
+    // Old behavior: accountIdx 5 vs a huge raw count → 5 >= huge is false → PASSES.
+    expect(5 >= Number(2n ** 64n - 1n)).toBe(false);   // the old bug
+    // Fixed: clamp first → 5 >= 0 → REJECTED.
+    expect(guardRejects(5, Number(2n ** 64n - 1n))).toBe(true);
+    // A legitimate in-range index is still allowed.
+    expect(guardRejects(5, 10)).toBe(false);
+  });
+});

--- a/app/__tests__/api/warmup-account-index-route-enforcement.test.ts
+++ b/app/__tests__/api/warmup-account-index-route-enforcement.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Regression: warmup must clamp numUsedAccounts against the slab's real maxAccounts
+ * IN THE ROUTE.
+ *
+ * warmup-account-index-clamp.test.ts exercises sanitizeAccountCount in isolation, so
+ * replacing the route's clamp with a raw Number() left it green. This drives the real
+ * GET handler with the SDK parsers mocked, and binds two properties:
+ *   1. the clamp exists — a sentinel count is rejected at the bound;
+ *   2. it uses the slab's maxAccounts — a plausible-but-garbage count that is below
+ *      the 4096 default but above the real cap is also rejected.
+ * A control confirms an in-range index passes the bound (fails later, differently).
+ */
+import { describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const h = vi.hoisted(() => ({ count: 0n as bigint, max: 0n as bigint }));
+
+vi.mock("@percolatorct/sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@percolatorct/sdk")>();
+  return {
+    ...actual,
+    fetchSlab: vi.fn(async () => new Uint8Array(64)),
+    parseEngine: vi.fn(() => ({ numUsedAccounts: h.count })),
+    parseParams: vi.fn(() => ({ maxAccounts: h.max, warmupPeriodSlots: 100n })),
+    parseAccount: vi.fn(() => ({ warmupStartedAtSlot: 0n, pnl: 0n, warmupSlopePerStep: 0n })),
+  };
+});
+
+vi.mock("@/lib/config", () => ({
+  // A non-v17 programId so the route doesn't 501; loopback rpc (fetchSlab is mocked).
+  getConfig: () => ({ programId: "11111111111111111111111111111111", rpcUrl: "http://localhost" }),
+  getAllProgramIds: () => [],
+}));
+
+const { GET } = await import("@/app/api/warmup/[slab]/[accountIdx]/route");
+
+const SLAB = "DJ54k4wH92NTtNP8RuHAwG8si1bevXEknzctDdqYN8eC";
+const call = (accountIdx: string) =>
+  GET(new NextRequest(`http://localhost/api/warmup/${SLAB}/${accountIdx}`), {
+    params: Promise.resolve({ slab: SLAB, accountIdx }),
+  });
+const errOf = async (r: Response) => String(((await r.json()) as { error?: string }).error);
+
+describe("warmup clamps numUsedAccounts against the slab's real maxAccounts", () => {
+  it("sentinel count (u64::MAX) is rejected at the bound (binds the clamp)", async () => {
+    h.count = 2n ** 64n - 1n; h.max = 256n;
+    const res = await call("5");
+    expect(res.status).toBe(404);
+    expect(await errOf(res)).toBe("Account not found");
+  });
+
+  it("plausible-but-garbage count above the real cap is rejected (binds maxAccounts)", async () => {
+    // 500 < the 4096 default but > this slab's real cap of 10.
+    h.count = 500n; h.max = 10n;
+    const res = await call("50");
+    expect(res.status).toBe(404);
+    expect(await errOf(res)).toBe("Account not found");
+  });
+
+  it("an in-range index passes the bound (control — different 404)", async () => {
+    h.count = 100n; h.max = 256n;
+    const res = await call("5");
+    expect(await errOf(res)).not.toBe("Account not found");
+  });
+});

--- a/app/app/api/warmup/[slab]/[accountIdx]/route.ts
+++ b/app/app/api/warmup/[slab]/[accountIdx]/route.ts
@@ -56,8 +56,12 @@ export async function GET(
     // Check if account index is valid. Clamp the on-chain count first — a
     // sentinel/garbage numUsedAccounts (uninitialized slab) would otherwise defeat
     // this bound and let parseAccount read an out-of-range slot (accountIdx has no
-    // upper bound of its own).
-    const numUsed = sanitizeAccountCount(Number(engine.numUsedAccounts));
+    // upper bound of its own). Pass the slab's real maxAccounts so a plausible-but-
+    // garbage count below the 4096 default is also rejected (mirrors MarketStatsCard).
+    const numUsed = sanitizeAccountCount(
+      Number(engine.numUsedAccounts),
+      Number(riskParams.maxAccounts),
+    );
     if (accountIdx >= numUsed) {
       return NextResponse.json({ error: "Account not found" }, { status: 404 });
     }

--- a/app/app/api/warmup/[slab]/[accountIdx]/route.ts
+++ b/app/app/api/warmup/[slab]/[accountIdx]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { Connection, PublicKey } from "@solana/web3.js";
 import { fetchSlab, parseAccount, parseEngine, parseParams } from "@percolatorct/sdk";
 import { getConfig, getAllProgramIds } from "@/lib/config";
+import { sanitizeAccountCount } from "@/lib/health";
 
 // v17 wrapper program IDs — parseEngine does not support v17 account format.
 // Fresh fee-split wrapper (2026-07-17). The 2026-06-26 wrapper (69VUZ7a2...) is
@@ -52,8 +53,12 @@ export async function GET(
     const engine = parseEngine(data);
     const riskParams = parseParams(data);
 
-    // Check if account index is valid
-    if (accountIdx >= engine.numUsedAccounts) {
+    // Check if account index is valid. Clamp the on-chain count first — a
+    // sentinel/garbage numUsedAccounts (uninitialized slab) would otherwise defeat
+    // this bound and let parseAccount read an out-of-range slot (accountIdx has no
+    // upper bound of its own).
+    const numUsed = sanitizeAccountCount(Number(engine.numUsedAccounts));
+    if (accountIdx >= numUsed) {
       return NextResponse.json({ error: "Account not found" }, { status: 404 });
     }
 


### PR DESCRIPTION
## What
Clamp `engine.numUsedAccounts` with `sanitizeAccountCount` before using it as the
`accountIdx` bound in `warmup/[slab]/[accountIdx]`.

## Why
The guard `accountIdx >= engine.numUsedAccounts` trusted the raw on-chain field, and
`accountIdx` has no upper bound (only `>= 0`). A sentinel/garbage `numUsedAccounts`
(u64::MAX / uninitialized slab) is huge, so the guard passed and `parseAccount` read
an out-of-range slot. `sanitizeAccountCount` clamps garbage (`> 4096` / negative /
sentinel) to `0`, so the bound correctly rejects.

## Changes
- warmup: `const numUsed = sanitizeAccountCount(Number(engine.numUsedAccounts))` as the bound.
- regression test: sentinel/over-cap/negative → 0; legit preserved; guard rejects a
  garbage-count index that previously passed.

## Testing
- `npx tsc --noEmit` — clean.
- New test + existing warmup suites — 3 files, 26 tests, all pass.

## Notes
- Frontend + devnet scope; v12-only (v17 returns 501). No program/keeper/mainnet changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warmup account validation to safely handle invalid, oversized, negative, and sentinel account counts.
  * Prevented out-of-range account indexes from being processed when account data is malformed.
  * Preserved valid in-range account access and existing version-specific behavior.

* **Tests**
  * Added regression coverage for account-count sanitization and route-level enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->