### PR TITLE
Guard computePnlPercent in usePortfolio so an outlier can't drop positions

### DIFF
--- a/app/__tests__/hooks/portfolio-pnl-percent-guard.test.ts
+++ b/app/__tests__/hooks/portfolio-pnl-percent-guard.test.ts
@@ -1,0 +1,36 @@
+/**
+ * PoC + regression — computePnlPercent must be guarded in usePortfolio.
+ *
+ * computePnlPercent throws when pnl*10000/denominator overflows MAX_SAFE_INTEGER
+ * (a dust position-initial-margin with large PnL). PositionsDock and ChartPnlBadge
+ * wrap it in try/catch → 0, but usePortfolio's two call sites did not — so the throw
+ * propagates to the per-account (v17) / per-market (v12) catch and silently DROPS
+ * that position or the whole market's accounts from the portfolio.
+ */
+import { describe, it, expect } from "vitest";
+import { computePnlPercent } from "@/lib/trading";
+
+// Mirrors the guarded pattern the fix installs (and PositionsDock already uses).
+const guarded = (pnl: bigint, denom: bigint): number => {
+  try {
+    return denom > 0n ? computePnlPercent(pnl, denom) : 0;
+  } catch {
+    return 0;
+  }
+};
+
+describe("usePortfolio computePnlPercent guard", () => {
+  it("computePnlPercent throws on dust-margin + large PnL (the hazard)", () => {
+    expect(() => computePnlPercent(10n ** 30n, 1n)).toThrow();
+  });
+
+  it("the guard returns 0 instead of throwing (so the position isn't dropped)", () => {
+    expect(guarded(10n ** 30n, 1n)).toBe(0);
+  });
+
+  it("legitimate values still compute a finite percent", () => {
+    const pct = guarded(50_000_000n, 100_000_000n); // +50 on 100 margin
+    expect(Number.isFinite(pct)).toBe(true);
+    expect(pct).toBeGreaterThan(0);
+  });
+});

--- a/app/hooks/usePortfolio.ts
+++ b/app/hooks/usePortfolio.ts
@@ -439,9 +439,17 @@ function buildV17Position(
   // this specific position. Falls back to capital when initial margin can't
   // be computed (e.g. flat position) to preserve prior behavior.
   const positionInitialMargin = computePositionInitialMargin(account.positionSize, effectiveEntryPrice, initialMarginBps);
-  const pnlPercent = positionInitialMargin > 0n
-    ? computePnlPercent(unrealizedPnl, positionInitialMargin)
-    : computePnlPercent(unrealizedPnl, account.capital);
+  // computePnlPercent throws when pnl*10000/denominator overflows MAX_SAFE_INTEGER
+  // (dust margin + large PnL). Guard so the throw can't propagate to the per-account
+  // catch and silently drop this position from the portfolio (mirrors PositionsDock).
+  let pnlPercent = 0;
+  try {
+    pnlPercent = positionInitialMargin > 0n
+      ? computePnlPercent(unrealizedPnl, positionInitialMargin)
+      : computePnlPercent(unrealizedPnl, account.capital);
+  } catch {
+    pnlPercent = 0;
+  }
 
   const liquidationDistancePct = computeLiquidationDistancePct(
     account.positionSize,
@@ -722,9 +730,17 @@ export async function fetchPortfolioSnapshot(
             // Falls back to capital when initial margin can't be computed (e.g.
             // flat position) to preserve prior behavior.
             const positionInitialMargin = computePositionInitialMargin(account.positionSize, effectiveEntryPrice, initialMarginBps);
-            const pnlPercent = positionInitialMargin > 0n
-              ? computePnlPercent(unrealizedPnl, positionInitialMargin)
-              : computePnlPercent(unrealizedPnl, account.capital);
+            // Guard: computePnlPercent throws on overflow (dust margin + large PnL);
+            // without this the throw drops the whole market's accounts (see the
+            // per-market catch below), mirroring PositionsDock's guard.
+            let pnlPercent = 0;
+            try {
+              pnlPercent = positionInitialMargin > 0n
+                ? computePnlPercent(unrealizedPnl, positionInitialMargin)
+                : computePnlPercent(unrealizedPnl, account.capital);
+            } catch {
+              pnlPercent = 0;
+            }
 
             // Liquidation distance percentage
             const liquidationDistancePct = computeLiquidationDistancePct(


### PR DESCRIPTION
## What
Wrap `usePortfolio`'s two `computePnlPercent` calls in try/catch → 0, matching
`PositionsDock` / `ChartPnlBadge`.

## Why
`computePnlPercent` throws when `pnl*10000/denominator` overflows `MAX_SAFE_INTEGER`
(a dust position-initial-margin with large PnL). `usePortfolio`'s two sites were
unguarded, so the throw propagated to the per-account (v17) / per-market (v12) catch
and **silently dropped** that position — or the whole market's accounts — from the
portfolio (including its capital, PnL, and the at-risk count).

## Changes
- usePortfolio: guard both `computePnlPercent` sites (the single-position path and
  the shared-scan path) → fall back to 0, mirroring PositionsDock.
- regression test: throws on dust margin + large PnL; the guard returns 0; legit
  values still compute a finite percent.

## Testing
- `npx tsc --noEmit` — clean.
- New test + Portfolio/usePortfolio suites — 5 files, 39 tests, all pass.

## Notes
- Frontend + devnet scope; no program/keeper/mainnet changes.