### PR TITLE
fix(deps): raise the brace-expansion floor to >=5.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
       "rollup": "4.59.0",
       "serialize-javascript": ">=7.0.5",
       "picomatch": ">=4.0.4",
-      "brace-expansion": ">=5.0.7 <6",
+      "brace-expansion": ">=5.0.9",
       "yaml": ">=2.8.3",
       "undici": ">=7.28.0 <8",
       "h3": ">=1.15.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ overrides:
   rollup: 4.59.0
   serialize-javascript: '>=7.0.5'
   picomatch: '>=4.0.4'
-  brace-expansion: '>=5.0.7 <6'
+  brace-expansion: '>=5.0.9'
   yaml: '>=2.8.3'
   undici: '>=7.28.0 <8'
   h3: '>=1.15.9'
@@ -5188,9 +5188,9 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -17356,7 +17356,7 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.3
 
@@ -19793,7 +19793,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
Raise the `brace-expansion` override from `>=5.0.7 <6` to `>=5.0.9`.

## Why

`pnpm audit --audit-level=high` flags it on `playground`. The old range sits below
the patched floor of **two** advisories:

| advisory | vulnerable | what |
|---|---|---|
| GHSA-mh99-v99m-4gvg | `>=4.0.0 <5.0.8` | DoS via unbounded expansion length (OOM crash) |
| GHSA-rgw5-rvv9-x895 | `>=4.0.0 <5.0.9` | DoS via unbounded intermediate arrays, **bypassing the CVE-2026-14257 mitigation** |

`>=5.0.9` clears both. Verified: brace-expansion no longer appears in the audit
output on this branch.

Dropping the `<6` ceiling is deliberate — an upper bound on a security floor is
what silently re-exposes you the next time the floor moves, which is precisely
what happened here.

## Scope — stated plainly, because the headline number does not change

**This closes `brace-expansion` only.** `pnpm audit` still exits 1 on this branch:
**18 other high findings remain**, across `fast-uri`, `ip-address`, `next`,
`postcss`, `sharp`, `socket.io-parser` and `undici`. They are pre-existing and
unrelated; bundling them into a one-line override bump would make this
unreviewable.

## Why this accumulated — worth more attention than the fix

The audit gate exists:

```yaml
# .github/workflows/test.yml:270
- name: Run security audit
  run: pnpm audit --audit-level=high
```

It lives in the **`security-tests`** job — one of the jobs that reports **SKIPPED**
on every PR, because it is gated on `packages/*`, which no longer exists on
`playground`. That is the same #2447 pattern I hit earlier with the app suite, but
this instance is sharper: **the dependency audit is among the dead jobs**, so 19
high advisories accumulated with the gate that would have caught them reporting
green.

I've filed that separately rather than expanding this PR — the remaining 18 want
individual assessment, and several (`next`, `undici`, `sharp`) are likely to need
real upgrades rather than overrides.

Related: percolator-indexer#193 fixes the *same package* in that repo, but a
*different* advisory — indexer was already at `>=5.0.8` and needed only the newer
bypass fix, whereas this repo was below both floors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `brace-expansion` version constraint to require a newer compatible release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->