### PR TITLE
fix(supabase): scope schema.sql write policies to service_role (GH#2499)

### DIFF
--- a/app/__tests__/lib/supabase-rls-write-policies.test.ts
+++ b/app/__tests__/lib/supabase-rls-write-policies.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Regression — GH#2499: `supabase/schema.sql` must not define PUBLIC write policies.
+ *
+ * A PostgreSQL RLS policy with no `TO` clause applies to the PUBLIC pseudo-role,
+ * which includes `anon` — the role behind NEXT_PUBLIC_SUPABASE_ANON_KEY. A write
+ * policy written that way lets anyone holding the public key INSERT/UPDATE through
+ * PostgREST, bypassing every check in the API routes.
+ *
+ * Scope note: this checks `schema.sql` ONLY, deliberately.
+ *
+ * The historical migrations under supabase/migrations/ do contain policies of this
+ * shape, but each was already dropped by a later migration —
+ *   - core financial tables → 20260402180100_drop_stale_core_table_rls_policies
+ *   - bug_reports          → 20260402180000_drop_stale_bug_reports_update_policy
+ *   - ideas                → 20260330120000_ideas_update_rls_service_role
+ *   - job_applications     → 044_fix_admin_users_rls
+ * so a database built from the migration chain is not affected. Migrations are
+ * immutable history; asserting over them would flag the original CREATE forever and
+ * pressure someone into editing an applied migration, which is worse than the thing
+ * being prevented.
+ *
+ * `schema.sql` is different: it is the reference schema still run by hand in the
+ * Supabase SQL Editor to bootstrap an environment. Permissive policies are OR'd, so
+ * running a version of it that omits `to service_role` re-opens write access
+ * alongside the correct policies — precisely what 20260402180100 exists to undo.
+ * That file is the live footgun, so that file is what this pins.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const SCHEMA = resolve(__dirname, "../../../supabase/schema.sql");
+
+/** Strip line comments so a policy quoted inside a comment isn't flagged. */
+function stripComments(sql: string): string {
+  return sql
+    .split("\n")
+    .map((l) => {
+      const i = l.indexOf("--");
+      return i === -1 ? l : l.slice(0, i);
+    })
+    .join("\n");
+}
+
+/** `create policy … for insert|update|delete|all …` statements, whitespace-normalised. */
+function writePolicyStatements(sql: string): string[] {
+  return stripComments(sql)
+    .split(";")
+    .map((s) => s.replace(/\s+/g, " ").trim())
+    .filter((s) => /^create\s+policy/i.test(s))
+    .filter((s) => /\bfor\s+(insert|update|delete|all)\b/i.test(s));
+}
+
+const sql = readFileSync(SCHEMA, "utf8");
+const writePolicies = writePolicyStatements(sql);
+
+describe("supabase/schema.sql write policies are role-scoped", () => {
+  it("actually finds write policies (guard against a silently empty sweep)", () => {
+    expect(writePolicies.length).toBeGreaterThan(0);
+  });
+
+  it("every write policy names a role — none defaults to PUBLIC", () => {
+    const unscoped = writePolicies.filter((s) => !/\bto\s+[a-z_]+/i.test(s));
+    expect(unscoped).toEqual([]);
+  });
+
+  it.each(["markets", "market_stats", "trades", "oracle_prices"])(
+    "%s write policies are service_role-scoped",
+    (table) => {
+      const writes = writePolicies.filter((s) =>
+        new RegExp(`\\bon ${table}\\b`, "i").test(s),
+      );
+      expect(writes.length, `${table} should have write policies`).toBeGreaterThan(0);
+      for (const w of writes) {
+        expect(w, `${table}: ${w}`).toMatch(/\bto service_role\b/i);
+      }
+    },
+  );
+
+  it("read policies are untouched — public SELECT is intentional here", () => {
+    const selects = stripComments(sql)
+      .split(";")
+      .map((s) => s.replace(/\s+/g, " ").trim())
+      .filter((s) => /^create\s+policy/i.test(s) && /\bfor\s+select\b/i.test(s));
+    expect(selects.length).toBeGreaterThan(0);
+  });
+});

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -105,12 +105,26 @@ create policy "Trades readable by all" on trades for select using (true);
 create policy "Prices readable by all" on oracle_prices for select using (true);
 
 -- Service role writes (API routes use service key)
-create policy "Service can insert markets" on markets for insert with check (true);
-create policy "Service can update markets" on markets for update using (true);
-create policy "Service can insert stats" on market_stats for insert with check (true);
-create policy "Service can update stats" on market_stats for update using (true);
-create policy "Service can insert trades" on trades for insert with check (true);
-create policy "Service can insert prices" on oracle_prices for insert with check (true);
+--
+-- GH#2499: every one of these MUST carry `to service_role`. A policy with no `TO`
+-- clause applies to the PUBLIC pseudo-role, which includes `anon` — the role behind
+-- NEXT_PUBLIC_SUPABASE_ANON_KEY — so an omission here lets anyone holding the public
+-- key INSERT fake markets/trades or UPDATE stats/prices straight through PostgREST,
+-- bypassing every check in the API routes.
+--
+-- This file previously omitted them. Migration 021 added service_role-only policies
+-- alongside, and 20260402180100 dropped these permissive ones by name, so a database
+-- built from `supabase/migrations/` is not affected. But this file is the reference
+-- schema that still gets run by hand in the Supabase SQL Editor to bootstrap an
+-- environment, and PostgreSQL OR's permissive policies — re-running the old version
+-- would silently re-open write access alongside the correct policies, exactly what
+-- 20260402180100 exists to undo. Fixed at the source so a fresh bootstrap is safe.
+create policy "Service can insert markets" on markets for insert to service_role with check (true);
+create policy "Service can update markets" on markets for update to service_role using (true) with check (true);
+create policy "Service can insert stats" on market_stats for insert to service_role with check (true);
+create policy "Service can update stats" on market_stats for update to service_role using (true) with check (true);
+create policy "Service can insert trades" on trades for insert to service_role with check (true);
+create policy "Service can insert prices" on oracle_prices for insert to service_role with check (true);
 
 -- Realtime subscriptions
 alter publication supabase_realtime add table markets;


### PR DESCRIPTION
Fixes #2499.

## The premise is correct. The claimed production impact is already mitigated — and I'd rather say so than let a High sit on the board unqualified.

**Confirmed:** all six write policies in `supabase/schema.sql` lacked a `TO`
clause, and a policy without one applies to the PUBLIC pseudo-role, which includes
`anon`. The report's reading of the SQL is exactly right.

**Not confirmed — the production exposure.** The report audits `schema.sql` but
not `supabase/migrations/`, and the migration chain already closes this. Migration
`021_fix_rls_policies.sql` created `*_service_only` policies `TO service_role`, and
`20260402180100_drop_stale_core_table_rls_policies.sql` dropped these six by name.
Its header describes the identical finding, four months ahead of this report:

> `schema.sql` … created INSERT/UPDATE policies … with NO `TO` clause — defaulting
> to the PUBLIC pseudo-role (all roles including anon) … An attacker with the
> public anon key could INSERT fake markets/trades or UPDATE market_stats/oracle_prices.

It also records that migration 021's own first attempt was a **silent no-op** — it
issued `DROP POLICY` against names (`markets_insert`) that never existed — which is
why a second migration was needed. Worth knowing: this class has bitten twice in a
way that *looked* fixed.

I swept the rest of the schema for the same shape rather than assuming these six
were it. Three more tables had it, and **all three are also already fixed**:

| table | stale policy | dropped by |
|---|---|---|
| `markets`/`market_stats`/`trades`/`oracle_prices` | 6 policies | `20260402180100` |
| `bug_reports` | insert + update | `20260402180000` |
| `ideas` | `Service can update ideas` | `20260330120000` |
| `job_applications` | `Service can update applications` | `044_fix_admin_users_rls` |

So on any database built from the migration chain, nothing is open. The CVSS 8.6
doesn't apply to a migrated deployment.

## What *is* still open, and is worth fixing

`schema.sql` itself. As `20260402180100`'s comment puts it, it is *"the reference
file sometimes run via Supabase SQL Editor"* — and PostgreSQL **OR**s permissive
policies. Running the old version against a migrated database re-creates the
wide-open policies *alongside* the correct ones and silently re-opens write access:
precisely what that migration exists to undo. A fresh environment bootstrapped from
it starts vulnerable outright.

That's a real footgun with a one-line-per-policy fix, so this PR fixes it at the
source. The UPDATE policies also gain `with check (true)` to match 021's
service_role versions — without it an UPDATE can read a row it may not write back.

## Test scope, deliberately narrow

The test pins `schema.sql` only. Historical migrations contain the original
`CREATE`s and always will; asserting over them would flag immutable history forever
and pressure someone into editing an applied migration — worse than the thing being
prevented. The comment in the test says this, so the next person doesn't "fix" the
gap by widening the sweep.

Mutation-verified: dropping `to service_role` from any single policy fails 2 tests.

```
cd app && npx vitest run
Test Files  282 passed | 1 skipped (283)
     Tests  2926 passed | 16 skipped (2942)
```

## Suggested follow-up, not in this PR

The report includes a verification query for checking live policy state. Running it
against each deployed Supabase project is still worth doing — my analysis covers
what the *repo* produces, and cannot tell you whether some environment had
`schema.sql` pasted into it by hand after its migrations ran. That's the one
scenario where the report's original severity would hold, and it's answerable only
against the live databases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened database write permissions so protected updates are limited to authorized service operations.
  - Prevented public access from creating or modifying protected records.
  - Preserved public read access where intended.
  - Ensured market and statistics updates continue to accept valid service-managed changes while maintaining the updated access restrictions.

- **Tests**
  - Added regression coverage to verify write policies remain properly restricted and public read policies remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->