### PR TITLE
Cap USD price formatters at MAX_PRICE_E6 (was the stale 1e15)

### DIFF
--- a/app/__tests__/lib/format-price-cap.test.ts
+++ b/app/__tests__/lib/format-price-cap.test.ts
@@ -1,0 +1,29 @@
+/**
+ * PoC + regression — the USD price formatters must reject values above the
+ * on-chain price cap (MAX_PRICE_E6 = 1e12 / $1M), not the stale 1e15 (=$1B).
+ *
+ * formatUsd / formatUsdPriceE6 rejected only priceE6 > 1e15, so a dust/garbage
+ * price (e.g. an uninitialized short liquidation price) between $1M and $1B
+ * rendered as a real dollar figure instead of "—". These formatters are used only
+ * for price-scale values (prices, spreads), so aligning to MAX_PRICE_E6 is safe.
+ *
+ * (This test asserts the FIXED behavior — it fails against the pre-fix 1e15
+ * threshold, which is the proof.)
+ */
+import { describe, it, expect } from "vitest";
+import { formatUsd, formatUsdPriceE6 } from "@/lib/format";
+import { MAX_PRICE_E6 } from "@/lib/oraclePrice";
+
+describe("USD price formatters honor MAX_PRICE_E6", () => {
+  it("rejects prices above the on-chain max ($1M)", () => {
+    const garbage = MAX_PRICE_E6 * 20n; // $20M in e6 — above $1M, below the stale $1B
+    expect(formatUsd(garbage)).toBe("$—");
+    expect(formatUsdPriceE6(garbage)).toBe("—");
+  });
+
+  it("still formats legitimate prices at/below the cap", () => {
+    expect(formatUsd(150_000_000n)).toBe("$150.00");     // $150
+    expect(formatUsdPriceE6(MAX_PRICE_E6)).toContain("$"); // $1M boundary still renders
+    expect(formatUsd(0n)).toBe("$—");                     // unchanged: 0 → dash
+  });
+});

--- a/app/__tests__/lib/format.test.ts
+++ b/app/__tests__/lib/format.test.ts
@@ -144,7 +144,7 @@ describe("formatUsd", () => {
   it("returns '$—' for absurdly large prices (defense-in-depth)", () => {
     // The $13T bug: raw on-chain value exceeds MAX_ORACLE_PRICE
     expect(formatUsd(13_065_687_626_137_560_000n)).toBe("$—");
-    // Just over the MAX_ORACLE_PRICE threshold
+    // Well above the price cap (MAX_PRICE_E6 = $1M)
     expect(formatUsd(1_000_000_000_000_001n)).toBe("$—");
   });
 
@@ -152,11 +152,13 @@ describe("formatUsd", () => {
     expect(formatUsd(-1n)).toBe("$—");
   });
 
-  it("formats prices at the MAX_ORACLE_PRICE boundary", () => {
-    // Exactly at limit ($1B) — should still format normally
-    const result = formatUsd(1_000_000_000_000_000n);
+  it("formats prices at the MAX_PRICE_E6 boundary ($1M)", () => {
+    // Exactly at the on-chain price cap — should still format normally
+    const result = formatUsd(1_000_000_000_000n);
     expect(result).not.toBe("$—");
-    expect(result.replace(/,/g, "")).toContain("1000000000");
+    expect(result.replace(/,/g, "")).toContain("1000000");
+    // Just over the cap → dash
+    expect(formatUsd(1_000_000_000_001n)).toBe("$—");
   });
 });
 

--- a/app/lib/format.ts
+++ b/app/lib/format.ts
@@ -1,3 +1,5 @@
+import { MAX_PRICE_E6 } from "@/lib/oraclePrice";
+
 /**
  * Normalize token decimals received across typed and untyped data boundaries.
  * Invalid values use the existing whole-unit fallback rather than reaching
@@ -89,8 +91,10 @@ export const LIQ_PRICE_UNLIQUIDATABLE = 18446744073709551615n; // max u64
  */
 export function formatUsd(priceE6: bigint | null | undefined): string {
   if (priceE6 == null) return "$0.00";
-  // Defense-in-depth: reject absurd values (matches Rust MAX_ORACLE_PRICE = 1e15)
-  if (priceE6 > 1_000_000_000_000_000n) return "$—";
+  // Defense-in-depth: reject absurd values above the on-chain price cap
+  // (MAX_PRICE_E6 = $1M in E6). These formatters are price-scale only, so a value
+  // above it is garbage (e.g. an uninitialized/dust liquidation price).
+  if (priceE6 > MAX_PRICE_E6) return "$—";
   if (priceE6 < 0n) return "$—";
   // PERC-297: 0 price means oracle data unavailable — show dash instead of "$0.00"
   if (priceE6 === 0n) return "$—";
@@ -99,7 +103,7 @@ export function formatUsd(priceE6: bigint | null | undefined): string {
 }
 
 export function formatUsdPriceE6(priceE6: bigint | null | undefined, fallback = "—"): string {
-  if (priceE6 == null || priceE6 <= 0n || priceE6 > 1_000_000_000_000_000n) return fallback;
+  if (priceE6 == null || priceE6 <= 0n || priceE6 > MAX_PRICE_E6) return fallback;
   const val = Number(priceE6) / 1_000_000;
   return `$${val.toLocaleString(undefined, { minimumFractionDigits: 6, maximumFractionDigits: 6 })}`;
 }


### PR DESCRIPTION
## What
Lower `formatUsd` / `formatUsdPriceE6`'s absurd-value threshold from `1e15` ($1B)
to `MAX_PRICE_E6` (`1e12` / $1M), the corrected on-chain price cap.

## Why
The formatters rejected only `priceE6 > 1e15`, so a dust/garbage price between $1M
and $1B (e.g. an uninitialized short liquidation price) rendered as a real dollar
figure instead of "—". Both formatters are **price-scale only** (prices, spreads);
large USD *amounts* use separate local `formatUsd(number)` helpers, so lowering the
cap is safe.

## Changes
- format: import `MAX_PRICE_E6` and use it as the threshold in both functions.
- regression test: value above $1M → dash; at/below → formatted.
- updated the existing boundary test (it asserted the old 1e15/$1B cap) to $1M.

## Testing
- `npx tsc --noEmit` — clean.
- format suite + new test — 2 files, 90 tests, all pass.

## Notes
- Frontend + devnet scope; no program/keeper/mainnet changes.
- Confirmed the lib `formatUsd`/`formatUsdPriceE6` importers are all price-scale
  (a spread in MarketStatsCard; entry/mark/liq prices elsewhere) — no large-amount
  display uses these.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * USD price formatting now consistently rejects values above the $1 million maximum.
  * Values at or below the limit—including zero and the exact cap—continue to format correctly.
* **Tests**
  * Added and updated coverage for price-limit boundaries and oversized values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->